### PR TITLE
[light] Eliminate dimming undershoot during addressable light transition

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -61,6 +61,10 @@ void AddressableLightTransformer::start() {
   this->target_color_ *= to_uint8_scale(end_values.get_brightness() * end_values.get_state());
 }
 
+inline constexpr uint8_t subtract_scaled_difference(uint8_t a, uint8_t b, int32_t scale) {
+  return uint8_t(int32_t(a) - (((int32_t(a) - int32_t(b)) * scale) / 256));
+}
+
 optional<LightColorValues> AddressableLightTransformer::apply() {
   float smoothed_progress = LightTransformer::smoothed_progress(this->get_progress_());
 
@@ -74,37 +78,36 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
   // all LEDs, we use the current state of each LED as the start.
 
   // We can't use a direct lerp smoothing here though - that would require creating a copy of the original
-  // state of each LED at the start of the transition.
-  // Instead, we "fake" the look of the LERP by using an exponential average over time and using
-  // dynamically-calculated alpha values to match the look.
+  // state of each LED at the start of the transition. Instead, we "fake" the look of lerp by calculating
+  // the delta between the current state and the target state, assuming that the delta represents the rest
+  // of the transition that was to be applied as of the previous transition step, and scaling the delta for
+  // what should be left after the current transition step. In this manner, the delta decays to zero as the
+  // transition progresses.
+  //
+  // Here's an example of how the algorithm progresses in discrete steps:
+  //
+  // At time = 0.00, 0% complete, 100% remaining, 100% will remain after this step, so the scale is 100% / 100% = 100%.
+  // At time = 0.10, 0% complete, 100% remaining, 90% will remain after this step, so the scale is 90% / 100% = 90%.
+  // At time = 0.20, 10% complete, 90% remaining, 80% will remain after this step, so the scale is 80% / 90% = 88.9%.
+  // At time = 0.50, 20% complete, 80% remaining, 50% will remain after this step, so the scale is 50% / 80% = 62.5%.
+  // At time = 0.90, 50% complete, 50% remaining, 10% will remain after this step, so the scale is 10% / 50% = 20%.
+  // At time = 0.91, 90% complete, 10% remaining, 9% will remain after this step, so the scale is 9% / 10% = 90%.
+  // At time = 1.00, 91% complete, 9% remaining, 0% will remain after this step, so the scale is 0% / 9% = 0%.
+  //
+  // Because the color values are quantized to 8 bit resolution after each step, the transition may appear
+  // non-linear when applying small deltas.
 
-  float denom = (1.0f - smoothed_progress);
-  float alpha = denom == 0.0f ? 1.0f : (smoothed_progress - this->last_transition_progress_) / denom;
-
-  // We need to use a low-resolution alpha here which makes the transition set in only after ~half of the length
-  // We solve this by accumulating the fractional part of the alpha over time.
-  float alpha255 = alpha * 255.0f;
-  float alpha255int = floorf(alpha255);
-  float alpha255remainder = alpha255 - alpha255int;
-
-  this->accumulated_alpha_ += alpha255remainder;
-  float alpha_add = floorf(this->accumulated_alpha_);
-  this->accumulated_alpha_ -= alpha_add;
-
-  alpha255 += alpha_add;
-  alpha255 = clamp(alpha255, 0.0f, 255.0f);
-  auto alpha8 = static_cast<uint8_t>(alpha255);
-
-  if (alpha8 != 0) {
-    uint8_t inv_alpha8 = 255 - alpha8;
-    Color add = this->target_color_ * alpha8;
-
-    for (auto led : this->light_)
-      led.set(add + led.get() * inv_alpha8);
+  if (smoothed_progress > this->last_transition_progress_ && this->last_transition_progress_ < 1.f) {
+    int32_t scale = int32_t(256.f * std::max((1.f - smoothed_progress) / (1.f - this->last_transition_progress_), 0.f));
+    for (auto led : this->light_) {
+      led.set_rgbw(subtract_scaled_difference(this->target_color_.red, led.get_red(), scale),
+                   subtract_scaled_difference(this->target_color_.green, led.get_green(), scale),
+                   subtract_scaled_difference(this->target_color_.blue, led.get_blue(), scale),
+                   subtract_scaled_difference(this->target_color_.white, led.get_white(), scale));
+    }
+    this->last_transition_progress_ = smoothed_progress;
+    this->light_.schedule_show();
   }
-
-  this->last_transition_progress_ = smoothed_progress;
-  this->light_.schedule_show();
 
   return {};
 }

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -113,7 +113,6 @@ class AddressableLightTransformer : public LightTransformer {
  protected:
   AddressableLight &light_;
   float last_transition_progress_{0.0f};
-  float accumulated_alpha_{0.0f};
   Color target_color_{};
 };
 


### PR DESCRIPTION
Note: Reuploaded cherry-pick of #11155 

# What does this implement/fix?

The existing algorithm for interpolating addressable light transitions often causes a noticeable dip in brightness even when transition between equal color values.  That's because it sums two scaled color values each of which has been truncated down to 8 bits so the result is often less than the expected sum.  Errors accumulate in ways that are not accounted for by the alpha remainder accumulator.

The new algorithm is simpler.  On each step, it calculates the ratio of progress remaining to the progress completed and scales the remaining delta accordingly.  This method provides a more accurate approximation of a linear transition and the remaining delta monotonically decays down to zero so the transition lands on target.

The results are markedly smoother and have fewer visual artifacts.

(Note that there is still some inaccuracy due to the round-trip gamma uncorrection and correction applied to each stored value and the use of an 8-bit gamma table.)

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  platform: esp32_rmt_led_strip
  # etc...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
