### PR TITLE
Add support for nbits for RC6 IR remote.

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1385,6 +1385,46 @@ async def rc6_action(var, config, args):
     template_ = await cg.templatable(config[CONF_COMMAND], args, cg.uint8)
     cg.add(var.set_command(template_))
 
+# RC6Nbits
+RC6NbitsData, RC6NbitsBinarySensor, RC6NbitsTrigger, RC6NbitsAction, RC6NbitsDumper = declare_protocol("RC6Nbits")
+RC6NBITS_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_NBITS): cv.hex_uint8_t,
+        cv.Required(CONF_CODE): cv.hex_uint64_t,
+    }
+)
+
+
+@register_binary_sensor("rc6nbits", RC6NbitsBinarySensor, RC6NBITS_SCHEMA)
+def rc6Nbits_binary_sensor(var, config):
+    cg.add(
+        var.set_data(
+            cg.StructInitializer(
+                RC6NbitsData,
+                ("nbits", config[CONF_NBITS]),
+                ("code", config[CONF_CODE]),
+            )
+        )
+    )
+
+
+@register_trigger("rc6nbits", RC6NbitsTrigger, RC6NbitsData)
+def rc6Nbits_trigger(var, config):
+    pass
+
+
+@register_dumper("rc6nbits", RC6NbitsDumper)
+def rc6Nbits_dumper(var, config):
+    pass
+
+
+@register_action("rc6nbits", RC6NbitsAction, RC6NBITS_SCHEMA)
+async def rc6Nbits_action(var, config, args):
+    template_ = await cg.templatable(config[CONF_NBITS], args, cg.uint8)
+    cg.add(var.set_nbits(template_))
+    template_ = await cg.templatable(config[CONF_CODE], args, cg.uint64)
+    cg.add(var.set_code(template_))
+
 
 # RC Switch Raw
 RC_SWITCH_TIMING_SCHEMA = cv.All([cv.uint8_t], cv.Length(min=2, max=2))

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1385,8 +1385,11 @@ async def rc6_action(var, config, args):
     template_ = await cg.templatable(config[CONF_COMMAND], args, cg.uint8)
     cg.add(var.set_command(template_))
 
+
 # RC6Nbits
-RC6NbitsData, RC6NbitsBinarySensor, RC6NbitsTrigger, RC6NbitsAction, RC6NbitsDumper = declare_protocol("RC6Nbits")
+RC6NbitsData, RC6NbitsBinarySensor, RC6NbitsTrigger, RC6NbitsAction, RC6NbitsDumper = (
+    declare_protocol("RC6Nbits")
+)
 RC6NBITS_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_NBITS): cv.hex_uint8_t,

