### PR TITLE
fix 1bpp rendering

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -12,8 +12,8 @@ import esphome_glyphsets as glyphsets
 from freetype import (
     FT_LOAD_NO_BITMAP,
     FT_LOAD_RENDER,
+    FT_LOAD_TARGET_MONO,
     Face,
-    ft_pixel_mode_grays,
     ft_pixel_mode_mono,
 )
 import requests
@@ -509,7 +509,6 @@ async def to_code(config):
     glyph_args = {}
     data = []
     bpp = config[CONF_BPP]
-    mode = ft_pixel_mode_grays
     scale = 256 // (1 << bpp)
     size = config[CONF_SIZE]
     # create the data array for all glyphs
@@ -524,8 +523,9 @@ async def to_code(config):
         flags = FT_LOAD_RENDER
         if bpp != 1:
             flags |= FT_LOAD_NO_BITMAP
+        else:
+            flags |= FT_LOAD_TARGET_MONO
         font.load_char(codepoint, flags)
-        font.glyph.render(mode)
         width = font.glyph.bitmap.width
         height = font.glyph.bitmap.rows
         buffer = font.glyph.bitmap.buffer


### PR DESCRIPTION
# What does this implement/fix?

Fix freetype rendering for 1bpp output.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6894

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
