### PR TITLE
[http_request]Use std::string for headers

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -18,8 +18,8 @@ namespace esphome {
 namespace http_request {
 
 struct Header {
-  const char *name;
-  const char *value;
+  std::string name;
+  std::string value;
 };
 
 // Some common HTTP status codes

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::start(std::string url, std::s
     container->client_.setUserAgent(this->useragent_);
   }
   for (const auto &header : headers) {
-    container->client_.addHeader(header.name, header.value, false, true);
+    container->client_.addHeader(header.name.c_str(), header.value.c_str(), false, true);
   }
 
   // returned needed headers must be collected before the requests

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
   container->set_secure(secure);
 
   for (const auto &header : headers) {
-    esp_http_client_set_header(client, header.name, header.value);
+    esp_http_client_set_header(client, header.name.c_str(), header.value.c_str());
   }
 
   const int body_len = body.length();

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -124,7 +124,7 @@ void OnlineImage::update() {
     default:
       accept_mime_type = "image/*";
   }
-  accept_header.value = (accept_mime_type + ",*/*;q=0.8").c_str();
+  accept_header.value = accept_mime_type + ",*/*;q=0.8";
 
   headers.push_back(accept_header);
 


### PR DESCRIPTION
# What does this implement/fix?

Store headers as std:string instead of const char*, to allow headers to be created at runtime
PR #8216 Added "Accept" headers on the online_image http requests. Since those are created at runtime, the stack is being cleaned up sometimes, and after the first image downloaded, the headers are not accepted by the server anymore.

Using std::string to store the headers instead keeps them in memory.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
