### PR TITLE
[ld2410s] New component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -286,6 +286,7 @@ esphome/components/kuntze/* @ssieb
 esphome/components/lc709203f/* @ilikecake
 esphome/components/lcd_menu/* @numo68
 esphome/components/ld2410/* @regevbr @sebcaps
+esphome/components/ld2410s/* @NovakIrs
 esphome/components/ld2412/* @Rihan9
 esphome/components/ld2420/* @descipher
 esphome/components/ld2450/* @hareeshmu

--- a/esphome/components/ld2410s/__init__.py
+++ b/esphome/components/ld2410s/__init__.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@NovakIrs"]
+
+DEPENDENCIES = ["uart"]
+
+MULTI_CONF = True
+
+ld2410s_ns = cg.esphome_ns.namespace("ld2410s")
+LD2410S = ld2410s_ns.class_("LD2410S", cg.Component, uart.UARTDevice)
+
+CONF_LD2410S_ID = "ld2410s_id"
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(LD2410S),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "ld2410s_uart",
+    require_tx=True,
+    require_rx=True,
+    parity="NONE",
+    stop_bits=1,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/esphome/components/ld2410s/binary_sensor.py
+++ b/esphome/components/ld2410s/binary_sensor.py
@@ -1,0 +1,29 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_HAS_TARGET, DEVICE_CLASS_OCCUPANCY
+
+from . import CONF_LD2410S_ID, LD2410S
+
+HAS_CALIBRATION_RUNNING = "has_calibration_running"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(HAS_CALIBRATION_RUNNING): binary_sensor.binary_sensor_schema(
+        icon="mdi:exclamation"
+    ),
+    cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_OCCUPANCY,
+        icon="mdi:motion-sensor",
+    ),
+}
+
+
+async def to_code(config):
+    ld2410s = await cg.get_variable(config[CONF_LD2410S_ID])
+    if has_target_config := config.get(CONF_HAS_TARGET):
+        sens = await binary_sensor.new_binary_sensor(has_target_config)
+        cg.add(ld2410s.set_presence_binary_sensor(sens))
+    if calibration_running_config := config.get(HAS_CALIBRATION_RUNNING):
+        sens = await binary_sensor.new_binary_sensor(calibration_running_config)
+        cg.add(ld2410s.set_calibration_runing_binary_sensor(sens))

--- a/esphome/components/ld2410s/binary_sensor.py
+++ b/esphome/components/ld2410s/binary_sensor.py
@@ -26,4 +26,4 @@ async def to_code(config):
         cg.add(ld2410s.set_presence_binary_sensor(sens))
     if calibration_running_config := config.get(HAS_CALIBRATION_RUNNING):
         sens = await binary_sensor.new_binary_sensor(calibration_running_config)
-        cg.add(ld2410s.set_calibration_runing_binary_sensor(sens))
+        cg.add(ld2410s.set_calibration_running_binary_sensor(sens))

--- a/esphome/components/ld2410s/button/__init__.py
+++ b/esphome/components/ld2410s/button/__init__.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+from esphome.components import button
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CALIBRATION,
+    CONF_FACTORY_RESET,
+    DEVICE_CLASS_UPDATE,
+    ENTITY_CATEGORY_CONFIG,
+)
+
+from .. import CONF_LD2410S_ID, LD2410S, ld2410s_ns
+
+LD2410SStartCalibrationButton = ld2410s_ns.class_(
+    "LD2410SStartCalibrationButton", button.Button
+)
+LD2410SFactoryResetButton = ld2410s_ns.class_(
+    "LD2410SFactoryResetButton", button.Button
+)
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(CONF_CALIBRATION): button.button_schema(
+        LD2410SStartCalibrationButton,
+        device_class=DEVICE_CLASS_UPDATE,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:refresh-auto",
+    ),
+    cv.Optional(CONF_FACTORY_RESET): button.button_schema(
+        LD2410SFactoryResetButton,
+        device_class=DEVICE_CLASS_UPDATE,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:factory",
+    ),
+}
+
+
+async def to_code(config):
+    ld2410s_component = await cg.get_variable(config[CONF_LD2410S_ID])
+
+    if calibration := config.get(CONF_CALIBRATION):
+        b = await button.new_button(calibration)
+        await cg.register_parented(b, config[CONF_LD2410S_ID])
+        cg.add(ld2410s_component.set_calibration_button(b))
+
+    if factory_reset := config.get(CONF_FACTORY_RESET):
+        b = await button.new_button(factory_reset)
+        await cg.register_parented(b, config[CONF_LD2410S_ID])
+        cg.add(ld2410s_component.set_factory_reset_button(b))

--- a/esphome/components/ld2410s/button/ld2410s_factory_reset_button.h
+++ b/esphome/components/ld2410s/button/ld2410s_factory_reset_button.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../ld2410s.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SFactoryResetButton : public button::Button, public Parented<LD2410S> {
+ public:
+  LD2410SFactoryResetButton() = default;
+
+ protected:
+  void press_action() override {
+#ifdef LD2410S_V2
+    this->parent_->factory_reset();
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/button/ld2410s_start_calibration_button.h
+++ b/esphome/components/ld2410s/button/ld2410s_start_calibration_button.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../ld2410s.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SStartCalibrationButton : public button::Button, public Parented<LD2410S> {
+ public:
+  LD2410SStartCalibrationButton() = default;
+
+ protected:
+  void press_action() override {
+#ifdef LD2410S_V2
+    this->parent_->calibration();
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -39,8 +39,9 @@ void LD2410S::send_() {
       break;
 
     case TxCmdState::SEND:
+      char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGVV(TAG, ">   [loop:%d] cmd:%04x > %s", this->loop_count_, this->tx_schedule_.get_command(),
-                format_hex_pretty(this->tx_frame_, this->tx_frame_size_, ' ').c_str());
+                format_hex_pretty_to(hex_buf, this->tx_frame_, this->tx_frame_size_, ' '));
       this->write_array(this->tx_frame_, this->tx_frame_size_);
       this->flush();
 
@@ -262,14 +263,16 @@ void LD2410S::parse_() {
       break;
 
     default:
+      char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGD(TAG, "Received Unknown package type!!! < %s",
-               format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+               format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
       break;
   }
 }
 void LD2410S::parse_short_data_frame_() {
+  char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
   ESP_LOGVV(TAG, "<   [loop:%d] short data < %s", this->loop_count_,
-            format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+            format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
 
   const bool presence_state = this->rx_.payload_data()[0] > 1;
   uint16_t distance = encode_uint16(this->rx_.payload_data()[2], this->rx_.payload_data()[1]);
@@ -286,8 +289,9 @@ void LD2410S::parse_data_frame_() {
   switch (this->rx_.payload_data()[0]) {
     case 0x01:  // standard data
     {
+      char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGVV(TAG, "<   [loop:%d] std data < %s", this->loop_count_,
-                format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+                format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
 
       const bool presence_state = this->rx_.payload_data()[1] > 1;
 
@@ -308,8 +312,9 @@ void LD2410S::parse_data_frame_() {
     case 0x03:  // calibration progress
     {
 #ifdef LD2410S_V2
+      char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGVV(TAG, "<   [loop:%d] std calibration < %s", this->loop_count_,
-                format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+                format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
 
       uint16_t progress = encode_uint16(this->rx_.payload_data()[2], this->rx_.payload_data()[1]);
 
@@ -328,8 +333,9 @@ void LD2410S::parse_data_frame_() {
     }
 
     default:
+      char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGV(TAG, "<XX [loop:%d] std, Unknown std frame type < %s", this->loop_count_,
-               format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+               format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
       break;
   }
 }
@@ -342,12 +348,13 @@ void LD2410S::parse_cmd_frame_() {
   read_seq_data(data_start, read_position, &command_word);
   read_seq_data(data_start, read_position, &ack);
 
+  char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
   if (ack == 0x0000) {
     ESP_LOGVV(TAG, "<   [loop:%d] cmd:%04x < %s", this->loop_count_, command_word,
-              format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+              format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
   } else {
     ESP_LOGD(TAG, "<XX [loop:%d] cmd:%04x Failed ack:%04x < %s", this->loop_count_, command_word, ack,
-             format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+             format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
   }
 
   this->tx_schedule_.verify_response(command_word, this->loop_count_);
@@ -457,8 +464,9 @@ RxEvaluationResult LD2410Srx::receive_byte(uint32_t loop_count, uint8_t byte) {
 
     case RxEvaluationResult::NOK:
     default:
+      char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGV(TAG, "<XX [loop:%d] %s < %s", loop_count, this->msg_.c_str(),
-               format_hex_pretty(this->rcv_buffer_, end_pos_ + 1, ' ').c_str());
+               format_hex_pretty_to(hex_buf, this->rcv_buffer_, end_pos_ + 1, ' '));
       this->reset();
       result = RxEvaluationResult::UNKNOWN;
       break;
@@ -556,7 +564,9 @@ RxEvaluationResult LD2410Srx::evaluate_size_(uint16_t end_pos) {
     return RxEvaluationResult::UNKNOWN;  // not enough data yet to determine size
 
   } else if (end_pos > this->expected_frame_size_) {
-    this->msg_ = "rx passed the expected frame, expected:" + to_string(this->expected_frame_size_);
+    char msg_buf[48];
+    snprintf(msg_buf, sizeof(msg_buf), "rx passed the expected frame, expected:%u", this->expected_frame_size_);
+    this->msg_ = msg_buf;
     return RxEvaluationResult::NOK;  // passed the end of short data frame
 
   } else {

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -560,8 +560,13 @@ RxEvaluationResult LD2410Srx::evaluate_size_(uint16_t end_pos) {
         this->size_field_size_ = FRAME_DATA_LENGTH_SIZE;
         if (end_pos - 1 >= this->header_footer_size_ + this->size_field_size_) {
           this->payload_size_ = read_int(this->rcv_buffer_, this->header_footer_size_, 2);
+          uint16_t overhead = 2 * this->header_footer_size_ + this->size_field_size_;
+          if (this->payload_size_ > RX_TX_BUFFER_SIZE - overhead) {
+            this->msg_ = "payload size exceeds buffer capacity";
+            return RxEvaluationResult::NOK;
+          }
           this->payload_pos_ = this->header_footer_size_ + this->size_field_size_;
-          this->expected_frame_size_ = 2 * this->header_footer_size_ + this->size_field_size_ + this->payload_size_;
+          this->expected_frame_size_ = overhead + this->payload_size_;
         }
       }
       break;

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -353,6 +353,9 @@ void LD2410S::parse_data_frame_() {
   }
 }
 void LD2410S::parse_cmd_frame_() {
+  if (this->rx_.payload_size() < 4)
+    return;
+
   uint8_t *data_start = this->rx_.payload_data();
   uint16_t read_position = 0;
   uint16_t command_word = 0;

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -1,0 +1,826 @@
+#include "ld2410s.h"
+
+namespace esphome::ld2410s {
+
+#pragma region LD2410S
+
+void LD2410S::setup() {
+  ESP_LOGD(TAG, "setup");
+
+#ifdef LD2410S_V2
+  this->publish_distance_(0, true);
+  this->publish_presence_(false, true);
+
+  this->publish_calibration_progress_(0, true);
+  this->publish_calibration_runing_(false, true);
+
+  this->set_threshold_selected_gate(0);
+
+  this->init_();
+#endif
+}
+void LD2410S::loop() {
+  if (!this->receive_()) {
+    if (!this->pause_tx_) {
+      this->send_();
+    }
+  }
+  this->loop_count_++;
+}
+float LD2410S::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+// prepares scheduled frames for sending
+// executes actual data sending
+void LD2410S::send_() {
+  switch (this->tx_schedule_.check_state(this->loop_count_)) {
+    case TxCmdState::SCHEDULED:
+      this->build_cmd_frame_(this->tx_schedule_.get_command(), this->tx_schedule_.get_sub_command());
+      this->tx_schedule_.confirm_ready_to_send();
+      break;
+
+    case TxCmdState::SEND:
+      ESP_LOGVV(TAG, ">   [loop:%d] cmd:%04x > %s", this->loop_count_, this->tx_schedule_.get_command(),
+                format_hex_pretty(this->tx_frame_, this->tx_frame_size_, ' ').c_str());
+      this->write_array(this->tx_frame_, this->tx_frame_size_);
+      this->flush();
+
+      this->tx_schedule_.confirm_sent();
+      this->sending_pause_();
+
+      break;
+
+    case TxCmdState::ERROR:
+      ESP_LOGD(TAG, ">XX [loop:%d] Scheduling command send failed!!!, re-initializing...", this->loop_count_);
+      this->tx_schedule_.reset_schedule();
+#ifdef LD2410S_V2
+      this->pause_tx_ = true;
+      this->set_timeout("Pausing Sending", 15000, [this]() {
+        this->pause_tx_ = false;
+        this->init_();
+      });
+
+#endif
+      static const uint8_t CFG_END[] = {0xFD, 0xFC, 0xFB, 0xFA, 0x02, 0x00, 0xFE, 0x00, 0x04, 0x03, 0x02, 0x01};
+      this->write_array(CFG_END, sizeof(CFG_END));
+      this->flush();
+      break;
+
+    case TxCmdState::EMPTY:
+      if (!this->init_done_) {
+        this->init_done_ = true;
+        ESP_LOGV(TAG, "+++ [loop:%d] Setup done", this->loop_count_);
+      }
+      break;
+
+    case TxCmdState::SENT:
+    default:
+      break;
+  }
+}
+// builds CMD_FRAME
+void LD2410S::build_cmd_frame_(uint16_t command, uint16_t sub_command) {
+  ESP_LOGV(TAG, ":>> [loop:%d] cmd:%04x Prepare frame ", this->loop_count_, command);
+
+  this->tx_frame_size_ = 0;
+
+  // Header
+  append_seq_data(this->tx_frame_, this->tx_frame_size_, &CMD_FRAME_HEADER);
+
+  // Frame size placeholder
+  uint16_t size_start = this->tx_frame_size_;
+  this->tx_frame_size_ += sizeof(size_start);
+
+  // Data start
+  uint16_t data_start = this->tx_frame_size_;
+
+  // Command
+  append_seq_data(this->tx_frame_, this->tx_frame_size_, &command, 1);
+
+  // Parameters
+  switch (command) {
+    case OUTPUT_MODE_SWITCH_CMD: {
+      if (this->minimal_output_) {
+        append_seq_data(this->tx_frame_, this->tx_frame_size_, OUTPUT_MODE_VALUE_MIN, 6);
+      } else {
+        append_seq_data(this->tx_frame_, this->tx_frame_size_, OUTPUT_MODE_VALUE_STD, 6);
+      }
+    } break;
+
+    case CONFIG_MODE_START_CMD:
+      append_seq_data(this->tx_frame_, this->tx_frame_size_, &CONFIG_MODE_START_VALUE);
+      break;
+
+    case CONFIG_MODE_END_CMD:
+      break;
+
+    case CFG_PARAMS_READ_CMD:
+
+      switch (sub_command) {
+        case CFG_MAX_DETECTION_VALUE:
+        case CFG_MIN_DETECTION_VALUE:
+        case CFG_NO_DELAY_VALUE:
+        case CFG_STATUS_FREQ_VALUE:
+        case CFG_DISTANCE_FREQ_VALUE:
+        case CFG_RESPONSE_SPEED_VALUE:
+          append_seq_data(this->tx_frame_, this->tx_frame_size_, &sub_command);
+          break;
+
+        default:
+          const uint16_t cfg_values[] = {CFG_MAX_DETECTION_VALUE, CFG_MIN_DETECTION_VALUE, CFG_NO_DELAY_VALUE,
+                                         CFG_STATUS_FREQ_VALUE,   CFG_DISTANCE_FREQ_VALUE, CFG_RESPONSE_SPEED_VALUE};
+          append_seq_data(this->tx_frame_, this->tx_frame_size_, &cfg_values, 6, sizeof(sub_command));
+          break;
+      }
+
+      break;
+
+    case CFG_FW_READ_CMD:
+      break;
+
+    case CFG_PARAMS_WRITE_CMD:
+      if (this->resp_speed_ == 0) {
+        ESP_LOGD(TAG, "CFG_PARAMS_WRITE_CMD Error, bad new_config");
+        return;
+      } else {
+        switch (sub_command) {
+          case CFG_MAX_DETECTION_VALUE:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, sub_command, &this->max_dist_);
+            break;
+
+          case CFG_MIN_DETECTION_VALUE:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, sub_command, &this->min_dist_);
+            break;
+
+          case CFG_NO_DELAY_VALUE:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, sub_command, &this->delay_);
+            break;
+
+          case CFG_STATUS_FREQ_VALUE:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, sub_command, &this->status_freq_);
+            break;
+
+          case CFG_DISTANCE_FREQ_VALUE:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, sub_command, &this->dist_freq_);
+            break;
+
+          case CFG_RESPONSE_SPEED_VALUE:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, sub_command, &this->resp_speed_);
+            break;
+
+          default:
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, CFG_MAX_DETECTION_VALUE, &this->max_dist_);
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, CFG_MIN_DETECTION_VALUE, &this->min_dist_);
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, CFG_NO_DELAY_VALUE, &this->delay_);
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, CFG_STATUS_FREQ_VALUE, &this->status_freq_);
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, CFG_DISTANCE_FREQ_VALUE, &this->dist_freq_);
+            append_seq_data_value(this->tx_frame_, this->tx_frame_size_, CFG_RESPONSE_SPEED_VALUE, &this->resp_speed_);
+            break;
+        }
+        break;
+      }
+
+    case CALIBRATION_CMD:
+      append_seq_data(this->tx_frame_, this->tx_frame_size_, &CALIBRATION_TRIGGER_VALUE);
+      append_seq_data(this->tx_frame_, this->tx_frame_size_, &CALIBRATION_RETENTION_VALUE);
+      append_seq_data(this->tx_frame_, this->tx_frame_size_, &CALIBRATION_TIME_VALUE);
+      break;
+
+    case CFG_GATE_THRESHOLD_TRIGGER_READ_CMD:
+    case CFG_GATE_THRESHOLD_HOLD_READ_CMD:
+    case CFG_GATE_THRESHOLD_SNR_READ_CMD:
+      if (sub_command != NO_SUB_CMD) {
+        append_seq_data(this->tx_frame_, this->tx_frame_size_, &sub_command);
+      } else {
+        for (uint16_t i = 0; i < 16; i++) {
+          append_seq_data(this->tx_frame_, this->tx_frame_size_, &i);
+        }
+      }
+      break;
+
+    case CFG_GATE_THRESHOLD_TRIGGER_WRITE_CMD:
+      append_gate_thresholds(this->tx_frame_, this->tx_frame_size_, sub_command, this->thresholds_trigger_);
+      break;
+
+    case CFG_GATE_THRESHOLD_HOLD_WRITE_CMD:
+      append_gate_thresholds(this->tx_frame_, this->tx_frame_size_, sub_command, this->thresholds_hold_);
+      break;
+
+    case CFG_GATE_THRESHOLD_SNR_WRITE_CMD:
+      append_gate_thresholds(this->tx_frame_, this->tx_frame_size_, sub_command, this->thresholds_snr_);
+      break;
+
+    default:
+      break;
+  }
+
+  // Frame size
+  uint16_t data_size = this->tx_frame_size_ - data_start;
+  append_seq_data(this->tx_frame_, size_start, &data_size);
+
+  // Footer
+  append_seq_data(this->tx_frame_, this->tx_frame_size_, &CMD_FRAME_FOOTER);
+}
+
+void LD2410S::sending_pause_() {
+  this->pause_tx_ = true;
+  this->set_timeout("Pausing Sending", TX_PAUSE_TIMEOUT, [this]() {
+    ESP_LOGVV("ld2410s", "Proceeding after tx pause of %d ms", TX_PAUSE_TIMEOUT);
+    this->pause_tx_ = false;
+  });
+}
+
+// receives frames and starts processing
+bool LD2410S::receive_() {
+  uint8_t rx;
+  int rx_bytes_count = 0;
+
+  while (this->available() && rx_bytes_count < RX_MAX_BYTES_PER_LOOP) {
+    if (!this->read_byte(&rx))
+      break;
+    rx_bytes_count++;
+
+    if (this->rx_.receive_byte(this->loop_count_, rx) == RxEvaluationResult::OK) {
+      this->parse_();
+      this->rx_.reset();
+    }
+  }
+  return rx_bytes_count > 0;
+}
+// starts received frame decoding, and handling received data
+void LD2410S::parse_() {
+  switch (this->rx_.frame_type()) {
+    case RxFrameType::SHORT_DATA_FRAME:
+      this->parse_short_data_frame_();
+      break;
+
+    case RxFrameType::STD_DATA_FRAME:
+      this->parse_data_frame_();
+      break;
+
+    case RxFrameType::CMD_FRAME:
+      this->parse_cmd_frame_();
+      break;
+
+    default:
+      ESP_LOGD(TAG, "Received Unknown package type!!! < %s",
+               format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+      break;
+  }
+}
+void LD2410S::parse_short_data_frame_() {
+  ESP_LOGVV(TAG, "<   [loop:%d] short data < %s", this->loop_count_,
+            format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+
+  const bool presence_state = this->rx_.payload_data()[0] > 1;
+  uint16_t distance = encode_uint16(this->rx_.payload_data()[2], this->rx_.payload_data()[1]);
+
+  if (!presence_state)
+    distance = 0;
+
+#ifdef LD2410S_V2
+  this->publish_distance_(distance);
+  this->publish_presence_(presence_state);
+#endif
+}
+void LD2410S::parse_data_frame_() {
+  switch (this->rx_.payload_data()[0]) {
+    case 0x01:  // standard data
+    {
+      ESP_LOGVV(TAG, "<   [loop:%d] std data < %s", this->loop_count_,
+                format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+
+      const bool presence_state = this->rx_.payload_data()[1] > 1;
+
+      uint16_t distance = encode_uint16(this->rx_.payload_data()[3], this->rx_.payload_data()[2]);
+      if (!presence_state)
+        distance = 0;
+
+#ifdef LD2410S_V2
+      this->publish_distance_(distance);
+      this->publish_presence_(presence_state);
+
+      this->parse_data_energy_values_read_(&this->rx_.payload_data()[6]);
+#endif
+
+      break;
+    }
+
+    case 0x03:  // calibration progress
+    {
+#ifdef LD2410S_V2
+      ESP_LOGVV(TAG, "<   [loop:%d] std calibration < %s", this->loop_count_,
+                format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+
+      uint16_t progress = encode_uint16(this->rx_.payload_data()[2], this->rx_.payload_data()[1]);
+
+      this->sending_pause_();
+
+      if (progress == 100) {
+        this->publish_calibration_runing_(false);
+        this->read_all_thresholds_();
+      } else {
+        this->publish_calibration_runing_(true);
+      }
+      this->publish_calibration_progress_(progress);
+#endif
+
+      break;
+    }
+
+    default:
+      ESP_LOGV(TAG, "<XX [loop:%d] std, Unknown std frame type < %s", this->loop_count_,
+               format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+      break;
+  }
+}
+void LD2410S::parse_cmd_frame_() {
+  uint8_t *data_start = this->rx_.payload_data();
+  uint16_t read_position = 0;
+  uint16_t command_word = 0;
+  uint16_t ack = 0;
+
+  read_seq_data(data_start, read_position, &command_word);
+  read_seq_data(data_start, read_position, &ack);
+
+  if (ack == 0x0000) {
+    ESP_LOGVV(TAG, "<   [loop:%d] cmd:%04x < %s", this->loop_count_, command_word,
+              format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+  } else {
+    ESP_LOGD(TAG, "<XX [loop:%d] cmd:%04x Failed ack:%04x < %s", this->loop_count_, command_word, ack,
+             format_hex_pretty(this->rx_.frame_data(), this->rx_.frame_size(), ' ').c_str());
+  }
+
+  this->tx_schedule_.verify_response(command_word, this->loop_count_);
+
+  uint8_t *data = &data_start[read_position];
+
+  switch (command_word) {
+    // Process acknowledgements
+
+#ifdef LD2410S_V2
+
+    case CONFIG_MODE_START_CMD | CMD_CONFIRMATION:
+      this->parse_ack_config_start_(data);
+      break;
+
+    case CONFIG_MODE_END_CMD | CMD_CONFIRMATION:
+      this->parse_ack_config_end_(data);
+      break;
+
+    case CALIBRATION_CMD | CMD_CONFIRMATION:
+      ESP_LOGI(TAG, "Calibration started");
+      break;
+
+      // Write command acknowledgements
+
+    case CFG_PARAMS_WRITE_CMD | CMD_CONFIRMATION:
+      ESP_LOGI(TAG, "Config written");
+      break;
+
+    case OUTPUT_MODE_SWITCH_CMD | CMD_CONFIRMATION:
+      this->parse_ack_minimal_output_(data);
+      break;
+
+    case CFG_GATE_THRESHOLD_TRIGGER_WRITE_CMD | CMD_CONFIRMATION:
+      ESP_LOGI(TAG, "Trigger Threshold written");
+      break;
+
+    case CFG_GATE_THRESHOLD_HOLD_WRITE_CMD | CMD_CONFIRMATION:
+      ESP_LOGI(TAG, "Trigger Hold written");
+      break;
+
+    case CFG_GATE_THRESHOLD_SNR_WRITE_CMD | CMD_CONFIRMATION:
+      ESP_LOGI(TAG, "Trigger SNR written");
+      break;
+
+      // Read command acknowledgements
+
+    case CFG_PARAMS_READ_CMD | CMD_CONFIRMATION:
+      this->parse_ack_config_read_(data);
+      break;
+
+    case CFG_FW_READ_CMD | CMD_CONFIRMATION:
+      this->parse_ack_fw_read_(data);
+      break;
+
+    case CFG_GATE_THRESHOLD_TRIGGER_READ_CMD | CMD_CONFIRMATION:
+      this->parse_ack_threshold_trigger_read_(data);
+      break;
+
+    case CFG_GATE_THRESHOLD_HOLD_READ_CMD | CMD_CONFIRMATION:
+      this->parse_ack_threshold_hold_read_(data);
+      break;
+
+    case CFG_GATE_THRESHOLD_SNR_READ_CMD | CMD_CONFIRMATION:
+      this->parse_ack_threshold_snr_read_(data);
+      break;
+#endif
+
+    default:
+      ESP_LOGD(TAG, "< Unknown: %4x", command_word);
+      break;
+  }
+}
+
+#pragma endregion
+
+#pragma region LD2410Srx
+
+// appends one byte to rx buffer, and checks if that makes complete frame
+RxEvaluationResult LD2410Srx::receive_byte(uint32_t loop_count, uint8_t byte) {
+  if (this->payload_ready_) {
+    this->reset();
+  }
+
+  this->rcv_buffer_[this->end_pos_] = byte;
+
+  RxEvaluationResult result = this->evaluate_header_(this->end_pos_ + 1);
+  if (result == RxEvaluationResult::OK) {
+    result = this->evaluate_size_(this->end_pos_ + 1);
+    if (result == RxEvaluationResult::OK) {
+      result = this->evaluate_footer_(this->end_pos_ + 1);
+    }
+  }
+
+  switch (result) {
+    case RxEvaluationResult::OK:
+      this->payload_ready_ = true;
+      break;
+
+    case RxEvaluationResult::UNKNOWN:
+      this->end_pos_++;
+      if (this->end_pos_ > RX_TX_BUFFER_SIZE) {
+        ESP_LOGV(TAG, "XX< [loop:%d] Received data buffer overflow, resetting", loop_count);
+        this->reset();
+      }
+      break;
+
+    case RxEvaluationResult::NOK:
+    default:
+      ESP_LOGV(TAG, "<XX [loop:%d] %s < %s", loop_count, this->msg_.c_str(),
+               format_hex_pretty(this->rcv_buffer_, end_pos_ + 1, ' ').c_str());
+      this->reset();
+      result = RxEvaluationResult::UNKNOWN;
+      break;
+  }
+
+  return result;
+}
+// checks if current rx buffer contains header
+RxEvaluationResult LD2410Srx::evaluate_header_(uint16_t end_pos) {
+  switch (this->frame_type_) {
+    case RxFrameType::CMD_FRAME:
+    case RxFrameType::STD_DATA_FRAME:
+    case RxFrameType::SHORT_DATA_FRAME:
+      return RxEvaluationResult::OK;  // already determined frame type
+
+    case RxFrameType::NOK:
+      return RxEvaluationResult::NOK;  // already determined bad header
+
+    case RxFrameType::UNKNOWN:
+    default:
+      break;  // need to determine frame type
+  }
+
+  if (end_pos == sizeof(SHORT_DATA_FRAME_HEADER) &&
+      memcmp(&this->rcv_buffer_[0], &SHORT_DATA_FRAME_HEADER, sizeof(SHORT_DATA_FRAME_HEADER)) == 0) {
+    this->frame_type_ = RxFrameType::SHORT_DATA_FRAME;
+    this->header_footer_size_ = sizeof(SHORT_DATA_FRAME_HEADER);
+    return RxEvaluationResult::OK;
+  }
+
+  if (end_pos == sizeof(STD_DATA_FRAME_HEADER) &&
+      memcmp(&this->rcv_buffer_[0], &STD_DATA_FRAME_HEADER, sizeof(STD_DATA_FRAME_HEADER)) == 0) {
+    this->frame_type_ = RxFrameType::STD_DATA_FRAME;
+    this->header_footer_size_ = sizeof(STD_DATA_FRAME_HEADER);
+    return RxEvaluationResult::OK;
+  }
+
+  if (end_pos == sizeof(CMD_FRAME_HEADER) &&
+      memcmp(&this->rcv_buffer_[0], &CMD_FRAME_HEADER, sizeof(CMD_FRAME_HEADER)) == 0) {
+    this->frame_type_ = RxFrameType::CMD_FRAME;
+    this->header_footer_size_ = sizeof(CMD_FRAME_HEADER);
+    return RxEvaluationResult::OK;
+  }
+
+  if (end_pos < sizeof(STD_DATA_FRAME_HEADER) && memcmp(&this->rcv_buffer_[0], &STD_DATA_FRAME_HEADER, end_pos) == 0) {
+    this->frame_type_ =
+        RxFrameType::UNKNOWN;  // not enough data yet to determine frame type, but it fits STD frame header
+    this->header_footer_size_ = 0;
+    return RxEvaluationResult::UNKNOWN;
+  }
+
+  if (end_pos < sizeof(CMD_FRAME_HEADER) && memcmp(&this->rcv_buffer_[0], &CMD_FRAME_HEADER, end_pos) == 0) {
+    this->frame_type_ =
+        RxFrameType::UNKNOWN;  // not enough data yet to determine frame type, but it fits CMD frame header
+    this->header_footer_size_ = 0;
+    return RxEvaluationResult::UNKNOWN;
+  }
+
+  this->msg_ = "Unkown header";
+  this->frame_type_ = RxFrameType::NOK;  // bad header
+  return RxEvaluationResult::NOK;
+}
+// checks if current rx buffer has proper size for decoded header
+RxEvaluationResult LD2410Srx::evaluate_size_(uint16_t end_pos) {
+  switch (this->frame_type_) {
+    case RxFrameType::SHORT_DATA_FRAME:
+      if (this->expected_frame_size_ == 0) {
+        this->size_field_size_ = 0;
+        this->payload_size_ = 3;
+        this->payload_pos_ = this->header_footer_size_;
+        this->expected_frame_size_ = 2 * this->header_footer_size_ + 3;
+      }
+      break;
+
+    case RxFrameType::STD_DATA_FRAME:
+    case RxFrameType::CMD_FRAME:
+      if (this->expected_frame_size_ == 0) {
+        this->size_field_size_ = FRAME_DATA_LENGTH_SIZE;
+        if (end_pos - 1 >= this->header_footer_size_ + this->size_field_size_) {
+          this->payload_size_ = read_int(this->rcv_buffer_, this->header_footer_size_, 2);
+          this->payload_pos_ = this->header_footer_size_ + this->size_field_size_;
+          this->expected_frame_size_ = 2 * this->header_footer_size_ + this->size_field_size_ + this->payload_size_;
+        }
+      }
+      break;
+
+    case RxFrameType::UNKNOWN:
+      return RxEvaluationResult::UNKNOWN;  // not enough data yet to determine size
+    case RxFrameType::NOK:                 // already determined bad header
+    default:                               // unknown header type
+      return RxEvaluationResult::NOK;
+  }
+
+  if (this->expected_frame_size_ == 0 || end_pos < this->expected_frame_size_) {
+    return RxEvaluationResult::UNKNOWN;  // not enough data yet to determine size
+
+  } else if (end_pos > this->expected_frame_size_) {
+    this->msg_ = "rx passed the expected frame, expected:" + to_string(this->expected_frame_size_);
+    return RxEvaluationResult::NOK;  // passed the end of short data frame
+
+  } else {
+    return RxEvaluationResult::OK;  // correct size
+  }
+}
+// checks if current rx buffer containts proper footer for decoded header
+RxEvaluationResult LD2410Srx::evaluate_footer_(uint16_t end_pos) {
+  switch (this->frame_type_) {
+    case RxFrameType::SHORT_DATA_FRAME:  // footer matches expected for short data frame
+      if (memcmp(&rcv_buffer_[end_pos - this->header_footer_size_], &SHORT_DATA_FRAME_FOOTER,
+                 sizeof(SHORT_DATA_FRAME_FOOTER)) == 0) {
+        return RxEvaluationResult::OK;
+      }
+      break;
+
+    case RxFrameType::STD_DATA_FRAME:  // footer matches expected for standard data frame
+      if (memcmp(&rcv_buffer_[end_pos - this->header_footer_size_], &STD_DATA_FRAME_FOOTER,
+                 sizeof(STD_DATA_FRAME_FOOTER)) == 0) {
+        return RxEvaluationResult::OK;
+      }
+      break;
+
+    case RxFrameType::CMD_FRAME:  // footer matches expected for command frame
+      if (memcmp(&rcv_buffer_[end_pos - this->header_footer_size_], &CMD_FRAME_FOOTER, sizeof(CMD_FRAME_FOOTER)) == 0) {
+        return RxEvaluationResult::OK;
+      }
+      break;
+
+    case RxFrameType::UNKNOWN:  // not enough data yet to determine size
+      return RxEvaluationResult::UNKNOWN;
+    case RxFrameType::NOK:  // already known bad data frame
+    default:                // unknown header type
+      break;
+  }
+  this->msg_ = "footer does not match header: ";
+  return RxEvaluationResult::NOK;  // footer does not match expected footer for frame type
+}
+// reset rx buffer
+void LD2410Srx::reset() {
+  // ESP_LOGV(TAG, "rx reset");
+  std::memset(this->rcv_buffer_, 0, RX_TX_BUFFER_SIZE);
+  this->end_pos_ = 0;
+  this->header_footer_size_ = 0;
+  this->size_field_size_ = 0;
+  this->frame_type_ = RxFrameType::UNKNOWN;
+  this->payload_ready_ = false;
+  this->payload_pos_ = 0;
+  this->payload_size_ = 0;
+  this->expected_frame_size_ = 0;
+}
+
+int LD2410Srx::read_int(const uint8_t *buffer, size_t pos, size_t len) {
+  unsigned int ret = 0;
+  int shift = 0;
+  for (size_t i = 0; i < len; i++) {
+    ret |= static_cast<unsigned int>(buffer[pos + i]) << shift;
+    shift += 8;
+  }
+  return ret;
+};
+
+#pragma endregion
+
+#pragma region LD2410Sschedule
+
+// Appends new task to schedule
+void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
+  ESP_LOGV(TAG, "append => cmd:%04x, prev_cmd:%04x, active:%d, last:%d", command,
+           this->commands_[this->last_ - 1].command, this->active_, this->last_);
+
+  if (this->last_ >= TX_SCHEDULE_BUFFER_SIZE) {
+    ESP_LOGW(TAG, "++: pos:[%d], cmd:%04x, Schedule buffer overflow, reseting buffer !!!", this->last_ - 1, command);
+
+    this->reset_schedule();
+    this->state_ = TxCmdState::ERROR;
+    return;
+  }
+
+  if (command != CONFIG_MODE_START_CMD) {
+    if (this->last_ <= 0) {
+      ESP_LOGV(TAG, "First cmd must be config start => appending config start and new cmd");
+      this->append(CONFIG_MODE_START_CMD);
+    } else {
+      // if previous cmd is config end, it's not possible tu just append new command
+      if (this->commands_[this->last_ - 1].command == CONFIG_MODE_END_CMD) {
+        if (command == CONFIG_MODE_END_CMD) {
+          ESP_LOGV(TAG, "Ignoring duplicated config end cmd");
+          return;
+        }
+
+        if (this->active_ == this->last_ - 1) {
+          ESP_LOGV(TAG, "Previous cmd is config end and it's already executing => appending config start and new cmd");
+          this->append(CONFIG_MODE_START_CMD);
+
+        } else {
+          ESP_LOGV(TAG, "Last cmd was config end and it's not executing executing yet => deleting last config end and "
+                        "appending new cmd");
+          this->last_--;
+        }
+      }
+    }
+  }
+
+  ESP_LOGV(TAG, "++: pos:[%d], cmd:%04x", this->last_, command);
+
+  this->commands_[this->last_].command = command;
+  this->commands_[this->last_].sub_command = sub_command;
+
+  this->last_++;
+
+  if (command != CONFIG_MODE_START_CMD && command != CONFIG_MODE_END_CMD) {
+    ESP_LOGV(TAG, "Appending end");
+    this->append(CONFIG_MODE_END_CMD);
+  }
+
+  if (this->state_ == TxCmdState::EMPTY) {
+    this->state_ = TxCmdState::SCHEDULED;
+  }
+}
+// Returns active scheduled task status
+TxCmdState LD2410Sschedule::check_state(uint32_t loop_count) {
+  switch (this->state_) {
+    case TxCmdState::SCHEDULED:
+      this->retry_count_ = 0;
+      ESP_LOGV(TAG, "::> [loop:%d] pos:%d[%d], cmd:%04x, Scheduled", loop_count, this->active_, this->last_ - 1,
+               this->get_command());
+      break;
+
+    case TxCmdState::SEND:
+      this->time_started_ = App.get_loop_component_start_time();
+      ESP_LOGV(TAG, "::> [loop:%d] pos:%d[%d], cmd:%04x, Send", loop_count, this->active_, this->last_ - 1,
+               this->get_command());
+      break;
+
+    case TxCmdState::SENT:
+      if (App.get_loop_component_start_time() > this->time_started_ + TX_CONFIRMATION_TIMEOUT) {
+        this->time_started_ = App.get_loop_component_start_time();
+
+        if (this->retry_count_ < TX_MAX_RESEND) {
+          ESP_LOGD(TAG, ":>> [loop:%d] pos:%d[%d], cmd:%04x, retry:%d, restart:%d, Send Timeout Expired, Resend!",
+                   loop_count, this->active_, this->last_ - 1, this->get_command(), this->retry_count_,
+                   this->restart_count_);
+          this->state_ = TxCmdState::SEND;
+          this->retry_count_++;
+
+        } else {
+          if (this->restart_count_ < TX_MAX_RESTART) {
+            ESP_LOGW(
+                TAG,
+                ":>> [loop:%d] pos:%d[:%d], cmd:%04x, retry:%d, restart:%d, Resend limit reached, Restart sequence!!",
+                loop_count, this->active_, this->last_ - 1, this->get_command(), this->retry_count_,
+                this->restart_count_);
+            this->state_ = TxCmdState::SCHEDULED;
+            this->retry_count_ = 0;
+            this->restart_count_++;
+            this->active_ = 0;
+
+          } else {
+            ESP_LOGE(
+                TAG,
+                ":>> [loop:%d] pos:%d[%d], cmd:%04x, retry:%d, restart:%d, Restart sequence limit reached, Giving up, "
+                "Reseting buffer!!!",
+                loop_count, this->active_, this->last_ - 1, this->get_command(), this->retry_count_,
+                this->restart_count_);
+            this->state_ = TxCmdState::ERROR;
+            this->retry_count_ = 0;
+            this->restart_count_ = 0;
+            this->active_ = 0;
+            this->last_ = 0;
+          }
+        }
+      }
+      break;
+
+    case TxCmdState::EMPTY:
+    default:
+      break;
+  }
+
+  return this->state_;
+}
+// Verifies if received response matches expected, if so procedes to next scheduled command
+void LD2410Sschedule::verify_response(uint16_t command_word, uint32_t loop_count) {
+  int16_t expected = this->get_command() | CMD_CONFIRMATION;
+  if (this->state_ == TxCmdState::SENT) {
+    if (command_word == expected) {
+      ESP_LOGD(TAG, "Sent cmd: %04x", this->get_command());
+      ESP_LOGV(TAG, "::< [loop:%d] pos:%d[%d], cmd:%04x, Sending confirmed, rx:%x", loop_count, this->active_,
+               this->last_ - 1, this->get_command(), command_word);
+
+      switch (command_word) {
+        // config start confirmed
+        case CONFIG_MODE_START_CMD | CMD_CONFIRMATION:
+          this->config_mode_ = true;
+          break;
+
+        // config end confirmed
+        case CONFIG_MODE_END_CMD | CMD_CONFIRMATION:
+          this->config_mode_ = false;
+          break;
+
+        default:
+          break;
+      }
+
+      // procede to next task
+      this->active_++;
+      this->state_ = TxCmdState::SCHEDULED;
+
+      if (this->active_ >= this->last_) {
+        ESP_LOGD(TAG, "::: Schedule emptyd, Reseting");
+        this->reset_schedule();
+      }
+
+      if (this->active_ >= TX_SCHEDULE_BUFFER_SIZE) {
+        ESP_LOGD(TAG, "::: Schedule overflow, Reseting");
+        this->reset_schedule();
+      }
+
+    } else {
+      if (this->active_ > 0 && command_word == (this->commands_[this->active_ - 1].command | CMD_CONFIRMATION)) {
+        ESP_LOGD(
+            TAG,
+            "::< [loop:%d] pos:%d[%d], cmd:%04x, received:%x, Received unexpected confirmation for previous command",
+            loop_count, this->active_, this->last_, this->get_command(), command_word);
+      } else {
+        ESP_LOGD(TAG, "::< [loop:%d] pos:%d[%d], cmd:%04x, received:%x, Received confirmation for wrong command",
+                 loop_count, this->active_, this->last_, this->get_command(), command_word);
+      }
+    }
+  } else {
+    ESP_LOGD(TAG, "::< [loop:%d] pos:%d[%d], cmd:%04x, received:%x, Received unexpected command confirmation",
+             loop_count, this->active_, this->last_, this->get_command(), command_word);
+  }
+}
+
+// Confirm frame ready for sending
+void LD2410Sschedule::confirm_ready_to_send() { this->state_ = TxCmdState::SEND; }
+
+// Confirm frame sent
+void LD2410Sschedule::confirm_sent() {
+  this->time_started_ = App.get_loop_component_start_time();
+  this->state_ = TxCmdState::SENT;
+  this->config_mode_ = true;
+}
+
+uint16_t LD2410Sschedule::get_command() { return this->commands_[this->active_].command; }
+uint16_t LD2410Sschedule::get_sub_command() { return this->commands_[this->active_].sub_command; }
+// Resets schedule buffer
+void LD2410Sschedule::reset_schedule() {
+  if (this->state_ == TxCmdState::EMPTY)
+    return;
+
+  std::memset(this->commands_, 0x88, this->last_ * sizeof(TxTaskT));
+  this->last_ = 0;
+  this->active_ = 0;
+  this->time_started_ = App.get_loop_component_start_time();
+  this->retry_count_ = 0;
+  this->restart_count_ = 0;
+  this->state_ = TxCmdState::EMPTY;
+  ESP_LOGV(TAG, "::: Schedule cleared");
+}
+
+#pragma endregion
+
+}  // namespace esphome::ld2410s

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -383,6 +383,8 @@ void LD2410S::parse_cmd_frame_() {
 #ifdef LD2410S_V2
 
     case CONFIG_MODE_START_CMD | CMD_CONFIRMATION:
+      if (this->rx_.payload_size() < 8)
+        break;
       this->parse_ack_config_start_(data);
       break;
 
@@ -419,22 +421,32 @@ void LD2410S::parse_cmd_frame_() {
       // Read command acknowledgements
 
     case CFG_PARAMS_READ_CMD | CMD_CONFIRMATION:
+      if (this->rx_.payload_size() < 28)
+        break;
       this->parse_ack_config_read_(data);
       break;
 
     case CFG_FW_READ_CMD | CMD_CONFIRMATION:
+      if (this->rx_.payload_size() < 14)
+        break;
       this->parse_ack_fw_read_(data);
       break;
 
     case CFG_GATE_THRESHOLD_TRIGGER_READ_CMD | CMD_CONFIRMATION:
+      if (this->rx_.payload_size() < 68)
+        break;
       this->parse_ack_threshold_trigger_read_(data);
       break;
 
     case CFG_GATE_THRESHOLD_HOLD_READ_CMD | CMD_CONFIRMATION:
+      if (this->rx_.payload_size() < 68)
+        break;
       this->parse_ack_threshold_hold_read_(data);
       break;
 
     case CFG_GATE_THRESHOLD_SNR_READ_CMD | CMD_CONFIRMATION:
+      if (this->rx_.payload_size() < 68)
+        break;
       this->parse_ack_threshold_snr_read_(data);
       break;
 #endif
@@ -656,8 +668,12 @@ int LD2410Srx::read_int(const uint8_t *buffer, size_t pos, size_t len) {
 
 // Appends new task to schedule
 void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
-  ESP_LOGV(TAG, "append => cmd:%04x, prev_cmd:%04x, active:%d, last:%d", command,
-           this->commands_[this->last_ - 1].command, this->active_, this->last_);
+  if (this->last_ > 0) {
+    ESP_LOGV(TAG, "append => cmd:%04x, prev_cmd:%04x, active:%d, last:%d", command,
+             this->commands_[this->last_ - 1].command, this->active_, this->last_);
+  } else {
+    ESP_LOGV(TAG, "append => cmd:%04x, prev_cmd:none, active:%d, last:%d", command, this->active_, this->last_);
+  }
 
   if (this->last_ >= TX_SCHEDULE_BUFFER_SIZE) {
     ESP_LOGW(TAG, "++: pos:[%d], cmd:%04x, Schedule buffer overflow, resetting buffer !!!", this->last_ - 1, command);

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -50,7 +50,7 @@ void LD2410S::send_() {
 
       break;
 
-    case TxCmdState::ERROR:
+    case TxCmdState::FAILED:
       ESP_LOGD(TAG, ">XX [loop:%d] Scheduling command send failed!!!, re-initializing...", this->loop_count_);
       this->tx_schedule_.reset_schedule();
 #ifdef LD2410S_V2
@@ -66,7 +66,7 @@ void LD2410S::send_() {
       this->flush();
       break;
 
-    case TxCmdState::EMPTY:
+    case TxCmdState::IDLE:
       if (!this->init_done_) {
         this->init_done_ = true;
         ESP_LOGV(TAG, "+++ [loop:%d] Setup done", this->loop_count_);
@@ -642,7 +642,7 @@ void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
     ESP_LOGW(TAG, "++: pos:[%d], cmd:%04x, Schedule buffer overflow, reseting buffer !!!", this->last_ - 1, command);
 
     this->reset_schedule();
-    this->state_ = TxCmdState::ERROR;
+    this->state_ = TxCmdState::FAILED;
     return;
   }
 
@@ -683,7 +683,7 @@ void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
     this->append(CONFIG_MODE_END_CMD);
   }
 
-  if (this->state_ == TxCmdState::EMPTY) {
+  if (this->state_ == TxCmdState::IDLE) {
     this->state_ = TxCmdState::SCHEDULED;
   }
 }
@@ -732,7 +732,7 @@ TxCmdState LD2410Sschedule::check_state(uint32_t loop_count) {
                 "Reseting buffer!!!",
                 loop_count, this->active_, this->last_ - 1, this->get_command(), this->retry_count_,
                 this->restart_count_);
-            this->state_ = TxCmdState::ERROR;
+            this->state_ = TxCmdState::FAILED;
             this->retry_count_ = 0;
             this->restart_count_ = 0;
             this->active_ = 0;
@@ -742,7 +742,7 @@ TxCmdState LD2410Sschedule::check_state(uint32_t loop_count) {
       }
       break;
 
-    case TxCmdState::EMPTY:
+    case TxCmdState::IDLE:
     default:
       break;
   }
@@ -818,7 +818,7 @@ uint16_t LD2410Sschedule::get_command() { return this->commands_[this->active_].
 uint16_t LD2410Sschedule::get_sub_command() { return this->commands_[this->active_].sub_command; }
 // Resets schedule buffer
 void LD2410Sschedule::reset_schedule() {
-  if (this->state_ == TxCmdState::EMPTY)
+  if (this->state_ == TxCmdState::IDLE)
     return;
 
   std::memset(this->commands_, 0x88, this->last_ * sizeof(TxTaskT));
@@ -827,7 +827,7 @@ void LD2410Sschedule::reset_schedule() {
   this->time_started_ = App.get_loop_component_start_time();
   this->retry_count_ = 0;
   this->restart_count_ = 0;
-  this->state_ = TxCmdState::EMPTY;
+  this->state_ = TxCmdState::IDLE;
   ESP_LOGV(TAG, "::: Schedule cleared");
 }
 

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -12,7 +12,7 @@ void LD2410S::setup() {
   this->publish_presence_(false, true);
 
   this->publish_calibration_progress_(0, true);
-  this->publish_calibration_runing_(false, true);
+  this->publish_calibration_running_(false, true);
 
   this->set_threshold_selected_gate(0);
 
@@ -334,10 +334,10 @@ void LD2410S::parse_data_frame_() {
       this->sending_pause_();
 
       if (progress == 100) {
-        this->publish_calibration_runing_(false);
+        this->publish_calibration_running_(false);
         this->read_all_thresholds_();
       } else {
-        this->publish_calibration_runing_(true);
+        this->publish_calibration_running_(true);
       }
       this->publish_calibration_progress_(progress);
 #endif
@@ -541,7 +541,7 @@ RxEvaluationResult LD2410Srx::evaluate_header_(uint16_t end_pos) {
     return RxEvaluationResult::UNKNOWN;
   }
 
-  this->msg_ = "Unkown header";
+  this->msg_ = "Unknown header";
   this->frame_type_ = RxFrameType::NOK;  // bad header
   return RxEvaluationResult::NOK;
 }
@@ -660,7 +660,7 @@ void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
            this->commands_[this->last_ - 1].command, this->active_, this->last_);
 
   if (this->last_ >= TX_SCHEDULE_BUFFER_SIZE) {
-    ESP_LOGW(TAG, "++: pos:[%d], cmd:%04x, Schedule buffer overflow, reseting buffer !!!", this->last_ - 1, command);
+    ESP_LOGW(TAG, "++: pos:[%d], cmd:%04x, Schedule buffer overflow, resetting buffer !!!", this->last_ - 1, command);
 
     this->reset_schedule();
     this->state_ = TxCmdState::FAILED;
@@ -672,7 +672,7 @@ void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
       ESP_LOGV(TAG, "First cmd must be config start => appending config start and new cmd");
       this->append(CONFIG_MODE_START_CMD);
     } else {
-      // if previous cmd is config end, it's not possible tu just append new command
+      // if previous cmd is config end, it's not possible to just append new command
       if (this->commands_[this->last_ - 1].command == CONFIG_MODE_END_CMD) {
         if (command == CONFIG_MODE_END_CMD) {
           ESP_LOGV(TAG, "Ignoring duplicated config end cmd");
@@ -684,7 +684,7 @@ void LD2410Sschedule::append(uint16_t command, uint16_t sub_command) {
           this->append(CONFIG_MODE_START_CMD);
 
         } else {
-          ESP_LOGV(TAG, "Last cmd was config end and it's not executing executing yet => deleting last config end and "
+          ESP_LOGV(TAG, "Last cmd was config end and it's not executing yet => deleting last config end and "
                         "appending new cmd");
           this->last_--;
         }
@@ -805,7 +805,7 @@ void LD2410Sschedule::verify_response(uint16_t command_word, uint32_t loop_count
       this->state_ = TxCmdState::SCHEDULED;
 
       if (this->active_ >= this->last_) {
-        ESP_LOGD(TAG, "::: Schedule emptyd, Reseting");
+        ESP_LOGD(TAG, "::: Schedule emptied, Resetting");
         this->reset_schedule();
       }
 

--- a/esphome/components/ld2410s/ld2410s.cpp
+++ b/esphome/components/ld2410s/ld2410s.cpp
@@ -274,6 +274,9 @@ void LD2410S::parse_short_data_frame_() {
   ESP_LOGVV(TAG, "<   [loop:%d] short data < %s", this->loop_count_,
             format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
 
+  if (this->rx_.payload_size() < 3)
+    return;
+
   const bool presence_state = this->rx_.payload_data()[0] > 1;
   uint16_t distance = encode_uint16(this->rx_.payload_data()[2], this->rx_.payload_data()[1]);
 
@@ -286,9 +289,15 @@ void LD2410S::parse_short_data_frame_() {
 #endif
 }
 void LD2410S::parse_data_frame_() {
+  if (this->rx_.payload_size() < 1)
+    return;
+
   switch (this->rx_.payload_data()[0]) {
     case 0x01:  // standard data
     {
+      if (this->rx_.payload_size() < 4)
+        break;
+
       char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGVV(TAG, "<   [loop:%d] std data < %s", this->loop_count_,
                 format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
@@ -303,7 +312,8 @@ void LD2410S::parse_data_frame_() {
       this->publish_distance_(distance);
       this->publish_presence_(presence_state);
 
-      this->parse_data_energy_values_read_(&this->rx_.payload_data()[6]);
+      if (this->rx_.payload_size() >= 7)
+        this->parse_data_energy_values_read_(&this->rx_.payload_data()[6]);
 #endif
 
       break;
@@ -312,6 +322,9 @@ void LD2410S::parse_data_frame_() {
     case 0x03:  // calibration progress
     {
 #ifdef LD2410S_V2
+      if (this->rx_.payload_size() < 3)
+        break;
+
       char hex_buf[format_hex_pretty_size(RX_TX_BUFFER_SIZE)];
       ESP_LOGVV(TAG, "<   [loop:%d] std calibration < %s", this->loop_count_,
                 format_hex_pretty_to(hex_buf, this->rx_.frame_data(), this->rx_.frame_size(), ' '));
@@ -456,7 +469,7 @@ RxEvaluationResult LD2410Srx::receive_byte(uint32_t loop_count, uint8_t byte) {
 
     case RxEvaluationResult::UNKNOWN:
       this->end_pos_++;
-      if (this->end_pos_ > RX_TX_BUFFER_SIZE) {
+      if (this->end_pos_ >= RX_TX_BUFFER_SIZE) {
         ESP_LOGV(TAG, "XX< [loop:%d] Received data buffer overflow, resetting", loop_count);
         this->reset();
       }
@@ -743,6 +756,12 @@ TxCmdState LD2410Sschedule::check_state(uint32_t loop_count) {
       break;
 
     case TxCmdState::IDLE:
+      // schedule has passed the end
+      if (this->last_ > 0 && !this->config_mode_ && this->active_ >= this->last_ - 1) {
+        this->reset_schedule();
+      }
+      break;
+
     default:
       break;
   }

--- a/esphome/components/ld2410s/ld2410s.h
+++ b/esphome/components/ld2410s/ld2410s.h
@@ -210,7 +210,7 @@ class LD2410S : public Component, public uart::UARTDevice {
   SUB_SENSOR(calibration_progress)
 #endif
 #ifdef USE_BINARY_SENSOR
-  SUB_BINARY_SENSOR(calibration_runing)
+  SUB_BINARY_SENSOR(calibration_running)
 #endif
 #ifdef USE_TEXT_SENSOR
   SUB_TEXT_SENSOR(fw_version)
@@ -325,7 +325,7 @@ class LD2410S : public Component, public uart::UARTDevice {
   void publish_distance_(uint16_t distance, bool force_publish = false);
   void publish_presence_(bool presence, bool force_publish = false);
   void publish_calibration_progress_(uint16_t calibration_progress, bool force_publish = false);
-  void publish_calibration_runing_(bool running, bool force_publish = false);
+  void publish_calibration_running_(bool running, bool force_publish = false);
   void publish_energy_values_(bool force_publish = false);
   void publish_fw_version_(const std::string &version, bool force_publish = false);
   void publish_threshold_trigger_(bool force_publish = false);

--- a/esphome/components/ld2410s/ld2410s.h
+++ b/esphome/components/ld2410s/ld2410s.h
@@ -128,7 +128,7 @@ static const uint32_t TX_PAUSE_TIMEOUT = 100;          // pause after receiving 
 #pragma endregion
 
 #pragma region enum
-enum class TxCmdState { EMPTY, SCHEDULED, SEND, SENT, ERROR };
+enum class TxCmdState { IDLE, SCHEDULED, SEND, SENT, FAILED };
 enum class RxFrameType { UNKNOWN, SHORT_DATA_FRAME, STD_DATA_FRAME, CMD_FRAME, NOK };
 enum class RxEvaluationResult { UNKNOWN, OK, NOK };
 #pragma endregion
@@ -193,7 +193,7 @@ class LD2410Sschedule {
   uint8_t restart_count_{0};
   uint8_t active_{0};
   uint8_t last_{0};
-  TxCmdState state_ = TxCmdState::EMPTY;
+  TxCmdState state_ = TxCmdState::IDLE;
   bool config_mode_{true};
 };
 

--- a/esphome/components/ld2410s/ld2410s.h
+++ b/esphome/components/ld2410s/ld2410s.h
@@ -1,0 +1,397 @@
+#pragma once
+
+#define LD2410S_V2
+
+// core
+#include "esphome/core/application.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+// components
+#include "esphome/components/uart/uart.h"
+
+#ifdef LD2410S_V2
+
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_BUTTON
+#include "esphome/components/button/button.h"
+#endif
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+#ifdef USE_SELECT
+#include "esphome/components/select/select.h"
+#endif
+
+#endif
+
+// std
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome::ld2410s {
+
+#pragma region ld2410s specific Constants
+
+// Constants
+static const char *const TAG = "ld2410s";
+
+static const uint16_t CMD_CONFIRMATION = 0x0100;  // Command confirmation response code
+
+static const uint8_t SHORT_DATA_FRAME_HEADER = 0x6E;
+static const uint8_t SHORT_DATA_FRAME_FOOTER = 0x62;
+static const uint32_t STD_DATA_FRAME_HEADER = 0xF1F2F3F4;
+static const uint32_t STD_DATA_FRAME_FOOTER = 0xF5F6F7F8;
+static const uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
+static const uint32_t CMD_FRAME_FOOTER = 0x01020304;
+
+static const uint16_t CONFIG_MODE_START_CMD = 0x00FF;
+static const uint16_t CONFIG_MODE_START_VALUE = 0x0001;
+static const uint16_t CONFIG_MODE_END_CMD = 0x00FE;
+
+static const uint16_t OUTPUT_MODE_SWITCH_CMD = 0x007A;
+static const uint8_t OUTPUT_MODE_VALUE_STD[] = {0x00, 0x00, 0x01, 0x00, 0x00, 0x00};
+static const uint8_t OUTPUT_MODE_VALUE_MIN[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+static const uint16_t CALIBRATION_CMD = 0x0009;
+static const uint16_t CALIBRATION_TRIGGER_VALUE = 0x0002;
+static const uint16_t CALIBRATION_RETENTION_VALUE = 0x0001;
+static const uint16_t CALIBRATION_TIME_VALUE = 0x0078;
+
+static const uint16_t CFG_FW_READ_CMD = 0x0000;
+
+static const uint16_t CFG_PARAMS_READ_CMD = 0x0071;
+static const uint16_t CFG_PARAMS_WRITE_CMD = 0x0070;
+static const uint16_t CFG_MAX_DETECTION_VALUE = 0x0005;
+static const uint16_t CFG_MIN_DETECTION_VALUE = 0x000A;
+static const uint16_t CFG_NO_DELAY_VALUE = 0x0006;
+static const uint16_t CFG_STATUS_FREQ_VALUE = 0x0002;
+static const uint16_t CFG_DISTANCE_FREQ_VALUE = 0x000C;
+static const uint16_t CFG_RESPONSE_SPEED_VALUE = 0x000B;
+static const std::string CFG_RESPONSE_SPEED_NORMAL = "Normal";
+static const std::string CFG_RESPONSE_SPEED_FAST = "Fast";
+
+static const uint16_t CFG_GATE_THRESHOLD_TRIGGER_READ_CMD = 0x0073;
+static const uint16_t CFG_GATE_THRESHOLD_TRIGGER_WRITE_CMD = 0x0072;
+static const uint32_t CFG_GATE_THRESHOLD_TRIGGER_WRITE_DATA[] = {
+    48, 42, 36, 34, 32, 31, 31, 31, 31,
+    31, 31, 31, 31, 31, 31, 31
+    // 10~95 dB
+};
+
+static const uint16_t CFG_GATE_THRESHOLD_HOLD_READ_CMD = 0x0077;
+static const uint16_t CFG_GATE_THRESHOLD_HOLD_WRITE_CMD = 0x0076;
+static const uint32_t CFG_GATE_THRESHOLD_HOLD_WRITE_DATA[] = {
+    45, 42, 33, 32, 28, 28, 28, 28, 28,
+    28, 28, 28, 28, 28, 28, 28
+    // 10~95 dB
+};
+
+static const uint16_t CFG_GATE_THRESHOLD_SNR_READ_CMD = 0x0075;
+static const uint16_t CFG_GATE_THRESHOLD_SNR_WRITE_CMD = 0x0074;
+static const uint32_t CFG_GATE_THRESHOLD_SNR_WRITE_DATA[] = {
+    51, 50, 30, 28, 25, 25, 25, 25, 25,
+    25, 25, 25, 25, 22, 22, 22
+    // 5~63 dB
+};
+
+// ToDo
+// static const uint16_t SN_READ_CMD = 0x0011;
+// static const uint16_t SN_WRITE_CMD = 0x0010;
+
+#pragma endregion
+
+#pragma region Constants
+static const uint16_t NO_SUB_CMD = 0xffff;
+static const uint16_t FRAME_DATA_LENGTH_SIZE = 2;
+
+static const size_t RX_TX_BUFFER_SIZE = 128;
+static const uint16_t RX_MAX_BYTES_PER_LOOP = 128;
+static const uint8_t TX_SCHEDULE_BUFFER_SIZE = 32;
+static const uint8_t TX_MAX_RESEND = 5;
+static const uint8_t TX_MAX_RESTART = 5;
+static const uint32_t TX_CONFIRMATION_TIMEOUT = 1000;  // timeout for waiting for cmd response
+static const uint32_t TX_PAUSE_TIMEOUT = 100;          // pause after receiving response
+#pragma endregion
+
+#pragma region enum
+enum class TxCmdState { EMPTY, SCHEDULED, SEND, SENT, ERROR };
+enum class RxFrameType { UNKNOWN, SHORT_DATA_FRAME, STD_DATA_FRAME, CMD_FRAME, NOK };
+enum class RxEvaluationResult { UNKNOWN, OK, NOK };
+#pragma endregion
+
+#pragma region struct
+struct TxTaskT {
+  uint16_t command;
+  uint16_t sub_command;
+};
+#pragma endregion
+
+class LD2410Srx {
+ public:
+  RxEvaluationResult receive_byte(uint32_t loop_count, uint8_t byte);
+
+  RxFrameType frame_type() const { return this->frame_type_; }
+  uint8_t *frame_data() { return this->rcv_buffer_; }
+  uint8_t frame_size() const { return this->end_pos_; }
+
+  uint8_t *payload_data() { return &this->rcv_buffer_[this->payload_pos_]; }
+  uint8_t payload_size() const { return this->payload_size_; }
+  bool payload_ready() const { return payload_ready_; }
+
+  void reset();
+
+ protected:
+  uint8_t rcv_buffer_[RX_TX_BUFFER_SIZE] = {};
+  uint16_t end_pos_{0};
+
+  uint16_t header_footer_size_{0};
+  uint16_t expected_frame_size_{0};
+  uint16_t size_field_size_{0};
+
+  uint16_t payload_pos_{0};
+  uint16_t payload_size_{0};
+  RxFrameType frame_type_{RxFrameType::UNKNOWN};
+  bool payload_ready_{false};
+
+  std::string msg_{""};
+
+  RxEvaluationResult evaluate_header_(uint16_t end_pos);
+  RxEvaluationResult evaluate_size_(uint16_t end_pos);
+  RxEvaluationResult evaluate_footer_(uint16_t end_pos);
+  static int read_int(const uint8_t *buffer, size_t pos, size_t len);
+};
+
+class LD2410Sschedule {
+ public:
+  void append(uint16_t command, uint16_t sub_command = NO_SUB_CMD);
+  TxCmdState check_state(uint32_t loop_count);
+  void confirm_ready_to_send();
+  void confirm_sent();
+  void verify_response(uint16_t command_word, uint32_t loop_count);
+  void reset_schedule();
+  uint16_t get_command();
+  uint16_t get_sub_command();
+
+ protected:
+  TxTaskT commands_[TX_SCHEDULE_BUFFER_SIZE] = {};
+  uint32_t time_started_{0};
+  uint8_t retry_count_{0};
+  uint8_t restart_count_{0};
+  uint8_t active_{0};
+  uint8_t last_{0};
+  TxCmdState state_ = TxCmdState::EMPTY;
+  bool config_mode_{true};
+};
+
+class LD2410S : public Component, public uart::UARTDevice {
+#ifdef LD2410S_V2
+#ifdef USE_SENSOR
+  SUB_SENSOR(distance)
+#endif
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(presence)
+#endif
+
+#ifdef USE_SENSOR
+  SUB_SENSOR(calibration_progress)
+#endif
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(calibration_runing)
+#endif
+#ifdef USE_TEXT_SENSOR
+  SUB_TEXT_SENSOR(fw_version)
+  SUB_TEXT_SENSOR(threshold_trigger)
+  SUB_TEXT_SENSOR(threshold_hold)
+  SUB_TEXT_SENSOR(threshold_snr)
+  SUB_TEXT_SENSOR(energy_values)
+#endif
+#ifdef USE_BUTTON
+  SUB_BUTTON(calibration)
+  SUB_BUTTON(factory_reset)
+#endif
+#ifdef USE_SWITCH
+  SUB_SWITCH(minimal_output)
+#endif
+#ifdef USE_SELECT
+  SUB_SELECT(response_speed)
+#endif
+#ifdef USE_NUMBER
+  SUB_NUMBER(max_distance)
+  SUB_NUMBER(min_distance)
+  SUB_NUMBER(no_delay)
+  SUB_NUMBER(status_reporting_freq)
+  SUB_NUMBER(distance_reporting_freq)
+  SUB_NUMBER(threshold_trigger)
+  SUB_NUMBER(threshold_hold)
+  SUB_NUMBER(threshold_snr)
+  SUB_NUMBER(threshold_selected_gate)
+#endif
+#endif
+
+ public:
+  void setup() override;
+  void loop() override;
+  float get_setup_priority() const override;
+
+#ifdef LD2410S_V2
+  void dump_config() override;
+
+  // button
+  void calibration();
+  void factory_reset();
+  // number
+  void set_delay(float delay);
+  void set_distance_reporting_freq(float distance_reporting_freq);
+  void set_max_distance(float max_distance);
+  void set_min_distance(float min_distance);
+  void set_status_reporting_freq(float status_reporting_freq);
+  void set_threshold_hold(float threshold_hold);
+  void set_threshold_selected_gate(float threshold_selected_gate);
+  void set_threshold_snr(float threshold_snr);
+  void set_threshold_trigger(float threshold_trigger);
+  // select
+  void set_response_speed_select(const std::string &response_speed_select);
+  // switch
+  void set_minimal_output(bool state);
+#endif
+
+ protected:
+  LD2410Sschedule tx_schedule_;
+  LD2410Srx rx_;
+
+  uint8_t tx_frame_[RX_TX_BUFFER_SIZE] = {};
+  uint16_t tx_frame_size_ = 0;
+
+  // settings_;
+  uint32_t thresholds_trigger_[16] = {};
+  uint32_t thresholds_hold_[16] = {};
+  uint32_t thresholds_snr_[16] = {};
+  uint32_t max_dist_{0};
+  uint32_t min_dist_{0};
+  uint32_t delay_{0};
+  uint32_t status_freq_{0};
+  uint32_t dist_freq_{0};
+  uint32_t resp_speed_{0};
+  uint8_t thresholds_selected_gate_{0};
+  bool pause_tx_{false};
+  bool minimal_output_{true};
+
+  uint32_t loop_count_{0};
+  bool init_done_{false};
+
+  uint32_t energy_values_[16] = {};
+  std::string energy_values_str_ = "";
+
+  void send_();
+  void build_cmd_frame_(uint16_t command, uint16_t sub_command = NO_SUB_CMD);
+  void sending_pause_();
+
+  bool receive_();
+  void parse_();
+  void parse_short_data_frame_();
+  void parse_data_frame_();
+  void parse_cmd_frame_();
+
+#ifdef LD2410S_V2
+  void init_();
+  void read_all_();
+  void read_all_thresholds_();
+
+  void parse_data_energy_values_read_(uint8_t *data);
+
+  void parse_ack_config_start_(const uint8_t *data);
+  void parse_ack_config_end_(const uint8_t *data);
+  void parse_ack_config_read_(uint8_t *data);
+  void parse_ack_fw_read_(const uint8_t *data);
+  void parse_ack_minimal_output_(uint8_t *data);
+  void parse_ack_threshold_trigger_read_(uint8_t *data);
+  void parse_ack_threshold_hold_read_(uint8_t *data);
+  void parse_ack_threshold_snr_read_(uint8_t *data);
+
+  void publish_distance_(uint16_t distance, bool force_publish = false);
+  void publish_presence_(bool presence, bool force_publish = false);
+  void publish_calibration_progress_(uint16_t calibration_progress, bool force_publish = false);
+  void publish_calibration_runing_(bool running, bool force_publish = false);
+  void publish_energy_values_(bool force_publish = false);
+  void publish_fw_version_(const std::string &version, bool force_publish = false);
+  void publish_threshold_trigger_(bool force_publish = false);
+  void publish_threshold_hold_(bool force_publish = false);
+  void publish_threshold_snr_(bool force_publish = false);
+
+  static std::string format_int(uint32_t *in, uint8_t len, uint8_t min_w);
+
+#endif
+
+  // append variable sized append_data to data, returns true if not overflow
+  template<typename T>
+  static bool append_seq_data(uint8_t *data, uint16_t &insert_position, const T *append_data,
+                              uint16_t append_array_size = 1, uint16_t actual_size = 0) {
+    size_t data_object_size = (actual_size == 0 ? sizeof(T) : actual_size);
+    auto bytes_to_copy = append_array_size * data_object_size;
+    if (insert_position + bytes_to_copy > RX_TX_BUFFER_SIZE) {
+      return false;
+    }
+
+    auto *write_ptr = &data[0] + insert_position;
+    memcpy(write_ptr, append_data, bytes_to_copy);
+
+    insert_position += bytes_to_copy;
+
+    return true;
+  }
+
+  // read variable sized uint from data and move read_position
+  template<typename T>
+  static bool read_seq_data(const uint8_t *data, uint16_t &read_position, T *out_data, uint16_t out_array_size = 1,
+                            uint16_t actual_size = 0) {
+    size_t data_object_size = (actual_size == 0 ? sizeof(T) : actual_size);
+    size_t bytes_to_read = out_array_size * data_object_size;
+
+    if (read_position + bytes_to_read > RX_TX_BUFFER_SIZE) {
+      return false;
+    }
+
+    const uint8_t *read_ptr = &data[0] + read_position;
+
+    memcpy(out_data, read_ptr, bytes_to_read);
+
+    read_position += bytes_to_read;
+    return true;
+  }
+
+  template<typename T>
+  static bool append_seq_data_value(uint8_t *data, uint16_t &insert_position, uint16_t identifier, const T *append_data,
+                                    uint16_t append_array_size = 1, uint16_t actual_size = 0) {
+    return append_seq_data(data, insert_position, &identifier) &&
+           append_seq_data(data, insert_position, append_data, append_array_size, actual_size);
+  }
+
+  static void append_gate_thresholds(uint8_t *data, uint16_t &insert_position, uint16_t sub_command,
+                                     const uint32_t *thresholds_array) {
+    if (sub_command != NO_SUB_CMD) {
+      append_seq_data(data, insert_position, &sub_command);
+      append_seq_data(data, insert_position, &thresholds_array[sub_command]);
+    } else {
+      for (uint16_t i = 0; i < 16; i++) {
+        append_seq_data(data, insert_position, &i, 1);
+        append_seq_data(data, insert_position, &thresholds_array[i]);
+      }
+    }
+  }
+};
+
+}  // namespace esphome::ld2410s

--- a/esphome/components/ld2410s/ld2410s.h
+++ b/esphome/components/ld2410s/ld2410s.h
@@ -383,6 +383,8 @@ class LD2410S : public Component, public uart::UARTDevice {
   static void append_gate_thresholds(uint8_t *data, uint16_t &insert_position, uint16_t sub_command,
                                      const uint32_t *thresholds_array) {
     if (sub_command != NO_SUB_CMD) {
+      if (sub_command >= 16)
+        return;
       append_seq_data(data, insert_position, &sub_command);
       append_seq_data(data, insert_position, &thresholds_array[sub_command]);
     } else {

--- a/esphome/components/ld2410s/ld2410s_v2.cpp
+++ b/esphome/components/ld2410s/ld2410s_v2.cpp
@@ -1,0 +1,387 @@
+#include "ld2410s.h"
+
+namespace esphome::ld2410s {
+
+#ifdef LD2410S_V2
+
+// PUBLIC
+
+void LD2410S::dump_config() {
+#ifdef USE_BUTTON
+  ESP_LOGCONFIG(TAG, "Buttons:");
+  LOG_BUTTON("  ", "Factory reset", this->factory_reset_button_);
+  LOG_BUTTON("  ", "Start calibration", this->calibration_button_);
+#endif
+
+#ifdef USE_SWITCH
+  ESP_LOGCONFIG(TAG, "Switches:");
+  LOG_SWITCH("  ", "Minimal Output", this->minimal_output_switch_);
+#endif
+
+  ESP_LOGCONFIG(TAG,
+                "Config Params Read: \n  max_dist:%d \n  min_dist:%d \n  delay:%d \n  status_freq:%d \n  dist_freq:%d "
+                "\n  resp_speed:%d",
+                this->max_dist_, this->min_dist_, this->delay_, this->status_freq_, this->dist_freq_,
+                this->resp_speed_);
+}
+
+void LD2410S::init_() {
+  ESP_LOGI(TAG, "init");
+  // App.feed_wdt();
+
+  this->init_done_ = false;
+
+  this->minimal_output_ = true;
+
+  this->read_all_();
+}
+void LD2410S::read_all_() {
+  this->tx_schedule_.append(OUTPUT_MODE_SWITCH_CMD);
+  this->tx_schedule_.append(CFG_FW_READ_CMD);
+  this->tx_schedule_.append(CFG_PARAMS_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_TRIGGER_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_HOLD_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_SNR_READ_CMD);
+}
+
+// button
+void LD2410S::calibration() { this->tx_schedule_.append(CALIBRATION_CMD); }
+void LD2410S::factory_reset() {
+  ESP_LOGI(TAG, "factory_reset");
+
+  this->max_dist_ = 16;
+  this->min_dist_ = 0;
+  this->delay_ = 10;
+  this->status_freq_ = 80;
+  this->dist_freq_ = 80;
+
+  this->minimal_output_ = true;
+
+  this->resp_speed_ = 5;
+
+  for (uint8_t i = 0; i < 16; i++) {
+    this->thresholds_trigger_[i] = CFG_GATE_THRESHOLD_TRIGGER_WRITE_DATA[i];
+    this->thresholds_hold_[i] = CFG_GATE_THRESHOLD_HOLD_WRITE_DATA[i];
+    this->thresholds_snr_[i] = CFG_GATE_THRESHOLD_SNR_WRITE_DATA[i];
+  }
+
+  this->tx_schedule_.append(OUTPUT_MODE_SWITCH_CMD);
+
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_TRIGGER_WRITE_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_HOLD_WRITE_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_SNR_WRITE_CMD);
+
+  this->tx_schedule_.append(CFG_PARAMS_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_TRIGGER_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_HOLD_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_SNR_READ_CMD);
+}
+// number
+void LD2410S::set_delay(float delay) {
+  this->delay_ = delay;
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD, CFG_NO_DELAY_VALUE);
+  this->no_delay_number_->publish_state(this->delay_);
+}
+void LD2410S::set_distance_reporting_freq(float distance_reporting_freq) {
+  this->dist_freq_ = distance_reporting_freq * 10;
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD, CFG_DISTANCE_FREQ_VALUE);
+  this->distance_reporting_freq_number_->publish_state(static_cast<float>(this->dist_freq_) / 10);
+}
+void LD2410S::set_max_distance(float max_distance) {
+  this->max_dist_ = static_cast<float>(max_distance) / 0.7f;
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD, CFG_MAX_DETECTION_VALUE);
+  this->max_distance_number_->publish_state(static_cast<float>(this->max_dist_) * 0.7);
+}
+void LD2410S::set_min_distance(float min_distance) {
+  this->min_dist_ = static_cast<float>(min_distance) / 0.7f;
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD, CFG_MIN_DETECTION_VALUE);
+  this->min_distance_number_->publish_state(static_cast<float>(this->min_dist_) * 0.7);
+}
+void LD2410S::set_status_reporting_freq(float status_reporting_freq) {
+  this->status_freq_ = status_reporting_freq * 10;
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD, CFG_STATUS_FREQ_VALUE);
+  this->status_reporting_freq_number_->publish_state(static_cast<float>(this->status_freq_) / 10);
+}
+void LD2410S::set_threshold_hold(float threshold_hold) {
+  this->thresholds_hold_[this->thresholds_selected_gate_] = threshold_hold;
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_HOLD_WRITE_CMD, this->thresholds_selected_gate_);
+  this->threshold_hold_number_->publish_state(this->thresholds_hold_[this->thresholds_selected_gate_]);
+  this->publish_threshold_hold_();
+}
+void LD2410S::set_threshold_selected_gate(float threshold_selected_gate) {
+  this->thresholds_selected_gate_ = threshold_selected_gate;
+#ifdef USE_NUMBER
+  this->threshold_selected_gate_number_->publish_state(this->thresholds_selected_gate_);
+  this->threshold_trigger_number_->publish_state(this->thresholds_trigger_[this->thresholds_selected_gate_]);
+  this->threshold_hold_number_->publish_state(this->thresholds_hold_[this->thresholds_selected_gate_]);
+  this->threshold_snr_number_->publish_state(this->thresholds_snr_[this->thresholds_selected_gate_]);
+#endif
+}
+void LD2410S::set_threshold_snr(float threshold_snr) {
+  this->thresholds_snr_[this->thresholds_selected_gate_] = threshold_snr;
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_SNR_WRITE_CMD, this->thresholds_selected_gate_);
+  this->threshold_snr_number_->publish_state(this->thresholds_snr_[this->thresholds_selected_gate_]);
+  this->publish_threshold_snr_();
+}
+void LD2410S::set_threshold_trigger(float threshold_trigger) {
+  this->thresholds_trigger_[this->thresholds_selected_gate_] = threshold_trigger;
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_TRIGGER_WRITE_CMD, this->thresholds_selected_gate_);
+  this->threshold_trigger_number_->publish_state(this->thresholds_trigger_[this->thresholds_selected_gate_]);
+  this->publish_threshold_trigger_();
+}
+// select
+void LD2410S::set_response_speed_select(const std::string &response_speed_select) {
+  this->resp_speed_ = response_speed_select == CFG_RESPONSE_SPEED_NORMAL ? 5 : 10;
+  this->tx_schedule_.append(CFG_PARAMS_WRITE_CMD, CFG_RESPONSE_SPEED_VALUE);
+#ifdef USE_SELECT
+  this->response_speed_select_->publish_state(this->resp_speed_ == 5 ? CFG_RESPONSE_SPEED_NORMAL
+                                                                     : CFG_RESPONSE_SPEED_FAST);
+#endif
+}
+// switch
+void LD2410S::set_minimal_output(bool state) {
+  this->minimal_output_ = state;
+  if (!state) {
+    for (auto &energy_value : this->energy_values_) {
+      energy_value = 0;
+    }
+  }
+  this->tx_schedule_.append(OUTPUT_MODE_SWITCH_CMD);
+}
+
+// PROTECTED
+void LD2410S::read_all_thresholds_() {
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_TRIGGER_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_HOLD_READ_CMD);
+  this->tx_schedule_.append(CFG_GATE_THRESHOLD_SNR_READ_CMD);
+}
+
+void LD2410S::parse_data_energy_values_read_(uint8_t *data) {
+  uint16_t read_position = 0;
+
+  for (uint32_t &energy_value : this->energy_values_) {
+    uint32_t val = 0;
+    read_seq_data(data, read_position, &val);
+
+    uint32_t db = 0;
+    if (val > 0) {
+      db = 10 * log10(val);
+    }
+    if (db > energy_value) {
+      energy_value = db;
+    }
+  }
+  this->publish_energy_values_();
+}
+
+void LD2410S::parse_ack_config_start_(const uint8_t *data) {
+  uint16_t read_position = 0;
+  uint16_t protocol_version = 0;
+  uint16_t buffer_size = 0;
+  read_seq_data(data, read_position, &protocol_version);  // does not exist it both documents
+  read_seq_data(data, read_position, &buffer_size);
+
+  ESP_LOGD(TAG, "CONFIG MODE ENABLED, protocol_version:%d  buffer_size:%d", protocol_version, buffer_size);
+}
+void LD2410S::parse_ack_config_end_(const uint8_t *data) { ESP_LOGD(TAG, "CONFIG MODE DISABLED"); }
+void LD2410S::parse_ack_minimal_output_(uint8_t *data) {
+  if (this->minimal_output_) {
+    ESP_LOGI(TAG, "Minimal Output Mode switched ON");
+  } else {
+    ESP_LOGI(TAG, "Minimal Output Mode switched OFF");
+  }
+#ifdef USE_SWITCH
+  this->minimal_output_switch_->publish_state(this->minimal_output_);
+#endif
+}
+void LD2410S::parse_ack_config_read_(uint8_t *data) {
+  uint16_t read_position = 0;
+  read_seq_data(data, read_position, &this->max_dist_);
+  read_seq_data(data, read_position, &this->min_dist_);
+  read_seq_data(data, read_position, &this->delay_);
+  read_seq_data(data, read_position, &this->status_freq_);
+  read_seq_data(data, read_position, &this->dist_freq_);
+  read_seq_data(data, read_position, &this->resp_speed_);
+
+#ifdef USE_NUMBER
+  this->max_distance_number_->publish_state(static_cast<float>(this->max_dist_) * 0.7);
+  this->min_distance_number_->publish_state(static_cast<float>(this->min_dist_) * 0.7);
+  this->no_delay_number_->publish_state(this->delay_);
+  this->status_reporting_freq_number_->publish_state(static_cast<float>(this->status_freq_) / 10);
+  this->distance_reporting_freq_number_->publish_state(static_cast<float>(this->dist_freq_) / 10);
+#endif
+#ifdef USE_SELECT
+  this->response_speed_select_->publish_state(this->resp_speed_ == 5 ? CFG_RESPONSE_SPEED_NORMAL
+                                                                     : CFG_RESPONSE_SPEED_FAST);
+#endif
+}
+void LD2410S::parse_ack_fw_read_(const uint8_t *data) {
+  uint16_t read_position = 0;
+  uint32_t equipment_type = 0;
+  uint16_t major_v = 0;
+  uint16_t minor_v = 0;
+  uint16_t patch_v = 0;
+  read_seq_data(data, read_position, &equipment_type);  // does not exist it both documents
+  read_seq_data(data, read_position, &major_v);
+  read_seq_data(data, read_position, &minor_v);
+  read_seq_data(data, read_position, &patch_v);
+  std::string version = "v" + std::to_string(major_v) + "." + std::to_string(minor_v) + "." + std::to_string(patch_v);
+
+  this->publish_fw_version_(version);
+}
+void LD2410S::parse_ack_threshold_trigger_read_(uint8_t *data) {
+  uint16_t read_position = 0;
+  read_seq_data(data, read_position, &this->thresholds_trigger_, 16, 4);
+
+#ifdef USE_NUMBER
+  this->threshold_trigger_number_->publish_state(this->thresholds_trigger_[this->thresholds_selected_gate_]);
+#endif
+
+  this->publish_threshold_trigger_();
+}
+void LD2410S::parse_ack_threshold_hold_read_(uint8_t *data) {
+  uint16_t read_position = 0;
+  read_seq_data(data, read_position, &this->thresholds_hold_, 16, 4);
+#ifdef USE_NUMBER
+  this->threshold_hold_number_->publish_state(this->thresholds_hold_[this->thresholds_selected_gate_]);
+#endif
+
+  this->publish_threshold_hold_();
+}
+void LD2410S::parse_ack_threshold_snr_read_(uint8_t *data) {
+  uint16_t read_position = 0;
+  read_seq_data(data, read_position, &this->thresholds_snr_, 16, 4);
+#ifdef USE_NUMBER
+  this->threshold_snr_number_->publish_state(this->thresholds_snr_[this->thresholds_selected_gate_]);
+#endif
+
+  this->publish_threshold_snr_();
+}
+
+void LD2410S::publish_distance_(uint16_t distance, bool force_publish) {
+#ifdef USE_SENSOR
+  if (this->distance_sensor_ != nullptr) {
+    if (this->distance_sensor_->state != distance || force_publish) {
+      this->distance_sensor_->publish_state(distance);
+    }
+  }
+#endif
+}
+void LD2410S::publish_presence_(bool presence, bool force_publish) {
+#ifdef USE_BINARY_SENSOR
+  if (this->presence_binary_sensor_ != nullptr) {
+    if (this->presence_binary_sensor_->state != presence || force_publish) {
+      this->presence_binary_sensor_->publish_state(presence);
+    }
+  }
+#endif
+}
+void LD2410S::publish_calibration_progress_(uint16_t calibration_progress, bool force_publish) {
+#ifdef USE_SENSOR
+  if (this->calibration_progress_sensor_ != nullptr) {
+    if (calibration_progress == 100) {
+      if (this->calibration_progress_sensor_->state != 0 || force_publish) {
+        this->calibration_progress_sensor_->publish_state(0);
+      }
+    } else {
+      if (this->calibration_progress_sensor_->state != calibration_progress || force_publish) {
+        this->calibration_progress_sensor_->publish_state(calibration_progress);
+      }
+    }
+  }
+#endif
+}
+void LD2410S::publish_calibration_runing_(bool running, bool force_publish) {
+#ifdef USE_BINARY_SENSOR
+  if (this->calibration_runing_binary_sensor_ != nullptr) {
+    if (this->calibration_runing_binary_sensor_->state != running || force_publish) {
+      this->calibration_runing_binary_sensor_->publish_state(running);
+    }
+  }
+#endif
+}
+void LD2410S::publish_fw_version_(const std::string &version, bool force_publish) {
+#ifdef USE_TEXT_SENSOR
+  if (this->fw_version_text_sensor_ != nullptr) {
+    if (this->fw_version_text_sensor_->state != version || force_publish) {
+      this->fw_version_text_sensor_->publish_state(version);
+    }
+  }
+#endif
+}
+void LD2410S::publish_threshold_trigger_(bool force_publish) {
+  std::string vals = format_int(this->thresholds_trigger_, 16, 2);
+
+#ifdef USE_TEXT_SENSOR
+  if (this->threshold_trigger_text_sensor_ != nullptr) {
+    if (this->threshold_trigger_text_sensor_->state != vals || force_publish) {
+      this->threshold_trigger_text_sensor_->publish_state(vals);
+    }
+  }
+#endif
+}
+void LD2410S::publish_threshold_hold_(bool force_publish) {
+  std::string vals = format_int(this->thresholds_hold_, 16, 2);
+
+#ifdef USE_TEXT_SENSOR
+  if (this->threshold_hold_text_sensor_ != nullptr) {
+    if (this->threshold_hold_text_sensor_->state != vals || force_publish) {
+      this->threshold_hold_text_sensor_->publish_state(vals);
+    }
+  }
+#endif
+}
+void LD2410S::publish_threshold_snr_(bool force_publish) {
+  std::string vals = format_int(this->thresholds_snr_, 16, 2);
+
+#ifdef USE_TEXT_SENSOR
+  if (this->threshold_snr_text_sensor_ != nullptr) {
+    if (this->threshold_snr_text_sensor_->state != vals || force_publish) {
+      this->threshold_snr_text_sensor_->publish_state(vals);
+    }
+  }
+#endif
+}
+void LD2410S::publish_energy_values_(bool force_publish) {
+  this->energy_values_str_ = format_int(this->energy_values_, 16, 2);
+
+#ifdef USE_TEXT_SENSOR
+  if (this->energy_values_text_sensor_ != nullptr) {
+    if (this->energy_values_text_sensor_->state != this->energy_values_str_ || force_publish) {
+      this->energy_values_text_sensor_->publish_state(this->energy_values_str_);
+    }
+  }
+#endif
+}
+
+std::string LD2410S::format_int(uint32_t *in, uint8_t len, uint8_t min_w) {
+  if (len == 0)
+    return "";
+
+  std::string result;
+  int sum = 0;
+  for (uint8_t i = 0; i < len; ++i) {
+    sum += in[i];
+
+    if (i > 0)
+      result += ',';
+
+    std::string num = std::to_string(in[i]);
+
+    if (num.length() < min_w)
+      result += std::string(min_w - num.length(), '0');
+
+    result += num;
+  }
+
+  if (sum == 0) {
+    result = "";
+  }
+
+  return result;
+}
+
+#endif
+
+}  // namespace esphome::ld2410s

--- a/esphome/components/ld2410s/ld2410s_v2.cpp
+++ b/esphome/components/ld2410s/ld2410s_v2.cpp
@@ -1,5 +1,8 @@
 #include "ld2410s.h"
 
+#include <cinttypes>
+#include <cstring>
+
 namespace esphome::ld2410s {
 
 #ifdef LD2410S_V2
@@ -226,7 +229,8 @@ void LD2410S::parse_ack_fw_read_(const uint8_t *data) {
   read_seq_data(data, read_position, &major_v);
   read_seq_data(data, read_position, &minor_v);
   read_seq_data(data, read_position, &patch_v);
-  std::string version = "v" + std::to_string(major_v) + "." + std::to_string(minor_v) + "." + std::to_string(patch_v);
+  char version[20];
+  snprintf(version, sizeof(version), "v%u.%u.%u", major_v, minor_v, patch_v);
 
   this->publish_fw_version_(version);
 }
@@ -367,10 +371,12 @@ std::string LD2410S::format_int(uint32_t *in, uint8_t len, uint8_t min_w) {
     if (i > 0)
       result += ',';
 
-    std::string num = std::to_string(in[i]);
+    char num[12];
+    snprintf(num, sizeof(num), "%" PRIu32, in[i]);
+    size_t num_len = strlen(num);
 
-    if (num.length() < min_w)
-      result += std::string(min_w - num.length(), '0');
+    if (num_len < min_w)
+      result += std::string(min_w - num_len, '0');
 
     result += num;
   }

--- a/esphome/components/ld2410s/ld2410s_v2.cpp
+++ b/esphome/components/ld2410s/ld2410s_v2.cpp
@@ -184,7 +184,7 @@ void LD2410S::parse_ack_config_start_(const uint8_t *data) {
   uint16_t read_position = 0;
   uint16_t protocol_version = 0;
   uint16_t buffer_size = 0;
-  read_seq_data(data, read_position, &protocol_version);  // does not exist it both documents
+  read_seq_data(data, read_position, &protocol_version);  // does not exist in both documents
   read_seq_data(data, read_position, &buffer_size);
 
   ESP_LOGD(TAG, "CONFIG MODE ENABLED, protocol_version:%d  buffer_size:%d", protocol_version, buffer_size);
@@ -227,7 +227,7 @@ void LD2410S::parse_ack_fw_read_(const uint8_t *data) {
   uint16_t major_v = 0;
   uint16_t minor_v = 0;
   uint16_t patch_v = 0;
-  read_seq_data(data, read_position, &equipment_type);  // does not exist it both documents
+  read_seq_data(data, read_position, &equipment_type);  // does not exist in both documents
   read_seq_data(data, read_position, &major_v);
   read_seq_data(data, read_position, &minor_v);
   read_seq_data(data, read_position, &patch_v);
@@ -298,11 +298,11 @@ void LD2410S::publish_calibration_progress_(uint16_t calibration_progress, bool 
   }
 #endif
 }
-void LD2410S::publish_calibration_runing_(bool running, bool force_publish) {
+void LD2410S::publish_calibration_running_(bool running, bool force_publish) {
 #ifdef USE_BINARY_SENSOR
-  if (this->calibration_runing_binary_sensor_ != nullptr) {
-    if (this->calibration_runing_binary_sensor_->state != running || force_publish) {
-      this->calibration_runing_binary_sensor_->publish_state(running);
+  if (this->calibration_running_binary_sensor_ != nullptr) {
+    if (this->calibration_running_binary_sensor_->state != running || force_publish) {
+      this->calibration_running_binary_sensor_->publish_state(running);
     }
   }
 #endif

--- a/esphome/components/ld2410s/ld2410s_v2.cpp
+++ b/esphome/components/ld2410s/ld2410s_v2.cpp
@@ -113,7 +113,9 @@ void LD2410S::set_threshold_hold(float threshold_hold) {
   this->publish_threshold_hold_();
 }
 void LD2410S::set_threshold_selected_gate(float threshold_selected_gate) {
-  this->thresholds_selected_gate_ = threshold_selected_gate;
+  if (threshold_selected_gate < 0 || threshold_selected_gate >= 16)
+    return;
+  this->thresholds_selected_gate_ = static_cast<uint8_t>(threshold_selected_gate);
 #ifdef USE_NUMBER
   this->threshold_selected_gate_number_->publish_state(this->thresholds_selected_gate_);
   this->threshold_trigger_number_->publish_state(this->thresholds_trigger_[this->thresholds_selected_gate_]);

--- a/esphome/components/ld2410s/number/__init__.py
+++ b/esphome/components/ld2410s/number/__init__.py
@@ -1,0 +1,171 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import (
+    DEVICE_CLASS_DISTANCE,
+    DEVICE_CLASS_DURATION,
+    DEVICE_CLASS_FREQUENCY,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_PULSE,
+    ICON_TIMELAPSE,
+    UNIT_DECIBEL,
+    UNIT_HERTZ,
+    UNIT_SECOND,
+)
+
+from .. import CONF_LD2410S_ID, LD2410S, ld2410s_ns
+
+LD2410SMaxDistanceNumber = ld2410s_ns.class_("LD2410SMaxDistanceNumber", number.Number)
+LD2410SMinDistanceNumber = ld2410s_ns.class_("LD2410SMinDistanceNumber", number.Number)
+LD2410SDelayNumber = ld2410s_ns.class_("LD2410SDelayNumber", number.Number)
+LD2410SStatusReportingFreqNumber = ld2410s_ns.class_(
+    "LD2410SStatusReportingFreqNumber", number.Number
+)
+LD2410SDistReportingFreqNumber = ld2410s_ns.class_(
+    "LD2410SDistReportingFreqNumber", number.Number
+)
+
+LD2410SThresholdTriggerNumber = ld2410s_ns.class_(
+    "LD2410SThresholdTriggerNumber", number.Number
+)
+LD2410SThresholdHoldNumber = ld2410s_ns.class_(
+    "LD2410SThresholdHoldNumber", number.Number
+)
+LD2410SThresholdSnrNumber = ld2410s_ns.class_(
+    "LD2410SThresholdSnrNumber", number.Number
+)
+LD2410SThresholdSelectedGateNumber = ld2410s_ns.class_(
+    "LD2410SThresholdSelectedGateNumber", number.Number
+)
+
+CONF_DISTANCE_REPORTING_FREQUENCY = "distance_reporting_frequency"
+CONF_MAX_DISTANCE = "max_distance"
+CONF_MIN_DISTANCE = "min_distance"
+CONF_NO_DELAY = "no_delay"
+CONF_STATUS_REPORTING_FREQUENCY = "status_reporting_frequency"
+CONF_THRESHOLD_TRIGGER = "threshold_trigger"
+CONF_THRESHOLD_HOLD = "threshold_hold"
+CONF_THRESHOLD_SNR = "threshold_snr"
+CONF_THRESHOLD_SELECTED_GATE = "threshold_selected_gate"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(CONF_MAX_DISTANCE): number.number_schema(
+        LD2410SMaxDistanceNumber,
+        device_class=DEVICE_CLASS_DISTANCE,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:arrow-collapse-right",
+    ),
+    cv.Optional(CONF_MIN_DISTANCE): number.number_schema(
+        LD2410SMinDistanceNumber,
+        device_class=DEVICE_CLASS_DISTANCE,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:arrow-collapse-left",
+    ),
+    cv.Optional(CONF_NO_DELAY): number.number_schema(
+        LD2410SDelayNumber,
+        device_class=DEVICE_CLASS_DURATION,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_SECOND,
+        icon=ICON_TIMELAPSE,
+    ),
+    cv.Optional(CONF_STATUS_REPORTING_FREQUENCY): number.number_schema(
+        LD2410SStatusReportingFreqNumber,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_HERTZ,
+        icon=ICON_PULSE,
+    ),
+    cv.Optional(CONF_DISTANCE_REPORTING_FREQUENCY): number.number_schema(
+        LD2410SDistReportingFreqNumber,
+        device_class=DEVICE_CLASS_FREQUENCY,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_HERTZ,
+        icon=ICON_PULSE,
+    ),
+    cv.Optional(CONF_THRESHOLD_TRIGGER): number.number_schema(
+        LD2410SThresholdTriggerNumber,
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_DECIBEL,
+        icon="mdi:pencil",
+    ),
+    cv.Optional(CONF_THRESHOLD_HOLD): number.number_schema(
+        LD2410SThresholdHoldNumber,
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_DECIBEL,
+        icon="mdi:pencil",
+    ),
+    cv.Optional(CONF_THRESHOLD_SNR): number.number_schema(
+        LD2410SThresholdSnrNumber,
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_DECIBEL,
+        icon="mdi:pencil",
+    ),
+    cv.Optional(CONF_THRESHOLD_SELECTED_GATE): number.number_schema(
+        LD2410SThresholdSelectedGateNumber,
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:tune-variant",
+    ),
+}
+
+
+async def to_code(config):
+    LD2410S_component = await cg.get_variable(config[CONF_LD2410S_ID])
+    if max_distance_config := config.get(CONF_MAX_DISTANCE):
+        n = await number.new_number(
+            max_distance_config, min_value=0.7, max_value=11.2, step=0.7
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_max_distance_number(n))
+    if min_distance_config := config.get(CONF_MIN_DISTANCE):
+        n = await number.new_number(
+            min_distance_config, min_value=0, max_value=11.2, step=0.7
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_min_distance_number(n))
+    if no_delay_config := config.get(CONF_NO_DELAY):
+        n = await number.new_number(no_delay_config, min_value=1, max_value=120, step=1)
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_no_delay_number(n))
+    if status_reporting_freq_config := config.get(CONF_STATUS_REPORTING_FREQUENCY):
+        n = await number.new_number(
+            status_reporting_freq_config, min_value=0.5, max_value=8, step=0.5
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_status_reporting_freq_number(n))
+    if distance_reporting_freq_config := config.get(CONF_DISTANCE_REPORTING_FREQUENCY):
+        n = await number.new_number(
+            distance_reporting_freq_config, min_value=0.5, max_value=8, step=0.5
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_distance_reporting_freq_number(n))
+
+    if threshold_trigger_config := config.get(CONF_THRESHOLD_TRIGGER):
+        n = await number.new_number(
+            threshold_trigger_config, min_value=10, max_value=95, step=1
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_threshold_trigger_number(n))
+    if threshold_hold_config := config.get(CONF_THRESHOLD_HOLD):
+        n = await number.new_number(
+            threshold_hold_config, min_value=10, max_value=95, step=1
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_threshold_hold_number(n))
+    if threshold_snr_config := config.get(CONF_THRESHOLD_SNR):
+        n = await number.new_number(
+            threshold_snr_config, min_value=5, max_value=63, step=1
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_threshold_snr_number(n))
+    if threshold_selected_gate_config := config.get(CONF_THRESHOLD_SELECTED_GATE):
+        n = await number.new_number(
+            threshold_selected_gate_config, min_value=0, max_value=15, step=1
+        )
+        await cg.register_parented(n, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_threshold_selected_gate_number(n))

--- a/esphome/components/ld2410s/number/ld2410s_delay_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_delay_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SDelayNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SDelayNumber() = default;
+
+ protected:
+  void control(float delay) override {
+#ifdef LD2410S_V2
+    this->parent_->set_delay(delay);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_distance_reporting_freq_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_distance_reporting_freq_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SDistReportingFreqNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SDistReportingFreqNumber() = default;
+
+ protected:
+  void control(float distance_reporting_freq) override {
+#ifdef LD2410S_V2
+    this->parent_->set_distance_reporting_freq(distance_reporting_freq);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_max_distance_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_max_distance_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SMaxDistanceNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SMaxDistanceNumber() = default;
+
+ protected:
+  void control(float max_distance) override {
+#ifdef LD2410S_V2
+    this->parent_->set_max_distance(max_distance);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_min_distance_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_min_distance_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SMinDistanceNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SMinDistanceNumber() = default;
+
+ protected:
+  void control(float min_distance) override {
+#ifdef LD2410S_V2
+    this->parent_->set_min_distance(min_distance);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_status_reporting_freq_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_status_reporting_freq_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SStatusReportingFreqNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SStatusReportingFreqNumber() = default;
+
+ protected:
+  void control(float status_reporting_freq) override {
+#ifdef LD2410S_V2
+    this->parent_->set_status_reporting_freq(status_reporting_freq);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_threshold_hold_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_threshold_hold_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SThresholdHoldNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SThresholdHoldNumber() = default;
+
+ protected:
+  void control(float threshold_hold) override {
+#ifdef LD2410S_V2
+    this->parent_->set_threshold_hold(threshold_hold);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_threshold_selected_gate_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_threshold_selected_gate_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SThresholdSelectedGateNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SThresholdSelectedGateNumber() = default;
+
+ protected:
+  void control(float threshold_selected_gate) override {
+#ifdef LD2410S_V2
+    this->parent_->set_threshold_selected_gate(threshold_selected_gate);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_threshold_snr_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_threshold_snr_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SThresholdSnrNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SThresholdSnrNumber() = default;
+
+ protected:
+  void control(float threshold_snr) override {
+#ifdef LD2410S_V2
+    this->parent_->set_threshold_snr(threshold_snr);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/number/ld2410s_threshold_trigger_number.h
+++ b/esphome/components/ld2410s/number/ld2410s_threshold_trigger_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SThresholdTriggerNumber : public number::Number, public Parented<LD2410S> {
+ public:
+  LD2410SThresholdTriggerNumber() = default;
+
+ protected:
+  void control(float threshold_trigger) override {
+#ifdef LD2410S_V2
+    this->parent_->set_threshold_trigger(threshold_trigger);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/select/__init__.py
+++ b/esphome/components/ld2410s/select/__init__.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
+
+from .. import CONF_LD2410S_ID, LD2410S, ld2410s_ns
+
+CONF_SELECTS = ["Normal", "Fast"]
+CONF_RESPONSE_SPEED = "response_speed"
+
+LD2410sResponseSpeedSelect = ld2410s_ns.class_(
+    "LD2410sResponseSpeedSelect", cg.Component
+)
+LD2410sExecCommandSelect = ld2410s_ns.class_("LD241s0ExecCommandSelect", cg.Component)
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(CONF_RESPONSE_SPEED): select.select_schema(
+        LD2410sResponseSpeedSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:speedometer",
+    ),
+}
+
+
+async def to_code(config):
+    LD2410S_component = await cg.get_variable(config[CONF_LD2410S_ID])
+    if response_speed_config := config.get(CONF_RESPONSE_SPEED):
+        sel = await select.new_select(
+            response_speed_config,
+            options=CONF_SELECTS,
+        )
+        await cg.register_parented(sel, config[CONF_LD2410S_ID])
+        cg.add(LD2410S_component.set_response_speed_select(sel))

--- a/esphome/components/ld2410s/select/__init__.py
+++ b/esphome/components/ld2410s/select/__init__.py
@@ -11,7 +11,7 @@ CONF_RESPONSE_SPEED = "response_speed"
 LD2410sResponseSpeedSelect = ld2410s_ns.class_(
     "LD2410sResponseSpeedSelect", cg.Component
 )
-LD2410sExecCommandSelect = ld2410s_ns.class_("LD241s0ExecCommandSelect", cg.Component)
+LD2410sExecCommandSelect = ld2410s_ns.class_("LD2410sExecCommandSelect", cg.Component)
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),

--- a/esphome/components/ld2410s/select/ld2410s_response_speed_select.h
+++ b/esphome/components/ld2410s/select/ld2410s_response_speed_select.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../ld2410s.h"
+#include "esphome/components/select/select.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410sResponseSpeedSelect : public Component, public select::Select, public Parented<LD2410S> {
+ public:
+  LD2410sResponseSpeedSelect() = default;
+
+ protected:
+  void control(const std::string &response_speed_select) override {
+#ifdef LD2410S_V2
+    this->parent_->set_response_speed_select(response_speed_select);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/sensor.py
+++ b/esphome/components/ld2410s/sensor.py
@@ -1,0 +1,32 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import DEVICE_CLASS_DISTANCE, UNIT_CENTIMETER, UNIT_PERCENT
+
+from . import CONF_LD2410S_ID, LD2410S
+
+CONF_CALIBRATION_PROGRESS = "calibration_progress"
+CONF_TARGET_DISTANCE = "target_distance"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(CONF_CALIBRATION_PROGRESS): sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        icon="mdi:percent",
+    ),
+    cv.Optional(CONF_TARGET_DISTANCE): sensor.sensor_schema(
+        device_class=DEVICE_CLASS_DISTANCE,
+        unit_of_measurement=UNIT_CENTIMETER,
+        icon="mdi:arrow-left-right",
+    ),
+}
+
+
+async def to_code(config):
+    ld2410s = await cg.get_variable(config[CONF_LD2410S_ID])
+    if calibration_progress_config := config.get(CONF_CALIBRATION_PROGRESS):
+        sens = await sensor.new_sensor(calibration_progress_config)
+        cg.add(ld2410s.set_calibration_progress_sensor(sens))
+    if target_distance_config := config.get(CONF_TARGET_DISTANCE):
+        sens = await sensor.new_sensor(target_distance_config)
+        cg.add(ld2410s.set_distance_sensor(sens))

--- a/esphome/components/ld2410s/switch/__init__.py
+++ b/esphome/components/ld2410s/switch/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import DEVICE_CLASS_SWITCH, ENTITY_CATEGORY_CONFIG
+
+from .. import CONF_LD2410S_ID, LD2410S, ld2410s_ns
+
+LD2410SMinimalOutputSwitch = ld2410s_ns.class_(
+    "LD2410SMinimalOutputSwitch", switch.Switch
+)
+
+CONF_MINIMAL_OUTPUT = "minimal_output"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(CONF_MINIMAL_OUTPUT): switch.switch_schema(
+        LD2410SMinimalOutputSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon="mdi:arrow-collapse-horizontal",
+    ),
+}
+
+
+async def to_code(config):
+    ld2410s_component = await cg.get_variable(config[CONF_LD2410S_ID])
+    if minimal_output_config := config.get(CONF_MINIMAL_OUTPUT):
+        s = await switch.new_switch(minimal_output_config)
+        await cg.register_parented(s, config[CONF_LD2410S_ID])
+        cg.add(ld2410s_component.set_minimal_output_switch(s))

--- a/esphome/components/ld2410s/switch/ld2410s_minimal_output_switch.h
+++ b/esphome/components/ld2410s/switch/ld2410s_minimal_output_switch.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "../ld2410s.h"
+
+namespace esphome {
+namespace ld2410s {
+
+class LD2410SMinimalOutputSwitch : public switch_::Switch, public Parented<LD2410S> {
+ public:
+  LD2410SMinimalOutputSwitch() = default;
+
+ protected:
+  void write_state(bool state) override {
+    this->publish_state(state);
+
+#ifdef LD2410S_V2
+    this->parent_->set_minimal_output(state);
+#endif
+  }
+};
+
+}  // namespace ld2410s
+}  // namespace esphome

--- a/esphome/components/ld2410s/text_sensor.py
+++ b/esphome/components/ld2410s/text_sensor.py
@@ -1,0 +1,60 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_CHIP
+
+from . import CONF_LD2410S_ID, LD2410S
+
+# , ld2410s_ns
+
+# LD2410STextSensor = ld2410s_ns.class_(
+#     "LD2410STextSensor", text_sensor.TextSensor, cg.Component
+# )
+
+CONF_ENERGY_VALUES = "energy_values"
+CONF_FW_VERSION = "fw_version"
+CONF_THRESHOLD_TRIGGERS = "threshold_triggers"
+CONF_THRESHOLD_HOLDS = "threshold_holds"
+CONF_THRESHOLD_SNRS = "threshold_snrs"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_LD2410S_ID): cv.use_id(LD2410S),
+    cv.Optional(CONF_FW_VERSION): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon=ICON_CHIP
+    ),
+    cv.Optional(CONF_THRESHOLD_TRIGGERS): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:tune-variant",
+    ),
+    cv.Optional(CONF_THRESHOLD_HOLDS): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:tune-variant",
+    ),
+    cv.Optional(CONF_THRESHOLD_SNRS): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:tune-variant",
+    ),
+    cv.Optional(CONF_ENERGY_VALUES): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon="mdi:lightning-bolt",
+    ),
+}
+
+
+async def to_code(config):
+    ld2410s = await cg.get_variable(config[CONF_LD2410S_ID])
+    if fw_version_config := config.get(CONF_FW_VERSION):
+        sens = await text_sensor.new_text_sensor(fw_version_config)
+        cg.add(ld2410s.set_fw_version_text_sensor(sens))
+    if threshold_trigger_config := config.get(CONF_THRESHOLD_TRIGGERS):
+        sens = await text_sensor.new_text_sensor(threshold_trigger_config)
+        cg.add(ld2410s.set_threshold_trigger_text_sensor(sens))
+    if threshold_hold_config := config.get(CONF_THRESHOLD_HOLDS):
+        sens = await text_sensor.new_text_sensor(threshold_hold_config)
+        cg.add(ld2410s.set_threshold_hold_text_sensor(sens))
+    if threshold_snr_config := config.get(CONF_THRESHOLD_SNRS):
+        sens = await text_sensor.new_text_sensor(threshold_snr_config)
+        cg.add(ld2410s.set_threshold_snr_text_sensor(sens))
+    if energy_values_config := config.get(CONF_ENERGY_VALUES):
+        sens = await text_sensor.new_text_sensor(energy_values_config)
+        cg.add(ld2410s.set_energy_values_text_sensor(sens))

--- a/tests/components/ld2410s/common.yaml
+++ b/tests/components/ld2410s/common.yaml
@@ -1,0 +1,76 @@
+uart:
+  id: uart_bus
+  tx_pin: ${uart_tx}
+  rx_pin: ${uart_rx}
+  baud_rate: 115200
+  parity: NONE
+  stop_bits: 1
+
+ld2410s:
+  uart_id: uart_bus
+
+sensor:
+  - platform: ld2410s
+    target_distance:
+      name: Target Distance
+    calibration_progress:
+      name: Calibration progress
+
+binary_sensor:
+  - platform: ld2410s
+    has_target:
+      name: Presence
+    has_calibration_running:
+      name: Calibration running
+
+text_sensor:
+  - platform: ld2410s
+    fw_version:
+      name: Firmware version
+    threshold_triggers:
+      name: Threshold Triggers
+    threshold_holds:
+      name: Threshold Holds
+    threshold_snrs:
+      name: Threshold SNRs
+    energy_values:
+      name: Energy Values
+
+number:
+  - platform: ld2410s
+    max_distance:
+      name: Max detect distance
+    min_distance:
+      name: Min detect distance
+    no_delay:
+      name: No detect report delay
+    status_reporting_frequency:
+      name: Status reporting frequency
+    distance_reporting_frequency:
+      name: Distance reporting frequency
+
+    threshold_trigger:
+      name: Threshold Trigger
+    threshold_hold:
+      name: Threshold Hold
+    threshold_snr:
+      name: Threshold SNR
+    threshold_selected_gate:
+      name: Threshold Selected Gate
+
+button:
+  - platform: ld2410s
+    calibration:
+      name: Start auto calibration
+    factory_reset:
+      name: Factory reset
+
+select:
+  - platform: ld2410s
+    response_speed:
+      name: Response speed
+
+switch:
+  - platform: ld2410s
+    minimal_output:
+      name: Minimal output

--- a/tests/components/ld2410s/test.esp32-ard.yaml
+++ b/tests/components/ld2410s/test.esp32-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  uart_tx: GPIO17
+  uart_rx: GPIO16
+
+<<: !include common.yaml

--- a/tests/components/ld2410s/test.esp32-c3-ard.yaml
+++ b/tests/components/ld2410s/test.esp32-c3-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  uart_tx: GPIO4
+  uart_rx: GPIO5
+
+<<: !include common.yaml

--- a/tests/components/ld2410s/test.esp32-c3-idf.yaml
+++ b/tests/components/ld2410s/test.esp32-c3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  uart_tx: GPIO4
+  uart_rx: GPIO5
+
+<<: !include common.yaml

--- a/tests/components/ld2410s/test.esp32-idf.yaml
+++ b/tests/components/ld2410s/test.esp32-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  uart_tx: GPIO17
+  uart_rx: GPIO16
+
+<<: !include common.yaml

--- a/tests/components/ld2410s/test.esp8266-ard.yaml
+++ b/tests/components/ld2410s/test.esp8266-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  uart_tx: GPIO4
+  uart_rx: GPIO5
+
+<<: !include common.yaml

--- a/tests/components/ld2410s/test.rp2040-ard.yaml
+++ b/tests/components/ld2410s/test.rp2040-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  uart_tx: GPIO4
+  uart_rx: GPIO5
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

This PR implements component for LR2410s radar sensor:
- ALL documented protocol options are implemented except s/n read/write
- command sending to sensor is qued and sent one per loop to avoid blocking
- receiving is limited to avoid blocking
- includes diagnostics needed to fine tune radar sensitivity
- includes safe defaults for gates threshold, hold and snr

This is full version with all bells and whistles is.
Under 1K stripped down version is here: https://github.com/esphome/esphome/pull/10452

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- https://github.com/esphome/esphome/pull/10452 Thiat is minimal version, without any controls, inteded to be below 1K lines.
- https://github.com/esphome/feature-requests/issues/2872
- https://github.com/MrUndead1996/ld2410s-esphome - Similar repository
- https://github.com/ProjectZed/ld2410s-esphome - Similar repository


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
- https://github.com/esphome/esphome-docs/pull/4798

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

This is working fine with esp32-idf-v5.4.0.
It works with arduino, esp32-idf-v5.4.2 and esp32-idf-v5.4.1 but it is recevinig random bytes. Still, it handles all that noise and works fine.

## Example entry for `config.yaml`:

```yaml

external_components:
  - source: github://pr#8486
    components: [ld2410s]
    refresh: 1h

uart:
  id: uart_bus
  tx_pin: ${uart_tx}
  rx_pin: ${uart_rx}
  baud_rate: 115200
  parity: NONE
  stop_bits: 1

ld2410s:
  uart_id: uart_bus

sensor:
  - platform: ld2410s
    target_distance:
      name: Target Distance
    calibration_progress:
      name: Calibration  progress

binary_sensor:
  - platform: ld2410s
    has_target:
      name: Presence
    has_calibration_running:
      name: Calibration running

text_sensor:
  - platform: ld2410s
    fw_version:
      name: Firmware version
    threshold_triggers:
      name: Threshold Triggers
    threshold_holds:
      name: Threshold Holds
    threshold_snrs:
      name: Threshold SNRs
    energy_values:
      name: Energy Values

number:
  - platform: ld2410s
    max_distance:
      name: Max detect distance
    min_distance:
      name: Min detect distance
    no_delay:
      name: No detect report delay
    status_reporting_frequency:
      name: Status reporting frequency
    distance_reporting_frequency:
      name: Distance reporting frequency

    threshold_trigger:
      name: Threshold Trigger
    threshold_hold:
      name: Threshold Hold
    threshold_snr:
      name: TThreshold SNR
    threshold_selected_gate:
      name: TrigThThresholdresholdger Selected Gate

button:
  - platform: ld2410s
    calibration:
      name: Start auto calibration
    factory_reset:
      name: Factory reset

select:
  - platform: ld2410s
    response_speed:
      name: Response speed

switch:
  - platform: ld2410s
    minimal_output:
      name: Minimal output

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in https://github.com/esphome/esphome-docs/pull/4798

Documentation is intended for final version v2 but may still need some adjustments after component is finalized.