--- a/esphome/components/remote_base/rc6_protocol_nbits.cpp
+++ b/esphome/components/remote_base/rc6_protocol_nbits.cpp
@@ -1,0 +1,100 @@
+#include "rc6_protocol_nbits.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace remote_base {
+
+static const char *const RC6NBITS_TAG = "remote.rc6nbits";
+
+static const uint16_t RC6NBITS_FREQ = 36000;
+static const uint16_t RC6NBITS_UNIT = 444;
+static const uint16_t RC6NBITS_HEADER_MARK = (6 * RC6NBITS_UNIT);
+static const uint16_t RC6NBITS_HEADER_SPACE = (2 * RC6NBITS_UNIT);
+static const uint16_t RC6NBITS_MODE_MASK = 0x07;
+static const uint32_t RC6NBITS_FOOTER_SPACE = (187 * RC6NBITS_UNIT);
+
+void RC6NbitsProtocol::encode(RemoteTransmitData *dst, const RC6NbitsData &data) {
+  dst->reserve(4 + 2 * data.nbits);
+  dst->set_carrier_frequency(RC6NBITS_FREQ);
+
+  // Encode header
+  dst->item(RC6NBITS_HEADER_MARK, RC6NBITS_HEADER_SPACE);
+
+  // Encode startbit
+  dst->item(RC6NBITS_UNIT, RC6NBITS_UNIT);
+
+  int i = 1;
+  int32_t next = 0;
+
+  for (uint64_t mask = 1ULL << (data.nbits - 1) ; mask; i++, mask >>= 1) {
+      uint16_t bit_time = (i == 4) ? 2 * RC6NBITS_UNIT : RC6NBITS_UNIT; // traditionally, toggle bit
+      if (data.code & mask) {
+        dst->mark(bit_time);
+        dst->space(bit_time);
+      } else {
+        dst->space(bit_time);
+        dst->mark(bit_time);
+      }
+  }
+
+  dst->space(RC6NBITS_FOOTER_SPACE);
+
+}
+
+optional<RC6NbitsData> RC6NbitsProtocol::decode(RemoteReceiveData src) {
+  RC6NbitsData data{
+      .nbits = 0,
+      .code = 0,
+  };
+
+  // Check if header matches
+  if (!src.expect_item(RC6NBITS_HEADER_MARK, RC6NBITS_HEADER_SPACE)) {
+    return {};
+  }
+
+  // Check if the start bit matches. (Should be 1)
+  if (src.peek() < 0) {
+    return {};
+  }
+  src.advance();
+  if (src.peek_space(RC6NBITS_UNIT))
+    src.advance();
+
+  // Data
+  uint8_t bit{0};
+  uint8_t offset{0};
+  uint64_t buffer{0};
+
+  while (offset < 64) {
+    if (src.get_index() == src.size() -1)
+      break;
+    bit = src.peek() > 0;
+    buffer = (buffer << 1) | bit;
+    src.advance();
+    offset ++;
+
+    uint16_t bit_time = (offset == 4) ? RC6NBITS_UNIT * 2: RC6NBITS_UNIT;
+    uint16_t next_bit_time = (offset == 3) ? RC6NBITS_UNIT * 2: RC6NBITS_UNIT;
+
+    if (src.get_index() == src.size() - 1)
+      break;
+
+    if (src.peek_mark(bit_time) || src.peek_space(bit_time)) {
+      src.advance();
+    } else if (!src.peek_mark(bit_time + next_bit_time) && !src.peek_space(bit_time + next_bit_time)) {
+      return {};
+    }
+  }
+
+  data.code = buffer;
+  data.nbits = offset;
+
+  return data;
+}
+
+void RC6NbitsProtocol::dump(const RC6NbitsData &data) {
+  ESP_LOGI(RC6NBITS_TAG, "Received RC6Nbits: nbits=%d, code=0x%llX", data.nbits, data.code);
+}
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/rc6_protocol_nbits.cpp
+++ b/esphome/components/remote_base/rc6_protocol_nbits.cpp
@@ -26,19 +26,18 @@ void RC6NbitsProtocol::encode(RemoteTransmitData *dst, const RC6NbitsData &data)
   int i = 1;
   int32_t next = 0;
 
