### PR TITLE
[online_image]Fix reset if buffer not allocated

### DIFF
--- a/esphome/components/online_image/image_decoder.cpp
+++ b/esphome/components/online_image/image_decoder.cpp
@@ -9,7 +9,9 @@ namespace online_image {
 static const char *const TAG = "online_image.decoder";
 
 bool ImageDecoder::set_size(int width, int height) {
-  bool resized = this->image_->resize_(width, height);
+  // Consider a noop (buffer already existing but no need to resize) a success.
+  bool resized = this->image_->resize_(width, height) >= 0;
+
   this->x_scale_ = static_cast<double>(this->image_->buffer_width_) / width;
   this->y_scale_ = static_cast<double>(this->image_->buffer_height_) / height;
   return resized;

--- a/esphome/components/online_image/image_decoder.cpp
+++ b/esphome/components/online_image/image_decoder.cpp
@@ -9,12 +9,10 @@ namespace online_image {
 static const char *const TAG = "online_image.decoder";
 
 bool ImageDecoder::set_size(int width, int height) {
-  // Consider a noop (buffer already existing but no need to resize) a success.
-  bool resized = this->image_->resize_(width, height) >= 0;
-
+  bool success = this->image_->resize_(width, height) > 0;
   this->x_scale_ = static_cast<double>(this->image_->buffer_width_) / width;
   this->y_scale_ = static_cast<double>(this->image_->buffer_height_) / height;
-  return resized;
+  return success;
 }
 
 void ImageDecoder::draw(int x, int y, int w, int h, const Color &color) {
@@ -53,8 +51,9 @@ size_t DownloadBuffer::read(size_t len) {
 }
 
 size_t DownloadBuffer::resize(size_t size) {
-  if (this->size_ == size) {
-    return size;
+  if (this->size_ >= size) {
+    // Avoid useless reallocations; if the buffer is big enough, don't reallocate.
+    return this->size_;
   }
   this->allocator_.deallocate(this->buffer_, this->size_);
   this->buffer_ = this->allocator_.allocate(size);
@@ -63,6 +62,8 @@ size_t DownloadBuffer::resize(size_t size) {
     this->size_ = size;
     return size;
   } else {
+    ESP_LOGE(TAG, "allocation of %zu bytes failed. Biggest block in heap: %zu Bytes", size,
+             this->allocator_.get_max_free_block_size());
     this->size_ = 0;
     return 0;
   }

--- a/esphome/components/online_image/jpeg_image.cpp
+++ b/esphome/components/online_image/jpeg_image.cpp
@@ -73,7 +73,9 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
 
   this->jpeg_.setUserPointer(this);
   this->jpeg_.setPixelType(RGB8888);
-  this->set_size(this->jpeg_.getWidth(), this->jpeg_.getHeight());
+  if (!this->set_size(this->jpeg_.getWidth(), this->jpeg_.getHeight())) {
+    return DECODE_ERROR_OUT_OF_MEMORY;
+  }
   if (!this->jpeg_.decode(0, 0, 0)) {
     ESP_LOGE(TAG, "Error while decoding.");
     this->jpeg_.close();

--- a/esphome/components/online_image/jpeg_image.cpp
+++ b/esphome/components/online_image/jpeg_image.cpp
@@ -58,7 +58,7 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
   }
 
   if (!this->jpeg_.openRAM(buffer, size, draw_callback)) {
-    ESP_LOGE(TAG, "Could not open image for decoding.");
+    ESP_LOGE(TAG, "Could not open image for decoding: %d", this->jpeg_.getLastError());
     return DECODE_ERROR_INVALID_TYPE;
   }
   auto jpeg_type = this->jpeg_.getJPEGType();

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -64,28 +64,28 @@ void OnlineImage::release() {
   }
 }
 
-ssize_t OnlineImage::resize_(int width_in, int height_in) {
+size_t OnlineImage::resize_(int width_in, int height_in) {
   int width = this->fixed_width_;
   int height = this->fixed_height_;
-  if (this->auto_resize_()) {
+  if (this->is_auto_resize_()) {
     width = width_in;
     height = height_in;
     if (this->width_ != width && this->height_ != height) {
       this->release();
     }
   }
+  size_t new_size = this->get_buffer_size_(width, height);
   if (this->buffer_) {
     // Buffer already allocated => no need to resize
-    return 0;
+    return new_size;
   }
-  ssize_t new_size = this->get_buffer_size_(width, height);
   ESP_LOGD(TAG, "Allocating new buffer of %zu bytes", new_size);
   this->buffer_ = this->allocator_.allocate(new_size);
   if (this->buffer_ == nullptr) {
     ESP_LOGE(TAG, "allocation of %zu bytes failed. Biggest block in heap: %zu Bytes", new_size,
              this->allocator_.get_max_free_block_size());
     this->end_connection_();
-    return -1;
+    return 0;
   }
   this->buffer_width_ = width;
   this->buffer_height_ = height;

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -64,7 +64,7 @@ void OnlineImage::release() {
   }
 }
 
-bool OnlineImage::resize_(int width_in, int height_in) {
+ssize_t OnlineImage::resize_(int width_in, int height_in) {
   int width = this->fixed_width_;
   int height = this->fixed_height_;
   if (this->auto_resize_()) {
@@ -75,22 +75,23 @@ bool OnlineImage::resize_(int width_in, int height_in) {
     }
   }
   if (this->buffer_) {
-    return false;
+    // Buffer already allocated => no need to resize
+    return 0;
   }
-  size_t new_size = this->get_buffer_size_(width, height);
+  ssize_t new_size = this->get_buffer_size_(width, height);
   ESP_LOGD(TAG, "Allocating new buffer of %zu bytes", new_size);
   this->buffer_ = this->allocator_.allocate(new_size);
   if (this->buffer_ == nullptr) {
     ESP_LOGE(TAG, "allocation of %zu bytes failed. Biggest block in heap: %zu Bytes", new_size,
              this->allocator_.get_max_free_block_size());
     this->end_connection_();
-    return false;
+    return -1;
   }
   this->buffer_width_ = width;
   this->buffer_height_ = height;
   this->width_ = width;
   ESP_LOGV(TAG, "New size: (%d, %d)", width, height);
-  return true;
+  return new_size;
 }
 
 void OnlineImage::update() {

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -99,7 +99,7 @@ class OnlineImage : public PollingComponent,
 
   int get_position_(int x, int y) const { return (x + y * this->buffer_width_) * this->get_bpp() / 8; }
 
-  ESPHOME_ALWAYS_INLINE bool auto_resize_() const { return this->fixed_width_ == 0 || this->fixed_height_ == 0; }
+  ESPHOME_ALWAYS_INLINE bool is_auto_resize_() const { return this->fixed_width_ == 0 || this->fixed_height_ == 0; }
 
   /**
    * @brief Resize the image buffer to the requested dimensions.
@@ -112,10 +112,9 @@ class OnlineImage : public PollingComponent,
    *
    * @param width
    * @param height
-   * @return 0 if no reallocation was needed, -1 if no memory could be allocated, the
-   *   size of the new buffer otherwise.
+   * @return 0 if no memory could be allocated, the size of the new buffer otherwise.
    */
-  ssize_t resize_(int width, int height);
+  size_t resize_(int width, int height);
 
   /**
    * @brief Draw a pixel into the buffer.

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -101,7 +101,21 @@ class OnlineImage : public PollingComponent,
 
   ESPHOME_ALWAYS_INLINE bool auto_resize_() const { return this->fixed_width_ == 0 || this->fixed_height_ == 0; }
 
-  bool resize_(int width, int height);
+  /**
+   * @brief Resize the image buffer to the requested dimensions.
+   *
+   * The buffer will be allocated if not existing.
+   * If the dimensions have been fixed in the yaml config, the buffer will be created
+   * with those dimensions and not resized, even on request.
+   * Otherwise, the old buffer will be deallocated and a new buffer with the requested
+   * allocated
+   *
+   * @param width
+   * @param height
+   * @return 0 if no reallocation was needed, -1 if no memory could be allocated, the
+   *   size of the new buffer otherwise.
+   */
+  ssize_t resize_(int width, int height);
 
   /**
    * @brief Draw a pixel into the buffer.


### PR DESCRIPTION
# What does this implement/fix?

When (re)allocating the image buffer, the "out of memory" case was being ignored by some decoders.
Make sure that decoders don't try to decode to an empty buffer.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
