### PR TITLE
[esp32] Accept more framework URL schemes as sources

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -304,6 +304,17 @@ def _format_framework_espidf_version(ver: cv.Version, release: str) -> str:
     return f"pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v{str(ver)}/esp-idf-v{str(ver)}.zip"
 
 
+def _is_framework_url(source: str) -> str:
+    # platformio accepts many URL schemes for framework repositories and archives including http, https, git, file, and symlink
+    import urllib.parse
+
+    try:
+        parsed = urllib.parse.urlparse(source)
+    except ValueError:
+        return False
+    return bool(parsed.scheme)
+
+
 # NOTE: Keep this in mind when updating the recommended version:
 #  * New framework historically have had some regressions, especially for WiFi.
 #    The new version needs to be thoroughly validated before changing the
@@ -386,7 +397,7 @@ def _check_versions(value):
         value[CONF_SOURCE] = value.get(
             CONF_SOURCE, _format_framework_arduino_version(version)
         )
-        if value[CONF_SOURCE].startswith("http"):
+        if _is_framework_url(value[CONF_SOURCE]):
             value[CONF_SOURCE] = (
                 f"pioarduino/framework-arduinoespressif32@{value[CONF_SOURCE]}"
             )
@@ -399,7 +410,7 @@ def _check_versions(value):
             CONF_SOURCE,
             _format_framework_espidf_version(version, value.get(CONF_RELEASE, None)),
         )
-        if value[CONF_SOURCE].startswith("http"):
+        if _is_framework_url(value[CONF_SOURCE]):
             value[CONF_SOURCE] = f"pioarduino/framework-espidf@{value[CONF_SOURCE]}"
 
     if CONF_PLATFORM_VERSION not in value:


### PR DESCRIPTION
# What does this implement/fix?

Make it easier to specify non-http sources for framework URLs by automatically prepending the packageio package name onto them just like for http.  Package IO supports numerous schemes as documented here: https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html#repository-git-hg-svn

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5460

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    version: 5.4.2
    source: symlink:///Users/jeff/code/esp-idf
    platform_version: 54.03.21-2
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
