### PR TITLE
[globals] Add RTC memory support

### DIFF
--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -8,12 +8,13 @@ from esphome.const import (
     CONF_TYPE,
     CONF_VALUE,
 )
-from esphome.core import CoroPriority, coroutine_with_priority
+from esphome.core import CORE, CoroPriority, coroutine_with_priority
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core"]
 globals_ns = cg.esphome_ns.namespace("globals")
 GlobalsComponent = globals_ns.class_("GlobalsComponent", cg.Component)
+RTCGlobalsComponent = globals_ns.class_("RTCGlobalsComponent", cg.Component)
 RestoringGlobalsComponent = globals_ns.class_(
     "RestoringGlobalsComponent", cg.PollingComponent
 )
@@ -24,6 +25,32 @@ GlobalVarSetAction = globals_ns.class_("GlobalVarSetAction", automation.Action)
 
 CONF_MAX_RESTORE_DATA_LENGTH = "max_restore_data_length"
 
+RTC_RESTORE_MODE = "RTC"
+PRIMITIVE_TYPES = {
+    "bool",
+    "char",
+    "float",
+    "double",
+    "uint8_t",
+    "uint16_t",
+    "uint32_t",
+    "uint64_t",
+    "int8_t",
+    "int16_t",
+    "int32_t",
+    "int64_t",
+}
+
+
+def extract_primitive_type(type_str):
+    # Extract the primitive type and length from stuff like uint8_t[10]
+    if "[" not in type_str:
+        return type_str, None
+    primitive_type, length_str = type_str.split("[", 1)
+    length = int(length_str.rstrip("]"))
+    return primitive_type, length
+
+
 # Base schema fields shared by both variants
 _BASE_SCHEMA = {
     cv.Required(CONF_ID): cv.declare_id(GlobalsComponent),
@@ -31,6 +58,34 @@ _BASE_SCHEMA = {
     cv.Optional(CONF_INITIAL_VALUE): cv.string_strict,
     cv.Optional(CONF_MAX_RESTORE_DATA_LENGTH): cv.int_range(0, 254),
 }
+
+
+def validate_restore_mode(value):
+    value = cv.one_of(RTC_RESTORE_MODE, upper=True)(value)
+    # Only RTC is available in ESP32
+    if isinstance(value, str) and value == RTC_RESTORE_MODE and not CORE.is_esp32:
+        raise cv.Invalid(
+            f"RTC restore mode is only supported on ESP32 platforms, but current platform is {CORE.target_platform}"
+        )
+    return value
+
+
+def validate_primitive_types(value):
+    value = cv.string_strict(value)
+    primitive_type, _ = extract_primitive_type(value)
+    if primitive_type not in PRIMITIVE_TYPES:
+        raise cv.Invalid(f"Type must be one of {PRIMITIVE_TYPES}, but got '{value}'")
+    return value
+
+
+# RTC-restoring globals: regular Component (no polling needed)
+_RTC_RESTORING_SCHEMA = cv.Schema(
+    {
+        **_BASE_SCHEMA,
+        cv.Required(CONF_TYPE): validate_primitive_types,
+        cv.Optional(CONF_RESTORE_VALUE, default="RTC"): validate_restore_mode,
+    }
+).extend(cv.COMPONENT_SCHEMA)
 
 # Non-restoring globals: regular Component (no polling needed)
 _NON_RESTORING_SCHEMA = cv.Schema(
@@ -51,8 +106,11 @@ _RESTORING_SCHEMA = cv.Schema(
 
 def _globals_schema(config: ConfigType) -> ConfigType:
     """Select schema based on restore_value setting."""
-    if config.get(CONF_RESTORE_VALUE, False):
+    restore_val = config.get(CONF_RESTORE_VALUE, False)
+    if restore_val is True:
         return _RESTORING_SCHEMA(config)
+    if restore_val == RTC_RESTORE_MODE:
+        return _RTC_RESTORING_SCHEMA(config)
     return _NON_RESTORING_SCHEMA(config)
 
 
@@ -65,27 +123,41 @@ CONFIG_SCHEMA = _globals_schema
 async def to_code(config):
     type_ = cg.RawExpression(config[CONF_TYPE])
     restore = config[CONF_RESTORE_VALUE]
-
-    # Special casing the strings to their own class with a different save/restore mechanism
-    if str(type_) == "std::string" and restore:
-        template_args = cg.TemplateArguments(
-            type_, config.get(CONF_MAX_RESTORE_DATA_LENGTH, 63) + 1
-        )
-        type = RestoringGlobalStringComponent
-    else:
-        template_args = cg.TemplateArguments(type_)
-        type = RestoringGlobalsComponent if restore else GlobalsComponent
-
-    res_type = type.template(template_args)
     initial_value = None
     if CONF_INITIAL_VALUE in config:
         initial_value = cg.RawExpression(config[CONF_INITIAL_VALUE])
 
-    rhs = type.new(template_args, initial_value)
+    if restore == RTC_RESTORE_MODE:
+        # RTC restore mode uses a global variable to store the values
+        rtc_var_id = f"{config[CONF_ID]}RTC"
+        primitive_type, length = extract_primitive_type(str(type_))
+        if length is None:
+            rtc_var_exp = f"RTC_DATA_ATTR {primitive_type} {rtc_var_id}"
+        else:
+            rtc_var_exp = f"RTC_DATA_ATTR {primitive_type} {rtc_var_id}[{length}]"
+        if initial_value:
+            rtc_var_exp += f" = {initial_value}"
+        cg.add_global(cg.RawExpression(rtc_var_exp))
+        template_args = cg.TemplateArguments(type_)
+        type = RTCGlobalsComponent
+        res_type = type.template(template_args)
+        rhs = type.new(template_args, cg.RawExpression(f"&{rtc_var_id}"))
+    else:
+        if str(type_) == "std::string" and restore:
+            # Special casing the strings to their own class with a different save/restore mechanism
+            template_args = cg.TemplateArguments(
+                type_, config.get(CONF_MAX_RESTORE_DATA_LENGTH, 63) + 1
+            )
+            type = RestoringGlobalStringComponent
+        else:
+            template_args = cg.TemplateArguments(type_)
+            type = RestoringGlobalsComponent if restore else GlobalsComponent
+        res_type = type.template(template_args)
+        rhs = type.new(template_args, initial_value)
     glob = cg.Pvariable(config[CONF_ID], rhs, res_type)
     await cg.register_component(glob, config)
 
-    if restore:
+    if restore is True:
         value = config[CONF_ID].id
         if isinstance(value, str):
             value = value.encode()

--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -78,7 +78,7 @@ _BASE_SCHEMA = {
 
 def validate_restore_mode(value):
     value = cv.one_of(RTC_RESTORE_MODE, upper=True)(value)
-    # Only RTC is available in ESP32
+    # RTC restore mode is only supported on ESP32
     if isinstance(value, str) and value == RTC_RESTORE_MODE and not CORE.is_esp32:
         raise cv.Invalid(
             f"RTC restore mode is only supported on ESP32 platforms, but current platform is {CORE.target_platform}"

--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -46,8 +46,24 @@ def extract_primitive_type(type_str):
     # Extract the primitive type and length from stuff like uint8_t[10]
     if "[" not in type_str:
         return type_str, None
-    primitive_type, length_str = type_str.split("[", 1)
-    length = int(length_str.rstrip("]"))
+    primitive_type, length_part = type_str.split("[", 1)
+    primitive_type = primitive_type.strip()
+    if "]" not in length_part:
+        raise cv.Invalid(
+            f"Invalid array type syntax '{type_str}': missing closing ']'"
+        )
+    length_str, _ = length_part.split("]", 1)
+    length_str = length_str.strip()
+    if not length_str:
+        raise cv.Invalid(
+            f"Invalid array type syntax '{type_str}': missing array length"
+        )
+    try:
+        length = int(length_str)
+    except ValueError as err:
+        raise cv.Invalid(
+            f"Invalid array length '{length_str}' in type '{type_str}': expected integer"
+        ) from err
     return primitive_type, length
 
 

--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -49,9 +49,7 @@ def extract_primitive_type(type_str):
     primitive_type, length_part = type_str.split("[", 1)
     primitive_type = primitive_type.strip()
     if "]" not in length_part:
-        raise cv.Invalid(
-            f"Invalid array type syntax '{type_str}': missing closing ']'"
-        )
+        raise cv.Invalid(f"Invalid array type syntax '{type_str}': missing closing ']'")
     length_str, _ = length_part.split("]", 1)
     length_str = length_str.strip()
     if not length_str:

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -3,6 +3,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/defines.h"
 #include <cstring>
 
 namespace esphome::globals {
@@ -22,6 +23,20 @@ template<typename T> class GlobalsComponent : public Component {
  protected:
   T value_{};
 };
+
+#ifdef USE_ESP32
+template<typename T> class RTCGlobalsComponent : public Component {
+ public:
+  explicit RTCGlobalsComponent(T *rtc_ptr) : rtc_ptr_(rtc_ptr) {}
+
+  T &value() { return *this->rtc_ptr_; }
+
+  void setup() override {}
+
+ protected:
+  T *rtc_ptr_;
+};
+#endif
 
 template<typename T> class RestoringGlobalsComponent : public PollingComponent {
  public:
@@ -144,5 +159,8 @@ template<class C, typename... Ts> class GlobalVarSetAction : public Action<Ts...
 template<typename T> T &id(GlobalsComponent<T> *value) { return value->value(); }
 template<typename T> T &id(RestoringGlobalsComponent<T> *value) { return value->value(); }
 template<typename T, uint8_t SZ> T &id(RestoringGlobalStringComponent<T, SZ> *value) { return value->value(); }
+#ifdef USE_ESP32
+template<typename T> T &id(RTCGlobalsComponent<T> *value) { return value->value(); }
+#endif
 
 }  // namespace esphome::globals

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -27,6 +27,7 @@ template<typename T> class GlobalsComponent : public Component {
 #ifdef USE_ESP32
 template<typename T> class RTCGlobalsComponent : public Component {
  public:
+  using value_type = T;
   explicit RTCGlobalsComponent(T *rtc_ptr) : rtc_ptr_(rtc_ptr) {}
 
   T &value() { return *this->rtc_ptr_; }

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -695,6 +695,7 @@ async def process_lambda(
         GlobalsComponent,
         RestoringGlobalsComponent,
         RestoringGlobalStringComponent,
+        RTCGlobalsComponent,
     )
 
     if value is None:
@@ -717,6 +718,7 @@ async def process_lambda(
                 full_id.type.inherits_from(GlobalsComponent)
                 or full_id.type.inherits_from(RestoringGlobalsComponent)
                 or full_id.type.inherits_from(RestoringGlobalStringComponent)
+                or full_id.type.inherits_from(RTCGlobalsComponent)
             )
         ):
             parts[i * 3 + 1] = var.value()

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -708,19 +708,23 @@ async def process_lambda(
     if isinstance(value, Expression):
         value = Lambda(value)
 
+    def _is_globals_component(full_id: ID | None) -> bool:
+        if full_id is None or not isinstance(full_id.type, MockObjClass):
+            return False
+        return any(
+            full_id.type.inherits_from(component)
+            for component in (
+                GlobalsComponent,
+                RestoringGlobalsComponent,
+                RestoringGlobalStringComponent,
+                RTCGlobalsComponent,
+            )
+        )
+
     parts = value.parts[:]
     for i, id in enumerate(value.requires_ids):
         full_id, var = await get_variable_with_full_id(id)
-        if (
-            full_id is not None
-            and isinstance(full_id.type, MockObjClass)
-            and (
-                full_id.type.inherits_from(GlobalsComponent)
-                or full_id.type.inherits_from(RestoringGlobalsComponent)
-                or full_id.type.inherits_from(RestoringGlobalStringComponent)
-                or full_id.type.inherits_from(RTCGlobalsComponent)
-            )
-        ):
+        if _is_globals_component(full_id):
             parts[i * 3 + 1] = var.value()
             continue
 

--- a/tests/components/globals/test.esp32-idf.yaml
+++ b/tests/components/globals/test.esp32-idf.yaml
@@ -1,1 +1,50 @@
 <<: !include common.yaml
+
+esphome:
+  on_boot:
+    then:
+      - lambda: |-
+          id(uint8_test_no_restore)++;
+          id(uint8_test_restore)++;
+          id(uint8_test_rpc)++;
+          id(uint8_test_no_restore_array)[0]++;
+          id(uint8_test_no_restore_array)[1]++;
+          id(uint8_test_restore_array)[0]++;
+          id(uint8_test_restore_array)[1]++;
+          id(uint8_test_rpc_array)[0]++;
+          id(uint8_test_rpc_array)[1]++;
+      - globals.set:
+          id: uint8_test_no_restore
+          value: 42
+      - globals.set:
+          id: uint8_test_restore
+          value: 42
+      - globals.set:
+          id: uint8_test_rpc
+          value: 42
+
+globals:
+  - id: uint8_test_no_restore
+    type: uint8_t
+    restore_value: no
+    initial_value: "0"
+  - id: uint8_test_restore
+    type: uint8_t
+    restore_value: yes
+    initial_value: "0"
+  - id: uint8_test_rpc
+    type: uint8_t
+    restore_value: RTC
+    initial_value: "0"
+  - id: uint8_test_no_restore_array
+    type: uint8_t[2]
+    restore_value: no
+    initial_value: '{0, 0}'
+  - id: uint8_test_restore_array
+    type: uint8_t[2]
+    restore_value: yes
+    initial_value: '{0, 0}'
+  - id: uint8_test_rpc_array
+    type: uint8_t[2]
+    restore_value: RTC
+    initial_value: '{0, 0}'

--- a/tests/components/globals/test.esp32-idf.yaml
+++ b/tests/components/globals/test.esp32-idf.yaml
@@ -1,5 +1,3 @@
-<<: !include common.yaml
-
 esphome:
   on_boot:
     then:

--- a/tests/components/globals/test.esp32-idf.yaml
+++ b/tests/components/globals/test.esp32-idf.yaml
@@ -15,13 +15,13 @@ esphome:
           id(uint8_test_rpc_array)[1]++;
       - globals.set:
           id: uint8_test_no_restore
-          value: 42
+          value: '42'
       - globals.set:
           id: uint8_test_restore
-          value: 42
+          value: '42'
       - globals.set:
           id: uint8_test_rpc
-          value: 42
+          value: '42'
 
 globals:
   - id: uint8_test_no_restore


### PR DESCRIPTION
# What does this implement/fix?

Adds RTC support for globals (persistence between deep sleeps).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6068

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# The code I used for testing
globals:
  - id: uint8_test_no_restore
    type: uint8_t
    restore_value: no
    initial_value: "0"
  - id: uint8_test_restore
    type: uint8_t
    restore_value: yes
    initial_value: "0"
  - id: uint8_test_rpc
    type: uint8_t
    restore_value: RTC
    initial_value: "0"
  - id: uint8_test_no_restore_array
    type: uint8_t[2]
    restore_value: no
    initial_value: '{0, 0}'
  - id: uint8_test_restore_array
    type: uint8_t[2]
    restore_value: yes
    initial_value: '{0, 0}'
  - id: uint8_test_rpc_array
    type: uint8_t[2]
    restore_value: RTC
    initial_value: '{0, 0}'

deep_sleep:
  id: deep_sleep_1

script:
  - id: test_globals
    then:
      - delay: 8s
      - lambda: |-
          // Print the values of all the globals
          ESP_LOGW("test_globals", "uint8_test_no_restore: %d", id(uint8_test_no_restore));
          ESP_LOGW("test_globals", "uint8_test_restore: %d", id(uint8_test_restore));
          ESP_LOGW("test_globals", "uint8_test_rpc: %d", id(uint8_test_rpc));
          ESP_LOGW("test_globals", "uint8_test_no_restore_array: [%d, %d]", id(uint8_test_no_restore_array)[0], id(uint8_test_no_restore_array)[1]);
          ESP_LOGW("test_globals", "uint8_test_restore_array: [%d, %d]", id(uint8_test_restore_array)[0], id(uint8_test_restore_array)[1]);
          ESP_LOGW("test_globals", "uint8_test_rpc_array: [%d, %d]", id(uint8_test_rpc_array)[0], id(uint8_test_rpc_array)[1]);
      - globals.set:
          id: uint8_test_no_restore
          value: !lambda return 42;
      - globals.set:
          id: uint8_test_restore
          value: !lambda return 42;
      - globals.set:
          id: uint8_test_rpc
          value: !lambda return 42;
      - lambda: |-
          // Increment the values of all the globals
          id(uint8_test_no_restore)++;
          id(uint8_test_restore)++;
          id(uint8_test_rpc)++;
          id(uint8_test_no_restore_array)[0]++;
          id(uint8_test_no_restore_array)[1]++;
          id(uint8_test_restore_array)[0]++;
          id(uint8_test_restore_array)[1]++;
          id(uint8_test_rpc_array)[0]++;
          id(uint8_test_rpc_array)[1]++;
          // Print the values of all the globals
          ESP_LOGW("test_globals", "uint8_test_no_restore: %d", id(uint8_test_no_restore));
          ESP_LOGW("test_globals", "uint8_test_restore: %d", id(uint8_test_restore));
          ESP_LOGW("test_globals", "uint8_test_rpc: %d", id(uint8_test_rpc));
          ESP_LOGW("test_globals", "uint8_test_no_restore_array: [%d, %d]", id(uint8_test_no_restore_array)[0], id(uint8_test_no_restore_array)[1]);
          ESP_LOGW("test_globals", "uint8_test_restore_array: [%d, %d]", id(uint8_test_restore_array)[0], id(uint8_test_restore_array)[1]);
          ESP_LOGW("test_globals", "uint8_test_rpc_array: [%d, %d]", id(uint8_test_rpc_array)[0], id(uint8_test_rpc_array)[1]);
      - deep_sleep.enter:
          id: deep_sleep_1
          sleep_duration: 10ms  
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
