### PR TITLE
esp32-cam: add psram dma config option explicitly

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -156,6 +156,7 @@ CONF_IDLE_FRAMERATE = "idle_framerate"
 # frame buffer
 CONF_FRAME_BUFFER_COUNT = "frame_buffer_count"
 CONF_FRAME_BUFFER_LOCATION = "frame_buffer_location"
+CONF_PSRAM_DMA = "psram_dma"
 
 # stream trigger
 CONF_ON_STREAM_START = "on_stream_start"
@@ -240,6 +241,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FRAME_BUFFER_LOCATION, default="PSRAM"): cv.enum(
                 ENUM_FB_LOCATION, upper=True
             ),
+            cv.Optional(CONF_PSRAM_DMA): cv.boolean,
             cv.Optional(CONF_ON_STREAM_START): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -340,6 +342,10 @@ async def to_code(config):
         cg.add(var.set_idle_update_interval(1000 / config[CONF_IDLE_FRAMERATE]))
     cg.add(var.set_frame_buffer_count(config[CONF_FRAME_BUFFER_COUNT]))
     cg.add(var.set_frame_buffer_location(config[CONF_FRAME_BUFFER_LOCATION]))
+    if CONF_PSRAM_DMA in config:
+        cg.add_build_flag(
+            f"-DCONFIG_CAMERA_PSRAM_DMA={'1' if config[CONF_PSRAM_DMA] else '0'}"
+        )
     cg.add(var.set_frame_size(config[CONF_RESOLUTION]))
 
     cg.add_define("USE_CAMERA")


### PR DESCRIPTION
# What does this implement/fix?

The esp32-camera library supported psram dma copy operations for a while now, but this was implicitly activated if the external_clock -> frequency was set to 16 MHz on ESP32-S2/S3.

Since this could lead to unintended activation of this experimental feature, [I've added a build flag](https://github.com/espressif/esp32-camera/pull/774) to activate/deactivate this feature.

This PR adds a setting to ESPHome to explicitly activate or deactivate it.

Note that the userbase of this feature is probably 0, as this feature is currently broken for the JPEG format, as I noted [here](https://github.com/espressif/esp32-camera/issues/775).

With the current esp32-camera version, setting this won't have any effect. However, as soon as a version post 2.1.0 is released, this setting will be start working.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5152

## Example entry for `config.yaml`:

```yaml
esp32_camera:
  name: My Camera
  external_clock:
    pin: GPIOXX
    frequency: 16MHz
  i2c_id: my_i2c_bus
  data_pins: [GPIOXX, GPIOXX, GPIOXX, GPIOXX, GPIOXX, GPIOXX, GPIOXX, GPIOXX]
  vsync_pin: GPIOXX
  href_pin: GPIOXX
  pixel_clock_pin: GPIOXX
  reset_pin: GPIOXX
  resolution: 640x480
  jpeg_quality: 10
  psram_dma: true
```
