### PR TITLE
[whirlpool] Add support DG11J1-39

### DIFF
--- a/esphome/components/climate_ir/climate_ir.h
+++ b/esphome/components/climate_ir/climate_ir.h
@@ -27,17 +27,15 @@ class ClimateIR : public Component,
             bool supports_dry = false, bool supports_fan_only = false,
             climate::ClimateFanModeMask fan_modes = climate::ClimateFanModeMask(),
             climate::ClimateSwingModeMask swing_modes = climate::ClimateSwingModeMask(),
-            climate::ClimatePresetMask presets = climate::ClimatePresetMask()) :
-            minimum_temperature_(minimum_temperature),
-            maximum_temperature_(maximum_temperature),
-            temperature_step_(temperature_step),
-            supports_dry_(supports_dry),
-            supports_fan_only_(supports_fan_only),
-            fan_modes_(fan_modes),
-            swing_modes_(swing_modes),
-            presets_(presets)
-    {
-    }
+            climate::ClimatePresetMask presets = climate::ClimatePresetMask())
+      : minimum_temperature_(minimum_temperature),
+        maximum_temperature_(maximum_temperature),
+        temperature_step_(temperature_step),
+        supports_dry_(supports_dry),
+        supports_fan_only_(supports_fan_only),
+        fan_modes_(fan_modes),
+        swing_modes_(swing_modes),
+        presets_(presets) {}
 
   void setup() override;
   void dump_config() override;

--- a/esphome/components/climate_ir/climate_ir.h
+++ b/esphome/components/climate_ir/climate_ir.h
@@ -27,16 +27,17 @@ class ClimateIR : public Component,
             bool supports_dry = false, bool supports_fan_only = false,
             climate::ClimateFanModeMask fan_modes = climate::ClimateFanModeMask(),
             climate::ClimateSwingModeMask swing_modes = climate::ClimateSwingModeMask(),
-            climate::ClimatePresetMask presets = climate::ClimatePresetMask()) {
-    this->minimum_temperature_ = minimum_temperature;
-    this->maximum_temperature_ = maximum_temperature;
-    this->temperature_step_ = temperature_step;
-    this->supports_dry_ = supports_dry;
-    this->supports_fan_only_ = supports_fan_only;
-    this->fan_modes_ = fan_modes;
-    this->swing_modes_ = swing_modes;
-    this->presets_ = presets;
-  }
+            climate::ClimatePresetMask presets = climate::ClimatePresetMask()) :
+            minimum_temperature_(minimum_temperature),
+            maximum_temperature_(maximum_temperature),
+            temperature_step_(temperature_step),
+            supports_dry_(supports_dry),
+            supports_fan_only_(supports_fan_only),
+            fan_modes_(fan_modes),
+            swing_modes_(swing_modes),
+            presets_(presets)
+    {
+    }
 
   void setup() override;
   void dump_config() override;
@@ -44,6 +45,9 @@ class ClimateIR : public Component,
   void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
   void set_sensor(sensor::Sensor *sensor) { this->sensor_ = sensor; }
   void set_humidity_sensor(sensor::Sensor *sensor) { this->humidity_sensor_ = sensor; }
+  void set_minimum_temperature(float minimum_temperature) { this->minimum_temperature_ = minimum_temperature; }
+  void set_maximum_temperature(float maximum_temperature) { this->maximum_temperature_ = maximum_temperature; }
+  void set_temperature_step(float temperature_step) { this->temperature_step_ = temperature_step; }
 
  protected:
   float minimum_temperature_, maximum_temperature_, temperature_step_;

