### PR TITLE
[psram] allow disabling

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -16,6 +16,7 @@ from esphome.components.esp32.const import (
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ADVANCED,
+    CONF_DISABLED,
     CONF_FRAMEWORK,
     CONF_ID,
     CONF_MODE,
@@ -102,6 +103,7 @@ def get_config_schema(config):
             cv.Optional(CONF_MODE, default=modes[0]): cv.one_of(*modes, lower=True),
             cv.Optional(CONF_ENABLE_ECC, default=False): cv.boolean,
             cv.Optional(CONF_SPEED, default=speeds[0]): cv.one_of(*speeds, upper=True),
+            cv.Optional(CONF_DISABLED, default=False): cv.boolean,
         }
     )(config)
 
@@ -112,6 +114,8 @@ FINAL_VALIDATE_SCHEMA = validate_psram_mode
 
 
 async def to_code(config):
+    if config[CONF_DISABLED]:
+        return
     if CORE.using_arduino:
         cg.add_build_flag("-DBOARD_HAS_PSRAM")
         if config[CONF_MODE] == TYPE_OCTAL:


### PR DESCRIPTION
# What does this implement/fix?

Some components autoload `psram`.  Normally this is fine, as it will just fail during boot with no consequences.  However, on the original ESP32, one of the psram pins can also be used for the ethernet clock and the psram initialization allocates that pin, so ethernet fails.  This allows the autoloaded psram component to be disabled.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5239

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
psram:
  disabled: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