-  for (uint64_t mask = 1ULL << (data.nbits - 1) ; mask; i++, mask >>= 1) {
-      uint16_t bit_time = (i == 4) ? 2 * RC6NBITS_UNIT : RC6NBITS_UNIT; // traditionally, toggle bit
-      if (data.code & mask) {
-        dst->mark(bit_time);
-        dst->space(bit_time);
-      } else {
-        dst->space(bit_time);
-        dst->mark(bit_time);
-      }
+  for (uint64_t mask = 1ULL << (data.nbits - 1); mask; i++, mask >>= 1) {
+    uint16_t bit_time = (i == 4) ? 2 * RC6NBITS_UNIT : RC6NBITS_UNIT;  // traditionally, toggle bit
+    if (data.code & mask) {
+      dst->mark(bit_time);
+      dst->space(bit_time);
+    } else {
+      dst->space(bit_time);
+      dst->mark(bit_time);
+    }
   }
 
   dst->space(RC6NBITS_FOOTER_SPACE);
-
 }
 
 optional<RC6NbitsData> RC6NbitsProtocol::decode(RemoteReceiveData src) {
@@ -66,15 +65,15 @@ optional<RC6NbitsData> RC6NbitsProtocol::decode(RemoteReceiveData src) {
   uint64_t buffer{0};
 
   while (offset < 64) {
-    if (src.get_index() == src.size() -1)
+    if (src.get_index() == src.size() - 1)
       break;
     bit = src.peek() > 0;
     buffer = (buffer << 1) | bit;
     src.advance();
-    offset ++;
+    offset++;
 
-    uint16_t bit_time = (offset == 4) ? RC6NBITS_UNIT * 2: RC6NBITS_UNIT;
-    uint16_t next_bit_time = (offset == 3) ? RC6NBITS_UNIT * 2: RC6NBITS_UNIT;
+    uint16_t bit_time = (offset == 4) ? RC6NBITS_UNIT * 2 : RC6NBITS_UNIT;
+    uint16_t next_bit_time = (offset == 3) ? RC6NBITS_UNIT * 2 : RC6NBITS_UNIT;
 
     if (src.get_index() == src.size() - 1)
       break;

--- a/esphome/components/remote_base/rc6_protocol_nbits.h
+++ b/esphome/components/remote_base/rc6_protocol_nbits.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "remote_base.h"
+
+namespace esphome {
+namespace remote_base {
+
+struct RC6NbitsData {
+  uint8_t nbits;
+  uint64_t code;
+
+  bool operator==(const RC6NbitsData &rhs) const { return nbits == rhs.nbits && code == rhs.code; }
+};
+
+class RC6NbitsProtocol : public RemoteProtocol<RC6NbitsData> {
+ public:
+  void encode(RemoteTransmitData *dst, const RC6NbitsData &data) override;
+  optional<RC6NbitsData> decode(RemoteReceiveData src) override;
+  void dump(const RC6NbitsData &data) override;
+};
+
+DECLARE_REMOTE_PROTOCOL(RC6Nbits)
+
+template<typename... Ts> class RC6NbitsAction : public RemoteTransmitterActionBase<Ts...> {
+ public:
+  TEMPLATABLE_VALUE(uint8_t, nbits)
+  TEMPLATABLE_VALUE(uint32_t, code)
+
+  void encode(RemoteTransmitData *dst, Ts... x) {
+    RC6NbitsData data{};
+    data.nbits = this->nbits_.value(x...);
+    data.code = this->code_.value(x...);
+    RC6NbitsProtocol().encode(dst, data);
+  }
+
+};
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/rc6_protocol_nbits.h
+++ b/esphome/components/remote_base/rc6_protocol_nbits.h
@@ -32,7 +32,6 @@ template<typename... Ts> class RC6NbitsAction : public RemoteTransmitterActionBa
     data.code = this->code_.value(x...);
     RC6NbitsProtocol().encode(dst, data);
   }
-
 };
 
 }  // namespace remote_base


### PR DESCRIPTION
RC6 protocol has 2 common modes:

Mode 0 - it has 3 mode bits, 1 toggle bit, 8 address bits and 8 data bits. This mode is currently supported in esphome.
A.K.A. [RC_TYPE_RC6_0](https://www.kernel.org/doc/html/v4.10/media/kapi/rc-core.html#c.rc_type)

RC6 also has variants with variable data size - 24/32/36 bits being common cases. Many remote controls use these modes, since they support more data bits, and thereby more commands.

This change adds supports for these variants.

The legacy code is kept as is. I added the variant as new rc6nbits protocol.

# What does this implement/fix?

Adds support for other RC6 variants with variable data length.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7140

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  services:
    - service: send_ir
      variables:
        protocol: string
        code: string
        nbits: int
      then:
        - if:
            condition:
              lambda: 'return protocol == "RC6";'
            then:
              - logger.log: "Sending RC6 data...!"
              - remote_transmitter.transmit_rc6:
                  address: !lambda |-
                      uint64_t i;
                      sscanf( code.c_str(), "%llx", &i );
                      return (i >> 8) & 0xff;
                  command: !lambda |-
                      uint64_t i;
                      sscanf( code.c_str(), "%llx", &i );
                      return i & 0xff;
        - if:
            condition:
              lambda: 'return protocol == "RC6Nbits";'
            then:
              - logger.log: "Sending RC6Nbits data...!"
              - remote_transmitter.transmit_rc6nbits:
                  code: !lambda |-
                      uint64_t i;
                      sscanf( code.c_str(), "%llx", &i );
                      return i;
                  nbits: !lambda return nbits;

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
