### PR TITLE
really clean build directory

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -354,14 +354,10 @@ def write_cpp(code_s):
 def clean_build():
     import shutil
 
-    pioenvs = CORE.relative_pioenvs_path()
-    if os.path.isdir(pioenvs):
-        _LOGGER.info("Deleting %s", pioenvs)
-        shutil.rmtree(pioenvs)
-    piolibdeps = CORE.relative_piolibdeps_path()
-    if os.path.isdir(piolibdeps):
-        _LOGGER.info("Deleting %s", piolibdeps)
-        shutil.rmtree(piolibdeps)
+    build_dir = CORE.relative_build_path("")
+    if os.path.isdir(build_dir):
+        _LOGGER.info("Deleting %s", build_dir)
+        shutil.rmtree(build_dir)
 
 
 GITIGNORE_CONTENT = """# Gitignore settings for ESPHome

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -179,7 +179,6 @@ def find_begin_end(text, begin_s, end_s):
 
 
 def write_platformio_ini(content):
-    update_storage_json()
     path = CORE.relative_build_path("platformio.ini")
 
     if os.path.isfile(path):
@@ -195,6 +194,7 @@ def write_platformio_ini(content):
 
 
 def write_platformio_project():
+    update_storage_json()
     mkdir_p(CORE.build_path)
 
     content = get_ini_content()
@@ -354,10 +354,9 @@ def write_cpp(code_s):
 def clean_build():
     import shutil
 
-    build_dir = CORE.relative_build_path("")
-    if os.path.isdir(build_dir):
-        _LOGGER.info("Deleting %s", build_dir)
-        shutil.rmtree(build_dir)
+    if os.path.isdir(CORE.build_path):
+        _LOGGER.info("Deleting %s", CORE.build_path)
+        shutil.rmtree(CORE.build_path)
 
 
 GITIGNORE_CONTENT = """# Gitignore settings for ESPHome


### PR DESCRIPTION
# What does this implement/fix?

deletes the entire build directory when cleaning

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
