### PR TITLE
[mitsubishi] Control both vanes on multi-vane Mitsubishi minisplit heads

### DIFF
--- a/esphome/components/mitsubishi/climate.py
+++ b/esphome/components/mitsubishi/climate.py
@@ -43,6 +43,8 @@ VERTICAL_DIRECTIONS = {
     "down": VerticalDirections.VERTICAL_DIRECTION_DOWN,
 }
 
+CONF_VERTICAL_VANES = "vertical_vanes"
+
 
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).extend(
     {
@@ -55,6 +57,7 @@ CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).ex
         cv.Optional(CONF_VERTICAL_DEFAULT, default="middle"): cv.enum(
             VERTICAL_DIRECTIONS
         ),
+        cv.Optional(CONF_VERTICAL_VANES, default=1): cv.int_range(1, 2),
     }
 )
 
@@ -67,3 +70,4 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_supports_fan_only(config[CONF_SUPPORTS_FAN_ONLY]))
     cg.add(var.set_horizontal_default(config[CONF_HORIZONTAL_DEFAULT]))
     cg.add(var.set_vertical_default(config[CONF_VERTICAL_DEFAULT]))
+    cg.add(var.set_vertical_vanes(config[CONF_VERTICAL_VANES]))

--- a/esphome/components/mitsubishi/climate.py
+++ b/esphome/components/mitsubishi/climate.py
@@ -42,6 +42,8 @@ VERTICAL_DIRECTIONS = {
     "down": VerticalDirections.VERTICAL_DIRECTION_DOWN,
 }
 
+CONF_VERTICAL_VANES = "vertical_vanes"
+
 
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).extend(
     {
@@ -54,6 +56,7 @@ CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).ex
         cv.Optional(CONF_VERTICAL_DEFAULT, default="middle"): cv.enum(
             VERTICAL_DIRECTIONS
         ),
+        cv.Optional(CONF_VERTICAL_VANES, default=1): cv.int_range(1, 2),
     }
 )
 
@@ -66,3 +69,4 @@ async def to_code(config):
     cg.add(var.set_supports_fan_only(config[CONF_SUPPORTS_FAN_ONLY]))
     cg.add(var.set_horizontal_default(config[CONF_HORIZONTAL_DEFAULT]))
     cg.add(var.set_vertical_default(config[CONF_VERTICAL_DEFAULT]))
+    cg.add(var.set_vertical_vanes(config[CONF_VERTICAL_VANES]))

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -51,7 +51,6 @@ const uint8_t MITSUBISHI_BYTE02 = 0x26;
 const uint8_t MITSUBISHI_BYTE03 = 0x01;
 const uint8_t MITSUBISHI_BYTE04 = 0x00;
 const uint8_t MITSUBISHI_BYTE13 = 0x00;
