### PR TITLE
[online_image] Improve error handling

### DIFF
--- a/esphome/components/online_image/image_decoder.cpp
+++ b/esphome/components/online_image/image_decoder.cpp
@@ -25,6 +25,15 @@ void ImageDecoder::draw(int x, int y, int w, int h, const Color &color) {
   }
 }
 
+DownloadBuffer::DownloadBuffer(size_t size) : size_(size) {
+  this->buffer_ = this->allocator_.allocate(size);
+  this->reset();
+  if (!this->buffer_) {
+    ESP_LOGE(TAG, "Initial allocation of download buffer failed!");
+    this->size_ = 0;
+  }
+}
+
 uint8_t *DownloadBuffer::data(size_t offset) {
   if (offset > this->size_) {
     ESP_LOGE(TAG, "Tried to access beyond download buffer bounds!!!");
@@ -46,12 +55,13 @@ size_t DownloadBuffer::resize(size_t size) {
     return size;
   }
   this->allocator_.deallocate(this->buffer_, this->size_);
-  this->size_ = size;
   this->buffer_ = this->allocator_.allocate(size);
   this->reset();
   if (this->buffer_) {
+    this->size_ = size;
     return size;
   } else {
+    this->size_ = 0;
     return 0;
   }
 }

--- a/esphome/components/online_image/image_decoder.h
+++ b/esphome/components/online_image/image_decoder.h
@@ -29,8 +29,12 @@ class ImageDecoder {
    * @brief Initialize the decoder.
    *
    * @param download_size The total number of bytes that need to be downloaded for the image.
+   * @return int          Returns 0 on success, a {@see DecodeError} value in case of an error.
    */
-  virtual void prepare(size_t download_size) { this->download_size_ = download_size; }
+  virtual int prepare(size_t download_size) {
+    this->download_size_ = download_size;
+    return 0;
+  }
 
   /**
    * @brief Decode a part of the image. It will try reading from the buffer.

--- a/esphome/components/online_image/image_decoder.h
+++ b/esphome/components/online_image/image_decoder.h
@@ -87,10 +87,7 @@ class ImageDecoder {
 
 class DownloadBuffer {
  public:
-  DownloadBuffer(size_t size) : size_(size) {
-    this->buffer_ = this->allocator_.allocate(size);
-    this->reset();
-  }
+  DownloadBuffer(size_t size);
 
   virtual ~DownloadBuffer() { this->allocator_.deallocate(this->buffer_, this->size_); }
 

--- a/esphome/components/online_image/jpeg_image.cpp
+++ b/esphome/components/online_image/jpeg_image.cpp
@@ -41,13 +41,14 @@ static int draw_callback(JPEGDRAW *jpeg) {
   return 1;
 }
 
-void JpegDecoder::prepare(size_t download_size) {
+int JpegDecoder::prepare(size_t download_size) {
   ImageDecoder::prepare(download_size);
   auto size = this->image_->resize_download_buffer(download_size);
   if (size < download_size) {
-    ESP_LOGE(TAG, "Resize failed!");
-    // TODO: return an error code;
+    ESP_LOGE(TAG, "Download buffer resize failed!");
+    return DECODE_ERROR_OUT_OF_MEMORY;
   }
+  return 0;
 }
 
 int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {

--- a/esphome/components/online_image/jpeg_image.h
+++ b/esphome/components/online_image/jpeg_image.h
@@ -21,7 +21,7 @@ class JpegDecoder : public ImageDecoder {
   JpegDecoder(OnlineImage *image) : ImageDecoder(image) {}
   ~JpegDecoder() override {}
 
-  void prepare(size_t download_size) override;
+  int prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
 
  protected:

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -152,7 +152,6 @@ void OnlineImage::update() {
   }
   auto prepare_result = this->decoder_->prepare(total_size);
   if (prepare_result < 0) {
-    ESP_LOGE(TAG, "Error while preparing image download: %d", prepare_result);
     this->end_connection_();
     this->download_error_callback_.call();
     return;

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -150,7 +150,13 @@ void OnlineImage::update() {
     this->download_error_callback_.call();
     return;
   }
-  this->decoder_->prepare(total_size);
+  auto prepare_result = this->decoder_->prepare(total_size);
+  if (prepare_result < 0) {
+    ESP_LOGE(TAG, "Error while preparing image download: %d", prepare_result);
+    this->end_connection_();
+    this->download_error_callback_.call();
+    return;
+  }
   ESP_LOGI(TAG, "Downloading image (Size: %d)", total_size);
   this->start_time_ = ::time(nullptr);
 }

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -40,11 +40,16 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
   decoder->draw(x, y, w, h, color);
 }
 
-void PngDecoder::prepare(size_t download_size) {
+int PngDecoder::prepare(size_t download_size) {
   ImageDecoder::prepare(download_size);
+  if (!this->pngle_) {
+    ESP_LOGE(TAG, "PNG decoder engine not initialized!");
+    return DECODE_ERROR_OUT_OF_MEMORY;
+  }
   pngle_set_user_data(this->pngle_, this);
   pngle_set_init_callback(this->pngle_, init_callback);
   pngle_set_draw_callback(this->pngle_, draw_callback);
+  return 0;
 }
 
 int HOT PngDecoder::decode(uint8_t *buffer, size_t size) {

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -21,7 +21,7 @@ class PngDecoder : public ImageDecoder {
   PngDecoder(OnlineImage *image) : ImageDecoder(image), pngle_(pngle_new()) {}
   ~PngDecoder() override { pngle_destroy(this->pngle_); }
 
-  void prepare(size_t download_size) override;
+  int prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?
JPEG images need to resize the download buffer to the full size before start downloading. If the resize fails (e.g. because of not enough memory), abort the downloading, instead of trying to download into a too small buffer.
This prevents crashing in such cases.

Also improved the same situation in case of PNG images (i.e. bail out earlier)

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
