### PR TITLE
[wifi] Implement access point WISP mode

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -59,12 +59,12 @@ _LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["network"]
 
-_LOGGER = logging.getLogger(__name__)
-
 NO_WIFI_VARIANTS = [const.VARIANT_ESP32H2, const.VARIANT_ESP32P4]
 CONF_SAVE = "save"
 CONF_MIN_AUTH_MODE = "min_auth_mode"
 CONF_POST_CONNECT_ROAMING = "post_connect_roaming"
+CONF_AP_MODE = "ap_mode"
+CONF_DNS_SERVERS = "dns_servers"
 
 # Maximum number of WiFi networks that can be configured
 # Limited to 127 because selected_sta_index_ is int8_t in C++
@@ -96,6 +96,13 @@ WIFI_MIN_AUTH_MODES = {
     "WPA3": WifiMinAuthMode.WIFI_MIN_AUTH_MODE_WPA3,
 }
 VALIDATE_WIFI_MIN_AUTH_MODE = cv.enum(WIFI_MIN_AUTH_MODES, upper=True)
+
+WiFiAPMode = wifi_ns.enum("WiFiAPMode")
+WIFI_AP_MODES = {
+    "FALLBACK": WiFiAPMode.WIFI_AP_MODE_FALLBACK,
+    "WISP": WiFiAPMode.WIFI_AP_MODE_WISP,
+}
+
 WiFiConnectedCondition = wifi_ns.class_("WiFiConnectedCondition", Condition)
 WiFiEnabledCondition = wifi_ns.class_("WiFiEnabledCondition", Condition)
 WiFiAPActiveCondition = wifi_ns.class_("WiFiAPActiveCondition", Condition)
@@ -182,11 +189,18 @@ WIFI_NETWORK_BASE = cv.Schema(
 )
 
 CONF_AP_TIMEOUT = "ap_timeout"
+
 WIFI_NETWORK_AP = WIFI_NETWORK_BASE.extend(
     {
         cv.Optional(
             CONF_AP_TIMEOUT, default=DEFAULT_AP_TIMEOUT
         ): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_AP_MODE, default="FALLBACK"): cv.enum(
+            WIFI_AP_MODES, upper=True
+        ),
+        cv.Optional(CONF_DNS_SERVERS): cv.All(
+            cv.ensure_list(cv.ipv4address), cv.Length(min=1, max=2)
+        ),
     }
 )
 
@@ -247,7 +261,32 @@ def final_validate(config):
         raise cv.Invalid(
             "Please specify at least an SSID or an Access Point to create."
         )