-const uint8_t MITSUBISHI_BYTE16 = 0x00;
 
 climate::ClimateTraits MitsubishiClimate::traits() {
   auto traits = climate::ClimateTraits();
@@ -112,7 +111,7 @@ void MitsubishiClimate::transmit_state() {
   // Byte 13: Constant 0x00
   // Byte 14: HVAC specfic, i.e. ECONO COOL, CLEAN MODE, always 0x00
   // Byte 15: HVAC specfic, i.e. POWERFUL, SMART SET, PLASMA, always 0x00
-  // Byte 16: Constant 0x00
+  // Byte 16: Left vane control (for specific models). Constants match right vane controls.
   // Byte 17: Checksum: SUM[Byte0...Byte16]
   uint8_t remote_state[18] = {0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00,
                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -216,15 +215,22 @@ void MitsubishiClimate::transmit_state() {
     case climate::CLIMATE_SWING_VERTICAL:
     case climate::CLIMATE_SWING_BOTH:
       remote_state[9] = remote_state[9] | MITSUBISHI_VERTICAL_VANE_SWING | MITSUBISHI_OTHERWISE;  // Vane Swing
+      if (this->vertical_vanes_ > 1) {
+        remote_state[16] = remote_state[16] | MITSUBISHI_VERTICAL_VANE_SWING;
+      }
       break;
     case climate::CLIMATE_SWING_OFF:
     default:
       remote_state[9] = remote_state[9] | this->default_vertical_direction_ |
                         MITSUBISHI_OTHERWISE;  // Off--> vertical default position
+      if (this->vertical_vanes_ > 1) {
+        remote_state[16] = remote_state[16] | this->default_vertical_direction_;
+      }
       break;
   }
 
   ESP_LOGD(TAG, "default_vertical_direction_: %02X", this->default_vertical_direction_);
+  ESP_LOGD(TAG, "vertical_vanes_: %" PRIu8, this->vertical_vanes_);
 
   // Special modes
   switch (this->preset.value_or(climate::CLIMATE_PRESET_NONE)) {
@@ -309,9 +315,8 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
     // Check Header && Footer
     if ((pos == 0 && byte != MITSUBISHI_BYTE00) || (pos == 1 && byte != MITSUBISHI_BYTE01) ||
         (pos == 2 && byte != MITSUBISHI_BYTE02) || (pos == 3 && byte != MITSUBISHI_BYTE03) ||
-        (pos == 4 && byte != MITSUBISHI_BYTE04) || (pos == 13 && byte != MITSUBISHI_BYTE13) ||
-        (pos == 16 && byte != MITSUBISHI_BYTE16)) {
-      ESP_LOGV(TAG, "Bytes 0,1,2,3,4,13 or 16 fail - invalid value");
+        (pos == 4 && byte != MITSUBISHI_BYTE04) || (pos == 13 && byte != MITSUBISHI_BYTE13)) {
+      ESP_LOGV(TAG, "Bytes 0,1,2,3,4, or 13 fail - invalid value");
       return false;
     }
   }
@@ -372,6 +377,8 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Vertical Vane
+  // On dual vane heads, the left vane is in [16] and right vane is in [9]. Left is ignored here because
+  // the swing_mode enum doesn't convey that level of detail.
   uint8_t vertical_vane = state_frame[9] & 0x38;  // Bits 3,4,5
   switch (vertical_vane) {
     case MITSUBISHI_VERTICAL_VANE_SWING:

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -109,7 +109,7 @@ void MitsubishiClimate::transmit_state() {
   // Byte 13: Constant 0x00
   // Byte 14: HVAC specfic, i.e. ECONO COOL, CLEAN MODE, always 0x00
   // Byte 15: HVAC specfic, i.e. POWERFUL, SMART SET, PLASMA, always 0x00
-  // Byte 16: Constant 0x00
+  // Byte 16: Left vane control (for specific models). Constants match right vane controls.
   // Byte 17: Checksum: SUM[Byte0...Byte16]
   uint8_t remote_state[18] = {0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00,
                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -212,15 +212,22 @@ void MitsubishiClimate::transmit_state() {
     case climate::CLIMATE_SWING_VERTICAL:
     case climate::CLIMATE_SWING_BOTH:
       remote_state[9] = remote_state[9] | MITSUBISHI_VERTICAL_VANE_SWING | MITSUBISHI_OTHERWISE;  // Vane Swing
+      if (this->vertical_vanes_ > 1) {
+        remote_state[16] = remote_state[16] | MITSUBISHI_VERTICAL_VANE_SWING;
+      }
       break;
     case climate::CLIMATE_SWING_OFF:
     default:
       remote_state[9] = remote_state[9] | this->default_vertical_direction_ |
                         MITSUBISHI_OTHERWISE;  // Off--> vertical default position
+      if (this->vertical_vanes_ > 1) {
+        remote_state[16] = remote_state[16] | this->default_vertical_direction_;
+      }
       break;
   }
 
   ESP_LOGD(TAG, "default_vertical_direction_: %02X", this->default_vertical_direction_);
+  ESP_LOGD(TAG, "vertical_vanes_: %d", this->vertical_vanes_);
 
   // Special modes
   switch (this->preset.value()) {
@@ -305,9 +312,8 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
     // Check Header && Footer
     if ((pos == 0 && byte != MITSUBISHI_BYTE00) || (pos == 1 && byte != MITSUBISHI_BYTE01) ||
         (pos == 2 && byte != MITSUBISHI_BYTE02) || (pos == 3 && byte != MITSUBISHI_BYTE03) ||
-        (pos == 4 && byte != MITSUBISHI_BYTE04) || (pos == 13 && byte != MITSUBISHI_BYTE13) ||
-        (pos == 16 && byte != MITSUBISHI_BYTE16)) {
-      ESP_LOGV(TAG, "Bytes 0,1,2,3,4,13 or 16 fail - invalid value");
+        (pos == 4 && byte != MITSUBISHI_BYTE04) || (pos == 13 && byte != MITSUBISHI_BYTE13)) {
+      ESP_LOGV(TAG, "Bytes 0,1,2,3,4, or 13 fail - invalid value");
       return false;
     }
   }
@@ -368,6 +374,8 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Vertical Vane
+  // On dual vane heads, the left vane is in [16] and right vane is in [9]. Left is ignored here because
+  // the swing_mode enum doesn't convey that level of detail.
   uint8_t vertical_vane = state_frame[9] & 0x38;  // Bits 3,4,5
   switch (vertical_vane) {
     case MITSUBISHI_VERTICAL_VANE_SWING:

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -62,6 +62,7 @@ class MitsubishiClimate final : public climate_ir::ClimateIR {
   void set_vertical_default(VerticalDirection vertical_direction) {
     this->default_vertical_direction_ = vertical_direction;
   }
+  void set_vertical_vanes(uint8_t vertical_vanes) { this->vertical_vanes_ = vertical_vanes; }
 
  protected:
   // Transmit via IR the state of this climate controller.
@@ -74,6 +75,7 @@ class MitsubishiClimate final : public climate_ir::ClimateIR {
 
   HorizontalDirection default_horizontal_direction_;
   VerticalDirection default_vertical_direction_;
+  uint8_t vertical_vanes_{1};
 
   climate::ClimateTraits traits() override;
 };

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -63,6 +63,7 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
   void set_vertical_default(VerticalDirection vertical_direction) {
     this->default_vertical_direction_ = vertical_direction;
   }
+  void set_vertical_vanes(int vertical_vanes) { this->vertical_vanes_ = vertical_vanes; }
 
  protected:
   // Transmit via IR the state of this climate controller.
@@ -75,6 +76,7 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
 
   HorizontalDirection default_horizontal_direction_;
   VerticalDirection default_vertical_direction_;
+  int vertical_vanes_;
 
   climate::ClimateTraits traits() override;
 };

--- a/tests/components/mitsubishi/common.yaml
+++ b/tests/components/mitsubishi/common.yaml
@@ -2,3 +2,4 @@ climate:
   - platform: mitsubishi
     name: Mitsubishi
     transmitter_id: xmitr
+    vertical_vanes: 1


### PR DESCRIPTION
# What does this implement/fix?

On Mitsubishi minisplit heads with two separate vertical vanes, the present implementation only sends commands to control the right vane.  This leaves the left vane pointing in (potentially) an undesired direction.  This patch allows the user to optionally tell esphome to send commands to control both vanes.  It is disabled by default so as not to break existing setups.  It presently does not allow different settings for each vane.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

https://community.home-assistant.io/t/rfc-improving-vane-controls-on-mitsubishi-minisplits/964862

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5808

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: mitsubishi
    name: "office-minisplit"
    set_fan_mode: "quiet_4levels"
    supports_dry: "true"
    supports_fan_only: "true"
    horizontal_default: "left"
    vertical_default: "up"
    vertical_vanes: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
