### PR TITLE
[wizard] use lowercase to match

### DIFF
--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -411,7 +411,7 @@ def wizard(path):
     safe_print("Options:")
     for board_id, board_data in boards_list:
         safe_print(f" - {board_id} - {board_data['name']}")
-        boards.append(board_id)
+        boards.append(board_id.lower())
 
     while True:
         board = safe_input(color(AnsiFore.BOLD_WHITE, "(board): "))


### PR DESCRIPTION
# What does this implement/fix?

The board names can have mixed case, but they're being matched against a lowercase entry.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/1427

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