--- a/esphome/components/whirlpool/climate.py
+++ b/esphome/components/whirlpool/climate.py
@@ -13,6 +13,7 @@ Model = whirlpool_ns.enum("Model")
 MODELS = {
     "DG11J1-3A": Model.MODEL_DG11J1_3A,
     "DG11J1-91": Model.MODEL_DG11J1_91,
+    "DG11J1-39": Model.MODEL_DG11J1_39,
 }
 
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(WhirlpoolClimate).extend(

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -32,12 +32,11 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
-WhirlpoolClimate::WhirlpoolClimate()
-    : climate_ir::ClimateIR(
-          WHIRLPOOL_DG11J1_3A_TEMP_MIN, WHIRLPOOL_DG11J1_3A_TEMP_MAX, 1.0f, true, true,
-          {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
-          {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}),
-      model_(MODEL_DG11J1_3A) {}
+WhirlpoolClimate()
+    : climate_ir::ClimateIR(MODEL_SETTINGS_ARR.front().minimum_temperature, MODEL_SETTINGS_ARR.front().maximum_temperature, 1.0f, true, true,
+                            {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
+                              climate::CLIMATE_FAN_HIGH},
+                            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
 
 void WhirlpoolClimate::transmit_state() {
   this->last_transmit_time_ = millis();  // setting the time of the last transmission.
@@ -85,8 +84,8 @@ void WhirlpoolClimate::transmit_state() {
   }
 
   // Temperature
-  auto temp = (uint8_t) roundf(clamp(this->target_temperature, this->temperature_min_(), this->temperature_max_()));
-  remote_state[3] |= (uint8_t) (temp - this->temperature_min_()) << 4;
+  auto temp = static_cast<uint8_t>(roundf(clamp(this->target_temperature, minimum_temperature_, maximum_temperature_)));
+  remote_state[3] |= static_cast<uint8_t>(temp - minimum_temperature_) << 4 + temperature_correction_;
 
   // Fan speed
   switch (this->fan_mode.value_or(climate::CLIMATE_FAN_ON)) {

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -86,7 +86,8 @@ void WhirlpoolClimate::transmit_state() {
 
   // Temperature
   auto temp = static_cast<uint8_t>(roundf(clamp(this->target_temperature, minimum_temperature_, maximum_temperature_)));
-  remote_state[3] |= (static_cast<uint8_t>(temp - minimum_temperature_) << 4) + static_cast<uint8_t>(temperature_correction_);
+  remote_state[3] |=
+      (static_cast<uint8_t>(temp - minimum_temperature_) << 4) + static_cast<uint8_t>(temperature_correction_);
 
   // Fan speed
   switch (this->fan_mode.value_or(climate::CLIMATE_FAN_ON)) {

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -86,7 +86,7 @@ void WhirlpoolClimate::transmit_state() {
 
   // Temperature
   auto temp = static_cast<uint8_t>(roundf(clamp(this->target_temperature, minimum_temperature_, maximum_temperature_)));
-  remote_state[3] |= static_cast<uint8_t>(temp - minimum_temperature_) << 4 + temperature_correction_;
+  remote_state[3] |= (static_cast<uint8_t>(temp - minimum_temperature_) << 4) + static_cast<uint8_t>(temperature_correction_);
 
   // Fan speed
   switch (this->fan_mode.value_or(climate::CLIMATE_FAN_ON)) {
@@ -270,7 +270,7 @@ bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
   int temp = remote_state[3] & 0xF0;
   ESP_LOGVV(TAG, "Temperature Raw: %02X", temp);
   temp = (uint8_t) temp >> 4;
-  temp += static_cast<int>(this->temperature_min_());
+  temp += static_cast<int>(this->minimum_temperature_);
   ESP_LOGVV(TAG, "Temperature Climate: %u", temp);
   this->target_temperature = temp;
 

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -32,7 +32,7 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
-WhirlpoolClimate()
+WhirlpoolClimate::WhirlpoolClimate()
     : climate_ir::ClimateIR(MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].minimum_temperature,
                             MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].maximum_temperature, 1.0f, true, true,
                             {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
@@ -86,8 +86,7 @@ void WhirlpoolClimate::transmit_state() {
 
   // Temperature
   auto temp = static_cast<uint8_t>(roundf(clamp(this->target_temperature, minimum_temperature_, maximum_temperature_)));
-  remote_state[3] |=
-      (static_cast<uint8_t>(temp - minimum_temperature_) << 4) + static_cast<uint8_t>(temperature_correction_);
+  remote_state[3] |= (static_cast<uint8_t>(temp - minimum_temperature_ + temperature_correction_) << 4);
 
   // Fan speed
   switch (this->fan_mode.value_or(climate::CLIMATE_FAN_ON)) {
@@ -270,8 +269,8 @@ bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
   // Set received temp
   int temp = remote_state[3] & 0xF0;
   ESP_LOGVV(TAG, "Temperature Raw: %02X", temp);
-  temp = (uint8_t) temp >> 4;
-  temp += static_cast<int>(this->minimum_temperature_);
+  temp = static_cast<uint8_t>(temp) >> 4;
+  temp += static_cast<int>(this->minimum_temperature_ - this->temperature_correction_);
   ESP_LOGVV(TAG, "Temperature Climate: %u", temp);
   this->target_temperature = temp;
 

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -32,12 +32,12 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
-  WhirlpoolClimate()
-      : climate_ir::ClimateIR(MODEL_SETTINGS_ARR.front().minimum_temperature,
-                              MODEL_SETTINGS_ARR.front().maximum_temperature, 1.0f, true, true,
-                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
-                               climate::CLIMATE_FAN_HIGH},
-                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
+WhirlpoolClimate()
+    : climate_ir::ClimateIR(MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].minimum_temperature,
+                            MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].maximum_temperature, 1.0f, true, true,
+                            {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
+                              climate::CLIMATE_FAN_HIGH},
+                            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
 
 void WhirlpoolClimate::transmit_state() {
   this->last_transmit_time_ = millis();  // setting the time of the last transmission.

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -32,11 +32,12 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
-WhirlpoolClimate()
-    : climate_ir::ClimateIR(MODEL_SETTINGS_ARR.front().minimum_temperature, MODEL_SETTINGS_ARR.front().maximum_temperature, 1.0f, true, true,
-                            {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
-                              climate::CLIMATE_FAN_HIGH},
-                            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
+  WhirlpoolClimate()
+      : climate_ir::ClimateIR(MODEL_SETTINGS_ARR.front().minimum_temperature,
+                              MODEL_SETTINGS_ARR.front().maximum_temperature, 1.0f, true, true,
+                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
+                               climate::CLIMATE_FAN_HIGH},
+                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
 
 void WhirlpoolClimate::transmit_state() {
   this->last_transmit_time_ = millis();  // setting the time of the last transmission.

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -33,11 +33,11 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
 WhirlpoolClimate::WhirlpoolClimate()
-    : climate_ir::ClimateIR(MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].minimum_temperature,
-                            MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].maximum_temperature, 1.0f, true, true,
-                            {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
-                              climate::CLIMATE_FAN_HIGH},
-                            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
+    : climate_ir::ClimateIR(
+          MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].minimum_temperature,
+          MODEL_SETTINGS_ARR[MODEL_DG11J1_3A].maximum_temperature, 1.0f, true, true,
+          {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+          {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
 
 void WhirlpoolClimate::transmit_state() {
   this->last_transmit_time_ = millis();  // setting the time of the last transmission.

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -52,7 +52,7 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
 
   static constexpr std::array<ModelSettings, Model::MODEL_COUNT> MODEL_SETTINGS_ARR = {
       ModelSettings(18.f, 32.f, 0.f), /* MODEL_DG11J1_3A */
-      ModelSettings(30.f, 16.f, 0.f), /* MODEL_DG11J1_91 */
+      ModelSettings(16.f, 30.f, 0.f), /* MODEL_DG11J1_91 */
       ModelSettings(18.f, 32.f, 2.f)  /* MODEL_DG11J1_39 */
   };
 

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -11,7 +11,7 @@ namespace whirlpool {
  * @brief Simple enum to represent models.
  */
 enum Model {
-  MODEL_DG11J1_3A = 0, /* Temperature range is from 18 to 32 */
+  MODEL_DG11J1_3A = 0, /* Temperature range is from 18 to 32 (default) */
   MODEL_DG11J1_91,     /* Temperature range is from 16 to 30 */
   MODEL_DG11J1_39,     /* Temperature range is from 18 to 32 */
   MODEL_COUNT
@@ -45,9 +45,9 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
 
  protected:
   struct ModelSettings {
-    decltype(climate_ir::ClimateIR::minimum_temperature_) minimum_temperature;
-    decltype(climate_ir::ClimateIR::maximum_temperature_) maximum_temperature;
-    decltype(temperature_correction_) temperature_correction;
+    float minimum_temperature;
+    float maximum_temperature;
+    float temperature_correction;
   };
 
   static constexpr std::array<ModelSettings, Model::MODEL_COUNT> MODEL_SETTINGS_ARR = {

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -1,21 +1,21 @@
 #pragma once
 
+#include <array>
+
 #include "esphome/components/climate_ir/climate_ir.h"
 
 namespace esphome {
 namespace whirlpool {
 
-/// Simple enum to represent models.
+/**
+ * @brief Simple enum to represent models.
+ */
 enum Model {
-  MODEL_DG11J1_3A = 0,  /// Temperature range is from 18 to 32
-  MODEL_DG11J1_91 = 1,  /// Temperature range is from 16 to 30
+  MODEL_DG11J1_3A = 0,  /* Temperature range is from 18 to 32 */
+  MODEL_DG11J1_91,  /* Temperature range is from 16 to 30 */
+  MODEL_DG11J1_39,
+  MODEL_COUNT
 };
-
-// Temperature
-const float WHIRLPOOL_DG11J1_3A_TEMP_MAX = 32.0;
-const float WHIRLPOOL_DG11J1_3A_TEMP_MIN = 18.0;
-const float WHIRLPOOL_DG11J1_91_TEMP_MAX = 30.0;
-const float WHIRLPOOL_DG11J1_91_TEMP_MIN = 16.0;
 
 class WhirlpoolClimate : public climate_ir::ClimateIR {
  public:
@@ -34,15 +34,28 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   }
 
   void set_model(Model model) {
-    this->model_ = model;
-    this->minimum_temperature_ = temperature_min_();
-    this->maximum_temperature_ = temperature_max_();
+    auto& model_settings = MODEL_SETTINGS_ARR[model];
+    set_minimum_temperature(model_settings.minimum_temperature);
+    set_maximum_temperature(model_settings.maximum_temperature);
+    temperature_correction_ = model_settings.temperature_correction;
   }
 
   // used to track when to send the power toggle command
   bool powered_on_assumed;
 
  protected:
+  struct ModelSettings {
+    decltype(climate_ir::ClimateIR::minimum_temperature_) minimum_temperature;
+    decltype(climate_ir::ClimateIR::maximum_temperature_) maximum_temperature;
+    decltype(temperature_correction_) temperature_correction;
+  };
+
+  static constexpr std::array<ModelSettings, Model::MODEL_COUNT> MODEL_SETTINGS_ARR = {
+    ModelSettings(18.f, 32.f, 0.f),   /* MODEL_DG11J1_3A */
+    ModelSettings(30.f, 16.f, 0.f),   /* MODEL_DG11J1_91 */
+    ModelSettings(18.f, 32.f, 2.f)    /* MODEL_DG11J1_39 */
+  };
+
   /// Transmit via IR the state of this climate controller.
   void transmit_state() override;
   /// Handle received IR Buffer
@@ -50,15 +63,9 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   /// Set the time of the last transmission.
   uint32_t last_transmit_time_{};
 
-  bool send_swing_cmd_{false};
-  Model model_;
+  float temperature_correction_{0.f};
 
-  float temperature_min_() {
-    return (model_ == MODEL_DG11J1_3A) ? WHIRLPOOL_DG11J1_3A_TEMP_MIN : WHIRLPOOL_DG11J1_91_TEMP_MIN;
-  }
-  float temperature_max_() {
-    return (model_ == MODEL_DG11J1_3A) ? WHIRLPOOL_DG11J1_3A_TEMP_MAX : WHIRLPOOL_DG11J1_91_TEMP_MAX;
-  }
+  bool send_swing_cmd_{false};
 };
 
 }  // namespace whirlpool

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -13,7 +13,7 @@ namespace whirlpool {
 enum Model {
   MODEL_DG11J1_3A = 0, /* Temperature range is from 18 to 32 */
   MODEL_DG11J1_91,     /* Temperature range is from 16 to 30 */
-  MODEL_DG11J1_39,
+  MODEL_DG11J1_39,     /* Temperature range is from 18 to 32 */
   MODEL_COUNT
 };
 

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -11,8 +11,8 @@ namespace whirlpool {
  * @brief Simple enum to represent models.
  */
 enum Model {
-  MODEL_DG11J1_3A = 0,  /* Temperature range is from 18 to 32 */
-  MODEL_DG11J1_91,  /* Temperature range is from 16 to 30 */
+  MODEL_DG11J1_3A = 0, /* Temperature range is from 18 to 32 */
+  MODEL_DG11J1_91,     /* Temperature range is from 16 to 30 */
   MODEL_DG11J1_39,
   MODEL_COUNT
 };
@@ -34,7 +34,7 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   }
 
   void set_model(Model model) {
-    auto& model_settings = MODEL_SETTINGS_ARR[model];
+    auto &model_settings = MODEL_SETTINGS_ARR[model];
     set_minimum_temperature(model_settings.minimum_temperature);
     set_maximum_temperature(model_settings.maximum_temperature);
     temperature_correction_ = model_settings.temperature_correction;
@@ -51,9 +51,9 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   };
 
   static constexpr std::array<ModelSettings, Model::MODEL_COUNT> MODEL_SETTINGS_ARR = {
-    ModelSettings(18.f, 32.f, 0.f),   /* MODEL_DG11J1_3A */
-    ModelSettings(30.f, 16.f, 0.f),   /* MODEL_DG11J1_91 */
-    ModelSettings(18.f, 32.f, 2.f)    /* MODEL_DG11J1_39 */
+      ModelSettings(18.f, 32.f, 0.f), /* MODEL_DG11J1_3A */
+      ModelSettings(30.f, 16.f, 0.f), /* MODEL_DG11J1_91 */
+      ModelSettings(18.f, 32.f, 2.f)  /* MODEL_DG11J1_39 */
   };
 
   /// Transmit via IR the state of this climate controller.

--- a/tests/components/whirlpool/common.yaml
+++ b/tests/components/whirlpool/common.yaml
@@ -13,4 +13,3 @@ climate:
     name: "Whirlpool AC 39"
     model: "DG11J1-39"
     transmitter_id: xmitr
-

--- a/tests/components/whirlpool/common.yaml
+++ b/tests/components/whirlpool/common.yaml
@@ -1,4 +1,16 @@
 climate:
   - platform: whirlpool
-    name: Whirlpool Climate
+    name: "Whirlpool AC 3A"
+    model: "DG11J1-3A"
     transmitter_id: xmitr
+
+  - platform: whirlpool
+    name: "Whirlpool AC 91"
+    model: "DG11J1-91"
+    transmitter_id: xmitr
+
+  - platform: whirlpool
+    name: "Whirlpool AC 39"
+    model: "DG11J1-39"
+    transmitter_id: xmitr
+


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6022

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  id: remote_transmitter_id
  pin: GPIO18
  carrier_duty_percent: 50%
  non_blocking: true
  rmt_symbols: 48

climate:
  - platform: whirlpool      
    name: "Air_cooler"
    model: DG11J1-39
    transmitter_id: remote_transmitter_id
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
