### PR TITLE
[pipsolar] Add separate update frequency for warnings and faults

### DIFF
--- a/esphome/components/pipsolar/__init__.py
+++ b/esphome/components/pipsolar/__init__.py
@@ -9,6 +9,7 @@ AUTO_LOAD = ["binary_sensor", "text_sensor", "sensor", "switch", "output"]
 MULTI_CONF = True
 
 CONF_PIPSOLAR_ID = "pipsolar_id"
+CONF_WARNINGS_UPDATE_INTERVAL = "warnings_update_interval"
 
 pipsolar_ns = cg.esphome_ns.namespace("pipsolar")
 PipsolarComponent = pipsolar_ns.class_("Pipsolar", cg.Component)
@@ -20,7 +21,14 @@ PIPSOLAR_COMPONENT_SCHEMA = cv.Schema(
 )
 
 CONFIG_SCHEMA = cv.All(
-    cv.Schema({cv.GenerateID(): cv.declare_id(PipsolarComponent)})
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(PipsolarComponent),
+            cv.Optional(
+                CONF_WARNINGS_UPDATE_INTERVAL
+            ): cv.positive_time_period_milliseconds,
+        }
+    )
     .extend(cv.polling_component_schema("1s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
@@ -30,3 +38,5 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    if warnings_update_interval := config.get(CONF_WARNINGS_UPDATE_INTERVAL):
+        cg.add(var.set_warnings_update_interval(warnings_update_interval))

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -9,6 +9,10 @@ static const char *const TAG = "pipsolar";
 void Pipsolar::setup() {
   this->state_ = STATE_IDLE;
   this->command_start_millis_ = 0;
+  if (this->warnings_update_interval_ > 0) {
+    this->set_interval("warnings", this->warnings_update_interval_,
+                       [this]() { this->request_poll_update_(POLLING_QPIWS); });
+  }
 }
 
 void Pipsolar::empty_uart_buffer_() {
@@ -768,8 +772,24 @@ void Pipsolar::dump_config() {
 }
 void Pipsolar::update() {
   for (auto &enabled_polling_command : this->enabled_polling_commands_) {
-    if (enabled_polling_command.length != 0) {
+    if (enabled_polling_command.length == 0) {
+      continue;
+    }
+    if (this->warnings_update_interval_ > 0 && enabled_polling_command.identifier == POLLING_QPIWS) {
+      continue;
+    }
+    enabled_polling_command.needs_update = true;
+  }
+}
+
+void Pipsolar::request_poll_update_(ENUMPollingCommand polling_command) {
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length == 0) {
+      continue;
+    }
+    if (enabled_polling_command.identifier == polling_command) {
       enabled_polling_command.needs_update = true;
+      return;
     }
   }
 }

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -189,6 +189,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   void loop() override;
   void dump_config() override;
   void update() override;
+  void set_warnings_update_interval(uint32_t interval) { this->warnings_update_interval_ = interval; }
 
  protected:
   static const size_t PIPSOLAR_READ_BUFFER_LENGTH = 128;  // maximum supported answer length
@@ -222,6 +223,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   void read_int_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor);
 
   void publish_binary_sensor_(esphome::optional<bool> b, binary_sensor::BinarySensor *sensor);
+  void request_poll_update_(ENUMPollingCommand polling_command);
 
   esphome::optional<bool> get_bit_(std::string bits, uint8_t bit_pos);
 
@@ -243,6 +245,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
 
   uint8_t last_polling_command_ = 0;
   PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
+  uint32_t warnings_update_interval_{0};
 };
 
 }  // namespace esphome::pipsolar

--- a/tests/components/pipsolar/common.yaml
+++ b/tests/components/pipsolar/common.yaml
@@ -7,6 +7,8 @@ esphome:
 
 pipsolar:
   id: inverter0
+  update_interval: 10s
+  warnings_update_interval: 2s
 
 binary_sensor:
   - platform: pipsolar


### PR DESCRIPTION
# What does this implement/fix?

It's sometimes desired to update the warning/fault sensors faster than other regular sensors. All of them are binary sensors so bumping the update frequency should not cause much of a bandwidth increase anyways. I'm personally using this to react fast to overload conditions, for which you have a 10s window before an overload fault is triggered and the inverter cuts power to all loads. This is mostly a quick draft. I'll get back to it when I have more time with it/testing done.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

TODO

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

TODO

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (This could be improved)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
