### PR TITLE
Component for Duco ventilation system

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -129,6 +129,11 @@ esphome/components/dps310/* @kbx81
 esphome/components/ds1307/* @badbadc0ffee
 esphome/components/ds2484/* @mrk-its
 esphome/components/dsmr/* @glmnet @zuidwijk
+esphome/components/duco/* @kokx
+esphome/components/duco/number/* @kokx
+esphome/components/duco/select/* @kokx
+esphome/components/duco/sensor/* @kokx
+esphome/components/duco/text_sensor/* @kokx
 esphome/components/duty_time/* @dudanov
 esphome/components/ee895/* @Stock-M
 esphome/components/ektf2232/touchscreen/* @jesserockz

--- a/esphome/components/duco/__init__.py
+++ b/esphome/components/duco/__init__.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
+from esphome.const import CONF_DISABLE_CRC, CONF_ID
+
+DEPENDENCIES = ["uart"]
+
+duco_ns = cg.esphome_ns.namespace("duco")
+Duco = duco_ns.class_("Duco", cg.Component, uart.UARTDevice)
+# ModbusDevice = duco_ns.class_("ModbusDevice")
+MULTI_CONF = True
+
+CONF_DUCO_ID = "duco_id"
+CONF_SEND_WAIT_TIME = "send_wait_time"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Duco),
+            cv.Optional(
+                CONF_SEND_WAIT_TIME, default="250ms"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_DISABLE_CRC, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+# A schema for components like sensors
+DUCO_COMPONENT_SCHEMA = cv.Schema({cv.GenerateID(CONF_DUCO_ID): cv.use_id(Duco)})
+
+
+async def to_code(config):
+    cg.add_global(duco_ns.using)
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    await uart.register_uart_device(var, config)
+
+    cg.add(var.set_send_wait_time(config[CONF_SEND_WAIT_TIME]))
+    cg.add(var.set_disable_crc(config[CONF_DISABLE_CRC]))

--- a/esphome/components/duco/__init__.py
+++ b/esphome/components/duco/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
-from esphome.const import CONF_DISABLE_CRC, CONF_ID
+from esphome.const import CONF_DISABLE_CRC, CONF_DISCOVERY, CONF_ID
 
 CODEOWNERS = ["@kokx"]
 DEPENDENCIES = ["uart"]
@@ -17,8 +17,6 @@ MULTI_CONF = True
 
 CONF_DUCO_ID = "duco_id"
 CONF_SEND_WAIT_TIME = "send_wait_time"
-
-CONF_DISCOVERY = "discovery"
 
 # A schema for components like sensors
 DUCO_COMPONENT_SCHEMA = cv.Schema({cv.GenerateID(CONF_DUCO_ID): cv.use_id(Duco)})

--- a/esphome/components/duco/__init__.py
+++ b/esphome/components/duco/__init__.py
@@ -5,6 +5,7 @@ from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_DISABLE_CRC, CONF_ID
 
+CODEOWNERS = ["@kokx"]
 DEPENDENCIES = ["uart"]
 
 duco_ns = cg.esphome_ns.namespace("duco")

--- a/esphome/components/duco/__init__.py
+++ b/esphome/components/duco/__init__.py
@@ -22,6 +22,16 @@ CONF_DISCOVERY = "discovery"
 # A schema for components like sensors
 DUCO_COMPONENT_SCHEMA = cv.Schema({cv.GenerateID(CONF_DUCO_ID): cv.use_id(Duco)})
 
+DISCOVERY_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DucoDiscovery),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(DUCO_COMPONENT_SCHEMA)
+)
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -30,13 +40,7 @@ CONFIG_SCHEMA = (
                 CONF_SEND_WAIT_TIME, default="250ms"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_DISABLE_CRC, default=False): cv.boolean,
-            cv.Optional(CONF_DISCOVERY): cv.Schema(
-                {
-                    cv.GenerateID(): cv.declare_id(DucoDiscovery),
-                }
-            )
-            .extend(cv.polling_component_schema("60s"))
-            .extend(DUCO_COMPONENT_SCHEMA),
+            cv.Optional(CONF_DISCOVERY): DISCOVERY_SCHEMA,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/duco/__init__.py
+++ b/esphome/components/duco/__init__.py
@@ -45,7 +45,7 @@ TIME_SCHEMA = (
             cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
         }
     )
-    .extend(cv.polling_component_schema("15m"))
+    .extend(cv.polling_component_schema("15min"))
     .extend(DUCO_COMPONENT_SCHEMA)
 )
 

--- a/esphome/components/duco/__init__.py
+++ b/esphome/components/duco/__init__.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import esphome.codegen as cg
-from esphome.components import uart
+from esphome.components import time, uart
 import esphome.config_validation as cv
-from esphome.const import CONF_DISABLE_CRC, CONF_DISCOVERY, CONF_ID
+from esphome.const import (
+    CONF_DISABLE_CRC,
+    CONF_DISCOVERY,
+    CONF_ID,
+    CONF_TIME,
+    CONF_TIME_ID,
+)
 
 CODEOWNERS = ["@kokx"]
 DEPENDENCIES = ["uart"]
@@ -13,6 +19,7 @@ Duco = duco_ns.class_("Duco", cg.Component, uart.UARTDevice)
 DucoDiscovery = duco_ns.class_(
     "DucoDiscovery", cg.PollingComponent, cg.Parented.template(Duco)
 )
+DucoTime = duco_ns.class_("DucoTime", cg.PollingComponent, cg.Parented.template(Duco))
 MULTI_CONF = True
 
 CONF_DUCO_ID = "duco_id"
@@ -31,6 +38,17 @@ DISCOVERY_SCHEMA = (
     .extend(DUCO_COMPONENT_SCHEMA)
 )
 
+TIME_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DucoTime),
+            cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+        }
+    )
+    .extend(cv.polling_component_schema("15m"))
+    .extend(DUCO_COMPONENT_SCHEMA)
+)
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -40,6 +58,7 @@ CONFIG_SCHEMA = (
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_DISABLE_CRC, default=False): cv.boolean,
             cv.Optional(CONF_DISCOVERY): DISCOVERY_SCHEMA,
+            cv.Optional(CONF_TIME): TIME_SCHEMA,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -56,6 +75,17 @@ async def to_code(config):
 
     cg.add(var.set_send_wait_time(config[CONF_SEND_WAIT_TIME]))
     cg.add(var.set_disable_crc(config[CONF_DISABLE_CRC]))
+
+    if CONF_TIME in config:
+        time_config = config[CONF_TIME]
+        time_var = cg.new_Pvariable(time_config[CONF_ID])
+        await cg.register_component(time_var, time_config)
+
+        if time_id := time_config.get(CONF_TIME_ID):
+            time_ = await cg.get_variable(time_id)
+            cg.add(time_var.set_time_id(time_))
+
+        cg.add(time_var.set_parent(var))
 
     if CONF_DISCOVERY in config:
         discovery_config = config[CONF_DISCOVERY]

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -227,7 +227,7 @@ void DucoDiscovery::loop() {
 
 void DucoDiscovery::receive_response(DucoMessage message) {
   if (message.function == 0x0e) {
-    ESP_LOGV(TAG, "Discovery response message: %s", format_hex_pretty(message).c_str());
+    ESP_LOGV(TAG, "Discovery response message: %s", format_hex_pretty(message.get_message()).c_str());
     this->parent_->stop_waiting(message.id);
 
     if (message.data[0] != 0x00) {

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -189,7 +189,5 @@ void Duco::debug_hex(std::vector<uint8_t> bytes, uint8_t separator) {
   delay(10);
 }
 
-void Duco::add_sensor_item(DucoDevice *sensor) { sensor->set_parent(this); }
-
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -225,7 +225,7 @@ void DucoDiscovery::loop() {
   }
 }
 
-void DucoDiscovery::receive_response(DucoMessage message) {
+void DucoDiscovery::receive_response(const DucoMessage &message) {
   if (message.function == 0x0e) {
     ESP_LOGV(TAG, "Discovery response message: %s", format_hex_pretty(message.get_message()).c_str());
     this->parent_->stop_waiting(message.id);

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -83,7 +83,7 @@ bool Duco::parse_byte_(uint8_t byte) {
 }
 
 void Duco::finalize_message_() {
-  if (this->rx_buffer_.size() == 0)
+  if (this->rx_buffer_.empty())
     return;
   const uint8_t *raw = &this->rx_buffer_[0];
 
@@ -178,7 +178,7 @@ const std::string DucoDiscovery::NODE_TYPE_BOX = "BOX";
 const std::string DucoDiscovery::NODE_TYPE_SWITCH = "SWITCH";
 const std::string DucoDiscovery::NODE_TYPE_UNKNOWN = "UNKNOWN";
 
-const std::string friendly_node_type(uint8_t type_code) {
+std::string friendly_node_type(uint8_t type_code) {
   switch (type_code) {
     case DucoDiscovery::NODE_TYPE_CODE_UCBAT:
       return DucoDiscovery::NODE_TYPE_UCBAT;

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -1,5 +1,5 @@
 #include "duco.h"
-#include "sensor/sensor.h"
+#include "text_sensor/sensor.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <vector>

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -197,8 +197,9 @@ const std::string friendly_node_type(uint8_t type_code) {
 
 void DucoDiscovery::update() {
   // display all found nodes
+  ESP_LOGI(TAG, "Discovered nodes:");
   for (auto &node : nodes_) {
-    ESP_LOGI(TAG, "Node %d: type %d (%s)", std::get<0>(node), std::get<1>(node),
+    ESP_LOGI(TAG, "  Node %d: type %d (%s)", std::get<0>(node), std::get<1>(node),
              friendly_node_type(std::get<1>(node)).c_str());
   }
 }
@@ -225,7 +226,7 @@ void DucoDiscovery::loop() {
 }
 
 void DucoDiscovery::receive_response(DucoMessage message) {
-  if (message.id == 0x0e) {
+  if (message.function == 0x0e) {
     ESP_LOGV(TAG, "Discovery response message: %s", format_hex_pretty(message).c_str());
     this->parent_->stop_waiting(message.id);
 

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -231,7 +231,7 @@ void DucoDiscovery::receive_response(const DucoMessage &message) {
 
     if (message.data[0] != 0x00) {
       // node was found, store its information
-      nodes_.emplace_back(std::make_tuple(next_node_, message.data[0]));
+      nodes_.emplace_back(next_node_, message.data[0]);
     }
 
     next_node_++;

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -227,7 +227,6 @@ void DucoDiscovery::loop() {
 
 void DucoDiscovery::receive_response(const DucoMessage &message) {
   if (message.function == 0x0e) {
-    ESP_LOGV(TAG, "Discovery response message: %s", format_hex_pretty(message.get_message()).c_str());
     this->parent_->stop_waiting(message.id);
 
     if (message.data[0] != 0x00) {

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -1,0 +1,196 @@
+#include "duco.h"
+#include "sensor/sensor.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include <vector>
+
+namespace esphome {
+namespace duco {
+
+static const char *const TAG = "duco";
+
+void Duco::setup() {
+  // no setup needed
+}
+void Duco::loop() {
+  const uint32_t now = millis();
+
+  if (now - this->last_byte_ > 50) {
+    // first try to finalize last message, before clearing the buffer
+    this->finalize_message_();
+
+    this->rx_buffer_.clear();
+    this->last_byte_ = now;
+  }
+
+  while (this->available()) {
+    uint8_t byte;
+    this->read_byte(&byte);
+    if (this->parse_byte_(byte)) {
+      this->last_byte_ = now;
+    } else {
+      this->rx_buffer_.clear();
+    }
+  }
+}
+
+bool Duco::parse_byte_(uint8_t byte) {
+  size_t at = this->rx_buffer_.size();
+  this->rx_buffer_.push_back(byte);
+  const uint8_t *raw = &this->rx_buffer_[0];
+  ESP_LOGV(TAG, "DUCO received Byte  %d (0X%x)", byte, byte);
+  // Byte 0: Packet length (match all)
+  if (at == 0)
+    return true;
+
+  // Byte 1: check if AA:55 header
+  if (at == 1 && raw[0] == 0xAA && raw[1] == 0x55) {
+    // ignore the AA:55 header
+    return false;
+  }
+
+  // Byte 1: function code
+  if (at == 1) {
+    return true;
+  }
+
+  if (at >= 2 && this->rx_buffer_[at - 1] == 0xAA && this->rx_buffer_[at] == 0x01 && !this->removed_last_) {
+    // The last byte was 0xAA, but the current one is 0x01, which means we ignore it (only once!)
+    // This is an edge case in processing, likely to prevent accidentally introducing AA:55 in a message
+    this->rx_buffer_.pop_back();
+    this->removed_last_ = true;
+    return true;
+  }
+  this->removed_last_ = false;
+
+  // Byte 2: Identification code
+  if (at == 2)
+    return true;
+
+  // finalize message when AA:55 is found
+  if (at >= 2 && this->rx_buffer_[at - 1] == 0xAA && this->rx_buffer_[at] == 0x55) {
+    this->rx_buffer_.pop_back();
+    this->rx_buffer_.pop_back();
+    at--;
+    at--;
+
+    this->finalize_message_();
+
+    // reset buffer after finalizing
+    return false;
+  }
+
+  return true;
+}
+
+void Duco::finalize_message_() {
+  if (this->rx_buffer_.size() == 0)
+    return;
+  const uint8_t *raw = &this->rx_buffer_[0];
+
+  uint8_t data_len = raw[0];
+
+  // Byte data_offset+len+1: CRC_HI (over all bytes)
+  uint16_t computed_crc = crc16(raw, data_len + 1);
+  uint16_t remote_crc = uint16_t(raw[data_len + 1]) | (uint16_t(raw[data_len + 2]) << 8);
+  if (computed_crc != remote_crc) {
+    if (this->disable_crc_) {
+      ESP_LOGD(TAG, "CRC Check failed, but ignored! %02X!=%02X", computed_crc, remote_crc);
+    } else {
+      ESP_LOGW(TAG, "CRC Check failed! %02X!=%02X", computed_crc, remote_crc);
+      return;
+    }
+  }
+  std::vector<uint8_t> data(this->rx_buffer_.begin(), this->rx_buffer_.begin() + data_len + 1);
+
+  // see if the response exists for waiting
+  auto it = waiting_for_response.find(data[2]);
+  if (it != waiting_for_response.end()) {
+    waiting_for_response[data[2]]->receive_response(data);
+  }
+}
+
+void Duco::dump_config() {
+  ESP_LOGCONFIG(TAG, "DUCO:");
+  ESP_LOGCONFIG(TAG, "  Send Wait Time: %d ms", this->send_wait_time_);
+  ESP_LOGCONFIG(TAG, "  CRC Disabled: %s", YESNO(this->disable_crc_));
+}
+
+float Duco::get_setup_priority() const {
+  // After UART bus
+  return setup_priority::BUS - 1.0f;
+}
+
+uint8_t Duco::next_id_() {
+  last_id_++;
+  if (last_id_ == 0xAA or last_id_ == 0x55) {
+    return next_id_();
+  }
+  return last_id_;
+}
+
+void Duco::stop_waiting(uint8_t message_id) {
+  auto it = waiting_for_response.find(message_id);
+
+  if (it != waiting_for_response.end()) {
+    waiting_for_response.erase(it);
+  }
+}
+
+void Duco::send(uint8_t function, std::vector<uint8_t> message, DucoDevice *device) {
+  std::vector<uint8_t> data;
+  uint8_t message_id = this->next_id_();
+
+  data.push_back(message.size() + 2);
+  data.push_back(function);
+  data.push_back(message_id);
+  data.insert(data.end(), message.begin(), message.end());
+
+  send_raw(data);
+
+  this->waiting_for_response[message_id] = device;
+}
+
+// Helper function for lambdas
+// Send raw command. Except CRC everything must be contained in payload
+void Duco::send_raw(const std::vector<uint8_t> &payload) {
+  if (payload.empty()) {
+    return;
+  }
+
+  auto crc = crc16(payload.data(), payload.size());
+
+  this->write_byte(0xAA);
+  this->write_byte(0x55);
+  this->write_array(payload);
+  this->write_byte(crc & 0xFF);
+  this->write_byte((crc >> 8) & 0xFF);
+  this->flush();
+
+  ESP_LOGD(TAG, "DUCO write: %s", format_hex_pretty(payload).c_str());
+  last_send_ = millis();
+}
+
+void Duco::debug_hex(std::vector<uint8_t> bytes, uint8_t separator) {
+  std::string res;
+  res += "DUCO msg: ";
+
+  size_t len = bytes.size();
+
+  char buf[5];
+
+  for (size_t i = 0; i < len; i++) {
+    if (i > 0) {
+      res += separator;
+    }
+    sprintf(buf, "%02X", bytes[i]);
+    res += buf;
+  }
+  ESP_LOGD(TAG, "%s", res.c_str());
+  delay(10);
+}
+
+void Duco::add_sensor_item(DucoDevice *sensor) { sensor->set_parent(this); }
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -152,7 +152,7 @@ void Duco::send(DucoMessage message, DucoDevice *device) {
   ESP_LOGD(TAG, "Duco message sent: %s", message.to_string().c_str());
 }
 
-void Duco::debug_hex(std::vector<uint8_t> bytes, uint8_t separator) {
+void Duco::debug_hex_(std::vector<uint8_t> bytes, uint8_t separator) {
   std::string res;
   res += "DUCO msg: ";
 

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -216,7 +216,7 @@ const std::string friendly_node_type(uint8_t type_code) {
 void DucoDiscovery::update() {
   // display all found nodes
   for (auto &node : nodes_) {
-    ESP_LOGW(TAG, "Node %d: type %d (%s)", std::get<0>(node), std::get<1>(node),
+    ESP_LOGI(TAG, "Node %d: type %d (%s)", std::get<0>(node), std::get<1>(node),
              friendly_node_type(std::get<1>(node)).c_str());
   }
 }

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -1,5 +1,4 @@
 #include "duco.h"
-#include "text_sensor/sensor.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include <vector>

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -232,7 +232,7 @@ void DucoDiscovery::receive_response(const DucoMessage &message) {
 
     if (message.data[0] != 0x00) {
       // node was found, store its information
-      nodes_.push_back(std::make_tuple(next_node_, message.data[0]));
+      nodes_.emplace_back(std::make_tuple(next_node_, message.data[0]));
     }
 
     next_node_++;

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -173,6 +173,7 @@ void Duco::debug_hex_(std::vector<uint8_t> bytes, uint8_t separator) {
 
 const std::string DucoDiscovery::NODE_TYPE_UCBAT = "UCBAT";
 const std::string DucoDiscovery::NODE_TYPE_UC = "UC";
+const std::string DucoDiscovery::NODE_TYPE_UCRH = "UCRH";
 const std::string DucoDiscovery::NODE_TYPE_UCCO2 = "UCCO2";
 const std::string DucoDiscovery::NODE_TYPE_BOX = "BOX";
 const std::string DucoDiscovery::NODE_TYPE_SWITCH = "SWITCH";
@@ -184,6 +185,8 @@ std::string friendly_node_type(uint8_t type_code) {
       return DucoDiscovery::NODE_TYPE_UCBAT;
     case DucoDiscovery::NODE_TYPE_CODE_UC:
       return DucoDiscovery::NODE_TYPE_UC;
+    case DucoDiscovery::NODE_TYPE_CODE_UCRH:
+      return DucoDiscovery::NODE_TYPE_UCRH;
     case DucoDiscovery::NODE_TYPE_CODE_UCCO2:
       return DucoDiscovery::NODE_TYPE_UCCO2;
     case DucoDiscovery::NODE_TYPE_CODE_BOX:

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -241,5 +241,40 @@ void DucoDiscovery::receive_response(const DucoMessage &message) {
   }
 }
 
+#ifdef USE_TIME
+void DucoTime::setup() {}
+
+void DucoTime::update() {
+  if (this->time_id_ != nullptr) {
+    ESPTime now = this->time_id_->now();
+    if (!now.is_valid()) {
+      ESP_LOGW(TAG, "Could not obtain valid time.");
+      return;
+    }
+
+    DucoMessage message;
+    message.function = 0x24;
+
+    message.data = {0x05,
+                    static_cast<uint8_t>(now.timestamp & 0xff),
+                    static_cast<uint8_t>((now.timestamp >> 8) & 0xff),
+                    static_cast<uint8_t>((now.timestamp >> 16) & 0xff),
+                    static_cast<uint8_t>((now.timestamp >> 24) & 0xff),
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00};
+
+    this->parent_->send(message, this);
+  }
+}
+
+void DucoTime::receive_response(const DucoMessage &message) {
+  if (message.function == 0x26) {
+    this->parent_->stop_waiting(message.id);
+  }
+}
+#endif
+
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/duco.cpp
+++ b/esphome/components/duco/duco.cpp
@@ -175,6 +175,7 @@ const std::string DucoDiscovery::NODE_TYPE_UCBAT = "UCBAT";
 const std::string DucoDiscovery::NODE_TYPE_UC = "UC";
 const std::string DucoDiscovery::NODE_TYPE_UCRH = "UCRH";
 const std::string DucoDiscovery::NODE_TYPE_UCCO2 = "UCCO2";
+const std::string DucoDiscovery::NODE_TYPE_VLV = "VLV";
 const std::string DucoDiscovery::NODE_TYPE_BOX = "BOX";
 const std::string DucoDiscovery::NODE_TYPE_SWITCH = "SWITCH";
 const std::string DucoDiscovery::NODE_TYPE_UNKNOWN = "UNKNOWN";
@@ -189,6 +190,8 @@ std::string friendly_node_type(uint8_t type_code) {
       return DucoDiscovery::NODE_TYPE_UCRH;
     case DucoDiscovery::NODE_TYPE_CODE_UCCO2:
       return DucoDiscovery::NODE_TYPE_UCCO2;
+    case DucoDiscovery::NODE_TYPE_CODE_VLV:
+      return DucoDiscovery::NODE_TYPE_VLV;
     case DucoDiscovery::NODE_TYPE_CODE_BOX:
       return DucoDiscovery::NODE_TYPE_BOX;
     case DucoDiscovery::NODE_TYPE_CODE_SWITCH:

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -53,5 +53,34 @@ class DucoDevice : public Parented<Duco> {
   virtual void receive_response(std::vector<uint8_t> message) {}
 };
 
+class DucoDiscovery : public DucoDevice, public PollingComponent {
+ public:
+  void loop() override;
+  void update() override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+
+  static const std::string NODE_TYPE_UCBAT;
+  static const std::string NODE_TYPE_UC;
+  static const std::string NODE_TYPE_UCCO2;
+  static const std::string NODE_TYPE_BOX;
+  static const std::string NODE_TYPE_SWITCH;
+  static const std::string NODE_TYPE_UNKNOWN;
+
+  static const uint8_t NODE_TYPE_CODE_UCBAT = 8;
+  static const uint8_t NODE_TYPE_CODE_UC = 9;
+  static const uint8_t NODE_TYPE_CODE_UCCO2 = 12;
+  static const uint8_t NODE_TYPE_CODE_BOX = 17;
+  static const uint8_t NODE_TYPE_CODE_SWITCH = 18;
+
+ protected:
+  // start with a delay of 1000 loops
+  uint32_t delay_{1000};
+  uint8_t next_node_{0};
+  bool waiting_for_response_ = false;
+
+  std::vector<std::tuple<uint8_t, uint8_t>> nodes_;
+};
+
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -102,7 +102,7 @@ class Duco : public uart::UARTDevice, public Component {
 
 class DucoDevice : public Parented<Duco> {
  public:
-  virtual void receive_response(std::vector<uint8_t> message) {}
+  virtual void receive_response(DucoMessage message) {}
 };
 
 class DucoDiscovery : public DucoDevice, public PollingComponent {
@@ -110,7 +110,7 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
   void loop() override;
   void update() override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 
   static const std::string NODE_TYPE_UCBAT;
   static const std::string NODE_TYPE_UC;

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -29,8 +29,6 @@ class Duco : public uart::UARTDevice, public Component {
   void set_send_wait_time(uint16_t time_in_ms) { send_wait_time_ = time_in_ms; }
   void set_disable_crc(bool disable_crc) { disable_crc_ = disable_crc; }
 
-  void add_sensor_item(DucoDevice *sensor);
-
   std::map<uint8_t, DucoDevice *> waiting_for_response;
   void stop_waiting(uint8_t message_id);
 

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -102,7 +102,7 @@ class Duco : public uart::UARTDevice, public Component {
 
 class DucoDevice : public Parented<Duco> {
  public:
-  virtual void receive_response(DucoMessage message) {}
+  virtual void receive_response(const DucoMessage &message) {}
 };
 
 class DucoDiscovery : public DucoDevice, public PollingComponent {
@@ -110,7 +110,7 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
   void loop() override;
   void update() override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 
   static const std::string NODE_TYPE_UCBAT;
   static const std::string NODE_TYPE_UC;

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+
+#include <vector>
+#include <map>
+
+namespace esphome {
+namespace duco {
+
+class DucoDevice;
+
+class Duco : public uart::UARTDevice, public Component {
+ public:
+  Duco() { this->last_id_ = 10; };
+
+  void setup() override;
+
+  void loop() override;
+
+  void dump_config() override;
+
+  float get_setup_priority() const override;
+
+  void send(uint8_t function, std::vector<uint8_t> message, DucoDevice *device);
+  void send_raw(const std::vector<uint8_t> &payload);
+  void set_send_wait_time(uint16_t time_in_ms) { send_wait_time_ = time_in_ms; }
+  void set_disable_crc(bool disable_crc) { disable_crc_ = disable_crc; }
+
+  void add_sensor_item(DucoDevice *sensor);
+
+  std::map<uint8_t, DucoDevice *> waiting_for_response;
+  void stop_waiting(uint8_t message_id);
+
+ protected:
+  uint8_t last_id_ = 0;
+  uint8_t next_id_();
+
+  bool parse_byte_(uint8_t byte);
+  void finalize_message_();
+  uint16_t send_wait_time_{250};
+  bool disable_crc_;
+  std::vector<uint8_t> rx_buffer_;
+  uint32_t last_byte_{0};
+  uint32_t last_send_{0};
+  bool removed_last_ = false;
+
+  void debug_hex(std::vector<uint8_t> bytes, uint8_t separator);
+};
+
+class DucoDevice : public Parented<Duco> {
+ public:
+  virtual void receive_response(std::vector<uint8_t> message) {}
+};
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -97,7 +97,7 @@ class Duco : public uart::UARTDevice, public Component {
   uint32_t last_send_{0};
   bool removed_last_ = false;
 
-  void debug_hex(std::vector<uint8_t> bytes, uint8_t separator);
+  void debug_hex_(std::vector<uint8_t> bytes, uint8_t separator);
 };
 
 class DucoDevice : public Parented<Duco> {

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -122,6 +122,7 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
   static const std::string NODE_TYPE_UC;
   static const std::string NODE_TYPE_UCRH;
   static const std::string NODE_TYPE_UCCO2;
+  static const std::string NODE_TYPE_VLV;
   static const std::string NODE_TYPE_BOX;
   static const std::string NODE_TYPE_SWITCH;
   static const std::string NODE_TYPE_UNKNOWN;
@@ -130,6 +131,7 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
   static const uint8_t NODE_TYPE_CODE_UC = 9;
   static const uint8_t NODE_TYPE_CODE_UCRH = 10;
   static const uint8_t NODE_TYPE_CODE_UCCO2 = 12;
+  static const uint8_t NODE_TYPE_CODE_VLV = 13;
   static const uint8_t NODE_TYPE_CODE_BOX = 17;
   static const uint8_t NODE_TYPE_CODE_SWITCH = 18;
 

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -120,6 +120,7 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
 
   static const std::string NODE_TYPE_UCBAT;
   static const std::string NODE_TYPE_UC;
+  static const std::string NODE_TYPE_UCRH;
   static const std::string NODE_TYPE_UCCO2;
   static const std::string NODE_TYPE_BOX;
   static const std::string NODE_TYPE_SWITCH;
@@ -127,6 +128,7 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
 
   static const uint8_t NODE_TYPE_CODE_UCBAT = 8;
   static const uint8_t NODE_TYPE_CODE_UC = 9;
+  static const uint8_t NODE_TYPE_CODE_UCRH = 10;
   static const uint8_t NODE_TYPE_CODE_UCCO2 = 12;
   static const uint8_t NODE_TYPE_CODE_BOX = 17;
   static const uint8_t NODE_TYPE_CODE_SWITCH = 18;

--- a/esphome/components/duco/duco.h
+++ b/esphome/components/duco/duco.h
@@ -4,8 +4,14 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
+#include <string>
 #include <vector>
 #include <map>
+
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+#include "esphome/core/time.h"
+#endif
 
 namespace esphome {
 namespace duco {
@@ -36,7 +42,7 @@ class DucoMessage {
     return message;
   }
 
-  std::string to_string() {
+  std::string to_string() const {
     std::string res;
 
     char buf[5];
@@ -133,6 +139,21 @@ class DucoDiscovery : public DucoDevice, public PollingComponent {
 
   std::vector<std::tuple<uint8_t, uint8_t>> nodes_;
 };
+
+#ifdef USE_TIME
+class DucoTime : public DucoDevice, public PollingComponent {
+ public:
+  void setup() override;
+  void update() override;
+
+  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
+
+  void receive_response(const DucoMessage &message) override;
+
+ protected:
+  time::RealTimeClock *time_id_{nullptr};
+};
+#endif
 
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/number/__init__.py
+++ b/esphome/components/duco/number/__init__.py
@@ -1,0 +1,38 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, DEVICE_CLASS_TEMPERATURE, UNIT_CELSIUS
+
+from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["duco"]
+CODEOWNERS = ["@kokx"]
+
+UNIT_DAYS = "days"
+
+CONF_FILTER_REMAINING = "filter_remaining"
+
+duco_ns = cg.esphome_ns.namespace("duco")
+DucoComfortTemperature = duco_ns.class_(
+    "DucoComfortTemperature", cg.PollingComponent, number.Number
+)
+
+CONFIG_SCHEMA = (
+    number.number_schema(
+        DucoComfortTemperature,
+        unit_of_measurement=UNIT_CELSIUS,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    )
+    .extend(DUCO_COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await number.register_number(var, config, min_value=10.0, max_value=25.5, step=0.1)
+
+    parent = await cg.get_variable(config[CONF_DUCO_ID])
+    cg.add(var.set_parent(parent))

--- a/esphome/components/duco/number/number.cpp
+++ b/esphome/components/duco/number/number.cpp
@@ -21,12 +21,12 @@ float DucoComfortTemperature::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoComfortTemperature::receive_response(std::vector<uint8_t> message) {
+void DucoComfortTemperature::receive_response(DucoMessage message) {
   // the DUCO box responds with the same message, both for reading and setting the comfort temperature
-  if (message[1] == 0x26) {
-    publish_state(message[6] / 10.0);
+  if (message.function == 0x26) {
+    publish_state(message.data[3] / 10.0);
 
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
 }
 

--- a/esphome/components/duco/number/number.cpp
+++ b/esphome/components/duco/number/number.cpp
@@ -10,8 +10,10 @@ static const char *const TAG = "duco number";
 void DucoComfortTemperature::setup() {}
 
 void DucoComfortTemperature::update() {
-  std::vector<uint8_t> message = {0x00, 0x12, 0x0a};
-  this->parent_->send(0x24, message, this);
+  DucoMessage message;
+  message.function = 0x24;
+  message.data = {0x00, 0x12, 0x0a};
+  this->parent_->send(message, this);
 }
 
 float DucoComfortTemperature::get_setup_priority() const {
@@ -31,8 +33,10 @@ void DucoComfortTemperature::receive_response(std::vector<uint8_t> message) {
 void DucoComfortTemperature::control(float number) {
   uint8_t temperature = number * 10;
 
-  std::vector<uint8_t> message = {0x01, 0x12, 0x0a, temperature, 0x00, 0x00, 0x00};
-  this->parent_->send(0x24, message, this);
+  DucoMessage message;
+  message.function = 0x24;
+  message.data = {0x01, 0x12, 0x0a, temperature, 0x00, 0x00, 0x00};
+  this->parent_->send(message, this);
 }
 
 }  // namespace duco

--- a/esphome/components/duco/number/number.cpp
+++ b/esphome/components/duco/number/number.cpp
@@ -21,7 +21,7 @@ float DucoComfortTemperature::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoComfortTemperature::receive_response(DucoMessage message) {
+void DucoComfortTemperature::receive_response(const DucoMessage &message) {
   // the DUCO box responds with the same message, both for reading and setting the comfort temperature
   if (message.function == 0x26) {
     publish_state(message.data[3] / 10.0);

--- a/esphome/components/duco/number/number.cpp
+++ b/esphome/components/duco/number/number.cpp
@@ -1,0 +1,39 @@
+#include "number.h"
+#include "../duco.h"
+#include <vector>
+
+namespace esphome {
+namespace duco {
+
+static const char *const TAG = "duco number";
+
+void DucoComfortTemperature::setup() {}
+
+void DucoComfortTemperature::update() {
+  std::vector<uint8_t> message = {0x00, 0x12, 0x0a};
+  this->parent_->send(0x24, message, this);
+}
+
+float DucoComfortTemperature::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoComfortTemperature::receive_response(std::vector<uint8_t> message) {
+  // the DUCO box responds with the same message, both for reading and setting the comfort temperature
+  if (message[1] == 0x26) {
+    publish_state(message[6] / 10.0);
+
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
+void DucoComfortTemperature::control(float number) {
+  uint8_t temperature = number * 10;
+
+  std::vector<uint8_t> message = {0x01, 0x12, 0x0a, temperature, 0x00, 0x00, 0x00};
+  this->parent_->send(0x24, message, this);
+}
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/number/number.cpp
+++ b/esphome/components/duco/number/number.cpp
@@ -24,7 +24,9 @@ float DucoComfortTemperature::get_setup_priority() const {
 void DucoComfortTemperature::receive_response(const DucoMessage &message) {
   // the DUCO box responds with the same message, both for reading and setting the comfort temperature
   if (message.function == 0x26) {
-    publish_state(message.data[3] / 10.0);
+    // ignore invalid values below 100 (and above 255, since it's only one byte)
+    if (message.data[3] >= 100)
+      publish_state(message.data[3] / 10.0);
 
     this->parent_->stop_waiting(message.id);
   }

--- a/esphome/components/duco/number/number.h
+++ b/esphome/components/duco/number/number.h
@@ -15,7 +15,7 @@ class DucoComfortTemperature : public DucoDevice, public PollingComponent, publi
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 
   void control(float number) override;
 };

--- a/esphome/components/duco/number/number.h
+++ b/esphome/components/duco/number/number.h
@@ -15,7 +15,7 @@ class DucoComfortTemperature : public DucoDevice, public PollingComponent, publi
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 
   void control(float number) override;
 };

--- a/esphome/components/duco/number/number.h
+++ b/esphome/components/duco/number/number.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+#include "../duco.h"
+
+namespace esphome {
+namespace duco {
+
+class DucoComfortTemperature : public DucoDevice, public PollingComponent, public number::Number {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+
+  void control(float number) override;
+};
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/select/__init__.py
+++ b/esphome/components/duco/select/__init__.py
@@ -31,7 +31,7 @@ DucoSelect = duco_ns.class_("DucoSelect", cg.PollingComponent, select.Select)
 CONFIG_SCHEMA = cv.All(
     select.select_schema(DucoSelect)
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(cv.polling_component_schema("5s"))
+    .extend(cv.polling_component_schema("3s"))
     .extend(DUCO_COMPONENT_SCHEMA)
     .extend({cv.GenerateID(): cv.declare_id(DucoSelect)})
 )

--- a/esphome/components/duco/select/__init__.py
+++ b/esphome/components/duco/select/__init__.py
@@ -1,0 +1,32 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["duco"]
+CODEOWNERS = ["@kokx"]
+
+DUCO_MODE_OPTIONS = ["AUTO", "MAN1", "MAN2", "MAN3", "EMPT", "CNT1", "CNT2", "CNT3"]
+
+duco_ns = cg.esphome_ns.namespace("duco")
+DucoSelect = duco_ns.class_("DucoSelect", cg.PollingComponent, select.Select)
+
+CONFIG_SCHEMA = cv.All(
+    select.select_schema(DucoSelect)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("5s"))
+    .extend(DUCO_COMPONENT_SCHEMA)
+    .extend({cv.GenerateID(): cv.declare_id(DucoSelect)})
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    await select.register_select(var, config, options=DUCO_MODE_OPTIONS)
+
+    parent = await cg.get_variable(config[CONF_DUCO_ID])
+    cg.add(parent.add_sensor_item(var))

--- a/esphome/components/duco/select/__init__.py
+++ b/esphome/components/duco/select/__init__.py
@@ -8,7 +8,22 @@ from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
 DEPENDENCIES = ["duco"]
 CODEOWNERS = ["@kokx"]
 
-DUCO_MODE_OPTIONS = ["AUTO", "MAN1", "MAN2", "MAN3", "EMPT", "CNT1", "CNT2", "CNT3"]
+DUCO_MODE_OPTIONS = [
+    "AUTO",
+    "MAN1",
+    "MAN2",
+    "MAN3",
+    "EMPT",
+    "CNT1",
+    "CNT2",
+    "CNT3",
+    "MAN1x2",
+    "MAN2x2",
+    "MAN3x2",
+    "MAN1x3",
+    "MAN2x3",
+    "MAN3x3",
+]
 
 duco_ns = cg.esphome_ns.namespace("duco")
 DucoSelect = duco_ns.class_("DucoSelect", cg.PollingComponent, select.Select)

--- a/esphome/components/duco/select/__init__.py
+++ b/esphome/components/duco/select/__init__.py
@@ -44,4 +44,4 @@ async def to_code(config):
     await select.register_select(var, config, options=DUCO_MODE_OPTIONS)
 
     parent = await cg.get_variable(config[CONF_DUCO_ID])
-    cg.add(parent.add_sensor_item(var))
+    cg.add(var.set_parent(parent))

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -51,7 +51,7 @@ float DucoSelect::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-const std::string code_to_string(uint8_t mode) {
+std::string code_to_string(uint8_t mode) {
   switch (mode) {
     case DucoSelect::MODE_CODE_MAN1:
       return DucoSelect::MODE_MAN1;
@@ -86,7 +86,7 @@ const std::string code_to_string(uint8_t mode) {
   return DucoSelect::MODE_AUTO;
 }
 
-uint8_t string_to_code(std::string mode) {
+uint8_t string_to_code(const std::string &mode) {
   if (mode == DucoSelect::MODE_MAN1) {
     return DucoSelect::MODE_CODE_MAN1;
   }

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -40,12 +40,10 @@ const uint8_t DucoSelect::MODE_CODE_MAN3x3 = 0xc6;
 void DucoSelect::setup() {}
 
 void DucoSelect::update() {
-  // ask for current mode
-  ESP_LOGD(TAG, "Ask for current mode");
-
-  // ask for information from node 1
-  std::vector<uint8_t> message = {0x02, 0x01};
-  this->parent_->send(0x0c, message, this);
+  DucoMessage message;
+  message.function = 0x0c;
+  message.data = {0x02, 0x01};
+  this->parent_->send(message, this);
 }
 
 float DucoSelect::get_setup_priority() const {
@@ -152,10 +150,10 @@ void DucoSelect::receive_response(std::vector<uint8_t> message) {
 }
 
 void DucoSelect::control(const std::string &value) {
-  ESP_LOGD(TAG, "TODO: Set value %s", value.c_str());
-  std::vector<uint8_t> message = {0x04, 0x01, string_to_code(value)};
-
-  this->parent_->send(0x0c, message, this);
+  DucoMessage message;
+  message.function = 0x0c;
+  message.data = {0x04, 0x01, string_to_code(value)};
+  this->parent_->send(message, this);
 }
 
 }  // namespace duco

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -15,12 +15,12 @@ const std::string DucoSelect::MODE_EMPT = "EMPT";
 const std::string DucoSelect::MODE_CNT1 = "CNT1";
 const std::string DucoSelect::MODE_CNT2 = "CNT2";
 const std::string DucoSelect::MODE_CNT3 = "CNT3";
-const std::string DucoSelect::MODE_MAN1x2 = "MAN1x2";
-const std::string DucoSelect::MODE_MAN2x2 = "MAN2x2";
-const std::string DucoSelect::MODE_MAN3x2 = "MAN3x2";
-const std::string DucoSelect::MODE_MAN1x3 = "MAN1x3";
-const std::string DucoSelect::MODE_MAN2x3 = "MAN2x3";
-const std::string DucoSelect::MODE_MAN3x3 = "MAN3x3";
+const std::string DucoSelect::MODE_MAN1X2 = "MAN1x2";
+const std::string DucoSelect::MODE_MAN2X2 = "MAN2x2";
+const std::string DucoSelect::MODE_MAN3X2 = "MAN3x2";
+const std::string DucoSelect::MODE_MAN1X3 = "MAN1x3";
+const std::string DucoSelect::MODE_MAN2X3 = "MAN2x3";
+const std::string DucoSelect::MODE_MAN3X3 = "MAN3x3";
 
 const uint8_t DucoSelect::MODE_CODE_AUTO = 0x00;
 const uint8_t DucoSelect::MODE_CODE_MAN1 = 0x04;
@@ -30,12 +30,12 @@ const uint8_t DucoSelect::MODE_CODE_EMPT = 0x07;
 const uint8_t DucoSelect::MODE_CODE_CNT1 = 0x08;
 const uint8_t DucoSelect::MODE_CODE_CNT2 = 0x09;
 const uint8_t DucoSelect::MODE_CODE_CNT3 = 0x0a;
-const uint8_t DucoSelect::MODE_CODE_MAN1x2 = 0x84;
-const uint8_t DucoSelect::MODE_CODE_MAN2x2 = 0x85;
-const uint8_t DucoSelect::MODE_CODE_MAN3x2 = 0x86;
-const uint8_t DucoSelect::MODE_CODE_MAN1x3 = 0xc4;
-const uint8_t DucoSelect::MODE_CODE_MAN2x3 = 0xc5;
-const uint8_t DucoSelect::MODE_CODE_MAN3x3 = 0xc6;
+const uint8_t DucoSelect::MODE_CODE_MAN1X2 = 0x84;
+const uint8_t DucoSelect::MODE_CODE_MAN2X2 = 0x85;
+const uint8_t DucoSelect::MODE_CODE_MAN3X2 = 0x86;
+const uint8_t DucoSelect::MODE_CODE_MAN1X3 = 0xc4;
+const uint8_t DucoSelect::MODE_CODE_MAN2X3 = 0xc5;
+const uint8_t DucoSelect::MODE_CODE_MAN3X3 = 0xc6;
 
 void DucoSelect::setup() {}
 
@@ -67,18 +67,18 @@ const std::string code_to_string(uint8_t mode) {
       return DucoSelect::MODE_CNT2;
     case DucoSelect::MODE_CODE_CNT3:
       return DucoSelect::MODE_CNT3;
-    case DucoSelect::MODE_CODE_MAN1x2:
-      return DucoSelect::MODE_MAN1x2;
-    case DucoSelect::MODE_CODE_MAN2x2:
-      return DucoSelect::MODE_MAN2x2;
-    case DucoSelect::MODE_CODE_MAN3x2:
-      return DucoSelect::MODE_MAN3x2;
-    case DucoSelect::MODE_CODE_MAN1x3:
-      return DucoSelect::MODE_MAN1x3;
-    case DucoSelect::MODE_CODE_MAN2x3:
-      return DucoSelect::MODE_MAN2x3;
-    case DucoSelect::MODE_CODE_MAN3x3:
-      return DucoSelect::MODE_MAN3x3;
+    case DucoSelect::MODE_CODE_MAN1X2:
+      return DucoSelect::MODE_MAN1X2;
+    case DucoSelect::MODE_CODE_MAN2X2:
+      return DucoSelect::MODE_MAN2X2;
+    case DucoSelect::MODE_CODE_MAN3X2:
+      return DucoSelect::MODE_MAN3X2;
+    case DucoSelect::MODE_CODE_MAN1X3:
+      return DucoSelect::MODE_MAN1X3;
+    case DucoSelect::MODE_CODE_MAN2X3:
+      return DucoSelect::MODE_MAN2X3;
+    case DucoSelect::MODE_CODE_MAN3X3:
+      return DucoSelect::MODE_MAN3X3;
     case DucoSelect::MODE_CODE_AUTO:
     default:
       return DucoSelect::MODE_AUTO;
@@ -108,23 +108,23 @@ uint8_t string_to_code(std::string mode) {
   if (mode == DucoSelect::MODE_CNT3) {
     return DucoSelect::MODE_CODE_CNT3;
   }
-  if (mode == DucoSelect::MODE_MAN1x2) {
-    return DucoSelect::MODE_CODE_MAN1x2;
+  if (mode == DucoSelect::MODE_MAN1X2) {
+    return DucoSelect::MODE_CODE_MAN1X2;
   }
-  if (mode == DucoSelect::MODE_MAN2x2) {
-    return DucoSelect::MODE_CODE_MAN2x2;
+  if (mode == DucoSelect::MODE_MAN2X2) {
+    return DucoSelect::MODE_CODE_MAN2X2;
   }
-  if (mode == DucoSelect::MODE_MAN3x2) {
-    return DucoSelect::MODE_CODE_MAN3x2;
+  if (mode == DucoSelect::MODE_MAN3X2) {
+    return DucoSelect::MODE_CODE_MAN3X2;
   }
-  if (mode == DucoSelect::MODE_MAN1x3) {
-    return DucoSelect::MODE_CODE_MAN1x3;
+  if (mode == DucoSelect::MODE_MAN1X3) {
+    return DucoSelect::MODE_CODE_MAN1X3;
   }
-  if (mode == DucoSelect::MODE_MAN2x3) {
-    return DucoSelect::MODE_CODE_MAN2x3;
+  if (mode == DucoSelect::MODE_MAN2X3) {
+    return DucoSelect::MODE_CODE_MAN2X3;
   }
-  if (mode == DucoSelect::MODE_MAN3x3) {
-    return DucoSelect::MODE_CODE_MAN3x3;
+  if (mode == DucoSelect::MODE_MAN3X3) {
+    return DucoSelect::MODE_CODE_MAN3X3;
   }
   if (mode == DucoSelect::MODE_AUTO) {
     return DucoSelect::MODE_CODE_AUTO;

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -132,20 +132,20 @@ uint8_t string_to_code(std::string mode) {
   return DucoSelect::MODE_CODE_AUTO;
 }
 
-void DucoSelect::receive_response(std::vector<uint8_t> message) {
-  if (message[1] == 0x0e && message[3] != 0x01) {
+void DucoSelect::receive_response(DucoMessage message) {
+  if (message.function == 0x0e && message.data[0] != 0x01) {
     // mode response received, parse it
-    auto mode = code_to_string(message[3]);
+    auto mode = code_to_string(message.data[0]);
 
     publish_state(mode);
 
     ESP_LOGD(TAG, "Current mode: %s", mode.c_str());
 
     // do not wait for new messages with the same ID
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
-  if (message[1] == 0x0e && message[3] == 0x01) {
-    this->parent_->stop_waiting(message[2]);
+  if (message.function == 0x0e && message.data[0] == 0x01) {
+    this->parent_->stop_waiting(message.id);
   }
 }
 

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -132,7 +132,7 @@ uint8_t string_to_code(const std::string &mode) {
   return DucoSelect::MODE_CODE_AUTO;
 }
 
-void DucoSelect::receive_response(DucoMessage message) {
+void DucoSelect::receive_response(const DucoMessage &message) {
   if (message.function == 0x0e && message.data[0] != 0x01) {
     // mode response received, parse it
     auto mode = code_to_string(message.data[0]);

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -15,6 +15,12 @@ const std::string DucoSelect::MODE_EMPT = "EMPT";
 const std::string DucoSelect::MODE_CNT1 = "CNT1";
 const std::string DucoSelect::MODE_CNT2 = "CNT2";
 const std::string DucoSelect::MODE_CNT3 = "CNT3";
+const std::string DucoSelect::MODE_MAN1x2 = "MAN1x2";
+const std::string DucoSelect::MODE_MAN2x2 = "MAN2x2";
+const std::string DucoSelect::MODE_MAN3x2 = "MAN3x2";
+const std::string DucoSelect::MODE_MAN1x3 = "MAN1x3";
+const std::string DucoSelect::MODE_MAN2x3 = "MAN2x3";
+const std::string DucoSelect::MODE_MAN3x3 = "MAN3x3";
 
 const uint8_t DucoSelect::MODE_CODE_AUTO = 0x00;
 const uint8_t DucoSelect::MODE_CODE_MAN1 = 0x04;
@@ -24,6 +30,12 @@ const uint8_t DucoSelect::MODE_CODE_EMPT = 0x07;
 const uint8_t DucoSelect::MODE_CODE_CNT1 = 0x08;
 const uint8_t DucoSelect::MODE_CODE_CNT2 = 0x09;
 const uint8_t DucoSelect::MODE_CODE_CNT3 = 0x0a;
+const uint8_t DucoSelect::MODE_CODE_MAN1x2 = 0x84;
+const uint8_t DucoSelect::MODE_CODE_MAN2x2 = 0x85;
+const uint8_t DucoSelect::MODE_CODE_MAN3x2 = 0x86;
+const uint8_t DucoSelect::MODE_CODE_MAN1x3 = 0xc4;
+const uint8_t DucoSelect::MODE_CODE_MAN2x3 = 0xc5;
+const uint8_t DucoSelect::MODE_CODE_MAN3x3 = 0xc6;
 
 void DucoSelect::setup() {}
 
@@ -57,6 +69,18 @@ const std::string code_to_string(uint8_t mode) {
       return DucoSelect::MODE_CNT2;
     case DucoSelect::MODE_CODE_CNT3:
       return DucoSelect::MODE_CNT3;
+    case DucoSelect::MODE_CODE_MAN1x2:
+      return DucoSelect::MODE_MAN1x2;
+    case DucoSelect::MODE_CODE_MAN2x2:
+      return DucoSelect::MODE_MAN2x2;
+    case DucoSelect::MODE_CODE_MAN3x2:
+      return DucoSelect::MODE_MAN3x2;
+    case DucoSelect::MODE_CODE_MAN1x3:
+      return DucoSelect::MODE_MAN1x3;
+    case DucoSelect::MODE_CODE_MAN2x3:
+      return DucoSelect::MODE_MAN2x3;
+    case DucoSelect::MODE_CODE_MAN3x3:
+      return DucoSelect::MODE_MAN3x3;
     case DucoSelect::MODE_CODE_AUTO:
     default:
       return DucoSelect::MODE_AUTO;
@@ -85,6 +109,24 @@ uint8_t string_to_code(std::string mode) {
   }
   if (mode == DucoSelect::MODE_CNT3) {
     return DucoSelect::MODE_CODE_CNT3;
+  }
+  if (mode == DucoSelect::MODE_MAN1x2) {
+    return DucoSelect::MODE_CODE_MAN1x2;
+  }
+  if (mode == DucoSelect::MODE_MAN2x2) {
+    return DucoSelect::MODE_CODE_MAN2x2;
+  }
+  if (mode == DucoSelect::MODE_MAN3x2) {
+    return DucoSelect::MODE_CODE_MAN3x2;
+  }
+  if (mode == DucoSelect::MODE_MAN1x3) {
+    return DucoSelect::MODE_CODE_MAN1x3;
+  }
+  if (mode == DucoSelect::MODE_MAN2x3) {
+    return DucoSelect::MODE_CODE_MAN2x3;
+  }
+  if (mode == DucoSelect::MODE_MAN3x3) {
+    return DucoSelect::MODE_CODE_MAN3x3;
   }
   if (mode == DucoSelect::MODE_AUTO) {
     return DucoSelect::MODE_CODE_AUTO;

--- a/esphome/components/duco/select/select.cpp
+++ b/esphome/components/duco/select/select.cpp
@@ -1,0 +1,120 @@
+#include "select.h"
+#include "../duco.h"
+#include <vector>
+
+namespace esphome {
+namespace duco {
+
+static const char *const TAG = "duco select";
+
+const std::string DucoSelect::MODE_AUTO = "AUTO";
+const std::string DucoSelect::MODE_MAN1 = "MAN1";
+const std::string DucoSelect::MODE_MAN2 = "MAN2";
+const std::string DucoSelect::MODE_MAN3 = "MAN3";
+const std::string DucoSelect::MODE_EMPT = "EMPT";
+const std::string DucoSelect::MODE_CNT1 = "CNT1";
+const std::string DucoSelect::MODE_CNT2 = "CNT2";
+const std::string DucoSelect::MODE_CNT3 = "CNT3";
+
+const uint8_t DucoSelect::MODE_CODE_AUTO = 0x00;
+const uint8_t DucoSelect::MODE_CODE_MAN1 = 0x04;
+const uint8_t DucoSelect::MODE_CODE_MAN2 = 0x05;
+const uint8_t DucoSelect::MODE_CODE_MAN3 = 0x06;
+const uint8_t DucoSelect::MODE_CODE_EMPT = 0x07;
+const uint8_t DucoSelect::MODE_CODE_CNT1 = 0x08;
+const uint8_t DucoSelect::MODE_CODE_CNT2 = 0x09;
+const uint8_t DucoSelect::MODE_CODE_CNT3 = 0x0a;
+
+void DucoSelect::setup() {}
+
+void DucoSelect::update() {
+  // ask for current mode
+  ESP_LOGD(TAG, "Ask for current mode");
+
+  // ask for information from node 1
+  std::vector<uint8_t> message = {0x02, 0x01};
+  this->parent_->send(0x0c, message, this);
+}
+
+float DucoSelect::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+const std::string code_to_string(uint8_t mode) {
+  switch (mode) {
+    case DucoSelect::MODE_CODE_MAN1:
+      return DucoSelect::MODE_MAN1;
+    case DucoSelect::MODE_CODE_MAN2:
+      return DucoSelect::MODE_MAN2;
+    case DucoSelect::MODE_CODE_MAN3:
+      return DucoSelect::MODE_MAN3;
+    case DucoSelect::MODE_CODE_EMPT:
+      return DucoSelect::MODE_EMPT;
+    case DucoSelect::MODE_CODE_CNT1:
+      return DucoSelect::MODE_CNT1;
+    case DucoSelect::MODE_CODE_CNT2:
+      return DucoSelect::MODE_CNT2;
+    case DucoSelect::MODE_CODE_CNT3:
+      return DucoSelect::MODE_CNT3;
+    case DucoSelect::MODE_CODE_AUTO:
+    default:
+      return DucoSelect::MODE_AUTO;
+  }
+  return DucoSelect::MODE_AUTO;
+}
+
+uint8_t string_to_code(std::string mode) {
+  if (mode == DucoSelect::MODE_MAN1) {
+    return DucoSelect::MODE_CODE_MAN1;
+  }
+  if (mode == DucoSelect::MODE_MAN2) {
+    return DucoSelect::MODE_CODE_MAN2;
+  }
+  if (mode == DucoSelect::MODE_MAN3) {
+    return DucoSelect::MODE_CODE_MAN3;
+  }
+  if (mode == DucoSelect::MODE_EMPT) {
+    return DucoSelect::MODE_CODE_EMPT;
+  }
+  if (mode == DucoSelect::MODE_CNT1) {
+    return DucoSelect::MODE_CODE_CNT1;
+  }
+  if (mode == DucoSelect::MODE_CNT2) {
+    return DucoSelect::MODE_CODE_CNT2;
+  }
+  if (mode == DucoSelect::MODE_CNT3) {
+    return DucoSelect::MODE_CODE_CNT3;
+  }
+  if (mode == DucoSelect::MODE_AUTO) {
+    return DucoSelect::MODE_CODE_AUTO;
+  }
+  return DucoSelect::MODE_CODE_AUTO;
+}
+
+void DucoSelect::receive_response(std::vector<uint8_t> message) {
+  if (message[1] == 0x0e && message[3] != 0x01) {
+    // mode response received, parse it
+    auto mode = code_to_string(message[3]);
+
+    publish_state(mode);
+
+    ESP_LOGD(TAG, "Current mode: %s", mode.c_str());
+
+    // do not wait for new messages with the same ID
+    this->parent_->stop_waiting(message[2]);
+  }
+  if (message[1] == 0x0e && message[3] == 0x01) {
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
+void DucoSelect::control(const std::string &value) {
+  ESP_LOGD(TAG, "TODO: Set value %s", value.c_str());
+  std::vector<uint8_t> message = {0x04, 0x01, string_to_code(value)};
+
+  this->parent_->send(0x0c, message, this);
+}
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/select/select.h
+++ b/esphome/components/duco/select/select.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/component.h"
+#include "esphome/components/select/select.h"
+#include "../duco.h"
+
+namespace esphome {
+namespace duco {
+
+class DucoSelect : public DucoDevice, public PollingComponent, public select::Select {
+ public:
+  static const std::string MODE_AUTO;
+  static const std::string MODE_MAN1;
+  static const std::string MODE_MAN2;
+  static const std::string MODE_MAN3;
+  static const std::string MODE_EMPT;
+  static const std::string MODE_CNT1;
+  static const std::string MODE_CNT2;
+  static const std::string MODE_CNT3;
+
+  static const uint8_t MODE_CODE_AUTO;
+  static const uint8_t MODE_CODE_MAN1;
+  static const uint8_t MODE_CODE_MAN2;
+  static const uint8_t MODE_CODE_MAN3;
+  static const uint8_t MODE_CODE_EMPT;
+  static const uint8_t MODE_CODE_CNT1;
+  static const uint8_t MODE_CODE_CNT2;
+  static const uint8_t MODE_CODE_CNT3;
+
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+
+  void control(const std::string &value) override;
+
+ protected:
+  uint8_t attempts = 0;
+};
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/select/select.h
+++ b/esphome/components/duco/select/select.h
@@ -45,7 +45,7 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 
   void control(const std::string &value) override;
 };

--- a/esphome/components/duco/select/select.h
+++ b/esphome/components/duco/select/select.h
@@ -45,7 +45,7 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 
   void control(const std::string &value) override;
 };

--- a/esphome/components/duco/select/select.h
+++ b/esphome/components/duco/select/select.h
@@ -48,9 +48,6 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
   void receive_response(std::vector<uint8_t> message) override;
 
   void control(const std::string &value) override;
-
- protected:
-  uint8_t attempts = 0;
 };
 
 }  // namespace duco

--- a/esphome/components/duco/select/select.h
+++ b/esphome/components/duco/select/select.h
@@ -18,6 +18,12 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
   static const std::string MODE_CNT1;
   static const std::string MODE_CNT2;
   static const std::string MODE_CNT3;
+  static const std::string MODE_MAN1x2;
+  static const std::string MODE_MAN2x2;
+  static const std::string MODE_MAN3x2;
+  static const std::string MODE_MAN1x3;
+  static const std::string MODE_MAN2x3;
+  static const std::string MODE_MAN3x3;
 
   static const uint8_t MODE_CODE_AUTO;
   static const uint8_t MODE_CODE_MAN1;
@@ -27,6 +33,12 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
   static const uint8_t MODE_CODE_CNT1;
   static const uint8_t MODE_CODE_CNT2;
   static const uint8_t MODE_CODE_CNT3;
+  static const uint8_t MODE_CODE_MAN1x2;
+  static const uint8_t MODE_CODE_MAN2x2;
+  static const uint8_t MODE_CODE_MAN3x2;
+  static const uint8_t MODE_CODE_MAN1x3;
+  static const uint8_t MODE_CODE_MAN2x3;
+  static const uint8_t MODE_CODE_MAN3x3;
 
   void setup() override;
   void update() override;

--- a/esphome/components/duco/select/select.h
+++ b/esphome/components/duco/select/select.h
@@ -18,12 +18,12 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
   static const std::string MODE_CNT1;
   static const std::string MODE_CNT2;
   static const std::string MODE_CNT3;
-  static const std::string MODE_MAN1x2;
-  static const std::string MODE_MAN2x2;
-  static const std::string MODE_MAN3x2;
-  static const std::string MODE_MAN1x3;
-  static const std::string MODE_MAN2x3;
-  static const std::string MODE_MAN3x3;
+  static const std::string MODE_MAN1X2;
+  static const std::string MODE_MAN2X2;
+  static const std::string MODE_MAN3X2;
+  static const std::string MODE_MAN1X3;
+  static const std::string MODE_MAN2X3;
+  static const std::string MODE_MAN3X3;
 
   static const uint8_t MODE_CODE_AUTO;
   static const uint8_t MODE_CODE_MAN1;
@@ -33,12 +33,12 @@ class DucoSelect : public DucoDevice, public PollingComponent, public select::Se
   static const uint8_t MODE_CODE_CNT1;
   static const uint8_t MODE_CODE_CNT2;
   static const uint8_t MODE_CODE_CNT3;
-  static const uint8_t MODE_CODE_MAN1x2;
-  static const uint8_t MODE_CODE_MAN2x2;
-  static const uint8_t MODE_CODE_MAN3x2;
-  static const uint8_t MODE_CODE_MAN1x3;
-  static const uint8_t MODE_CODE_MAN2x3;
-  static const uint8_t MODE_CODE_MAN3x3;
+  static const uint8_t MODE_CODE_MAN1X2;
+  static const uint8_t MODE_CODE_MAN2X2;
+  static const uint8_t MODE_CODE_MAN3X2;
+  static const uint8_t MODE_CODE_MAN1X3;
+  static const uint8_t MODE_CODE_MAN2X3;
+  static const uint8_t MODE_CODE_MAN3X3;
 
   void setup() override;
   void update() override;

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_CO2,
     CONF_ID,
     DEVICE_CLASS_CARBON_DIOXIDE,
+    DEVICE_CLASS_EMPTY,
     STATE_CLASS_MEASUREMENT,
     UNIT_PARTS_PER_MILLION,
 )
@@ -15,8 +16,15 @@ from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
 DEPENDENCIES = ["duco"]
 CODEOWNERS = ["@kokx"]
 
+UNIT_DAYS = "days"
+
+CONF_FILTER_REMAINING = "filter_remaining"
+
 duco_ns = cg.esphome_ns.namespace("duco")
 DucoCo2Sensor = duco_ns.class_("DucoCo2Sensor", cg.PollingComponent, sensor.Sensor)
+DucoFilterRemainingSensor = duco_ns.class_(
+    "DucoFilterRemainingSensor", cg.PollingComponent, sensor.Sensor
+)
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -34,7 +42,15 @@ CONFIG_SCHEMA = cv.Schema(
                 }
             )
             .extend(cv.polling_component_schema("60s"))
+        ),
+        cv.Optional(CONF_FILTER_REMAINING): sensor.sensor_schema(
+            unit_of_measurement=UNIT_DAYS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_EMPTY,
+            state_class=STATE_CLASS_MEASUREMENT,
         )
+        .extend({cv.GenerateID(): cv.declare_id(DucoFilterRemainingSensor)})
+        .extend(cv.polling_component_schema("1200s")),
     }
 ).extend(DUCO_COMPONENT_SCHEMA)
 
@@ -47,3 +63,10 @@ async def to_code(config):
         await sensor.register_sensor(sensvar, co2_sensor_config)
         cg.add(sensvar.set_parent(parent))
         cg.add(sensvar.set_address(co2_sensor_config[CONF_ADDRESS]))
+
+    if CONF_FILTER_REMAINING in config:
+        filter_remaining_config = config[CONF_FILTER_REMAINING]
+        sensvar = cg.new_Pvariable(filter_remaining_config[CONF_ID])
+        await cg.register_component(sensvar, filter_remaining_config)
+        await sensor.register_sensor(sensvar, filter_remaining_config)
+        cg.add(sensvar.set_parent(parent))

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["duco"]
+CODEOWNERS = ["@kokx"]
+
+duco_ns = cg.esphome_ns.namespace("duco")
+DucoSensor = duco_ns.class_("DucoSensor", cg.PollingComponent, sensor.Sensor)
+
+CONFIG_SCHEMA = cv.All(
+    sensor.sensor_schema(DucoSensor)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("60s"))
+    .extend(DUCO_COMPONENT_SCHEMA)
+    .extend({cv.GenerateID(): cv.declare_id(DucoSensor)})
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    await sensor.register_sensor(var, config)
+
+    parent = await cg.get_variable(config[CONF_DUCO_ID])
+    cg.add(parent.add_sensor_item(var))

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -6,9 +6,12 @@ from esphome.const import (
     CONF_CO2,
     CONF_ID,
     DEVICE_CLASS_CARBON_DIOXIDE,
+    DEVICE_CLASS_DURATION,
     DEVICE_CLASS_EMPTY,
     STATE_CLASS_MEASUREMENT,
     UNIT_PARTS_PER_MILLION,
+    UNIT_PERCENT,
+    UNIT_SECOND,
 )
 
 from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
@@ -19,11 +22,19 @@ CODEOWNERS = ["@kokx"]
 UNIT_DAYS = "days"
 
 CONF_FILTER_REMAINING = "filter_remaining"
+CONF_FLOW_LEVEL = "flow_level"
+CONF_TIME_REMAINING = "time_remaining"
 
 duco_ns = cg.esphome_ns.namespace("duco")
 DucoCo2Sensor = duco_ns.class_("DucoCo2Sensor", cg.PollingComponent, sensor.Sensor)
 DucoFilterRemainingSensor = duco_ns.class_(
     "DucoFilterRemainingSensor", cg.PollingComponent, sensor.Sensor
+)
+DucoFlowLevelSensor = duco_ns.class_(
+    "DucoFlowLevelSensor", cg.PollingComponent, sensor.Sensor
+)
+DucoStateTimeRemainingSensor = duco_ns.class_(
+    "DucoStateTimeRemainingSensor", cg.PollingComponent, sensor.Sensor
 )
 
 CONFIG_SCHEMA = cv.Schema(
@@ -46,11 +57,27 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_FILTER_REMAINING): sensor.sensor_schema(
             unit_of_measurement=UNIT_DAYS,
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=DEVICE_CLASS_DURATION,
             state_class=STATE_CLASS_MEASUREMENT,
         )
         .extend({cv.GenerateID(): cv.declare_id(DucoFilterRemainingSensor)})
         .extend(cv.polling_component_schema("1200s")),
+        cv.Optional(CONF_FLOW_LEVEL): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_EMPTY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoFlowLevelSensor)})
+        .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_TIME_REMAINING): sensor.sensor_schema(
+            unit_of_measurement=UNIT_SECOND,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_DURATION,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoStateTimeRemainingSensor)})
+        .extend(cv.polling_component_schema("60s")),
     }
 ).extend(DUCO_COMPONENT_SCHEMA)
 
@@ -69,4 +96,18 @@ async def to_code(config):
         sensvar = cg.new_Pvariable(filter_remaining_config[CONF_ID])
         await cg.register_component(sensvar, filter_remaining_config)
         await sensor.register_sensor(sensvar, filter_remaining_config)
+        cg.add(sensvar.set_parent(parent))
+
+    if CONF_FLOW_LEVEL in config:
+        flow_level_config = config[CONF_FLOW_LEVEL]
+        sensvar = cg.new_Pvariable(flow_level_config[CONF_ID])
+        await cg.register_component(sensvar, flow_level_config)
+        await sensor.register_sensor(sensvar, flow_level_config)
+        cg.add(sensvar.set_parent(parent))
+
+    if CONF_TIME_REMAINING in config:
+        time_remaining_config = config[CONF_TIME_REMAINING]
+        sensvar = cg.new_Pvariable(time_remaining_config[CONF_ID])
+        await cg.register_component(sensvar, time_remaining_config)
+        await sensor.register_sensor(sensvar, time_remaining_config)
         cg.add(sensvar.set_parent(parent))

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ADDRESS,
+    CONF_CO2,
+    CONF_ID,
+    DEVICE_CLASS_CARBON_DIOXIDE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PARTS_PER_MILLION,
+)
+
+from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
+
+DEPENDENCIES = ["duco"]
+CODEOWNERS = ["@kokx"]
+
+duco_ns = cg.esphome_ns.namespace("duco")
+DucoCo2Sensor = duco_ns.class_("DucoCo2Sensor", cg.PollingComponent, sensor.Sensor)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_CO2): cv.ensure_list(
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_PARTS_PER_MILLION,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_CARBON_DIOXIDE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            )
+            .extend(
+                {
+                    cv.GenerateID(): cv.declare_id(DucoCo2Sensor),
+                    cv.Required(CONF_ADDRESS): cv.int_range(0, 68),
+                }
+            )
+            .extend(cv.polling_component_schema("60s"))
+        )
+    }
+).extend(DUCO_COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_DUCO_ID])
+    for co2_sensor_config in config[CONF_CO2]:
+        sensvar = cg.new_Pvariable(co2_sensor_config[CONF_ID])
+        await cg.register_component(sensvar, co2_sensor_config)
+        await sensor.register_sensor(sensvar, co2_sensor_config)
+        cg.add(sensvar.set_parent(parent))
+        cg.add(sensvar.set_address(co2_sensor_config[CONF_ADDRESS]))

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -4,11 +4,16 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ADDRESS,
     CONF_CO2,
+    CONF_HUMIDITY,
     CONF_ID,
+    CONF_TEMPERATURE,
     DEVICE_CLASS_CARBON_DIOXIDE,
     DEVICE_CLASS_DURATION,
     DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
     UNIT_PARTS_PER_MILLION,
     UNIT_PERCENT,
     UNIT_SECOND,
@@ -27,6 +32,12 @@ CONF_TIME_REMAINING = "time_remaining"
 
 duco_ns = cg.esphome_ns.namespace("duco")
 DucoCo2Sensor = duco_ns.class_("DucoCo2Sensor", cg.PollingComponent, sensor.Sensor)
+DucoHumiditySensor = duco_ns.class_(
+    "DucoHumiditySensor", cg.PollingComponent, sensor.Sensor
+)
+DucoHumidityTemperatureSensor = duco_ns.class_(
+    "DucoHumidityTemperatureSensor", cg.PollingComponent, sensor.Sensor
+)
 DucoFilterRemainingSensor = duco_ns.class_(
     "DucoFilterRemainingSensor", cg.PollingComponent, sensor.Sensor
 )
@@ -35,6 +46,36 @@ DucoFlowLevelSensor = duco_ns.class_(
 )
 DucoStateTimeRemainingSensor = duco_ns.class_(
     "DucoStateTimeRemainingSensor", cg.PollingComponent, sensor.Sensor
+)
+
+HUMIDITY_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_HUMIDITY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend(
+            {
+                cv.GenerateID(): cv.declare_id(DucoHumiditySensor),
+            }
+        )
+        .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend(
+            {
+                cv.GenerateID(): cv.declare_id(DucoHumidityTemperatureSensor),
+            }
+        )
+        .extend(cv.polling_component_schema("60s")),
+        cv.Required(CONF_ADDRESS): cv.int_range(0, 68),
+    }
 )
 
 CONFIG_SCHEMA = cv.Schema(
@@ -54,6 +95,7 @@ CONFIG_SCHEMA = cv.Schema(
             )
             .extend(cv.polling_component_schema("60s"))
         ),
+        cv.Optional(CONF_HUMIDITY): cv.ensure_list(HUMIDITY_SCHEMA),
         cv.Optional(CONF_FILTER_REMAINING): sensor.sensor_schema(
             unit_of_measurement=UNIT_DAYS,
             accuracy_decimals=0,
@@ -84,12 +126,32 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_DUCO_ID])
-    for co2_sensor_config in config[CONF_CO2]:
-        sensvar = cg.new_Pvariable(co2_sensor_config[CONF_ID])
-        await cg.register_component(sensvar, co2_sensor_config)
-        await sensor.register_sensor(sensvar, co2_sensor_config)
-        cg.add(sensvar.set_parent(parent))
-        cg.add(sensvar.set_address(co2_sensor_config[CONF_ADDRESS]))
+
+    if CONF_CO2 in config:
+        for co2_sensor_config in config[CONF_CO2]:
+            sensvar = cg.new_Pvariable(co2_sensor_config[CONF_ID])
+            await cg.register_component(sensvar, co2_sensor_config)
+            await sensor.register_sensor(sensvar, co2_sensor_config)
+            cg.add(sensvar.set_parent(parent))
+            cg.add(sensvar.set_address(co2_sensor_config[CONF_ADDRESS]))
+
+    if CONF_HUMIDITY in config:
+        for humidity_config in config[CONF_HUMIDITY]:
+            if CONF_HUMIDITY in humidity_config:
+                humidity_sensor_config = humidity_config[CONF_HUMIDITY]
+                sensvar = cg.new_Pvariable(humidity_sensor_config[CONF_ID])
+                await cg.register_component(sensvar, humidity_sensor_config)
+                await sensor.register_sensor(sensvar, humidity_sensor_config)
+                cg.add(sensvar.set_parent(parent))
+                cg.add(sensvar.set_address(humidity_config[CONF_ADDRESS]))
+
+            if CONF_TEMPERATURE in humidity_config:
+                temperature_sensor_config = humidity_config[CONF_TEMPERATURE]
+                sensvar = cg.new_Pvariable(temperature_sensor_config[CONF_ID])
+                await cg.register_component(sensvar, temperature_sensor_config)
+                await sensor.register_sensor(sensvar, temperature_sensor_config)
+                cg.add(sensvar.set_parent(parent))
+                cg.add(sensvar.set_address(humidity_config[CONF_ADDRESS]))
 
     if CONF_FILTER_REMAINING in config:
         filter_remaining_config = config[CONF_FILTER_REMAINING]

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -29,7 +29,7 @@ UNIT_DAYS = "days"
 CONF_FILTER_REMAINING = "filter_remaining"
 CONF_FLOW_LEVEL = "flow_level"
 CONF_TIME_REMAINING = "time_remaining"
-
+CONF_BYPASS = "bypass"
 CONF_TEMPERATURE_ODA = "temperature_oda"
 CONF_TEMPERATURE_SUP = "temperature_sup"
 CONF_TEMPERATURE_ETA = "temperature_eta"
@@ -51,6 +51,9 @@ DucoTemperatureSensor = duco_ns.class_(
 )
 DucoBoxTemperatureSensor = duco_ns.class_(
     "DucoBoxTemperatureSensor", cg.PollingComponent, sensor.Sensor
+)
+DucoBypassSensor = duco_ns.class_(
+    "DucoBypassSensor", cg.PollingComponent, sensor.Sensor
 )
 DucoFilterRemainingSensor = duco_ns.class_(
     "DucoFilterRemainingSensor", cg.PollingComponent, sensor.Sensor
@@ -165,6 +168,14 @@ CONFIG_SCHEMA = cv.Schema(
         )
         .extend({cv.GenerateID(): cv.declare_id(DucoBoxTemperatureSensor)})
         .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_BYPASS): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_EMPTY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoBypassSensor)})
+        .extend(cv.polling_component_schema("60s")),
     }
 ).extend(DUCO_COMPONENT_SCHEMA)
 
@@ -248,3 +259,10 @@ async def to_code(config):
         await sensor.register_sensor(sensvar, eha_temperature_config)
         cg.add(sensvar.set_parent(parent))
         cg.add(sensvar.set_type(SENSOR_TYPE_EHA))
+
+    if CONF_BYPASS in config:
+        bypass_config = config[CONF_BYPASS]
+        sensvar = cg.new_Pvariable(bypass_config[CONF_ID])
+        await cg.register_component(sensvar, bypass_config)
+        await sensor.register_sensor(sensvar, bypass_config)
+        cg.add(sensvar.set_parent(parent))

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -138,7 +138,7 @@ CONFIG_SCHEMA = cv.Schema(
         .extend(cv.polling_component_schema("60s")),
         cv.Optional(CONF_TEMPERATURE_ODA): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
-            accuracy_decimals=0,
+            accuracy_decimals=1,
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         )
@@ -146,7 +146,7 @@ CONFIG_SCHEMA = cv.Schema(
         .extend(cv.polling_component_schema("60s")),
         cv.Optional(CONF_TEMPERATURE_SUP): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
-            accuracy_decimals=0,
+            accuracy_decimals=1,
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         )
@@ -154,7 +154,7 @@ CONFIG_SCHEMA = cv.Schema(
         .extend(cv.polling_component_schema("60s")),
         cv.Optional(CONF_TEMPERATURE_ETA): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
-            accuracy_decimals=0,
+            accuracy_decimals=1,
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         )
@@ -162,7 +162,7 @@ CONFIG_SCHEMA = cv.Schema(
         .extend(cv.polling_component_schema("60s")),
         cv.Optional(CONF_TEMPERATURE_EHA): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
-            accuracy_decimals=0,
+            accuracy_decimals=1,
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         )

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -30,6 +30,17 @@ CONF_FILTER_REMAINING = "filter_remaining"
 CONF_FLOW_LEVEL = "flow_level"
 CONF_TIME_REMAINING = "time_remaining"
 
+CONF_TEMPERATURE_ODA = "temperature_oda"
+CONF_TEMPERATURE_SUP = "temperature_sup"
+CONF_TEMPERATURE_ETA = "temperature_eta"
+CONF_TEMPERATURE_EHA = "temperature_eha"
+
+SENSOR_TYPE_ODA = 0
+SENSOR_TYPE_SUP = 1
+SENSOR_TYPE_ETA = 2
+SENSOR_TYPE_EHA = 3
+
+
 duco_ns = cg.esphome_ns.namespace("duco")
 DucoCo2Sensor = duco_ns.class_("DucoCo2Sensor", cg.PollingComponent, sensor.Sensor)
 DucoHumiditySensor = duco_ns.class_(
@@ -37,6 +48,9 @@ DucoHumiditySensor = duco_ns.class_(
 )
 DucoTemperatureSensor = duco_ns.class_(
     "DucoTemperatureSensor", cg.PollingComponent, sensor.Sensor
+)
+DucoBoxTemperatureSensor = duco_ns.class_(
+    "DucoBoxTemperatureSensor", cg.PollingComponent, sensor.Sensor
 )
 DucoFilterRemainingSensor = duco_ns.class_(
     "DucoFilterRemainingSensor", cg.PollingComponent, sensor.Sensor
@@ -119,6 +133,38 @@ CONFIG_SCHEMA = cv.Schema(
         )
         .extend({cv.GenerateID(): cv.declare_id(DucoStateTimeRemainingSensor)})
         .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_TEMPERATURE_ODA): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoBoxTemperatureSensor)})
+        .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_TEMPERATURE_SUP): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoBoxTemperatureSensor)})
+        .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_TEMPERATURE_ETA): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoBoxTemperatureSensor)})
+        .extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_TEMPERATURE_EHA): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        )
+        .extend({cv.GenerateID(): cv.declare_id(DucoBoxTemperatureSensor)})
+        .extend(cv.polling_component_schema("60s")),
     }
 ).extend(DUCO_COMPONENT_SCHEMA)
 
@@ -170,3 +216,35 @@ async def to_code(config):
         await cg.register_component(sensvar, time_remaining_config)
         await sensor.register_sensor(sensvar, time_remaining_config)
         cg.add(sensvar.set_parent(parent))
+
+    if CONF_TEMPERATURE_ODA in config:
+        oda_temperature_config = config[CONF_TEMPERATURE_ODA]
+        sensvar = cg.new_Pvariable(oda_temperature_config[CONF_ID])
+        await cg.register_component(sensvar, oda_temperature_config)
+        await sensor.register_sensor(sensvar, oda_temperature_config)
+        cg.add(sensvar.set_parent(parent))
+        cg.add(sensvar.set_type(SENSOR_TYPE_ODA))
+
+    if CONF_TEMPERATURE_SUP in config:
+        sup_temperature_config = config[CONF_TEMPERATURE_SUP]
+        sensvar = cg.new_Pvariable(sup_temperature_config[CONF_ID])
+        await cg.register_component(sensvar, sup_temperature_config)
+        await sensor.register_sensor(sensvar, sup_temperature_config)
+        cg.add(sensvar.set_parent(parent))
+        cg.add(sensvar.set_type(SENSOR_TYPE_SUP))
+
+    if CONF_TEMPERATURE_ETA in config:
+        eta_temperature_config = config[CONF_TEMPERATURE_ETA]
+        sensvar = cg.new_Pvariable(eta_temperature_config[CONF_ID])
+        await cg.register_component(sensvar, eta_temperature_config)
+        await sensor.register_sensor(sensvar, eta_temperature_config)
+        cg.add(sensvar.set_parent(parent))
+        cg.add(sensvar.set_type(SENSOR_TYPE_ETA))
+
+    if CONF_TEMPERATURE_EHA in config:
+        eha_temperature_config = config[CONF_TEMPERATURE_EHA]
+        sensvar = cg.new_Pvariable(eha_temperature_config[CONF_ID])
+        await cg.register_component(sensvar, eha_temperature_config)
+        await sensor.register_sensor(sensvar, eha_temperature_config)
+        cg.add(sensvar.set_parent(parent))
+        cg.add(sensvar.set_type(SENSOR_TYPE_EHA))

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -35,8 +35,8 @@ DucoCo2Sensor = duco_ns.class_("DucoCo2Sensor", cg.PollingComponent, sensor.Sens
 DucoHumiditySensor = duco_ns.class_(
     "DucoHumiditySensor", cg.PollingComponent, sensor.Sensor
 )
-DucoHumidityTemperatureSensor = duco_ns.class_(
-    "DucoHumidityTemperatureSensor", cg.PollingComponent, sensor.Sensor
+DucoTemperatureSensor = duco_ns.class_(
+    "DucoTemperatureSensor", cg.PollingComponent, sensor.Sensor
 )
 DucoFilterRemainingSensor = duco_ns.class_(
     "DucoFilterRemainingSensor", cg.PollingComponent, sensor.Sensor
@@ -46,36 +46,6 @@ DucoFlowLevelSensor = duco_ns.class_(
 )
 DucoStateTimeRemainingSensor = duco_ns.class_(
     "DucoStateTimeRemainingSensor", cg.PollingComponent, sensor.Sensor
-)
-
-HUMIDITY_SCHEMA = cv.Schema(
-    {
-        cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_PERCENT,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_HUMIDITY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        )
-        .extend(
-            {
-                cv.GenerateID(): cv.declare_id(DucoHumiditySensor),
-            }
-        )
-        .extend(cv.polling_component_schema("60s")),
-        cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        )
-        .extend(
-            {
-                cv.GenerateID(): cv.declare_id(DucoHumidityTemperatureSensor),
-            }
-        )
-        .extend(cv.polling_component_schema("60s")),
-        cv.Required(CONF_ADDRESS): cv.int_range(0, 68),
-    }
 )
 
 CONFIG_SCHEMA = cv.Schema(
@@ -95,7 +65,36 @@ CONFIG_SCHEMA = cv.Schema(
             )
             .extend(cv.polling_component_schema("60s"))
         ),
-        cv.Optional(CONF_HUMIDITY): cv.ensure_list(HUMIDITY_SCHEMA),
+        cv.Optional(CONF_TEMPERATURE): cv.ensure_list(
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            )
+            .extend(
+                {
+                    cv.GenerateID(): cv.declare_id(DucoTemperatureSensor),
+                    cv.Required(CONF_ADDRESS): cv.int_range(0, 68),
+                }
+            )
+            .extend(cv.polling_component_schema("60s"))
+        ),
+        cv.Optional(CONF_HUMIDITY): cv.ensure_list(
+            sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_HUMIDITY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            )
+            .extend(
+                {
+                    cv.GenerateID(): cv.declare_id(DucoHumiditySensor),
+                    cv.Required(CONF_ADDRESS): cv.int_range(0, 68),
+                }
+            )
+            .extend(cv.polling_component_schema("60s"))
+        ),
         cv.Optional(CONF_FILTER_REMAINING): sensor.sensor_schema(
             unit_of_measurement=UNIT_DAYS,
             accuracy_decimals=0,
@@ -136,22 +135,20 @@ async def to_code(config):
             cg.add(sensvar.set_address(co2_sensor_config[CONF_ADDRESS]))
 
     if CONF_HUMIDITY in config:
-        for humidity_config in config[CONF_HUMIDITY]:
-            if CONF_HUMIDITY in humidity_config:
-                humidity_sensor_config = humidity_config[CONF_HUMIDITY]
-                sensvar = cg.new_Pvariable(humidity_sensor_config[CONF_ID])
-                await cg.register_component(sensvar, humidity_sensor_config)
-                await sensor.register_sensor(sensvar, humidity_sensor_config)
-                cg.add(sensvar.set_parent(parent))
-                cg.add(sensvar.set_address(humidity_config[CONF_ADDRESS]))
+        for humidity_sensor_config in config[CONF_HUMIDITY]:
+            sensvar = cg.new_Pvariable(humidity_sensor_config[CONF_ID])
+            await cg.register_component(sensvar, humidity_sensor_config)
+            await sensor.register_sensor(sensvar, humidity_sensor_config)
+            cg.add(sensvar.set_parent(parent))
+            cg.add(sensvar.set_address(humidity_sensor_config[CONF_ADDRESS]))
 
-            if CONF_TEMPERATURE in humidity_config:
-                temperature_sensor_config = humidity_config[CONF_TEMPERATURE]
-                sensvar = cg.new_Pvariable(temperature_sensor_config[CONF_ID])
-                await cg.register_component(sensvar, temperature_sensor_config)
-                await sensor.register_sensor(sensvar, temperature_sensor_config)
-                cg.add(sensvar.set_parent(parent))
-                cg.add(sensvar.set_address(humidity_config[CONF_ADDRESS]))
+    if CONF_TEMPERATURE in config:
+        for temperature_sensor_config in config[CONF_TEMPERATURE]:
+            sensvar = cg.new_Pvariable(temperature_sensor_config[CONF_ID])
+            await cg.register_component(sensvar, temperature_sensor_config)
+            await sensor.register_sensor(sensvar, temperature_sensor_config)
+            cg.add(sensvar.set_parent(parent))
+            cg.add(sensvar.set_address(temperature_sensor_config[CONF_ADDRESS]))
 
     if CONF_FILTER_REMAINING in config:
         filter_remaining_config = config[CONF_FILTER_REMAINING]

--- a/esphome/components/duco/sensor/__init__.py
+++ b/esphome/components/duco/sensor/__init__.py
@@ -24,7 +24,7 @@ from .. import CONF_DUCO_ID, DUCO_COMPONENT_SCHEMA
 DEPENDENCIES = ["duco"]
 CODEOWNERS = ["@kokx"]
 
-UNIT_DAYS = "days"
+UNIT_DAYS = "d"
 
 CONF_FILTER_REMAINING = "filter_remaining"
 CONF_FLOW_LEVEL = "flow_level"

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -21,7 +21,7 @@ float DucoCo2Sensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoCo2Sensor::receive_response(DucoMessage message) {
+void DucoCo2Sensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x12) {
     uint16_t co2_value = (message.data[5] << 8) + message.data[4];
     publish_state(co2_value);
@@ -46,7 +46,7 @@ float DucoFilterRemainingSensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoFilterRemainingSensor::receive_response(DucoMessage message) {
+void DucoFilterRemainingSensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x26) {
     uint8_t filter_remaining = message.data[3];
     publish_state(filter_remaining);
@@ -69,7 +69,7 @@ float DucoFlowLevelSensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoFlowLevelSensor::receive_response(DucoMessage message) {
+void DucoFlowLevelSensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x0e) {
     uint8_t flow_level = message.data[2];
     publish_state(flow_level);
@@ -92,7 +92,7 @@ float DucoStateTimeRemainingSensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoStateTimeRemainingSensor::receive_response(DucoMessage message) {
+void DucoStateTimeRemainingSensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x0e) {
     uint16_t time_remaining = (message.data[13] << 8) + message.data[12];
     publish_state(time_remaining);

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -1,0 +1,37 @@
+#include "sensor.h"
+#include "../duco.h"
+#include <vector>
+
+namespace esphome {
+namespace duco {
+
+static const char *const TAG = "duco sensor";
+
+void DucoCo2Sensor::setup() {}
+
+void DucoCo2Sensor::update() {
+  // ask for current mode
+  ESP_LOGD(TAG, "CO2: Get sensor information");
+
+  std::vector<uint8_t> message = {0x01, address_, 0x00, 0x49, 0x04};
+  this->parent_->send(0x10, message, this);
+}
+
+float DucoCo2Sensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoCo2Sensor::receive_response(std::vector<uint8_t> message) {
+  if (message[1] == 0x12) {
+    uint16_t co2_value = (message[8] << 8) + message[7];
+    publish_state(co2_value);
+
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
+void DucoCo2Sensor::set_address(uint8_t address) { this->address_ = address; }
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -36,9 +36,6 @@ void DucoCo2Sensor::set_address(uint8_t address) { this->address_ = address; }
 void DucoFilterRemainingSensor::setup() {}
 
 void DucoFilterRemainingSensor::update() {
-  // ask for current mode
-  ESP_LOGD(TAG, "Filter time remaining: Get sensor information");
-
   std::vector<uint8_t> message = {0x00, 0x30, 0x09};
   this->parent_->send(0x24, message, this);
 }
@@ -52,6 +49,48 @@ void DucoFilterRemainingSensor::receive_response(std::vector<uint8_t> message) {
   if (message[1] == 0x26) {
     uint8_t filter_remaining = message[6];
     publish_state(filter_remaining);
+
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
+void DucoFlowLevelSensor::setup() {}
+
+void DucoFlowLevelSensor::update() {
+  std::vector<uint8_t> message = {0x02, 0x01};
+  this->parent_->send(0x0c, message, this);
+}
+
+float DucoFlowLevelSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoFlowLevelSensor::receive_response(std::vector<uint8_t> message) {
+  if (message[1] == 0x0e) {
+    uint8_t flow_level = message[5];
+    publish_state(flow_level);
+
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
+void DucoStateTimeRemainingSensor::setup() {}
+
+void DucoStateTimeRemainingSensor::update() {
+  std::vector<uint8_t> message = {0x02, 0x01};
+  this->parent_->send(0x0c, message, this);
+}
+
+float DucoStateTimeRemainingSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoStateTimeRemainingSensor::receive_response(std::vector<uint8_t> message) {
+  if (message[1] == 0x0e) {
+    uint16_t time_remaining = (message[16] << 8) + message[15];
+    publish_state(time_remaining);
 
     this->parent_->stop_waiting(message[2]);
   }

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -10,11 +10,10 @@ static const char *const TAG = "duco sensor";
 void DucoCo2Sensor::setup() {}
 
 void DucoCo2Sensor::update() {
-  // ask for current mode
-  ESP_LOGD(TAG, "CO2: Get sensor information");
-
-  std::vector<uint8_t> message = {0x01, address_, 0x00, 0x49, 0x04};
-  this->parent_->send(0x10, message, this);
+  DucoMessage message;
+  message.function = 0x10;
+  message.data = {0x01, address_, 0x00, 0x49, 0x04};
+  this->parent_->send(message, this);
 }
 
 float DucoCo2Sensor::get_setup_priority() const {
@@ -36,8 +35,10 @@ void DucoCo2Sensor::set_address(uint8_t address) { this->address_ = address; }
 void DucoFilterRemainingSensor::setup() {}
 
 void DucoFilterRemainingSensor::update() {
-  std::vector<uint8_t> message = {0x00, 0x30, 0x09};
-  this->parent_->send(0x24, message, this);
+  DucoMessage message;
+  message.function = 0x24;
+  message.data = {0x00, 0x30, 0x09};
+  this->parent_->send(message, this);
 }
 
 float DucoFilterRemainingSensor::get_setup_priority() const {
@@ -57,8 +58,10 @@ void DucoFilterRemainingSensor::receive_response(std::vector<uint8_t> message) {
 void DucoFlowLevelSensor::setup() {}
 
 void DucoFlowLevelSensor::update() {
-  std::vector<uint8_t> message = {0x02, 0x01};
-  this->parent_->send(0x0c, message, this);
+  DucoMessage message;
+  message.function = 0x0c;
+  message.data = {0x02, 0x01};
+  this->parent_->send(message, this);
 }
 
 float DucoFlowLevelSensor::get_setup_priority() const {
@@ -78,8 +81,10 @@ void DucoFlowLevelSensor::receive_response(std::vector<uint8_t> message) {
 void DucoStateTimeRemainingSensor::setup() {}
 
 void DucoStateTimeRemainingSensor::update() {
-  std::vector<uint8_t> message = {0x02, 0x01};
-  this->parent_->send(0x0c, message, this);
+  DucoMessage message;
+  message.function = 0x0c;
+  message.data = {0x02, 0x01};
+  this->parent_->send(message, this);
 }
 
 float DucoStateTimeRemainingSensor::get_setup_priority() const {

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -33,5 +33,29 @@ void DucoCo2Sensor::receive_response(std::vector<uint8_t> message) {
 
 void DucoCo2Sensor::set_address(uint8_t address) { this->address_ = address; }
 
+void DucoFilterRemainingSensor::setup() {}
+
+void DucoFilterRemainingSensor::update() {
+  // ask for current mode
+  ESP_LOGD(TAG, "Filter time remaining: Get sensor information");
+
+  std::vector<uint8_t> message = {0x00, 0x30, 0x09};
+  this->parent_->send(0x24, message, this);
+}
+
+float DucoFilterRemainingSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoFilterRemainingSensor::receive_response(std::vector<uint8_t> message) {
+  if (message[1] == 0x26) {
+    uint8_t filter_remaining = message[6];
+    publish_state(filter_remaining);
+
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -21,12 +21,12 @@ float DucoCo2Sensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoCo2Sensor::receive_response(std::vector<uint8_t> message) {
-  if (message[1] == 0x12) {
-    uint16_t co2_value = (message[8] << 8) + message[7];
+void DucoCo2Sensor::receive_response(DucoMessage message) {
+  if (message.function == 0x12) {
+    uint16_t co2_value = (message.data[5] << 8) + message.data[4];
     publish_state(co2_value);
 
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
 }
 
@@ -46,12 +46,12 @@ float DucoFilterRemainingSensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoFilterRemainingSensor::receive_response(std::vector<uint8_t> message) {
-  if (message[1] == 0x26) {
-    uint8_t filter_remaining = message[6];
+void DucoFilterRemainingSensor::receive_response(DucoMessage message) {
+  if (message.function == 0x26) {
+    uint8_t filter_remaining = message.data[3];
     publish_state(filter_remaining);
 
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
 }
 
@@ -69,12 +69,12 @@ float DucoFlowLevelSensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoFlowLevelSensor::receive_response(std::vector<uint8_t> message) {
-  if (message[1] == 0x0e) {
-    uint8_t flow_level = message[5];
+void DucoFlowLevelSensor::receive_response(DucoMessage message) {
+  if (message.function == 0x0e) {
+    uint8_t flow_level = message.data[2];
     publish_state(flow_level);
 
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
 }
 
@@ -92,12 +92,12 @@ float DucoStateTimeRemainingSensor::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoStateTimeRemainingSensor::receive_response(std::vector<uint8_t> message) {
-  if (message[1] == 0x0e) {
-    uint16_t time_remaining = (message[16] << 8) + message[15];
+void DucoStateTimeRemainingSensor::receive_response(DucoMessage message) {
+  if (message.function == 0x0e) {
+    uint16_t time_remaining = (message.data[13] << 8) + message.data[12];
     publish_state(time_remaining);
 
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
 }
 

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -1,0 +1,35 @@
+#include "sensor.h"
+#include "../duco.h"
+#include <vector>
+
+namespace esphome {
+namespace duco {
+
+static const char *const TAG = "duco sensor";
+
+void DucoSensor::setup() {}
+
+void DucoSensor::update() {
+  // ask for serial
+  std::vector<uint8_t> message = {0x01, 0x01, 0x00, 0x1a, 0x10};
+  this->parent_->send(0x10, message, this);
+}
+
+float DucoSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoSensor::receive_response(std::vector<uint8_t> message) {
+  if (message[1] == 0x12) {
+    // Serial response received, parse it
+    std::string serial(message.begin() + 5, message.end());
+    ESP_LOGD(TAG, "Box Serial: %s", serial.c_str());
+
+    // do not wait for new messages with the same ID
+    this->parent_->stop_waiting(message[2]);
+  }
+}
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -24,7 +24,10 @@ float DucoCo2Sensor::get_setup_priority() const {
 void DucoCo2Sensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x12) {
     uint16_t co2_value = (message.data[5] << 8) + message.data[4];
-    publish_state(co2_value);
+    // only publish the state if the co2 value is below 10000
+    // otherwise the value is likely invalid
+    if (co2_value <= 10000)
+      publish_state(co2_value);
 
     this->parent_->stop_waiting(message.id);
   }

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -35,6 +35,62 @@ void DucoCo2Sensor::receive_response(const DucoMessage &message) {
 
 void DucoCo2Sensor::set_address(uint8_t address) { this->address_ = address; }
 
+void DucoHumiditySensor::setup() {}
+
+void DucoHumiditySensor::update() {
+  DucoMessage message;
+  message.function = 0x10;
+  message.data = {0x01, address_, 0x00, 0x49, 0x04};
+  this->parent_->send(message, this);
+}
+
+float DucoHumiditySensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoHumiditySensor::receive_response(const DucoMessage &message) {
+  if (message.function == 0x12) {
+    uint16_t rh_value = (message.data[7] << 8) + message.data[6];
+    // only publish the state if the co2 value is below 10000
+    // otherwise the value is likely invalid
+    if (rh_value <= 10000)
+      publish_state(rh_value / 100.0);
+
+    this->parent_->stop_waiting(message.id);
+  }
+}
+
+void DucoHumiditySensor::set_address(uint8_t address) { this->address_ = address; }
+
+void DucoHumidityTemperatureSensor::setup() {}
+
+void DucoHumidityTemperatureSensor::update() {
+  DucoMessage message;
+  message.function = 0x10;
+  message.data = {0x01, address_, 0x00, 0x49, 0x04};
+  this->parent_->send(message, this);
+}
+
+float DucoHumidityTemperatureSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoHumidityTemperatureSensor::receive_response(const DucoMessage &message) {
+  if (message.function == 0x12) {
+    uint16_t rh_value = (message.data[7] << 8) + message.data[6];
+    // only publish the state if the co2 value is below 10000
+    // otherwise the value is likely invalid
+    if (rh_value <= 10000)
+      publish_state(rh_value / 100.0);
+
+    this->parent_->stop_waiting(message.id);
+  }
+}
+
+void DucoHumidityTemperatureSensor::set_address(uint8_t address) { this->address_ = address; }
+
 void DucoFilterRemainingSensor::setup() {}
 
 void DucoFilterRemainingSensor::update() {

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -119,6 +119,32 @@ void DucoBoxTemperatureSensor::receive_response(const DucoMessage &message) {
 
 void DucoBoxTemperatureSensor::set_type(uint8_t type) { this->type_ = type; }
 
+void DucoBypassSensor::setup() {}
+
+void DucoBypassSensor::update() {
+  DucoMessage message;
+  message.function = 0x24;
+  message.data = {0x00, 0x10, 0x09};
+  this->parent_->send(message, this);
+}
+
+float DucoBypassSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoBypassSensor::receive_response(const DucoMessage &message) {
+  if (message.function == 0x26) {
+    uint16_t bypass_value = message.data[3];
+    // only publish the state if the co2 value is below 10000
+    // otherwise the value is likely invalid
+    if (bypass_value <= 100)
+      publish_state(bypass_value);
+
+    this->parent_->stop_waiting(message.id);
+  }
+}
+
 void DucoFilterRemainingSensor::setup() {}
 
 void DucoFilterRemainingSensor::update() {

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -91,6 +91,34 @@ void DucoTemperatureSensor::receive_response(const DucoMessage &message) {
 
 void DucoTemperatureSensor::set_address(uint8_t address) { this->address_ = address; }
 
+void DucoBoxTemperatureSensor::setup() {}
+
+void DucoBoxTemperatureSensor::update() {
+  DucoMessage message;
+  message.function = 0x24;
+  message.data = {0x00, type_, 0x09};
+  this->parent_->send(message, this);
+}
+
+float DucoBoxTemperatureSensor::get_setup_priority() const {
+  // After DUCO
+  return setup_priority::BUS - 2.0f;
+}
+
+void DucoBoxTemperatureSensor::receive_response(const DucoMessage &message) {
+  if (message.function == 0x26) {
+    uint16_t temp_value = (message.data[4] << 8) + message.data[3];
+    // only publish the state if the co2 value is below 10000
+    // otherwise the value is likely invalid
+    if (temp_value <= 1000)
+      publish_state(temp_value / 10.0);
+
+    this->parent_->stop_waiting(message.id);
+  }
+}
+
+void DucoBoxTemperatureSensor::set_type(uint8_t type) { this->type_ = type; }
+
 void DucoFilterRemainingSensor::setup() {}
 
 void DucoFilterRemainingSensor::update() {

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -24,9 +24,9 @@ float DucoCo2Sensor::get_setup_priority() const {
 void DucoCo2Sensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x12) {
     uint16_t co2_value = (message.data[5] << 8) + message.data[4];
-    // only publish the state if the co2 value is below 10000
+    // only publish the state if the co2 value is below 10000 or above 300
     // otherwise the value is likely invalid
-    if (co2_value <= 10000)
+    if (co2_value <= 10000 && co2_value >= 300)
       publish_state(co2_value);
 
     this->parent_->stop_waiting(message.id);

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -63,33 +63,33 @@ void DucoHumiditySensor::receive_response(const DucoMessage &message) {
 
 void DucoHumiditySensor::set_address(uint8_t address) { this->address_ = address; }
 
-void DucoHumidityTemperatureSensor::setup() {}
+void DucoTemperatureSensor::setup() {}
 
-void DucoHumidityTemperatureSensor::update() {
+void DucoTemperatureSensor::update() {
   DucoMessage message;
   message.function = 0x10;
   message.data = {0x01, address_, 0x00, 0x49, 0x04};
   this->parent_->send(message, this);
 }
 
-float DucoHumidityTemperatureSensor::get_setup_priority() const {
+float DucoTemperatureSensor::get_setup_priority() const {
   // After DUCO
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoHumidityTemperatureSensor::receive_response(const DucoMessage &message) {
+void DucoTemperatureSensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x12) {
-    uint16_t rh_value = (message.data[7] << 8) + message.data[6];
+    uint16_t temp_value = (message.data[3] << 8) + message.data[2];
     // only publish the state if the co2 value is below 10000
     // otherwise the value is likely invalid
-    if (rh_value <= 10000)
-      publish_state(rh_value / 100.0);
+    if (temp_value <= 1000)
+      publish_state(temp_value / 10.0);
 
     this->parent_->stop_waiting(message.id);
   }
 }
 
-void DucoHumidityTemperatureSensor::set_address(uint8_t address) { this->address_ = address; }
+void DucoTemperatureSensor::set_address(uint8_t address) { this->address_ = address; }
 
 void DucoFilterRemainingSensor::setup() {}
 

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -107,10 +107,10 @@ float DucoBoxTemperatureSensor::get_setup_priority() const {
 
 void DucoBoxTemperatureSensor::receive_response(const DucoMessage &message) {
   if (message.function == 0x26) {
-    uint16_t temp_value = (message.data[4] << 8) + message.data[3];
-    // only publish the state if the co2 value is below 10000
+    int16_t temp_value = (message.data[4] << 8) + message.data[3];
+    // only publish the state if the temperature value is reasonable
     // otherwise the value is likely invalid
-    if (temp_value <= 1000)
+    if (temp_value <= 1000 && temp_value > -100)
       publish_state(temp_value / 10.0);
 
     this->parent_->stop_waiting(message.id);

--- a/esphome/components/duco/sensor/sensor.cpp
+++ b/esphome/components/duco/sensor/sensor.cpp
@@ -110,7 +110,7 @@ void DucoBoxTemperatureSensor::receive_response(const DucoMessage &message) {
     int16_t temp_value = (message.data[4] << 8) + message.data[3];
     // only publish the state if the temperature value is reasonable
     // otherwise the value is likely invalid
-    if (temp_value <= 1000 && temp_value > -100)
+    if (temp_value <= 1000 && temp_value > -1000)
       publish_state(temp_value / 10.0);
 
     this->parent_->stop_waiting(message.id);

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -15,7 +15,7 @@ class DucoCo2Sensor : public DucoDevice, public PollingComponent, public sensor:
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 
   void set_address(uint8_t address);
 
@@ -30,7 +30,7 @@ class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, pu
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 };
 
 class DucoFlowLevelSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
@@ -40,7 +40,7 @@ class DucoFlowLevelSensor : public DucoDevice, public PollingComponent, public s
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 };
 
 class DucoStateTimeRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
@@ -50,7 +50,7 @@ class DucoStateTimeRemainingSensor : public DucoDevice, public PollingComponent,
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 };
 
 }  // namespace duco

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -15,7 +15,7 @@ class DucoCo2Sensor : public DucoDevice, public PollingComponent, public sensor:
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 
   void set_address(uint8_t address);
 
@@ -30,7 +30,7 @@ class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, pu
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 };
 
 class DucoFlowLevelSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
@@ -40,7 +40,7 @@ class DucoFlowLevelSensor : public DucoDevice, public PollingComponent, public s
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 };
 
 class DucoStateTimeRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
@@ -50,7 +50,7 @@ class DucoStateTimeRemainingSensor : public DucoDevice, public PollingComponent,
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 };
 
 }  // namespace duco

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "../duco.h"
+
+namespace esphome {
+namespace duco {
+
+class DucoCo2Sensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+
+  void set_address(uint8_t address);
+
+ protected:
+  uint8_t address_;
+};
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -23,5 +23,15 @@ class DucoCo2Sensor : public DucoDevice, public PollingComponent, public sensor:
   uint8_t address_;
 };
 
+class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+};
+
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -33,5 +33,25 @@ class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, pu
   void receive_response(std::vector<uint8_t> message) override;
 };
 
+class DucoFlowLevelSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+};
+
+class DucoStateTimeRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+};
+
 }  // namespace duco
 }  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+#include "../duco.h"
+
+namespace esphome {
+namespace duco {
+
+class DucoSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(std::vector<uint8_t> message) override;
+
+ protected:
+  uint8_t attempts = 0;
+};
+
+}  // namespace duco
+}  // namespace esphome

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -69,6 +69,16 @@ class DucoBoxTemperatureSensor : public DucoDevice, public PollingComponent, pub
   uint8_t type_;
 };
 
+class DucoBypassSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(const DucoMessage &message) override;
+};
+
 class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
  public:
   void setup() override;

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -23,6 +23,36 @@ class DucoCo2Sensor : public DucoDevice, public PollingComponent, public sensor:
   uint8_t address_;
 };
 
+class DucoHumiditySensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(const DucoMessage &message) override;
+
+  void set_address(uint8_t address);
+
+ protected:
+  uint8_t address_;
+};
+
+class DucoHumidityTemperatureSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(const DucoMessage &message) override;
+
+  void set_address(uint8_t address);
+
+ protected:
+  uint8_t address_;
+};
+
 class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
  public:
   void setup() override;

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -53,6 +53,22 @@ class DucoTemperatureSensor : public DucoDevice, public PollingComponent, public
   uint8_t address_;
 };
 
+class DucoBoxTemperatureSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+ public:
+  void setup() override;
+  void update() override;
+
+  float get_setup_priority() const override;
+
+  void receive_response(const DucoMessage &message) override;
+
+  void set_type(uint8_t type);
+
+ protected:
+  uint8_t address_;
+  uint8_t type_;
+};
+
 class DucoFilterRemainingSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
  public:
   void setup() override;

--- a/esphome/components/duco/sensor/sensor.h
+++ b/esphome/components/duco/sensor/sensor.h
@@ -38,7 +38,7 @@ class DucoHumiditySensor : public DucoDevice, public PollingComponent, public se
   uint8_t address_;
 };
 
-class DucoHumidityTemperatureSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+class DucoTemperatureSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/duco/text_sensor/__init__.py
+++ b/esphome/components/duco/text_sensor/__init__.py
@@ -9,14 +9,14 @@ DEPENDENCIES = ["duco"]
 CODEOWNERS = ["@kokx"]
 
 duco_ns = cg.esphome_ns.namespace("duco")
-DucoSensor = duco_ns.class_("DucoSensor", cg.PollingComponent, text_sensor.TextSensor)
+DucoSerial = duco_ns.class_("DucoSerial", cg.PollingComponent, text_sensor.TextSensor)
 
 CONFIG_SCHEMA = cv.All(
-    text_sensor.text_sensor_schema(DucoSensor)
+    text_sensor.text_sensor_schema(DucoSerial)
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(cv.polling_component_schema("60s"))
+    .extend(cv.polling_component_schema("300s"))
     .extend(DUCO_COMPONENT_SCHEMA)
-    .extend({cv.GenerateID(): cv.declare_id(DucoSensor)})
+    .extend({cv.GenerateID(): cv.declare_id(DucoSerial)})
 )
 
 

--- a/esphome/components/duco/text_sensor/__init__.py
+++ b/esphome/components/duco/text_sensor/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import sensor
+from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
@@ -9,10 +9,10 @@ DEPENDENCIES = ["duco"]
 CODEOWNERS = ["@kokx"]
 
 duco_ns = cg.esphome_ns.namespace("duco")
-DucoSensor = duco_ns.class_("DucoSensor", cg.PollingComponent, sensor.Sensor)
+DucoSensor = duco_ns.class_("DucoSensor", cg.PollingComponent, text_sensor.TextSensor)
 
 CONFIG_SCHEMA = cv.All(
-    sensor.sensor_schema(DucoSensor)
+    text_sensor.text_sensor_schema(DucoSensor)
     .extend(cv.COMPONENT_SCHEMA)
     .extend(cv.polling_component_schema("60s"))
     .extend(DUCO_COMPONENT_SCHEMA)
@@ -24,7 +24,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
-    await sensor.register_sensor(var, config)
+    await text_sensor.register_text_sensor(var, config)
 
     parent = await cg.get_variable(config[CONF_DUCO_ID])
     cg.add(parent.add_sensor_item(var))

--- a/esphome/components/duco/text_sensor/__init__.py
+++ b/esphome/components/duco/text_sensor/__init__.py
@@ -27,4 +27,4 @@ async def to_code(config):
     await text_sensor.register_text_sensor(var, config)
 
     parent = await cg.get_variable(config[CONF_DUCO_ID])
-    cg.add(parent.add_sensor_item(var))
+    cg.add(var.set_parent(parent))

--- a/esphome/components/duco/text_sensor/sensor.cpp
+++ b/esphome/components/duco/text_sensor/sensor.cpp
@@ -26,6 +26,8 @@ void DucoSensor::receive_response(std::vector<uint8_t> message) {
     std::string serial(message.begin() + 5, message.end());
     ESP_LOGD(TAG, "Box Serial: %s", serial.c_str());
 
+    publish_state(serial);
+
     // do not wait for new messages with the same ID
     this->parent_->stop_waiting(message[2]);
   }

--- a/esphome/components/duco/text_sensor/sensor.h
+++ b/esphome/components/duco/text_sensor/sensor.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "esphome/core/log.h"
-#include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "../duco.h"
 
 namespace esphome {
 namespace duco {
 
-class DucoSensor : public DucoDevice, public PollingComponent, public sensor::Sensor {
+class DucoSensor : public DucoDevice, public PollingComponent, public text_sensor::TextSensor {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/duco/text_sensor/serial.cpp
+++ b/esphome/components/duco/text_sensor/serial.cpp
@@ -21,7 +21,7 @@ float DucoSerial::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoSerial::receive_response(DucoMessage message) {
+void DucoSerial::receive_response(const DucoMessage &message) {
   if (message.function == 0x12) {
     // Serial response received, parse it
     std::string serial(message.data.begin() + 2, message.data.end());

--- a/esphome/components/duco/text_sensor/serial.cpp
+++ b/esphome/components/duco/text_sensor/serial.cpp
@@ -10,9 +10,10 @@ static const char *const TAG = "duco sensor";
 void DucoSerial::setup() {}
 
 void DucoSerial::update() {
-  // ask for serial
-  std::vector<uint8_t> message = {0x01, 0x01, 0x00, 0x1a, 0x10};
-  this->parent_->send(0x10, message, this);
+  DucoMessage message;
+  message.function = 0x10;
+  message.data = {0x01, 0x01, 0x00, 0x1a, 0x10};
+  this->parent_->send(message, this);
 }
 
 float DucoSerial::get_setup_priority() const {

--- a/esphome/components/duco/text_sensor/serial.cpp
+++ b/esphome/components/duco/text_sensor/serial.cpp
@@ -1,4 +1,4 @@
-#include "sensor.h"
+#include "serial.h"
 #include "../duco.h"
 #include <vector>
 
@@ -7,20 +7,20 @@ namespace duco {
 
 static const char *const TAG = "duco sensor";
 
-void DucoSensor::setup() {}
+void DucoSerial::setup() {}
 
-void DucoSensor::update() {
+void DucoSerial::update() {
   // ask for serial
   std::vector<uint8_t> message = {0x01, 0x01, 0x00, 0x1a, 0x10};
   this->parent_->send(0x10, message, this);
 }
 
-float DucoSensor::get_setup_priority() const {
+float DucoSerial::get_setup_priority() const {
   // After DUCO
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoSensor::receive_response(std::vector<uint8_t> message) {
+void DucoSerial::receive_response(std::vector<uint8_t> message) {
   if (message[1] == 0x12) {
     // Serial response received, parse it
     std::string serial(message.begin() + 5, message.end());

--- a/esphome/components/duco/text_sensor/serial.cpp
+++ b/esphome/components/duco/text_sensor/serial.cpp
@@ -21,16 +21,16 @@ float DucoSerial::get_setup_priority() const {
   return setup_priority::BUS - 2.0f;
 }
 
-void DucoSerial::receive_response(std::vector<uint8_t> message) {
-  if (message[1] == 0x12) {
+void DucoSerial::receive_response(DucoMessage message) {
+  if (message.function == 0x12) {
     // Serial response received, parse it
-    std::string serial(message.begin() + 5, message.end());
+    std::string serial(message.data.begin() + 2, message.data.end());
     ESP_LOGD(TAG, "Box Serial: %s", serial.c_str());
 
     publish_state(serial);
 
     // do not wait for new messages with the same ID
-    this->parent_->stop_waiting(message[2]);
+    this->parent_->stop_waiting(message.id);
   }
 }
 

--- a/esphome/components/duco/text_sensor/serial.cpp
+++ b/esphome/components/duco/text_sensor/serial.cpp
@@ -24,7 +24,8 @@ float DucoSerial::get_setup_priority() const {
 void DucoSerial::receive_response(const DucoMessage &message) {
   if (message.function == 0x12) {
     // Serial response received, parse it
-    std::string serial(message.data.begin() + 2, message.data.end());
+    auto null_pos = std::find(message.data.begin() + 2, message.data.end(), 0x00);
+    std::string serial(message.data.begin() + 2, null_pos);
     ESP_LOGD(TAG, "Box Serial: %s", serial.c_str());
 
     publish_state(serial);

--- a/esphome/components/duco/text_sensor/serial.h
+++ b/esphome/components/duco/text_sensor/serial.h
@@ -16,9 +16,6 @@ class DucoSerial : public DucoDevice, public PollingComponent, public text_senso
   float get_setup_priority() const override;
 
   void receive_response(std::vector<uint8_t> message) override;
-
- protected:
-  uint8_t attempts = 0;
 };
 
 }  // namespace duco

--- a/esphome/components/duco/text_sensor/serial.h
+++ b/esphome/components/duco/text_sensor/serial.h
@@ -15,7 +15,7 @@ class DucoSerial : public DucoDevice, public PollingComponent, public text_senso
 
   float get_setup_priority() const override;
 
-  void receive_response(DucoMessage message) override;
+  void receive_response(const DucoMessage &message) override;
 };
 
 }  // namespace duco

--- a/esphome/components/duco/text_sensor/serial.h
+++ b/esphome/components/duco/text_sensor/serial.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace duco {
 
-class DucoSensor : public DucoDevice, public PollingComponent, public text_sensor::TextSensor {
+class DucoSerial : public DucoDevice, public PollingComponent, public text_sensor::TextSensor {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/duco/text_sensor/serial.h
+++ b/esphome/components/duco/text_sensor/serial.h
@@ -15,7 +15,7 @@ class DucoSerial : public DucoDevice, public PollingComponent, public text_senso
 
   float get_setup_priority() const override;
 
-  void receive_response(std::vector<uint8_t> message) override;
+  void receive_response(DucoMessage message) override;
 };
 
 }  // namespace duco

--- a/tests/components/duco/common.yaml
+++ b/tests/components/duco/common.yaml
@@ -1,0 +1,42 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+uart:
+  - id: duco_uart
+    baud_rate: 57600
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+
+duco:
+  uart_id: duco_uart
+  discovery: {}
+
+text_sensor:
+  - platform: duco
+    name: "Serial Number"
+
+select:
+  - platform: duco
+    name: "Mode"
+
+sensor:
+  - platform: duco
+    co2:
+      - address: 3
+        name: "CO2 Bedroom"
+      - address: 4
+        name: "CO2 Livingroom"
+    filter_remaining:
+      name: "Filter Time Remaining"
+    flow_level:
+      name: "Flow Level"
+      update_interval: "5s"
+    time_remaining:
+      name: "Mode Time Remaining"
+      update_interval: "5s"
+
+number:
+  - platform: duco
+    name: "Comfort Temperature"
+    update_interval: "10s"

--- a/tests/components/duco/test.esp32-ard.yaml
+++ b/tests/components/duco/test.esp32-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+
+<<: !include common.yaml

--- a/tests/components/duco/test.esp32-c3-ard.yaml
+++ b/tests/components/duco/test.esp32-c3-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+<<: !include common.yaml

--- a/tests/components/duco/test.esp32-c3-idf.yaml
+++ b/tests/components/duco/test.esp32-c3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+<<: !include common.yaml

--- a/tests/components/duco/test.esp32-idf.yaml
+++ b/tests/components/duco/test.esp32-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+
+<<: !include common.yaml

--- a/tests/components/duco/test.esp8266-ard.yaml
+++ b/tests/components/duco/test.esp8266-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+<<: !include common.yaml

--- a/tests/components/duco/test.rp2040-ard.yaml
+++ b/tests/components/duco/test.rp2040-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a component that allows control of a Duco heat recovery ventilation system. It adds a select component to set the current ventilation mode, sensors for the serial number, CO2-sensors, remaining filter time, flow level and time remaining in the current ventilation mode.

At the time of writing this is only tested on a DucoBox Energy Comfort D325, it may not work on every Duco ventilation system.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4528

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
duco:
  uart_id: duco_uart
  discovery: {}
  time:
    time_id: sntp_time

text_sensor:
  - platform: duco
    name: "Serial Number"

select:
  - platform: duco
    name: "Mode"

sensor:
  - platform: duco
    co2:
      - address: 3
        name: "CO2 Bedroom"
      - address: 4
        name: "CO2 Livingroom"
    temperature:
      - address: 3
        name: "Temperature Bedroom"
      - address: 4
        name: "Temperature Livingroom"
      - address: 1
        name: "Temperature Bathroom"
      - address: 58
        name: "Temperature Office"
    humidity:
      - address: 1
        name: "Humidity Bathroom"
      - address: 58
        name: "Humidity Office"
    filter_remaining:
      name: "Filter Time Remaining"
    flow_level:
      name: "Flow Level"
    time_remaining:
      name: "Mode Time Remaining"
    bypass:
      name: "Bypass"
    temperature_oda:
      name: "Temperature Outdoor Air"
    temperature_eha:
      name: "Temperature Outdoor Exhaust"
    temperature_sup:
      name: "Temperature Supply To Room"
    temperature_eta:
      name: "Temperature Indoor Exhaust"

number:
  - platform: duco
    name: "Comfort Temperature"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