-    if has_ap and not has_captive_portal and not has_web_server:
+
+    # Check if AP is configured in WISP mode (acts as a wireless bridge/repeater)
+    ap_is_wisp_mode = False
+    if has_ap:
+        ap_config = config.get(CONF_AP)
+        if ap_config:
+            # AP in WISP mode is not for configuration, it's a wireless bridge
+            ap_is_wisp_mode = ap_config.get(CONF_AP_MODE) == "WISP"
+            if ap_is_wisp_mode and not has_sta:
+                raise cv.Invalid(
+                    "WISP mode requires at least one STA network (wifi.ssid or wifi.networks)"
+                )
+            # WISP mode requires ESP-IDF framework for NAT support
+            if ap_is_wisp_mode and not (CORE.is_esp32 and not CORE.using_arduino):
+                raise cv.Invalid(
+                    "WISP mode (wireless bridge with NAT) is only supported with ESP-IDF framework"
+                )
+            if CONF_DNS_SERVERS in ap_config and not ap_is_wisp_mode:
+                raise cv.Invalid("wifi.ap.dns_servers requires ap_mode: WISP")
+            if ap_is_wisp_mode and CONF_DNS_SERVERS not in ap_config:
+                _LOGGER.warning(
+                    "WISP mode is enabled but no dns_servers are configured. "
+                    "Clients may not receive DNS via DHCP."
+                )
+
+    if has_ap and not has_captive_portal and not has_web_server and not ap_is_wisp_mode:
         _LOGGER.warning(
             "WiFi AP is configured but neither captive_portal nor web_server is enabled. "
             "The AP will not be usable for configuration or monitoring. "
@@ -474,6 +513,20 @@ async def to_code(config):
             lambda ap: cg.add(var.set_ap(wifi_network(conf, ap, ip_config))),
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
+        cg.add(var.set_ap_mode(conf[CONF_AP_MODE]))
+
+        # Configure NAT routing if WISP mode is enabled
+        if conf[CONF_AP_MODE] == "WISP":
+            cg.add_define("USE_WIFI_NAT")
+            # Enable NAT in ESP-IDF sdkconfig
+            add_idf_sdkconfig_option("CONFIG_LWIP_IP_FORWARD", True)
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV4_NAPT", True)
+
+            # Configure upstream DNS servers for DHCP to advertise to clients
+            if CONF_DNS_SERVERS in conf:
+                for dns_server in conf[CONF_DNS_SERVERS]:
+                    cg.add(var.add_dns_server(ip_address_literal(str(dns_server))))
+
         cg.add_define("USE_WIFI_AP")
     elif CORE.is_esp32 and not CORE.using_arduino:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -498,6 +498,13 @@ void WiFiComponent::start() {
       ESP_LOGV(TAG, "Setting Output Power Option failed");
     }
 
+#ifdef USE_WIFI_AP
+    // Start AP immediately if WISP mode is enabled (before STA connection starts)
+    if (this->has_ap() && this->ap_mode_ == WIFI_AP_MODE_WISP) {
+      this->setup_ap_config_();
+    }
+#endif
+
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
     // Synchronize power_save_ with semaphore state before applying
     if (this->high_performance_semaphore_ != nullptr) {
@@ -538,8 +545,8 @@ void WiFiComponent::start() {
     // Without fast_connect: go straight to scanning (or hidden mode if all networks are hidden)
     this->start_initial_connection_();
 #endif
-#ifdef USE_WIFI_AP
   } else if (this->has_ap()) {
+#ifdef USE_WIFI_AP
     this->setup_ap_config_();
     if (!std::isnan(this->output_power_) && !this->wifi_apply_output_power_(this->output_power_)) {
       ESP_LOGV(TAG, "Setting Output Power Option failed");
@@ -1338,13 +1345,26 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
     this->retry_phase_ = WiFiRetryPhase::INITIAL_CONNECT;
     this->num_retried_ = 0;
     if (this->has_ap()) {
+      // Stop captive portal regardless of AP mode (don't expose setup portal to internet)
 #ifdef USE_CAPTIVE_PORTAL
       if (this->is_captive_portal_active_()) {
         captive_portal::global_captive_portal->end();
       }
 #endif
-      ESP_LOGD(TAG, "Disabling AP");
-      this->wifi_mode_({}, false);
+      // Handle AP deactivation based on configured mode
+      if (this->ap_mode_ == WIFI_AP_MODE_FALLBACK) {
+        ESP_LOGD(TAG, "Disabling fallback AP");
+        this->wifi_mode_({}, false);
+      } else if (this->ap_mode_ == WIFI_AP_MODE_WISP) {
+        ESP_LOGD(TAG, "Keeping AP active in WISP mode");
+        // AP stays active alongside STA connection
+#ifdef USE_WIFI_NAT
+        // Enable NAT routing between STA and AP in WISP mode
+        if (this->ap_setup_) {
+          this->enable_nat_esp_idf_();
+        }
+#endif
+      }
     }
 #ifdef USE_IMPROV
     if (this->is_esp32_improv_active_()) {

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -8,6 +8,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/string_ref.h"
 
+#include <array>
 #include <span>
 #include <string>
 #include <vector>
@@ -122,6 +123,14 @@ enum class RoamingState : uint8_t {
   CONNECTING,
   /// Roam connection failed, reconnecting to any available AP
   RECONNECTING,
+};
+
+/// Controls when the access point is active
+enum WiFiAPMode : uint8_t {
+  /// AP only active when STA fails to connect (default behavior)
+  WIFI_AP_MODE_FALLBACK = 0,
+  /// AP always active alongside STA (WISP/wireless bridge mode)
+  WIFI_AP_MODE_WISP = 1,
 };
 
 /// Controls how RETRY_HIDDEN phase selects networks to try
@@ -348,6 +357,14 @@ class WiFiComponent : public Component {
   void set_ap(const WiFiAP &ap);
   WiFiAP get_ap() { return this->ap_; }
   void set_ap_timeout(uint32_t ap_timeout) { ap_timeout_ = ap_timeout; }
+  void set_ap_mode(WiFiAPMode mode) { ap_mode_ = mode; }
+#ifdef USE_WIFI_NAT
+  void add_dns_server(network::IPAddress dns) {
+    if (this->dns_server_count_ < this->dns_servers_.size()) {
+      this->dns_servers_[this->dns_server_count_++] = dns;
+    }
+  }
+#endif  // USE_WIFI_NAT
 #endif  // USE_WIFI_AP
 
   void enable();
@@ -519,6 +536,15 @@ class WiFiComponent : public Component {
   void setup_ap_config_();
 #endif  // USE_WIFI_AP
 
+#ifdef USE_WIFI_NAT
+#ifdef USE_ESP32
+  /// Helper for ESP-IDF: enable NAT using global STA and AP netif instances
+  void enable_nat_esp_idf_();
+  /// Helper for ESP-IDF: disable NAT using global AP netif instance
+  void disable_nat_esp_idf_();
+#endif  // USE_ESP32
+#endif  // USE_WIFI_NAT
+
   void print_connect_params_();
   WiFiAP build_params_for_current_phase_();
 
@@ -676,7 +702,11 @@ class WiFiComponent : public Component {
   uint32_t roaming_last_check_{0};
 #ifdef USE_WIFI_AP
   uint32_t ap_timeout_{};
-#endif
+  WiFiAPMode ap_mode_{WIFI_AP_MODE_FALLBACK};
+#ifdef USE_WIFI_NAT
+  std::array<network::IPAddress, 2> dns_servers_{};
+#endif  // USE_WIFI_NAT
+#endif  // USE_WIFI_AP
 
   // Group all 8-bit values together
   WiFiComponentState state_{WIFI_COMPONENT_STATE_OFF};
@@ -689,6 +719,9 @@ class WiFiComponent : public Component {
   // int8_t limits to 127 APs (enforced in __init__.py via MAX_WIFI_NETWORKS)
   int8_t selected_sta_index_{-1};
   uint8_t roaming_attempts_{0};
+#ifdef USE_WIFI_NAT
+  uint8_t dns_server_count_{0};
+#endif  // USE_WIFI_NAT
 
 #if USE_NETWORK_IPV6
   uint8_t num_ipv6_addresses_{0};

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -9,6 +9,11 @@
 #include <esp_wifi.h>
 #include <esp_wifi_types.h>
 #include <freertos/FreeRTOS.h>
+
+#ifdef USE_WIFI_NAT
+#include <lwip/lwip_napt.h>
+#include <lwip/tcpip.h>
+#endif
 #include <freertos/event_groups.h>
 #include <freertos/task.h>
 
@@ -220,6 +225,9 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
 
   if (current_mode == set_mode)
     return true;
+
+  const char *mode_names[] = {"NULL", "STA", "AP", "APSTA"};
+  ESP_LOGD(TAG, "wifi_mode_() changing from %s to %s", mode_names[current_mode], mode_names[set_mode]);
 
   if (set_sta && !current_sta) {
     ESP_LOGV(TAG, "Enabling STA");
@@ -775,6 +783,15 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_connected = false;
     s_sta_connecting = false;
     error_from_callback_ = true;
+
+#ifdef USE_WIFI_NAT
+    // Disable NAT when STA disconnects in WISP mode
+    if (this->ap_mode_ == WIFI_AP_MODE_WISP && this->ap_setup_) {
+      ESP_LOGD(TAG, "Disabling NAT due to STA disconnect");
+      this->disable_nat_esp_idf_();
+    }
+#endif  // USE_WIFI_NAT
+
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     static constexpr uint8_t EMPTY_BSSID[6] = {};
     for (auto *listener : this->connect_state_listeners_) {
@@ -871,6 +888,12 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_STOP) {
     ESP_LOGV(TAG, "AP stop");
     this->ap_started_ = false;
+#ifdef USE_WIFI_NAT
+    if (this->ap_mode_ == WIFI_AP_MODE_WISP && this->ap_setup_) {
+      ESP_LOGD(TAG, "Disabling NAT due to AP stop");
+      this->disable_nat_esp_idf_();
+    }
+#endif  // USE_WIFI_NAT
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_PROBEREQRECVED) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
@@ -1021,6 +1044,34 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
       ESP_LOGV(TAG, "Failed to set DHCP captive portal URI: %s", esp_err_to_name(err));
     } else {
       ESP_LOGV(TAG, "DHCP Captive Portal URI set to: %s", captive_portal_uri);
+    }
+  }
+#endif
+
+#ifdef USE_WIFI_NAT
+  // Configure DNS servers for DHCP to advertise in WISP mode
+  if (this->ap_mode_ == WIFI_AP_MODE_WISP && this->dns_server_count_ > 0) {
+    // Enable DHCP DNS option
+    uint8_t dns_offer = 1;
+    err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_DOMAIN_NAME_SERVER, &dns_offer,
+                                 sizeof(dns_offer));
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Failed to enable DHCP DNS option: %s", esp_err_to_name(err));
+    }
+
+    // Set DNS servers to advertise via DHCP
+    esp_netif_dns_info_t dns_info;
+    for (size_t i = 0; i < this->dns_server_count_ && i < this->dns_servers_.size(); i++) {
+      dns_info.ip = this->dns_servers_[i];
+
+      esp_netif_dns_type_t dns_type = (i == 0) ? ESP_NETIF_DNS_MAIN : ESP_NETIF_DNS_BACKUP;
+      err = esp_netif_set_dns_info(s_ap_netif, dns_type, &dns_info);
+
+      if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to configure DNS server %zu: %s", i, esp_err_to_name(err));
+      } else {
+        ESP_LOGI(TAG, "Configured DHCP to advertise DNS server %zu: " IPSTR, i, IP2STR(&dns_info.ip.u_addr.ip4));
+      }
     }
   }
 #endif
@@ -1176,6 +1227,74 @@ network::IPAddress WiFiComponent::wifi_dns_ip_(int num) {
   const ip_addr_t *dns_ip = dns_getserver(num);
   return network::IPAddress(dns_ip);
 }
+
+#ifdef USE_WIFI_NAT
+// Internal implementation: Enable NAT routing from upstream to downstream interface
+static void enable_nat_internal_(esp_netif_t *upstream_netif, esp_netif_t *downstream_netif) {
+  if (!upstream_netif || !downstream_netif) {
+    ESP_LOGW(TAG, "Cannot enable NAT: invalid network interfaces");
+    return;
+  }
+
+  // Get the downstream (AP) IP address for NAT
+  esp_netif_ip_info_t downstream_ip;
+  esp_err_t err = esp_netif_get_ip_info(downstream_netif, &downstream_ip);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Failed to get downstream IP info for NAT: %s", esp_err_to_name(err));
+    return;
+  }
+
+  // Log upstream interface info
+  esp_netif_ip_info_t upstream_ip;
+  if (esp_netif_get_ip_info(upstream_netif, &upstream_ip) == ESP_OK) {
+    ESP_LOGD(TAG, "Enabling NAT: upstream=" IPSTR " -> downstream=" IPSTR, IP2STR(&upstream_ip.ip),
+             IP2STR(&downstream_ip.ip));
+  }
+
+  uint32_t ap_ip = downstream_ip.ip.addr;
+
+  // Enable NAT (ip_napt_enable returns void)
+  // Must lock TCPIP core when calling lwIP functions from non-lwIP tasks
+  LOCK_TCPIP_CORE();
+  ip_napt_enable(ap_ip, 1);
+  UNLOCK_TCPIP_CORE();
+
+  ESP_LOGD(TAG, "NAT enabled successfully");
+}
+
+// Internal implementation: Disable NAT routing on downstream interface
+static void disable_nat_internal_(esp_netif_t *downstream_netif) {
+  if (!downstream_netif) {
+    ESP_LOGW(TAG, "Cannot disable NAT: invalid network interface");
+    return;
+  }
+
+  // Get the downstream (AP) IP address
+  esp_netif_ip_info_t ip;
+  esp_err_t err = esp_netif_get_ip_info(downstream_netif, &ip);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Failed to get downstream IP info for NAT disable: %s", esp_err_to_name(err));
+    return;
+  }
+
+  uint32_t ap_ip = ip.ip.addr;
+  ESP_LOGD(TAG, "Disabling NAT for downstream IP: " IPSTR, IP2STR(&ip.ip));
+
+  // Disable NAT (ip_napt_enable returns void)
+  // Must lock TCPIP core when calling lwIP functions from non-lwIP tasks
+  LOCK_TCPIP_CORE();
+  ip_napt_enable(ap_ip, 0);
+  UNLOCK_TCPIP_CORE();
+
+  ESP_LOGD(TAG, "NAT disabled successfully");
+}
+
+// Public helper: Enable NAT using ESP-IDF global netif instances
+void WiFiComponent::enable_nat_esp_idf_() { enable_nat_internal_(s_sta_netif, s_ap_netif); }
+
+// Public helper: Disable NAT using ESP-IDF global AP netif instance
+void WiFiComponent::disable_nat_esp_idf_() { disable_nat_internal_(s_ap_netif); }
+#endif  // USE_WIFI_NAT
 
 }  // namespace esphome::wifi
 #endif  // USE_ESP32

--- a/tests/components/wifi/test-wisp.esp32-idf.yaml
+++ b/tests/components/wifi/test-wisp.esp32-idf.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: wifi-wisp-test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: MySSID
+  password: password1
+  ap:
+    ssid: "WISP_AP"
+    password: "wisp12345678"
+    ap_mode: wisp
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
+logger:


### PR DESCRIPTION
# What does this implement/fix?

Allows to use ESP32 devices as an Access Point with WISP mode.

In this mode, NAT is enabled between the wifi station and the access point. 

This is useful for providing guest networks or dedicated networks for other IoT devices.

I plan to add additional modes in future like `bridge`, which would not enable NAT and DHCP server, which would be more useful to make a repeater.

In fact, I plan to someday be able to achieve the same as https://github.com/BlinxFox/nep-gw within ESPHome so that I can extract data from my (future) NEP inverter locally.

On my tests with optimal WiFi Signal, I got pretty reasonable speeds:

<img width="815" height="290" alt="chrome_i51pBh4xY3" src="https://github.com/user-attachments/assets/fb4841a7-c328-4ab3-a50f-eb4affd5f769" />

**Notes:**

1. Used https://github.com/dchristl/esp32_nat_router_extended as reference.
1. My strategy was to make the minimal changes possible yet achieving some useful functionality. For example, I thought about extracting some configuration from `wifi.ap` into some new components like `dhcp_server`, `dns_server`, `nat` and maybe even a dedicated `wifi_ap`. I guess it makes sense when you think about mixing this with Ethernet, like: using wifi station to create ethernet bridge (for connecting devices that only has ethernet ports). Or the opposite, creating an AP to act as a wired repeater (interesting for POE devices like ZWA-2).
1. This PR was developed with a lot of help from Claude Sonnet 4.5.
1. I'm targeting `release` branch temporarily. `dev` branch has a bug where USB logs won't work with my board, but I haven't reported yet.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (probably there's some)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esphome:
  name: esphome-wisp
  platformio_options:
    # qio results into a boot loop when using esp-idf and flashing via USB
    # https://github.com/platformio/platform-espressif32/blob/268f561df4793d631d02e4ff5e67b6b11d1be4ec/boards/esp32-s3-devkitc-1.json#L16
    board_build.flash_mode: dio

esp32:
  board: esp32-s3-devkitc-1
  flash_size: 16MB
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_ESP32_S3_BOX_BOARD: "y"

wifi:
  reboot_timeout: 0s
  ap:
    password: !secret ap_password
    ap_mode: wisp
    dns_servers:
      - 192.168.1.1
  networks:
    - ssid: !secret wifi_ssid
      password: !secret wifi_password
      priority: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
