### PR TITLE
[nvm][fram_i2c] Add NVM component with FRAM I2C platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -184,6 +184,7 @@ esphome/components/fastled_base/* @OttoWinter
 esphome/components/feedback/* @ianchi
 esphome/components/fingerprint_grow/* @alexborro @loongyh @OnFreund
 esphome/components/font/* @clydebarrow @esphome/core
+esphome/components/fram_i2c/* @pgolawsk
 esphome/components/fs3000/* @kahrendt
 esphome/components/ft5x06/* @clydebarrow
 esphome/components/ft63x6/* @gpambrozio
@@ -361,6 +362,7 @@ esphome/components/noblex/* @AGalfra
 esphome/components/npi19/* @bakerkj
 esphome/components/nrf52/* @tomaszduda23
 esphome/components/number/* @esphome/core
+esphome/components/nvm/* @pgolawsk
 esphome/components/one_wire/* @ssieb
 esphome/components/online_image/* @clydebarrow @guillempages
 esphome/components/opentherm/* @olegtarasov

--- a/esphome/components/fram_i2c/__init__.py
+++ b/esphome/components/fram_i2c/__init__.py
@@ -1,0 +1,31 @@
+"""I2C FRAM platform for NVM component.
+
+This provides I2C FRAM (Ferroelectric RAM) support as an NVM platform.
+FRAM features:
+- Unlimited write cycles (no wear)
+- No write delays (instant writes)
+- Fast read/write operations
+- Non-volatile storage
+
+Example configuration:
+
+    nvm:
+      - platform: fram_i2c
+        id: my_fram
+        address: 0x50
+        model: MB85RC256
+        partitions:
+          - id: preferences
+            type: preferences
+            size: 4KB
+          - id: sensor_cache
+            type: raw
+            size: 12KB
+"""
+
+from .nvm import CONFIG_SCHEMA as CONFIG_SCHEMA, to_code as to_code
+
+__all__ = ["CONFIG_SCHEMA", "to_code"]
+
+CODEOWNERS = ["@pgolawsk"]
+DEPENDENCIES = ["i2c"]

--- a/esphome/components/fram_i2c/__init__.py
+++ b/esphome/components/fram_i2c/__init__.py
@@ -23,7 +23,7 @@ Example configuration:
             size: 12KB
 """
 
-from .nvm import CONFIG_SCHEMA as CONFIG_SCHEMA, to_code as to_code
+from .nvm import CONFIG_SCHEMA, to_code
 
 __all__ = ["CONFIG_SCHEMA", "to_code"]
 

--- a/esphome/components/fram_i2c/fram_i2c.cpp
+++ b/esphome/components/fram_i2c/fram_i2c.cpp
@@ -1,0 +1,164 @@
+#include "fram_i2c.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace nvm {
+
+static const char *const TAG = "nvm.fram_i2c";
+
+void FramI2cPlatform::setup() {
+  // Check if FRAM is connected
+  if (!this->is_connected()) {
+    ESP_LOGE(TAG, "FRAM not found at address 0x%02X", this->address_);
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGCONFIG(TAG, "FRAM I2C initialized:");
+  ESP_LOGCONFIG(TAG, "  Model: %s", model_.name);
+  ESP_LOGCONFIG(TAG, "  Size: %u bytes", model_.size_bytes);
+  ESP_LOGCONFIG(TAG, "  Address width: %u bits", model_.address_width * 8);
+
+  // Call parent setup to initialize partitions
+  NvmPlatform::setup();
+}
+
+void FramI2cPlatform::dump_config() {
+  ESP_LOGCONFIG(TAG, "FRAM I2C Platform:");
+  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "  Model: %s", model_.name);
+  ESP_LOGCONFIG(TAG, "  Size: %u bytes", model_.size_bytes);
+  ESP_LOGCONFIG(TAG, "  Address width: %u bits", model_.address_width * 8);
+
+  // Call parent dump_config to show partitions
+  NvmPlatform::dump_config();
+}
+
+void FramI2cPlatform::set_model(uint32_t size_bytes) {
+  for (const auto &model : FRAM_I2C_MODELS) {
+    if (model.size_bytes == size_bytes) {
+      model_ = model;
+      return;
+    }
+  }
+  ESP_LOGW(TAG, "Unknown FRAM size %u, using default settings", size_bytes);
+  model_.size_bytes = size_bytes;
+  model_.address_width = 2;  // Default to 16-bit addressing
+  model_.name = "Unknown";
+}
+
+bool FramI2cPlatform::is_connected() {
+  // Try to read one byte to check if device is present
+  uint8_t data;
+  return this->read_bytes(0, &data, 1);
+}
+
+bool FramI2cPlatform::read_bytes(uint32_t memaddr, uint8_t *data, size_t len) {
+  if (memaddr + len > model_.size_bytes) {
+    ESP_LOGE(TAG, "Read out of bounds: addr=%u, len=%zu, size=%u", memaddr, len, model_.size_bytes);
+    return false;
+  }
+
+  if (model_.address_width == 2) {
+    return this->read_bytes_16(memaddr, data, len);
+  } else {
+    return this->read_bytes_ext(memaddr, data, len);
+  }
+}
+
+bool FramI2cPlatform::write_bytes(uint32_t memaddr, const uint8_t *data, size_t len) {
+  if (memaddr + len > model_.size_bytes) {
+    ESP_LOGE(TAG, "Write out of bounds: addr=%u, len=%zu, size=%u", memaddr, len, model_.size_bytes);
+    return false;
+  }
+
+  if (model_.address_width == 2) {
+    return this->write_bytes_16(memaddr, data, len);
+  } else {
+    return this->write_bytes_ext(memaddr, data, len);
+  }
+}
+
+bool FramI2cPlatform::read_bytes_16(uint32_t memaddr, uint8_t *data, size_t len) {
+  // Standard I2C FRAM read: [device_addr+W][addr_high][addr_low] then [device_addr+R][data...]
+  uint8_t addr_buf[2];
+  addr_buf[0] = (memaddr >> 8) & 0xFF;
+  addr_buf[1] = memaddr & 0xFF;
+
+  ESP_LOGV(TAG, "Read addr=0x%04X, len=%zu", memaddr, len);
+  // Write address, then read data
+  i2c::ErrorCode err = this->write_read(addr_buf, 2, data, len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Read failed at address 0x%04X: error %d", memaddr, err);
+    return false;
+  }
+
+  return true;
+}
+
+bool FramI2cPlatform::write_bytes_16(uint32_t memaddr, const uint8_t *data, size_t len) {
+  // Standard I2C FRAM write: [device_addr+W][addr_high][addr_low][data...]
+  // FRAM doesn't need page write delays like EEPROM
+
+  ESP_LOGV(TAG, "Write addr=0x%04X, len=%zu", memaddr, len);
+  // Prepare buffer: address + data (using unique_ptr to avoid STL vector overhead)
+  auto buf = std::make_unique<uint8_t[]>(2 + len);
+  buf[0] = (memaddr >> 8) & 0xFF;
+  buf[1] = memaddr & 0xFF;
+  std::copy(data, data + len, buf.get() + 2);
+
+  i2c::ErrorCode err = this->write(buf.get(), 2 + len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Write failed at address 0x%04X: error %d", memaddr, err);
+    return false;
+  }
+
+  return true;
+}
+
+bool FramI2cPlatform::read_bytes_ext(uint32_t memaddr, uint8_t *data, size_t len) {
+  // Extended address FRAM (17/18-bit): address high bits go into device address
+  // For 17-bit: device address bits [1:0] become address bits [16:15]
+  // For 18-bit: device address bits [1:0] become address bits [17:16]
+
+  uint8_t addr_high = (memaddr >> 16) & 0x03;
+  uint8_t modified_address = (this->address_ & 0xFC) | addr_high;
+
+  uint8_t addr_buf[2];
+  addr_buf[0] = (memaddr >> 8) & 0xFF;
+  addr_buf[1] = memaddr & 0xFF;
+
+  ESP_LOGV(TAG, "Read ext addr=0x%06X, len=%zu, i2c_addr=0x%02X", memaddr, len, modified_address);
+  // Use modified address for this transaction
+  i2c::ErrorCode err = this->bus_->write_readv(modified_address, addr_buf, 2, data, len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Extended read failed at address 0x%06X: error %d", memaddr, err);
+    return false;
+  }
+
+  return true;
+}
+
+bool FramI2cPlatform::write_bytes_ext(uint32_t memaddr, const uint8_t *data, size_t len) {
+  // Extended address FRAM write
+  uint8_t addr_high = (memaddr >> 16) & 0x03;
+  uint8_t modified_address = (this->address_ & 0xFC) | addr_high;
+
+  ESP_LOGV(TAG, "Write ext addr=0x%06X, len=%zu, i2c_addr=0x%02X", memaddr, len, modified_address);
+  // Using unique_ptr to avoid STL vector overhead
+  auto buf = std::make_unique<uint8_t[]>(2 + len);
+  buf[0] = (memaddr >> 8) & 0xFF;
+  buf[1] = memaddr & 0xFF;
+  std::copy(data, data + len, buf.get() + 2);
+
+  i2c::ErrorCode err = this->bus_->write(modified_address, buf.get(), 2 + len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Extended write failed at address 0x%06X: error %d", memaddr, err);
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace nvm
+}  // namespace esphome

--- a/esphome/components/fram_i2c/fram_i2c.cpp
+++ b/esphome/components/fram_i2c/fram_i2c.cpp
@@ -1,8 +1,7 @@
 #include "fram_i2c.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace fram_i2c {
+namespace esphome::fram_i2c {
 
 static const char *const TAG = "fram_i2c";
 
@@ -160,5 +159,4 @@ bool FramI2cPlatform::write_bytes_ext_(uint32_t memaddr, const uint8_t *data, si
   return true;
 }
 
-}  // namespace fram_i2c
-}  // namespace esphome
+}  // namespace esphome::fram_i2c

--- a/esphome/components/fram_i2c/fram_i2c.cpp
+++ b/esphome/components/fram_i2c/fram_i2c.cpp
@@ -62,7 +62,7 @@ bool FramI2cPlatform::read_bytes(uint32_t memaddr, uint8_t *data, size_t len) {
   if (model_.address_width == 2) {
     return this->read_bytes_16(memaddr, data, len);
   } else {
-    return this->read_bytes_ext(memaddr, data, len);
+    return this->read_bytes_ext_(memaddr, data, len);
   }
 }
 
@@ -75,7 +75,7 @@ bool FramI2cPlatform::write_bytes(uint32_t memaddr, const uint8_t *data, size_t 
   if (model_.address_width == 2) {
     return this->write_bytes_16(memaddr, data, len);
   } else {
-    return this->write_bytes_ext(memaddr, data, len);
+    return this->write_bytes_ext_(memaddr, data, len);
   }
 }
 
@@ -116,7 +116,7 @@ bool FramI2cPlatform::write_bytes_16(uint32_t memaddr, const uint8_t *data, size
   return true;
 }
 
-bool FramI2cPlatform::read_bytes_ext(uint32_t memaddr, uint8_t *data, size_t len) {
+bool FramI2cPlatform::read_bytes_ext_(uint32_t memaddr, uint8_t *data, size_t len) {
   // Extended address FRAM (17/18-bit): address high bits go into device address
   // For 17-bit: device address bits [1:0] become address bits [16:15]
   // For 18-bit: device address bits [1:0] become address bits [17:16]
@@ -139,7 +139,7 @@ bool FramI2cPlatform::read_bytes_ext(uint32_t memaddr, uint8_t *data, size_t len
   return true;
 }
 
-bool FramI2cPlatform::write_bytes_ext(uint32_t memaddr, const uint8_t *data, size_t len) {
+bool FramI2cPlatform::write_bytes_ext_(uint32_t memaddr, const uint8_t *data, size_t len) {
   // Extended address FRAM write
   uint8_t addr_high = (memaddr >> 16) & 0x03;
   uint8_t modified_address = (this->address_ & 0xFC) | addr_high;

--- a/esphome/components/fram_i2c/fram_i2c.cpp
+++ b/esphome/components/fram_i2c/fram_i2c.cpp
@@ -2,9 +2,9 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace nvm {  // NOLINT(bugprone-suspicious-namespace-alias)
+namespace fram_i2c {
 
-static const char *const TAG = "nvm.fram_i2c";
+static const char *const TAG = "fram_i2c";
 
 void FramI2cPlatform::setup() {
   // Check if FRAM is connected
@@ -160,5 +160,5 @@ bool FramI2cPlatform::write_bytes_ext_(uint32_t memaddr, const uint8_t *data, si
   return true;
 }
 
-}  // namespace nvm
+}  // namespace fram_i2c
 }  // namespace esphome

--- a/esphome/components/fram_i2c/fram_i2c.cpp
+++ b/esphome/components/fram_i2c/fram_i2c.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace nvm {
+namespace nvm {  // NOLINT(bugprone-suspicious-namespace-alias)
 
 static const char *const TAG = "nvm.fram_i2c";
 

--- a/esphome/components/fram_i2c/fram_i2c.h
+++ b/esphome/components/fram_i2c/fram_i2c.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "esphome/components/nvm/nvm.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace nvm {
+
+/// FRAM model definitions
+struct FramModel {
+  uint32_t size_bytes;    ///< Size in bytes
+  uint8_t address_width;  ///< Address width in bytes (2 for 16-bit, 3 for 17/18-bit)
+  const char *name;       ///< Model name for logging
+};
+
+/// Supported I2C FRAM models
+static const FramModel FRAM_I2C_MODELS[] = {
+    {8 * 1024, 2, "MB85RC64"},    // 64 Kbit = 8 KB
+    {16 * 1024, 2, "MB85RC128"},  // 128 Kbit = 16 KB
+    {32 * 1024, 2, "MB85RC256"},  // 256 Kbit = 32 KB
+    {64 * 1024, 3, "MB85RC512"},  // 512 Kbit = 64 KB (17-bit address)
+    {128 * 1024, 3, "MB85RC1M"},  // 1 Mbit = 128 KB (18-bit address)
+};
+
+/// I2C FRAM platform for NVM component
+///
+/// This platform supports Fujitsu MB85RC series I2C FRAM devices.
+/// FRAM features:
+/// - Unlimited write cycles (no wear)
+/// - No write delays (instant writes)
+/// - Fast read/write operations
+/// - Non-volatile storage
+///
+/// Supported models:
+/// - MB85RC64: 8 KB, 16-bit addressing
+/// - MB85RC128: 16 KB, 16-bit addressing
+/// - MB85RC256: 32 KB, 16-bit addressing
+/// - MB85RC512: 64 KB, 17-bit addressing (uses address bits in device address)
+/// - MB85RC1M: 128 KB, 18-bit addressing (uses address bits in device address)
+class FramI2cPlatform : public NvmPlatform, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  /// Run at IO priority (1500) so hardware is ready before partitions (BUS = 2000)
+  float get_setup_priority() const override { return setup_priority::IO; }
+
+  /// Set FRAM model by size
+  void set_model(uint32_t size_bytes);
+
+  /// Set FRAM model directly
+  void set_model_config(uint32_t size_bytes, uint8_t address_width, const char *name) {
+    model_.size_bytes = size_bytes;
+    model_.address_width = address_width;
+    model_.name = name;
+  }
+
+  // ========== NvmPlatform overrides ==========
+  bool read_bytes(uint32_t memaddr, uint8_t *data, size_t len) override;
+  bool write_bytes(uint32_t memaddr, const uint8_t *data, size_t len) override;
+  uint32_t get_total_size() const override { return model_.size_bytes; }
+
+  /// Check if FRAM is connected
+  bool is_connected();
+
+ protected:
+  /// Read with 16-bit address (standard I2C FRAM)
+  bool read_bytes_16(uint32_t memaddr, uint8_t *data, size_t len);
+
+  /// Write with 16-bit address (standard I2C FRAM)
+  bool write_bytes_16(uint32_t memaddr, const uint8_t *data, size_t len);
+
+  /// Read with extended address (17/18-bit via I2C)
+  bool read_bytes_ext(uint32_t memaddr, uint8_t *data, size_t len);
+
+  /// Write with extended address (17/18-bit via I2C)
+  bool write_bytes_ext(uint32_t memaddr, const uint8_t *data, size_t len);
+
+  FramModel model_{32 * 1024, 2, "MB85RC256"};  // Default: MB85RC256
+};
+
+}  // namespace nvm
+}  // namespace esphome

--- a/esphome/components/fram_i2c/fram_i2c.h
+++ b/esphome/components/fram_i2c/fram_i2c.h
@@ -3,8 +3,7 @@
 #include "esphome/components/nvm/nvm.h"
 #include "esphome/components/i2c/i2c.h"
 
-namespace esphome {
-namespace fram_i2c {
+namespace esphome::fram_i2c {
 
 // Import NvmPlatform from nvm namespace for inheritance
 using nvm::NvmPartition;
@@ -82,5 +81,4 @@ class FramI2cPlatform : public NvmPlatform, public i2c::I2CDevice {
   FramModel model_{32 * 1024, 2, "MB85RC256"};  // Default: MB85RC256
 };
 
-}  // namespace fram_i2c
-}  // namespace esphome
+}  // namespace esphome::fram_i2c

--- a/esphome/components/fram_i2c/fram_i2c.h
+++ b/esphome/components/fram_i2c/fram_i2c.h
@@ -70,10 +70,10 @@ class FramI2cPlatform : public NvmPlatform, public i2c::I2CDevice {
   bool write_bytes_16(uint32_t memaddr, const uint8_t *data, size_t len);
 
   /// Read with extended address (17/18-bit via I2C)
-  bool read_bytes_ext(uint32_t memaddr, uint8_t *data, size_t len);
+  bool read_bytes_ext_(uint32_t memaddr, uint8_t *data, size_t len);
 
   /// Write with extended address (17/18-bit via I2C)
-  bool write_bytes_ext(uint32_t memaddr, const uint8_t *data, size_t len);
+  bool write_bytes_ext_(uint32_t memaddr, const uint8_t *data, size_t len);
 
   FramModel model_{32 * 1024, 2, "MB85RC256"};  // Default: MB85RC256
 };

--- a/esphome/components/fram_i2c/fram_i2c.h
+++ b/esphome/components/fram_i2c/fram_i2c.h
@@ -4,7 +4,11 @@
 #include "esphome/components/i2c/i2c.h"
 
 namespace esphome {
-namespace nvm {  // NOLINT(bugprone-suspicious-namespace-alias)
+namespace fram_i2c {
+
+// Import NvmPlatform from nvm namespace for inheritance
+using nvm::NvmPartition;
+using nvm::NvmPlatform;
 
 /// FRAM model definitions
 struct FramModel {
@@ -78,5 +82,5 @@ class FramI2cPlatform : public NvmPlatform, public i2c::I2CDevice {
   FramModel model_{32 * 1024, 2, "MB85RC256"};  // Default: MB85RC256
 };
 
-}  // namespace nvm
+}  // namespace fram_i2c
 }  // namespace esphome

--- a/esphome/components/fram_i2c/fram_i2c.h
+++ b/esphome/components/fram_i2c/fram_i2c.h
@@ -4,7 +4,7 @@
 #include "esphome/components/i2c/i2c.h"
 
 namespace esphome {
-namespace nvm {
+namespace nvm {  // NOLINT(bugprone-suspicious-namespace-alias)
 
 /// FRAM model definitions
 struct FramModel {

--- a/esphome/components/fram_i2c/nvm.py
+++ b/esphome/components/fram_i2c/nvm.py
@@ -1,0 +1,133 @@
+"""I2C FRAM platform for NVM component.
+
+This provides I2C FRAM (Ferroelectric RAM) support as an NVM platform.
+
+Example configuration:
+
+    nvm:
+      - platform: fram_i2c
+        id: my_fram
+        address: 0x50
+        model: MB85RC256
+        partitions:
+          - id: preferences
+            type: preferences
+            size: 4KB
+          - id: sensor_cache
+            type: raw
+            size: 12KB
+"""
+
+import esphome.codegen as cg
+from esphome.components import i2c, nvm
+import esphome.config_validation as cv
+from esphome.const import CONF_ADDRESS, CONF_ID, CONF_MODEL, CONF_SIZE
+
+CODEOWNERS = ["@pgolawsk"]
+DEPENDENCIES = ["i2c"]
+
+# FRAM I2C platform class
+FramI2cPlatform = nvm.nvm_ns.class_("FramI2cPlatform", nvm.NvmPlatform, i2c.I2CDevice)
+
+# FRAM model definitions (size in bytes)
+# All models use default I²C address 0x50 (configurable via A0-A2 pins to 0x50-0x57)
+FRAM_MODELS = {
+    # Fujitsu MB85RC FRAM Series
+    "MB85RC64": 8 * 1024,  # 64 Kbit = 8 KB
+    "MB85RC128": 16 * 1024,  # 128 Kbit = 16 KB
+    "MB85RC256": 32 * 1024,  # 256 Kbit = 32 KB (also MB85RC256V)
+    "MB85RC512": 64 * 1024,  # 512 Kbit = 64 KB (also MB85RC512T)
+    "MB85RC1M": 128 * 1024,  # 1 Mbit = 128 KB (also MB85RC1MT)
+    "MB85RC2M": 256 * 1024,  # 2 Mbit = 256 KB (also MB85RC2MT)
+    # Infineon/Cypress FRAM Series
+    "FM24CL64B": 8 * 1024,  # 64 Kbit = 8 KB
+    "FM24CL256B": 32 * 1024,  # 256 Kbit = 32 KB
+    "CY15B104QSN": 512 * 1024,  # 4 Mbit = 512 KB
+    "CY15B108QSN": 1024 * 1024,  # 8 Mbit = 1 MB
+}
+
+
+def validate_fram_config(config):
+    """Validate that model or size is specified, and partitions fit within FRAM size."""
+    # Check that either model or size is specified
+    if CONF_MODEL not in config and CONF_SIZE not in config:
+        raise cv.Invalid("Either 'model' or 'size' must be specified for FRAM device")
+
+    # When using custom size, I2C address must be explicitly specified
+    # (different FRAM devices have different default addresses)
+    if CONF_SIZE in config and CONF_MODEL not in config and CONF_ADDRESS not in config:
+        raise cv.Invalid(
+            "I2C 'address' must be specified when using custom 'size' "
+            "(different FRAM devices have different default addresses)"
+        )
+
+    # Determine FRAM size
+    if CONF_MODEL in config:
+        fram_size = FRAM_MODELS[config[CONF_MODEL]]
+    else:
+        fram_size = config[CONF_SIZE]
+
+    # Validate partitions fit within FRAM size
+    for partition in config.get(nvm.CONF_PARTITIONS, []):
+        partition_size = partition[
+            CONF_SIZE
+        ]  # Already converted to int by cv.validate_bytes
+        partition_offset = partition.get("offset", 0)
+        partition_end = partition_offset + partition_size
+
+        if partition_end > fram_size:
+            raise cv.Invalid(
+                f"Partition '{partition[CONF_ID]}' (offset={partition_offset}, "
+                f"size={partition_size}) exceeds FRAM size ({fram_size} bytes). "
+                f"Partition end: {partition_end}, FRAM size: {fram_size}"
+            )
+
+    return config
+
+
+def validate_fram_address(config):
+    """Set default I2C address for known models, require explicit address for custom size."""
+    # If model is specified without address, use default 0x50 (standard for MB85RC series)
+    if CONF_MODEL in config and CONF_ADDRESS not in config:
+        config[CONF_ADDRESS] = 0x50
+    # If custom size without address, validation in validate_fram_config will catch it
+    return config
+
+
+# FRAM I2C platform schema
+CONFIG_SCHEMA = cv.All(
+    nvm.NVM_PLATFORM_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(FramI2cPlatform),
+            cv.Optional(CONF_ADDRESS): cv.i2c_address,
+            cv.Optional(CONF_MODEL): cv.one_of(*FRAM_MODELS.keys(), upper=True),
+            cv.Optional(CONF_SIZE): cv.validate_bytes,
+        }
+    ).extend(i2c.i2c_device_schema(None)),
+    validate_fram_address,
+    validate_fram_config,
+    nvm.validate_preferences_partition_count,
+    nvm.validate_nvm_i2c_address,
+)
+
+
+async def to_code(config):
+    """Generate code for FRAM I2C platform."""
+    # Create FRAM platform
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    # Set FRAM size (from model or custom size)
+    if CONF_MODEL in config:
+        model_size = FRAM_MODELS[config[CONF_MODEL]]
+        cg.add(var.set_model(model_size))
+    elif CONF_SIZE in config:
+        cg.add(var.set_model(config[CONF_SIZE]))
+
+    # Register I2C device (this sets the address via set_i2c_address)
+    await i2c.register_i2c_device(var, config)
+
+    # Register partitions
+    await nvm.register_nvm_platform(var, config)
+
+    # Register as component
+    await cg.register_component(var, config)

--- a/esphome/components/fram_i2c/nvm.py
+++ b/esphome/components/fram_i2c/nvm.py
@@ -26,8 +26,9 @@ from esphome.const import CONF_ADDRESS, CONF_ID, CONF_MODEL, CONF_SIZE
 CODEOWNERS = ["@pgolawsk"]
 DEPENDENCIES = ["i2c"]
 
-# FRAM I2C platform class
-FramI2cPlatform = nvm.nvm_ns.class_("FramI2cPlatform", nvm.NvmPlatform, i2c.I2CDevice)
+# FRAM I2C namespace and platform class
+fram_i2c_ns = cg.esphome_ns.namespace("fram_i2c")
+FramI2cPlatform = fram_i2c_ns.class_("FramI2cPlatform", nvm.NvmPlatform, i2c.I2CDevice)
 
 # FRAM model definitions (size in bytes)
 # All models use default I²C address 0x50 (configurable via A0-A2 pins to 0x50-0x57)

--- a/esphome/components/nvm/__init__.py
+++ b/esphome/components/nvm/__init__.py
@@ -1,0 +1,226 @@
+"""NVM (Non-Volatile Memory) component for ESPHome.
+
+This component provides a unified interface for NVM devices like FRAM and EEPROM,
+with support for partitions that can be used for preferences, raw data, or key-value storage.
+
+Example configuration:
+
+    nvm:
+      - platform: fram_i2c
+        id: my_fram
+        address: 0x50
+        model: MB85RC256
+        partitions:
+          - id: preferences
+            type: preferences
+            size: 4kB
+          - id: sensor_cache
+            type: raw
+            size: 12kB
+          - id: config
+            type: key_value
+            size: 2kB
+"""
+
+from dataclasses import dataclass, field
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ADDRESS, CONF_ID, CONF_OFFSET, CONF_SIZE, CONF_TYPE
+from esphome.core import CORE
+
+CODEOWNERS = ["@pgolawsk"]
+
+
+# ========== State Management using CORE.data pattern ==========
+# This avoids module-level globals that persist between compilation runs
+
+DOMAIN = "nvm"
+
+
+@dataclass
+class NvmData:
+    """State for NVM component validation across MULTI_CONF instances."""
+
+    preferences_partition_count: int = 0
+    i2c_devices: dict = field(default_factory=dict)
+
+
+def _get_data() -> NvmData:
+    """Get or create NVM state from CORE.data."""
+    if DOMAIN not in CORE.data:
+        CORE.data[DOMAIN] = NvmData()
+    return CORE.data[DOMAIN]
+
+
+MULTI_CONF = True
+IS_PLATFORM_COMPONENT = True
+
+# NVM namespace
+nvm_ns = cg.esphome_ns.namespace("nvm")
+
+# C++ classes
+NvmPlatform = nvm_ns.class_("NvmPlatform", cg.Component)
+NvmPartition = nvm_ns.class_("NvmPartition")
+PreferencesPartition = nvm_ns.class_("PreferencesPartition", NvmPartition, cg.Component)
+RawPartition = nvm_ns.class_("RawPartition", NvmPartition)
+KeyValuePartition = nvm_ns.class_("KeyValuePartition", NvmPartition, cg.Component)
+PartitionType = nvm_ns.enum("PartitionType", is_class=True)
+
+# Partition type enum values
+PARTITION_TYPE_PREFERENCES = PartitionType.PREFERENCES
+PARTITION_TYPE_RAW = PartitionType.RAW
+PARTITION_TYPE_KEY_VALUE = PartitionType.KEY_VALUE
+
+# Configuration keys
+CONF_PARTITIONS = "partitions"
+
+
+def _validate_partition_id(config):
+    """Validate and set the correct ID type based on partition type."""
+    partition_type = config[CONF_TYPE]
+    if partition_type == "preferences":
+        config[CONF_ID] = cv.declare_id(PreferencesPartition)(config[CONF_ID])
+    elif partition_type == "raw":
+        config[CONF_ID] = cv.declare_id(RawPartition)(config[CONF_ID])
+    elif partition_type == "key_value":
+        config[CONF_ID] = cv.declare_id(KeyValuePartition)(config[CONF_ID])
+    return config
+
+
+# Partition configuration schema
+PARTITION_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(NvmPartition),
+            cv.Required(CONF_TYPE): cv.one_of(
+                "preferences", "raw", "key_value", lower=True
+            ),
+            cv.Required(CONF_SIZE): cv.All(cv.validate_bytes, cv.Range(min=1)),
+            cv.Optional(CONF_OFFSET, default=0): cv.All(
+                cv.positive_int, cv.Range(min=0)
+            ),
+        }
+    ),
+    _validate_partition_id,
+)
+
+
+async def register_nvm_platform(platform_var, config):
+    """Register an NVM platform with its partitions."""
+    # Add partitions
+    for partition_config in config.get(CONF_PARTITIONS, []):
+        partition_type = partition_config[CONF_TYPE]
+        partition_size = partition_config[
+            CONF_SIZE
+        ]  # Already converted to int by cv.validate_bytes
+        partition_offset = partition_config[CONF_OFFSET]
+
+        # Determine partition type enum and target class
+        if partition_type == "preferences":
+            partition_type_enum = PARTITION_TYPE_PREFERENCES
+            target_class = PreferencesPartition
+        elif partition_type == "raw":
+            partition_type_enum = PARTITION_TYPE_RAW
+            target_class = RawPartition
+        elif partition_type == "key_value":
+            partition_type_enum = PARTITION_TYPE_KEY_VALUE
+            target_class = KeyValuePartition
+        else:
+            raise cv.Invalid(f"Unknown partition type: {partition_type}")
+
+        # Create partition config struct
+        partition_id_obj = partition_config[CONF_ID]
+        partition_config_struct = cg.StructInitializer(
+            nvm_ns.class_("PartitionConfig"),
+            ("id", partition_id_obj.id),
+            ("type", partition_type_enum),
+            ("offset", partition_offset),
+            ("size", partition_size),
+        )
+
+        # Create partition via platform and register it as a variable
+        # Pvariable both declares the global variable AND registers it with CORE
+        # so it can be accessed via id() in lambdas
+        # Note: add_partition() returns NvmPartition*, we cast to the derived type
+        cg.Pvariable(
+            partition_id_obj,
+            cg.RawExpression(
+                f"static_cast<{target_class}*>"
+                f"({platform_var.add_partition(partition_config_struct)})"
+            ),
+        )
+        # Note: PreferencesPartition is registered with App.register_component() in C++
+        # add_partition(), so setup() will be called automatically by Application
+
+
+# ========== Validation Functions ==========
+
+
+def validate_nvm_i2c_address(config):
+    """Validate that I2C address is unique per I2C bus across all NVM devices.
+
+    This prevents multiple NVM configurations from accessing the same
+    physical device on the same bus, which would cause data corruption.
+
+    Same address on different I2C buses is allowed (different physical devices).
+    """
+    # Get address from config (may be None for platforms without I2C)
+    address = config.get(CONF_ADDRESS)
+    if address is None:
+        return config
+
+    # Get I2C bus ID (defaults to None for default bus)
+    from esphome.const import CONF_I2C_ID
+
+    i2c_id = config.get(CONF_I2C_ID)
+    # Convert i2c_id to a hashable key (it might be an ID object)
+    if i2c_id is not None and hasattr(i2c_id, "id"):
+        i2c_id = i2c_id.id
+
+    # Create a unique key for this (bus, address) combination
+    device_key = (i2c_id, address)
+
+    # Get config ID for error messages
+    config_id = config.get(CONF_ID)
+    if hasattr(config_id, "id"):
+        config_id = config_id.id
+
+    # Check for duplicate using CORE.data
+    data = _get_data()
+    if device_key in data.i2c_devices:
+        existing_id = data.i2c_devices[device_key]
+        bus_desc = f" on I2C bus '{i2c_id}'" if i2c_id else " on default I2C bus"
+        raise cv.Invalid(
+            f"Duplicate NVM I2C address 0x{address:02X}{bus_desc}. "
+            f"Already used by '{existing_id}'. "
+            f"Each NVM device must have a unique I2C address on the same bus."
+        )
+
+    data.i2c_devices[device_key] = config_id
+    return config
+
+
+# Base NVM platform schema (platforms will extend this)
+NVM_PLATFORM_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.declare_id(NvmPlatform),
+        cv.Optional(CONF_PARTITIONS, default=[]): cv.ensure_list(PARTITION_SCHEMA),
+    }
+)
+
+
+def validate_preferences_partition_count(config):
+    """Validate that only one preferences partition exists across all NVM devices."""
+    data = _get_data()
+    for partition in config.get(CONF_PARTITIONS, []):
+        if partition[CONF_TYPE] == "preferences":
+            data.preferences_partition_count += 1
+            if data.preferences_partition_count > 1:
+                raise cv.Invalid(
+                    "Only one preferences partition is allowed across all NVM devices. "
+                    "Multiple preferences partitions would conflict as they all replace "
+                    "the global preferences backend."
+                )
+
+    return config

--- a/esphome/components/nvm/__init__.py
+++ b/esphome/components/nvm/__init__.py
@@ -76,15 +76,16 @@ PARTITION_TYPE_KEY_VALUE = PartitionType.KEY_VALUE
 CONF_PARTITIONS = "partitions"
 
 
+_PARTITION_TYPE_TO_CLASS = {
+    "preferences": PreferencesPartition,
+    "raw": RawPartition,
+    "key_value": KeyValuePartition,
+}
+
+
 def _validate_partition_id(config):
-    """Validate and set the correct ID type based on partition type."""
-    partition_type = config[CONF_TYPE]
-    if partition_type == "preferences":
-        config[CONF_ID] = cv.declare_id(PreferencesPartition)(config[CONF_ID])
-    elif partition_type == "raw":
-        config[CONF_ID] = cv.declare_id(RawPartition)(config[CONF_ID])
-    elif partition_type == "key_value":
-        config[CONF_ID] = cv.declare_id(KeyValuePartition)(config[CONF_ID])
+    """Specialize the declared partition ID to its concrete C++ class."""
+    config[CONF_ID].type = _PARTITION_TYPE_TO_CLASS[config[CONF_TYPE]]
     return config
 
 
@@ -92,7 +93,7 @@ def _validate_partition_id(config):
 PARTITION_SCHEMA = cv.All(
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(NvmPartition),
+            cv.Required(CONF_ID): cv.declare_id(NvmPartition),
             cv.Required(CONF_TYPE): cv.one_of(
                 "preferences", "raw", "key_value", lower=True
             ),

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -1,0 +1,1092 @@
+#include "nvm.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+#include <array>
+#include <cstring>
+
+namespace esphome {
+namespace nvm {
+
+static const char *const TAG = "nvm";
+
+// Static member definitions for NvmDataPartition
+const uint8_t NvmDataPartition::OFF_MAGIC;
+const uint8_t NvmDataPartition::OFF_VERSION;
+const uint8_t NvmDataPartition::OFF_TYPE;
+const uint8_t NvmDataPartition::OFF_RESERVED;
+const uint8_t NvmDataPartition::OFF_SIZE;
+const uint8_t NvmDataPartition::OFF_FIRST_FREE;
+const uint32_t NvmDataPartition::HEADER_SIZE;
+const uint32_t NvmDataPartition::MAGIC;
+const uint8_t NvmDataPartition::VERSION;
+
+const char *partition_type_to_string(PartitionType type) {
+  switch (type) {
+    case PartitionType::PREFERENCES:
+      return "preferences";
+    case PartitionType::RAW:
+      return "raw";
+    case PartitionType::KEY_VALUE:
+      return "key_value";
+    default:
+      return "unknown";
+  }
+}
+
+// ========== NvmPartition ==========
+
+NvmPartition::NvmPartition(NvmPlatform *parent, const PartitionConfig &config) : parent_(parent), config_(config) {}
+
+bool NvmPartition::read(uint32_t offset, uint8_t *data, size_t len) {
+  if (offset + len > config_.size) {
+    ESP_LOGE(TAG, "Partition '%s' read out of bounds: offset=%u, len=%zu, size=%u", config_.id.c_str(), offset, len,
+             config_.size);
+    return false;
+  }
+  ESP_LOGV(TAG, "Partition '%s' read: offset=%u, len=%zu", config_.id.c_str(), offset, len);
+  return parent_->read_bytes(config_.offset + offset, data, len);
+}
+
+bool NvmPartition::write(uint32_t offset, const uint8_t *data, size_t len) {
+  if (offset + len > config_.size) {
+    ESP_LOGE(TAG, "Partition '%s' write out of bounds: offset=%u, len=%zu, size=%u", config_.id.c_str(), offset, len,
+             config_.size);
+    return false;
+  }
+  ESP_LOGV(TAG, "Partition '%s' write: offset=%u, len=%zu", config_.id.c_str(), offset, len);
+  return parent_->write_bytes(config_.offset + offset, data, len);
+}
+
+// ========== NvmPlatform ==========
+
+void NvmPlatform::setup() {
+  // Calculate automatic offsets for partitions
+  this->calculate_partition_offsets();
+
+  // Validate all partitions
+  for (const auto &partition : partitions_) {
+    if (!this->validate_partition_config(partition->config_)) {
+      this->mark_failed();
+      return;
+    }
+  }
+
+  // Note: PreferencesPartition is registered with App in add_partition(),
+  // so its setup() will be called automatically by the Application
+
+  ESP_LOGCONFIG(TAG, "NVM Platform initialized with %zu partitions", partitions_.size());
+}
+
+void NvmPlatform::dump_config() {
+  ESP_LOGCONFIG(TAG, "NVM Platform:");
+  ESP_LOGCONFIG(TAG, "  Total size: %u bytes", this->get_total_size());
+  ESP_LOGCONFIG(TAG, "  Partitions: %zu", partitions_.size());
+
+  for (const auto &partition : partitions_) {
+    ESP_LOGCONFIG(TAG, "    '%s': type=%s, offset=0x%04X, size=%u bytes", partition->get_id().c_str(),
+                  partition_type_to_string(partition->get_type()), partition->get_offset(), partition->get_size());
+    // Call partition-specific dump_config for detailed info
+    if (partition->get_type() == PartitionType::KEY_VALUE) {
+      static_cast<KeyValuePartition *>(partition.get())->dump_config();
+    }
+    // PreferencesPartition has its own dump_config called by Application (it's a Component)
+  }
+}
+
+NvmPartition *NvmPlatform::add_partition(const PartitionConfig &config) {
+  // Create appropriate partition type
+  std::unique_ptr<NvmPartition> partition;
+
+  switch (config.type) {
+    case PartitionType::PREFERENCES: {
+      auto pref_partition = std::make_unique<PreferencesPartition>(this, config);
+      // Register with Application so setup() is called automatically
+      App.register_component(pref_partition.get());
+      partition = std::move(pref_partition);
+      break;
+    }
+    case PartitionType::RAW:
+      partition = std::make_unique<RawPartition>(this, config);
+      break;
+    case PartitionType::KEY_VALUE:
+      partition = std::make_unique<KeyValuePartition>(this, config);
+      break;
+    default:
+      ESP_LOGE(TAG, "Unknown partition type: %d", static_cast<int>(config.type));
+      return nullptr;
+  }
+
+  ESP_LOGD(TAG, "Configured partition '%s': type=%s, offset=0x%04X, size=%u bytes", config.id.c_str(),
+           partition_type_to_string(config.type), config.offset, config.size);
+
+  partitions_.push_back(std::move(partition));
+  return partitions_.back().get();
+}
+
+NvmPartition *NvmPlatform::get_partition(const std::string &id) {
+  for (const auto &partition : partitions_) {
+    if (partition->get_id() == id) {
+      return partition.get();
+    }
+  }
+  return nullptr;
+}
+
+bool NvmPlatform::validate_partition_config(const PartitionConfig &config) {
+  // Check size
+  if (config.size == 0) {
+    ESP_LOGE(TAG, "Partition '%s' has zero size", config.id.c_str());
+    return false;
+  }
+
+  // Check bounds
+  if (config.offset + config.size > this->get_total_size()) {
+    ESP_LOGE(TAG, "Partition '%s' exceeds device size: offset=%u, size=%u, device_size=%u", config.id.c_str(),
+             config.offset, config.size, this->get_total_size());
+    return false;
+  }
+
+  // Check for overlap
+  if (!this->check_partition_overlap(config)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool NvmPlatform::check_partition_overlap(const PartitionConfig &config) {
+  for (const auto &partition : partitions_) {
+    // Skip the partition being validated (for updates)
+    if (partition->get_id() == config.id) {
+      continue;
+    }
+
+    // Check for overlap
+    uint32_t existing_end = partition->get_offset() + partition->get_size();
+    uint32_t new_end = config.offset + config.size;
+
+    if (config.offset < existing_end && new_end > partition->get_offset()) {
+      ESP_LOGE(TAG, "Partition '%s' overlaps with partition '%s'", config.id.c_str(), partition->get_id().c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+void NvmPlatform::calculate_partition_offsets() {
+  uint32_t current_offset = 0;
+
+  for (auto &partition : partitions_) {
+    // If offset is 0, auto-calculate
+    if (partition->config_.offset == 0) {
+      partition->config_.offset = current_offset;
+    }
+
+    // Update current offset for next partition
+    current_offset = partition->config_.offset + partition->config_.size;
+  }
+}
+
+// ========== KeyValuePartition ==========
+
+int KeyValuePartition::get(const std::string &key, uint8_t *value, size_t max_len) {
+  // Ensure partition is initialized
+  this->ensure_initialized_();
+
+  ESP_LOGV(TAG, "KeyValue '%s' get: key='%s', max_len=%zu", this->get_id().c_str(), key.c_str(), max_len);
+
+  uint32_t offset, value_offset;
+  uint16_t value_len;
+
+  if (!this->find_key(key, offset, value_offset, value_len)) {
+    ESP_LOGV(TAG, "KeyValue '%s' get: key='%s' not found", this->get_id().c_str(), key.c_str());
+    return -1;  // Key not found
+  }
+
+  // Limit read length
+  size_t read_len = std::min(static_cast<size_t>(value_len), max_len);
+  // value_offset is relative to data area, need to add HEADER_SIZE for absolute partition offset
+  if (!this->read(HEADER_SIZE + value_offset, value, read_len)) {
+    return -1;
+  }
+
+  ESP_LOGV(TAG, "KeyValue '%s' get: key='%s' found, len=%zu", this->get_id().c_str(), key.c_str(), read_len);
+  return static_cast<int>(read_len);
+}
+
+bool KeyValuePartition::set(const std::string &key, const uint8_t *value, size_t len) {
+  // Ensure partition is initialized
+  this->ensure_initialized_();
+
+  ESP_LOGV(TAG, "KeyValue '%s' set: key='%s', len=%zu", this->get_id().c_str(), key.c_str(), len);
+
+  // Check if key already exists
+  uint32_t existing_offset, value_offset;
+  uint16_t existing_len;
+
+  if (this->find_key(key, existing_offset, value_offset, existing_len)) {
+    // Key exists - check if new value fits
+    if (len <= existing_len) {
+      // Overwrite in place (add HEADER_SIZE to convert from data-relative to absolute)
+      return this->write(HEADER_SIZE + value_offset, value, len);
+    } else {
+      // Need to erase and rewrite
+      this->erase(key);
+    }
+  }
+
+  // Find end of storage (start after header)
+  uint32_t write_offset = HEADER_SIZE;
+  uint8_t marker;
+  bool is_first_entry = (write_offset == HEADER_SIZE);  // Track if this is the first entry
+  while (write_offset < this->get_size()) {
+    if (!this->read(write_offset, &marker, 1)) {
+      break;
+    }
+    if (marker == 0xFF || marker == 0x00) {
+      // Empty slot found
+      break;
+    }
+    is_first_entry = false;  // Found an existing entry, so not first time
+    // Skip entry: key_len(1) + key + value_len(2) + value
+    uint8_t key_len = marker;
+    uint16_t value_len;
+    this->read(write_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&value_len), 2);
+    write_offset += 1 + key_len + 2 + value_len;
+  }
+
+  // Check if we have space
+  size_t entry_size = 1 + key.size() + 2 + len;
+  if (write_offset + entry_size > this->get_size()) {
+    ESP_LOGE(TAG, "KeyValue partition '%s' full, cannot store key '%s'", this->get_id().c_str(), key.c_str());
+    return false;
+  }
+
+  // Write entry
+  uint8_t key_len = static_cast<uint8_t>(key.size());
+  uint16_t value_len = static_cast<uint16_t>(len);
+
+  this->write(write_offset, &key_len, 1);
+  this->write(write_offset + 1, reinterpret_cast<const uint8_t *>(key.c_str()), key.size());
+  this->write(write_offset + 1 + key.size(), reinterpret_cast<uint8_t *>(&value_len), 2);
+  this->write(write_offset + 1 + key.size() + 2, value, len);
+
+  ESP_LOGV(TAG, "KeyValue '%s' set: key='%s' written at offset=%u", this->get_id().c_str(), key.c_str(), write_offset);
+
+  // Update first_free_offset if we wrote past it
+  uint32_t new_first_free = write_offset + entry_size;
+  if (new_first_free > HEADER_SIZE) {
+    this->write(12, reinterpret_cast<uint8_t *>(&new_first_free), 4);
+    ESP_LOGVV(TAG, "KeyValue '%s' updated first_free to %u", this->get_id().c_str(), new_first_free);
+  }
+
+  // Check usage and warn if approaching capacity
+  this->check_usage_();
+
+  return true;
+}
+
+bool KeyValuePartition::erase(const std::string &key) {
+  // Ensure partition is initialized
+  this->ensure_initialized_();
+
+  ESP_LOGV(TAG, "KeyValue '%s' erase: key='%s'", this->get_id().c_str(), key.c_str());
+
+  uint32_t offset, value_offset;
+  uint16_t value_len;
+
+  if (!this->find_key(key, offset, value_offset, value_len)) {
+    ESP_LOGV(TAG, "KeyValue '%s' erase: key='%s' not found", this->get_id().c_str(), key.c_str());
+    return false;  // Key not found
+  }
+
+  // Mark as deleted by zeroing key length (need to add HEADER_SIZE to convert to absolute offset)
+  uint8_t zero = 0;
+  this->write(HEADER_SIZE + offset, &zero, 1);
+
+  ESP_LOGV(TAG, "KeyValue '%s' erase: key='%s' erased", this->get_id().c_str(), key.c_str());
+  return true;
+}
+
+bool KeyValuePartition::has_key(const std::string &key) {
+  uint32_t offset, value_offset;
+  uint16_t value_len;
+  return this->find_key(key, offset, value_offset, value_len);
+}
+
+int KeyValuePartition::get_string(const std::string &key, char *buf, size_t buf_len, const char *default_value) {
+  if (buf == nullptr || buf_len == 0) {
+    return -1;
+  }
+
+  int len = this->get(key, reinterpret_cast<uint8_t *>(buf), buf_len - 1);
+  if (len < 0) {
+    // Key not found, copy default value
+    if (default_value != nullptr) {
+      size_t default_len = strlen(default_value);
+      size_t copy_len = std::min(default_len, buf_len - 1);
+      memcpy(buf, default_value, copy_len);
+      buf[copy_len] = '\0';
+      return static_cast<int>(copy_len);
+    }
+    buf[0] = '\0';
+    return 0;
+  }
+
+  // Null-terminate the string
+  buf[len] = '\0';
+  return len;
+}
+
+std::string KeyValuePartition::get_string(const std::string &key, const std::string &default_value) {
+  // Use std::array for compile-time known size (avoid STL vector overhead)
+  std::array<uint8_t, 256> buffer{};
+  int len = this->get(key, buffer.data(), buffer.size());
+  if (len < 0) {
+    return default_value;
+  }
+  return std::string(buffer.begin(), buffer.begin() + len);
+}
+
+bool KeyValuePartition::set_string(const std::string &key, const std::string &value) {
+  return this->set(key, reinterpret_cast<const uint8_t *>(value.c_str()), value.size());
+}
+
+bool KeyValuePartition::find_key(const std::string &key, uint32_t &offset, uint32_t &value_offset,
+                                 uint16_t &value_len) {
+  // Start after header
+  uint32_t current_offset = HEADER_SIZE;
+
+  while (current_offset < this->get_size()) {
+    uint8_t key_len;
+    if (!this->read(current_offset, &key_len, 1)) {
+      break;
+    }
+
+    // Check for empty slot
+    if (key_len == 0xFF || key_len == 0x00) {
+      break;
+    }
+
+    // Check if key matches
+    if (key_len == key.size()) {
+      // Use unique_ptr for runtime-sized buffer (avoid STL vector overhead)
+      auto stored_key = std::make_unique<uint8_t[]>(key_len);
+      this->read(current_offset + 1, stored_key.get(), key_len);
+
+      if (std::string(stored_key.get(), stored_key.get() + key_len) == key) {
+        // Found it! Return offsets relative to data area (without header)
+        offset = current_offset - HEADER_SIZE;
+        this->read(current_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&value_len), 2);
+        value_offset = current_offset + 1 + key_len + 2 - HEADER_SIZE;
+        return true;
+      }
+    }
+
+    // Skip to next entry
+    uint16_t entry_value_len;
+    this->read(current_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&entry_value_len), 2);
+    current_offset += 1 + key_len + 2 + entry_value_len;
+  }
+
+  return false;
+}
+
+void KeyValuePartition::compact() {
+  // TODO: Implement compaction to remove deleted entries
+  // This would read all valid entries, erase the partition, and rewrite them
+}
+
+uint32_t KeyValuePartition::calculate_used_bytes_() {
+  // Start after header and include header in used bytes
+  uint32_t current_offset = HEADER_SIZE;
+  uint32_t used_bytes = HEADER_SIZE;  // Account for header
+
+  while (current_offset < this->get_size()) {
+    uint8_t key_len;
+    if (!this->read(current_offset, &key_len, 1)) {
+      break;
+    }
+
+    // Check for empty slot
+    if (key_len == 0xFF || key_len == 0x00) {
+      break;
+    }
+
+    // Skip deleted entries (key_len == 0 from erase())
+    if (key_len == 0) {
+      // Read the old value length to skip this entry
+      // Note: after key_len(0), there's still the old key + value_len + value
+      // But we can't know the key length anymore, so we need to scan differently
+      // For now, just count it as used space (compaction will recover it)
+      // Read value_len at offset + 1 (where key would have been, but we don't know its length)
+      // This is a limitation - deleted entries are counted as used until compaction
+      // For simplicity, we'll stop counting here since we can't reliably skip
+      break;
+    }
+
+    // Read value length
+    uint16_t value_len;
+    this->read(current_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&value_len), 2);
+
+    // Add entry size: key_len(1) + key + value_len(2) + value
+    used_bytes += 1 + key_len + 2 + value_len;
+    current_offset += 1 + key_len + 2 + value_len;
+  }
+
+  return used_bytes;
+}
+
+uint32_t KeyValuePartition::get_used_bytes() {
+  // Use first_free_offset from header for O(1) calculation
+  this->ensure_initialized_();
+
+  uint32_t first_free = HEADER_SIZE;
+  this->read(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+
+  // If first_free is 0 or invalid, fall back to scanning
+  if (first_free < HEADER_SIZE || first_free > this->get_size()) {
+    return this->calculate_used_bytes_();
+  }
+
+  ESP_LOGVV(TAG, "KeyValue '%s' get_used_bytes: first_free=%u", this->get_id().c_str(), first_free);
+  return first_free;
+}
+
+float KeyValuePartition::get_usage_percent() {
+  uint32_t used = this->get_used_bytes();
+  return (used * 100.0f) / this->get_size();
+}
+
+void KeyValuePartition::check_usage_() {
+  float usage_percent = this->get_usage_percent();
+
+  if (usage_percent > WARNING_L2_PERCENT) {
+    ESP_LOGW(TAG, "KeyValue partition '%s' is %.0f%% full! Consider increasing partition size", this->get_id().c_str(),
+             usage_percent);
+  } else if (usage_percent > WARNING_L1_PERCENT && !this->warned_L1_percent_) {
+    ESP_LOGW(TAG, "KeyValue partition '%s' is %.0f%% full. Consider increasing partition size soon",
+             this->get_id().c_str(), usage_percent);
+    this->warned_L1_percent_ = true;
+  }
+}
+
+void KeyValuePartition::dump_config() {
+  ESP_LOGCONFIG(TAG, "KeyValue Partition '%s':", this->get_id().c_str());
+  ESP_LOGCONFIG(TAG, "  Size: %u bytes", this->get_size());
+  uint32_t used = this->get_used_bytes();
+  if (used > 0) {
+    float usage_percent = this->get_usage_percent();
+    ESP_LOGCONFIG(TAG, "  Used: %u bytes (%.1f%%)", used, usage_percent);
+  }
+  // Initialize if needed to show header info
+  this->ensure_initialized_();
+  if (this->initialized_) {
+    uint32_t magic = 0;
+    uint8_t version = 0;
+    uint8_t type = 0;
+    uint32_t stored_size = 0;
+    uint32_t first_free = 0;
+    this->read(0, reinterpret_cast<uint8_t *>(&magic), 4);
+    this->read(4, &version, 1);
+    this->read(5, &type, 1);
+    this->read(8, reinterpret_cast<uint8_t *>(&stored_size), 4);
+    this->read(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+    ESP_LOGCONFIG(TAG, "  Header: magic=0x%08X, version=%u, type=%u, size=%u, first_free=%u", magic, version, type,
+                  stored_size, first_free);
+  }
+}
+
+void KeyValuePartition::ensure_initialized_() {
+  if (this->initialized_) {
+    return;
+  }
+
+  uint32_t magic = 0;
+  this->read(0, reinterpret_cast<uint8_t *>(&magic), 4);
+  ESP_LOGVV(TAG, "KeyValue '%s' init: magic=0x%08X, expected=0x%08X", this->get_id().c_str(), magic, MAGIC);
+
+  bool needs_clear = false;
+
+  if (magic != MAGIC) {
+    ESP_LOGW(TAG, "KeyValue partition '%s' has invalid magic (0x%08X), initializing", this->get_id().c_str(), magic);
+    needs_clear = true;
+  } else {
+    uint8_t version = 0;
+    this->read(4, &version, 1);
+    ESP_LOGVV(TAG, "KeyValue '%s' init: version=%u, expected=%u", this->get_id().c_str(), version, VERSION);
+    if (version != VERSION) {
+      ESP_LOGW(TAG, "KeyValue partition '%s' version mismatch (%u vs %u), reinitializing", this->get_id().c_str(),
+               version, VERSION);
+      needs_clear = true;
+    } else {
+      // Validate partition type
+      uint8_t type = 0;
+      this->read(5, &type, 1);
+      ESP_LOGVV(TAG, "KeyValue '%s' init: type=%u, expected=%u", this->get_id().c_str(), type,
+                static_cast<uint8_t>(PartitionType::KEY_VALUE));
+      if (type != static_cast<uint8_t>(PartitionType::KEY_VALUE)) {
+        ESP_LOGW(TAG, "KeyValue partition '%s' type mismatch (%u vs %u), reinitializing", this->get_id().c_str(), type,
+                 static_cast<uint8_t>(PartitionType::KEY_VALUE));
+        needs_clear = true;
+      } else {
+        // Validate stored partition size
+        uint32_t stored_size = 0;
+        this->read(8, reinterpret_cast<uint8_t *>(&stored_size), 4);
+        if (stored_size != this->get_size()) {
+          ESP_LOGW(TAG, "KeyValue partition '%s' size changed (%u vs %u), reinitializing", this->get_id().c_str(),
+                   stored_size, this->get_size());
+          needs_clear = true;
+        } else {
+          // Validate first_free_offset - scan to find actual end if needed
+          uint32_t first_free = 0;
+          this->read(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+          ESP_LOGVV(TAG, "KeyValue '%s' init: first_free=%u", this->get_id().c_str(), first_free);
+
+          // Sanity check: if first_free is beyond partition size, reinitialize
+          if (first_free > this->get_size()) {
+            ESP_LOGW(TAG, "KeyValue partition '%s' has invalid first_free offset (%u), reinitializing",
+                     this->get_id().c_str(), first_free);
+            needs_clear = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (needs_clear) {
+    this->clear_partition_();
+  }
+
+  this->initialized_ = true;
+}
+
+void KeyValuePartition::clear_partition_() {
+  ESP_LOGI(TAG, "Created partition '%s': type=key_value, size=%u bytes", this->get_id().c_str(), this->get_size());
+
+  uint32_t partition_size = this->get_size();
+
+  // Clear the entire partition
+  for (uint32_t i = 0; i < partition_size; i += 32) {
+    std::array<uint8_t, 32> zeros{};
+    uint32_t len = (i + 32 > partition_size) ? (partition_size - i) : 32;
+    this->write(i, zeros.data(), len);
+  }
+
+  // Write header
+  uint32_t magic = MAGIC;
+  this->write(0, reinterpret_cast<uint8_t *>(&magic), 4);
+
+  uint8_t version = VERSION;
+  this->write(4, &version, 1);
+
+  uint8_t type = static_cast<uint8_t>(PartitionType::KEY_VALUE);
+  this->write(5, &type, 1);
+
+  uint16_t reserved = 0;
+  this->write(6, reinterpret_cast<uint8_t *>(&reserved), 2);
+
+  uint32_t size = partition_size;
+  this->write(8, reinterpret_cast<uint8_t *>(&size), 4);
+
+  // Write first free offset (initially after header)
+  uint32_t first_free = HEADER_SIZE;
+  this->write(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+
+  // Verify write
+  uint32_t verify_magic = 0;
+  this->read(0, reinterpret_cast<uint8_t *>(&verify_magic), 4);
+  ESP_LOGVV(TAG, "KeyValue '%s' verify: magic=0x%08X", this->get_id().c_str(), verify_magic);
+}
+
+// ========== NvmDataPartition ==========
+
+bool NvmDataPartition::validate_header_(PartitionType expected_type) {
+  uint32_t magic = 0;
+  this->read(OFF_MAGIC, reinterpret_cast<uint8_t *>(&magic), 4);
+
+  if (magic != MAGIC) {
+    return false;
+  }
+
+  uint8_t version = 0;
+  this->read(OFF_VERSION, &version, 1);
+  if (version != VERSION) {
+    return false;
+  }
+
+  uint8_t type = 0;
+  this->read(OFF_TYPE, &type, 1);
+  if (type != static_cast<uint8_t>(expected_type)) {
+    return false;
+  }
+
+  uint32_t stored_size = 0;
+  this->read(OFF_SIZE, reinterpret_cast<uint8_t *>(&stored_size), 4);
+  if (stored_size != this->get_size()) {
+    return false;
+  }
+
+  return true;
+}
+
+void NvmDataPartition::write_header_(uint32_t partition_size, PartitionType type, uint32_t first_free) {
+  uint32_t magic = MAGIC;
+  uint8_t version = VERSION;
+  uint8_t type_val = static_cast<uint8_t>(type);
+  uint16_t reserved = 0;
+
+  this->write(OFF_MAGIC, reinterpret_cast<uint8_t *>(&magic), 4);
+  this->write(OFF_VERSION, &version, 1);
+  this->write(OFF_TYPE, &type_val, 1);
+  this->write(OFF_RESERVED, reinterpret_cast<uint8_t *>(&reserved), 2);
+  this->write(OFF_SIZE, reinterpret_cast<uint8_t *>(&partition_size), 4);
+  this->write(OFF_FIRST_FREE, reinterpret_cast<uint8_t *>(&first_free), 4);
+}
+
+uint32_t NvmDataPartition::read_first_free_() {
+  uint32_t first_free = HEADER_SIZE;
+  this->read(OFF_FIRST_FREE, reinterpret_cast<uint8_t *>(&first_free), 4);
+  return first_free;
+}
+
+void NvmDataPartition::update_first_free_(uint32_t first_free) {
+  this->write(OFF_FIRST_FREE, reinterpret_cast<uint8_t *>(&first_free), 4);
+}
+
+void NvmDataPartition::check_usage_warnings_(uint32_t used, uint32_t total) {
+  float usage_percent = (used * 100.0f) / total;
+
+  if (usage_percent > WARNING_L2_PERCENT) {
+    ESP_LOGW(TAG, "Partition '%s' is %.0f%% full! Consider increasing partition size", this->get_id().c_str(),
+             usage_percent);
+  } else if (usage_percent > WARNING_L1_PERCENT && !this->warned_L1_percent_) {
+    ESP_LOGW(TAG, "Partition '%s' is %.0f%% full. Consider increasing partition size soon", this->get_id().c_str(),
+             usage_percent);
+    this->warned_L1_percent_ = true;
+  }
+}
+
+void NvmDataPartition::log_mismatch_(const char *issue, uint32_t actual, uint32_t expected) {
+  ESP_LOGW(TAG, "Partition '%s' %s (actual=0x%08X, expected=0x%08X)", this->get_id().c_str(), issue, actual, expected);
+}
+
+float NvmDataPartition::get_usage_percent() {
+  uint32_t first_free = this->read_first_free_();
+  float usage = (first_free * 100.0f) / this->get_size();
+  return usage;
+}
+
+// ========== PreferencesPartition ==========
+
+void PreferencesPartition::setup() {
+  ESP_LOGVV(TAG, "PreferencesPartition setup: size=%u", this->get_size());
+
+  // Initialize the pool
+  this->ensure_initialized_();
+
+  // Save the original NVS preferences before replacing
+  // This is needed to delegate the boot counter key which must stay in NVS
+  // because safe_mode reads it before NVM preferences is initialized
+  this->nvs_preferences_ = global_preferences;
+
+  // Set global preferences pointer
+  global_preferences = this;
+
+  ESP_LOGVV(TAG, "PreferencesPartition setup complete, initialized=%d", this->initialized_);
+}
+
+void PreferencesPartition::dump_config() {
+  ESP_LOGCONFIG(TAG, "Preferences Partition:");
+  ESP_LOGCONFIG(TAG, "  Size: %u bytes", this->get_size());
+  if (this->pool_used_ > 0) {
+    float usage_percent = (this->pool_used_ * 100.0f) / this->get_size();
+    ESP_LOGCONFIG(TAG, "  Used: %u bytes (%.1f%%)", this->pool_used_, usage_percent);
+  }
+  if (this->pool_cleared_) {
+    ESP_LOGCONFIG(TAG, "  Pool was cleared");
+  }
+  ESP_LOGCONFIG(TAG, "  Boot counter: delegated to NVS");
+}
+
+ESPPreferenceObject PreferencesPartition::make_preference(size_t length, uint32_t type, bool in_flash) {
+  return this->make_preference(length, type);
+}
+
+ESPPreferenceObject PreferencesPartition::make_preference(size_t length, uint32_t type) {
+  // Delegate boot counter to NVS - safe_mode reads it before NVM is initialized
+  if (type == RTC_KEY && this->nvs_preferences_ != nullptr) {
+    ESP_LOGV(TAG, "Delegating boot counter key %u to NVS", type);
+    return this->nvs_preferences_->make_preference(length, type);
+  }
+  return ESPPreferenceObject(new NvmPreferenceBackend(this, type));
+}
+
+bool PreferencesPartition::sync() {
+  // Also sync NVS preferences (for delegated keys like boot counter)
+  if (this->nvs_preferences_ != nullptr) {
+    this->nvs_preferences_->sync();
+  }
+  return true;
+}
+
+bool PreferencesPartition::reset() {
+  this->pool_cleared_ = true;
+  uint32_t pool_size = this->get_size();
+
+  // Clear the entire pool area
+  for (uint32_t i = 0; i < pool_size; i += 32) {
+    std::array<uint8_t, 32> zeros{};
+    uint32_t len = (i + 32 > pool_size) ? (pool_size - i) : 32;
+    this->write(i, zeros.data(), len);
+  }
+
+  // Write unified header (16 bytes): magic(4) + version(1) + type(1) + reserved(2) + size(4) + first_free(4)
+  uint32_t magic = MAGIC;
+  uint8_t version = VERSION;
+  uint8_t type = static_cast<uint8_t>(PartitionType::PREFERENCES);
+  uint16_t reserved = 0;
+  uint32_t first_free = HEADER_SIZE;
+
+  this->write(0, reinterpret_cast<uint8_t *>(&magic), 4);
+  this->write(4, &version, 1);
+  this->write(5, &type, 1);
+  this->write(6, reinterpret_cast<uint8_t *>(&reserved), 2);
+  this->write(8, reinterpret_cast<uint8_t *>(&pool_size), 4);
+  this->write(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+
+  this->pool_used_ = HEADER_SIZE;
+  this->warned_L1_percent_ = false;
+  ESP_LOGD(TAG, "Factory reset: NVM preferences cleared");
+  return true;
+}
+
+void PreferencesPartition::ensure_initialized_() {
+  if (this->initialized_) {
+    return;
+  }
+
+  uint32_t pool_size = this->get_size();
+  ESP_LOGVV(TAG, "Lazy initialization - pool_size=%u", pool_size);
+
+  // Read unified header (16 bytes): magic(4) + version(1) + type(1) + reserved(2) + size(4) + first_free(4)
+  uint32_t magic = 0;
+  this->read(0, reinterpret_cast<uint8_t *>(&magic), 4);
+  ESP_LOGVV(TAG, "Read magic: 0x%08X, expected: 0x%08X", magic, MAGIC);
+
+  bool needs_clear = false;
+
+  if (magic != MAGIC) {
+    ESP_LOGW(TAG, "Preferences partition '%s' has invalid magic (0x%08X), initializing", this->get_id().c_str(), magic);
+    needs_clear = true;
+  } else {
+    // Magic matches - verify version and type
+    uint8_t version = 0;
+    this->read(4, &version, 1);
+    ESP_LOGVV(TAG, "Read version: %u, expected: %u", version, VERSION);
+
+    uint8_t type = 0;
+    this->read(5, &type, 1);
+    ESP_LOGVV(TAG, "Read type: %u, expected: %u", type, static_cast<uint8_t>(PartitionType::PREFERENCES));
+
+    if (version != VERSION) {
+      ESP_LOGW(TAG, "Version mismatch (%u != %u), reinitializing pool", version, VERSION);
+      needs_clear = true;
+    } else if (type != static_cast<uint8_t>(PartitionType::PREFERENCES)) {
+      ESP_LOGW(TAG, "Type mismatch (%u != %u), reinitializing pool", type,
+               static_cast<uint8_t>(PartitionType::PREFERENCES));
+      needs_clear = true;
+    } else {
+      // Read stored pool size
+      uint32_t stored_size = 0;
+      this->read(8, reinterpret_cast<uint8_t *>(&stored_size), 4);
+      ESP_LOGVV(TAG, "Read stored_size: %u, actual: %u", stored_size, pool_size);
+
+      if (stored_size != pool_size) {
+        ESP_LOGW(TAG, "Pool size mismatch (%u != %u), reinitializing", stored_size, pool_size);
+        needs_clear = true;
+      } else {
+        // Read first_free offset
+        uint32_t first_free = 0;
+        this->read(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+        ESP_LOGVV(TAG, "Read first_free: %u", first_free);
+
+        if (first_free > pool_size || first_free < HEADER_SIZE) {
+          ESP_LOGW(TAG, "Invalid first_free offset (%u), reinitializing", first_free);
+          needs_clear = true;
+        } else {
+          this->pool_used_ = first_free;
+        }
+      }
+    }
+  }
+
+  if (!needs_clear) {
+    // Calculate pool usage before checking pool size change
+    this->pool_used_ = this->calculate_pool_used_();
+
+    // Check if pool size decreased and data doesn't fit
+    uint32_t stored_pool_size = 0;
+    this->read(8, reinterpret_cast<uint8_t *>(&stored_pool_size), 4);
+    ESP_LOGVV(TAG, "Stored pool size: %u, current: %u, used: %u", stored_pool_size, pool_size, this->pool_used_);
+
+    if (stored_pool_size != 0 && pool_size < stored_pool_size) {
+      // Pool size decreased - check if data still fits
+      if (this->pool_used_ > pool_size) {
+        ESP_LOGW(TAG, "Pool size decreased from %u to %u and data (%u bytes) doesn't fit! Clearing pool.",
+                 stored_pool_size, pool_size, this->pool_used_);
+        needs_clear = true;
+      } else {
+        ESP_LOGW(TAG, "Pool size decreased from %u to %u. Data (%u bytes) fits, preserving.", stored_pool_size,
+                 pool_size, this->pool_used_);
+      }
+    }
+  }
+
+  if (!needs_clear) {
+    ESP_LOGD(TAG, "NVM preferences pool restored successfully");
+    float usage_percent = (this->pool_used_ * 100.0f) / pool_size;
+    ESP_LOGD(TAG, "Pool usage: %u/%u bytes (%.1f%%)", this->pool_used_, pool_size, usage_percent);
+
+    // Warn if pool is too small (over WARNING_L2_PERCENT at startup)
+    if (usage_percent > WARNING_L2_PERCENT) {
+      ESP_LOGW(TAG, "Pool is %.0f%% full! Consider increasing partition size", usage_percent);
+    } else if (usage_percent > WARNING_L1_PERCENT) {
+      ESP_LOGW(TAG, "Pool is %.0f%% full. Consider increasing partition size soon", usage_percent);
+      this->warned_L1_percent_ = true;
+    }
+  }
+
+  if (needs_clear) {
+    this->pool_cleared_ = true;
+    ESP_LOGI(TAG, "Created partition '%s': type=preferences, size=%u bytes", this->get_id().c_str(), pool_size);
+    // Clear the pool area by writing zeros
+    for (uint32_t i = 0; i < pool_size; i += 32) {
+      std::array<uint8_t, 32> zeros{};
+      uint32_t len = (i + 32 > pool_size) ? (pool_size - i) : 32;
+      this->write(i, zeros.data(), len);
+    }
+
+    // Write unified header (16 bytes): magic(4) + version(1) + type(1) + reserved(2) + size(4) + first_free(4)
+    uint32_t magic = MAGIC;
+    uint8_t version = VERSION;
+    uint8_t type = static_cast<uint8_t>(PartitionType::PREFERENCES);
+    uint16_t reserved = 0;
+    uint32_t first_free = HEADER_SIZE;
+
+    this->write(0, reinterpret_cast<uint8_t *>(&magic), 4);
+    this->write(4, &version, 1);
+    this->write(5, &type, 1);
+    this->write(6, reinterpret_cast<uint8_t *>(&reserved), 2);
+    this->write(8, reinterpret_cast<uint8_t *>(&pool_size), 4);
+    this->write(12, reinterpret_cast<uint8_t *>(&first_free), 4);
+
+    // Verify write
+    uint32_t verify_magic = 0;
+    this->read(0, reinterpret_cast<uint8_t *>(&verify_magic), 4);
+    ESP_LOGVV(TAG, "Verify magic after write: 0x%08X", verify_magic);
+
+    // Verify first key slot is zero
+    uint32_t verify_key = 0;
+    this->read(HEADER_SIZE, reinterpret_cast<uint8_t *>(&verify_key), 4);
+    ESP_LOGVV(TAG, "Verify first key slot: 0x%08X", verify_key);
+
+    this->pool_used_ = HEADER_SIZE;
+  }
+
+  this->initialized_ = true;
+}
+
+uint32_t PreferencesPartition::calculate_pool_used_() {
+  uint32_t pool_size = this->get_size();
+  uint32_t addr = HEADER_SIZE;
+  uint32_t iterations = 0;
+  const uint32_t max_iterations = 100;
+
+  while (addr < pool_size && iterations < max_iterations) {
+    iterations++;
+    uint32_t key = 0;
+    this->read(addr, reinterpret_cast<uint8_t *>(&key), 4);
+
+    if (key == 0) {
+      // Empty slot - this is where the pool ends
+      return addr;
+    }
+
+    uint32_t size = 0;
+    this->read(addr + 4, reinterpret_cast<uint8_t *>(&size), 4);
+
+    // Invalid size - return current position
+    if (size > 1024 || size == 0xFFFFFFFF) {
+      return addr;
+    }
+
+    addr += 8 + size + 4;  // key + size + data + hash
+  }
+
+  return addr;
+}
+
+// ========== NvmPreferenceBackend ==========
+
+uint32_t NvmPreferenceBackend::find_key_(uint32_t key_hash) {
+  // Ensure pool is initialized before searching
+  this->partition_->ensure_initialized_();
+
+  if (!this->partition_->initialized_) {
+    ESP_LOGW(TAG, "find_key_: Pool not initialized");
+    return 0;
+  }
+
+  uint32_t pool_size = this->partition_->get_size();
+  uint32_t addr = NvmDataPartition::HEADER_SIZE;
+  uint32_t iterations = 0;
+  const uint32_t max_iterations = 100;  // Safety limit
+
+  ESP_LOGV(TAG, "find_key_: looking for 0x%08X, pool_size=%u", key_hash, pool_size);
+
+  while (addr < pool_size && iterations < max_iterations) {
+    iterations++;
+    uint32_t key_from_nvm = 0;
+    this->partition_->read(addr, reinterpret_cast<uint8_t *>(&key_from_nvm), 4);
+
+    if (key_from_nvm == key_hash) {
+      ESP_LOGV(TAG, "Found key 0x%08X at offset %u (iteration %u)", key_hash, addr, iterations);
+      return addr;
+    }
+
+    if (key_from_nvm == 0) {
+      ESP_LOGV(TAG, "Empty slot at offset %u, storing key 0x%08X (iteration %u)", addr, key_hash, iterations);
+      this->partition_->write(addr, reinterpret_cast<uint8_t *>(&key_hash), 4);
+      return addr;
+    }
+
+    uint32_t size_from_nvm = 0;
+    this->partition_->read(addr + 4, reinterpret_cast<uint8_t *>(&size_from_nvm), 4);
+
+    // Safety check: if size is unreasonably large, clear remaining pool and use this slot
+    if (size_from_nvm > 1024 || size_from_nvm == 0xFFFFFFFF) {
+      ESP_LOGW(TAG, "Invalid size %u at offset %u, clearing remaining pool", size_from_nvm, addr);
+      // Clear from this address to end of pool
+      for (uint32_t i = addr; i < pool_size; i += 32) {
+        std::array<uint8_t, 32> zeros{};
+        uint32_t len = (i + 32 > pool_size) ? (pool_size - i) : 32;
+        this->partition_->write(i, zeros.data(), len);
+      }
+      // Now use this slot
+      this->partition_->write(addr, reinterpret_cast<uint8_t *>(&key_hash), 4);
+      return addr;
+    }
+
+    addr += 8 + size_from_nvm + 4;  // key + size + data + crc
+  }
+
+  if (iterations >= max_iterations) {
+    ESP_LOGW(TAG, "Max iterations reached in find_key_");
+  }
+
+  return 0;
+}
+
+bool NvmPreferenceBackend::save(const uint8_t *data, size_t len) {
+  uint32_t key_hash = fnv1_hash(std::to_string(this->type_));
+  ESP_LOGV(TAG, "Save: type=%u, key_hash=0x%08X, len=%u", this->type_, key_hash, len);
+
+  uint32_t addr = this->find_key_(key_hash);
+
+  if (addr == 0) {
+    ESP_LOGW(TAG, "Save: Could not find/allocate slot for key 0x%08X (pool may be full)", key_hash);
+    return false;
+  }
+
+  // Check if this is an update (key already exists at this address)
+  uint32_t existing_key = 0;
+  this->partition_->read(addr, reinterpret_cast<uint8_t *>(&existing_key), 4);
+  bool is_update = (existing_key == key_hash);
+  ESP_LOGV(TAG, "Save: addr=%u, existing_key=0x%08X, is_update=%d", addr, existing_key, is_update);
+
+  // Use FNV-1a hash for data integrity
+  uint32_t hash = FNV1_OFFSET_BASIS;
+  for (size_t i = 0; i < len; i++) {
+    hash ^= data[i];
+    hash *= FNV1_PRIME;
+  }
+
+  // Write size + data + hash
+  // Use unique_ptr for runtime-sized buffer (avoid STL vector overhead)
+  auto buffer = std::make_unique<uint8_t[]>(4 + len + 4);
+  // Size (4 bytes)
+  buffer[0] = len & 0xFF;
+  buffer[1] = (len >> 8) & 0xFF;
+  buffer[2] = (len >> 16) & 0xFF;
+  buffer[3] = (len >> 24) & 0xFF;
+  // Data
+  std::memcpy(buffer.get() + 4, data, len);
+  // Hash (4 bytes)
+  buffer[4 + len] = hash & 0xFF;
+  buffer[4 + len + 1] = (hash >> 8) & 0xFF;
+  buffer[4 + len + 2] = (hash >> 16) & 0xFF;
+  buffer[4 + len + 3] = (hash >> 24) & 0xFF;
+
+  ESP_LOGVV(TAG, "Save: Writing to offset %u, hash=0x%08X", addr, hash);
+  this->partition_->write(addr + 4, buffer.get(), 4 + len + 4);
+
+  // Update pool usage tracking
+  uint32_t entry_size = 4 + 4 + len + 4;  // key + size + data + hash
+  uint32_t new_used = addr + entry_size;
+  if (new_used > this->partition_->pool_used_) {
+    this->partition_->pool_used_ = new_used;
+    // Update first_free_offset in header
+    this->partition_->write(12, reinterpret_cast<uint8_t *>(&new_used), 4);
+  }
+
+  // Check for WARNING_L1_PERCENT warning
+  float usage_percent = (this->partition_->pool_used_ * 100.0f) / this->partition_->get_size();
+  if (usage_percent > NvmDataPartition::WARNING_L1_PERCENT && !this->partition_->warned_L1_percent_) {
+    ESP_LOGW(TAG, "Pool is %.0f%% full (%u/%u bytes). Consider increasing partition size", usage_percent,
+             this->partition_->pool_used_, this->partition_->get_size());
+    this->partition_->warned_L1_percent_ = true;
+  }
+
+  return true;
+}
+
+bool NvmPreferenceBackend::load(uint8_t *data, size_t len) {
+  uint32_t key_hash = fnv1_hash(std::to_string(this->type_));
+  ESP_LOGV(TAG, "Load: type=%u, key_hash=0x%08X, len=%u", this->type_, key_hash, len);
+
+  uint32_t addr = this->find_key_(key_hash);
+
+  if (addr == 0) {
+    ESP_LOGV(TAG, "Load: Key 0x%08X not found", key_hash);
+    return false;
+  }
+
+  uint32_t size_from_nvm = 0;
+  this->partition_->read(addr + 4, reinterpret_cast<uint8_t *>(&size_from_nvm), 4);
+  ESP_LOGVV(TAG, "Load: addr=%u, size_from_nvm=%u, expected=%u", addr, size_from_nvm, len);
+
+  if (size_from_nvm != len) {
+    ESP_LOGVV(TAG, "Load: Size mismatch (got %u, expected %u) - key may be from old config", size_from_nvm, len);
+    return false;
+  }
+
+  this->partition_->read(addr + 8, data, len);
+  uint32_t hash_from_nvm = 0;
+  this->partition_->read(addr + 8 + len, reinterpret_cast<uint8_t *>(&hash_from_nvm), 4);
+
+  // Use FNV-1a hash for data integrity
+  uint32_t hash = FNV1_OFFSET_BASIS;
+  for (size_t i = 0; i < len; i++) {
+    hash ^= data[i];
+    hash *= FNV1_PRIME;
+  }
+
+  ESP_LOGVV(TAG, "Load: computed hash=0x%08X, stored hash=0x%08X, match=%d", hash, hash_from_nvm,
+            hash == hash_from_nvm);
+  return hash == hash_from_nvm;
+}
+
+}  // namespace nvm
+}  // namespace esphome

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -7,8 +7,7 @@
 #include <cstring>
 #include <utility>
 
-namespace esphome {
-namespace nvm {
+namespace esphome::nvm {
 
 static const char *const TAG = "nvm";
 
@@ -1069,5 +1068,4 @@ bool NvmPreferenceBackend::load(uint8_t *data, size_t len) {
   return hash == hash_from_nvm;
 }
 
-}  // namespace nvm
-}  // namespace esphome
+}  // namespace esphome::nvm

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -104,7 +104,9 @@ NvmPartition *NvmPlatform::add_partition(const PartitionConfig &config) {
     case PartitionType::PREFERENCES: {
       auto pref_partition = std::make_unique<PreferencesPartition>(this, config);
       // Register with Application so setup() is called automatically
-      App.register_component(pref_partition.get());
+      // App.register_component_(pref_partition.get()); // App.register_component_ is protected now
+      // App.register_component(pref_partition.get());
+      // We let the platform setup call it or we do it directly
       partition = std::move(pref_partition);
       break;
     }
@@ -682,14 +684,6 @@ void PreferencesPartition::setup() {
   // Initialize the pool
   this->ensure_initialized_();
 
-  // Save the original NVS preferences before replacing
-  // This is needed to delegate the boot counter key which must stay in NVS
-  // because safe_mode reads it before NVM preferences is initialized
-  this->nvs_preferences_ = global_preferences;
-
-  // Set global preferences pointer
-  global_preferences = this;
-
   ESP_LOGVV(TAG, "PreferencesPartition setup complete, initialized=%d", this->initialized_);
 }
 
@@ -703,29 +697,17 @@ void PreferencesPartition::dump_config() {
   if (this->pool_cleared_) {
     ESP_LOGCONFIG(TAG, "  Pool was cleared");
   }
-  ESP_LOGCONFIG(TAG, "  Boot counter: delegated to NVS");
 }
 
-ESPPreferenceObject PreferencesPartition::make_preference(size_t length, uint32_t type, bool in_flash) {
+NvmPreferenceObject PreferencesPartition::make_preference(size_t length, uint32_t type, bool in_flash) {
   return this->make_preference(length, type);
 }
 
-ESPPreferenceObject PreferencesPartition::make_preference(size_t length, uint32_t type) {
-  // Delegate boot counter to NVS - safe_mode reads it before NVM is initialized
-  if (type == RTC_KEY && this->nvs_preferences_ != nullptr) {
-    ESP_LOGV(TAG, "Delegating boot counter key %u to NVS", type);
-    return this->nvs_preferences_->make_preference(length, type);
-  }
-  return ESPPreferenceObject(new NvmPreferenceBackend(this, type));
+NvmPreferenceObject PreferencesPartition::make_preference(size_t length, uint32_t type) {
+  return NvmPreferenceObject(new NvmPreferenceBackend(this, type));
 }
 
-bool PreferencesPartition::sync() {
-  // Also sync NVS preferences (for delegated keys like boot counter)
-  if (this->nvs_preferences_ != nullptr) {
-    this->nvs_preferences_->sync();
-  }
-  return true;
-}
+bool PreferencesPartition::sync() { return true; }
 
 bool PreferencesPartition::reset() {
   this->pool_cleared_ = true;

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -74,8 +74,13 @@ void NvmPlatform::setup() {
     }
   }
 
-  // Note: PreferencesPartition is registered with App in add_partition(),
-  // so its setup() will be called automatically by the Application
+  // PreferencesPartition is a Component but Application::register_component_ is protected,
+  // so we drive its setup() ourselves after the platform itself is ready.
+  for (const auto &partition : partitions_) {
+    if (partition->get_type() == PartitionType::PREFERENCES) {
+      static_cast<PreferencesPartition *>(partition.get())->setup();
+    }
+  }
 
   ESP_LOGCONFIG(TAG, "NVM Platform initialized with %zu partitions", partitions_.size());
 }
@@ -101,15 +106,9 @@ NvmPartition *NvmPlatform::add_partition(const PartitionConfig &config) {
   std::unique_ptr<NvmPartition> partition;
 
   switch (config.type) {
-    case PartitionType::PREFERENCES: {
-      auto pref_partition = std::make_unique<PreferencesPartition>(this, config);
-      // Register with Application so setup() is called automatically
-      // App.register_component_(pref_partition.get()); // App.register_component_ is protected now
-      // App.register_component(pref_partition.get());
-      // We let the platform setup call it or we do it directly
-      partition = std::move(pref_partition);
+    case PartitionType::PREFERENCES:
+      partition = std::make_unique<PreferencesPartition>(this, config);
       break;
-    }
     case PartitionType::RAW:
       partition = std::make_unique<RawPartition>(this, config);
       break;

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstring>
+#include <utility>
 
 namespace esphome {
 namespace nvm {
@@ -36,7 +37,7 @@ const char *partition_type_to_string(PartitionType type) {
 
 // ========== NvmPartition ==========
 
-NvmPartition::NvmPartition(NvmPlatform *parent, const PartitionConfig &config) : parent_(parent), config_(config) {}
+NvmPartition::NvmPartition(NvmPlatform *parent, PartitionConfig config) : parent_(parent), config_(std::move(config)) {}
 
 bool NvmPartition::read(uint32_t offset, uint8_t *data, size_t len) {
   if (offset + len > config_.size) {
@@ -62,7 +63,7 @@ bool NvmPartition::write(uint32_t offset, const uint8_t *data, size_t len) {
 
 void NvmPlatform::setup() {
   // Calculate automatic offsets for partitions
-  this->calculate_partition_offsets();
+  this->calculate_partition_offsets_();
 
   // Validate all partitions
   for (const auto &partition : partitions_) {
@@ -148,14 +149,14 @@ bool NvmPlatform::validate_partition_config(const PartitionConfig &config) {
   }
 
   // Check for overlap
-  if (!this->check_partition_overlap(config)) {
+  if (!this->check_partition_overlap_(config)) {
     return false;
   }
 
   return true;
 }
 
-bool NvmPlatform::check_partition_overlap(const PartitionConfig &config) {
+bool NvmPlatform::check_partition_overlap_(const PartitionConfig &config) {
   for (const auto &partition : partitions_) {
     // Skip the partition being validated (for updates)
     if (partition->get_id() == config.id) {
@@ -174,7 +175,7 @@ bool NvmPlatform::check_partition_overlap(const PartitionConfig &config) {
   return true;
 }
 
-void NvmPlatform::calculate_partition_offsets() {
+void NvmPlatform::calculate_partition_offsets_() {
   uint32_t current_offset = 0;
 
   for (auto &partition : partitions_) {
@@ -199,7 +200,7 @@ int KeyValuePartition::get(const std::string &key, uint8_t *value, size_t max_le
   uint32_t offset, value_offset;
   uint16_t value_len;
 
-  if (!this->find_key(key, offset, value_offset, value_len)) {
+  if (!this->find_key_(key, offset, value_offset, value_len)) {
     ESP_LOGV(TAG, "KeyValue '%s' get: key='%s' not found", this->get_id().c_str(), key.c_str());
     return -1;  // Key not found
   }
@@ -225,7 +226,7 @@ bool KeyValuePartition::set(const std::string &key, const uint8_t *value, size_t
   uint32_t existing_offset, value_offset;
   uint16_t existing_len;
 
-  if (this->find_key(key, existing_offset, value_offset, existing_len)) {
+  if (this->find_key_(key, existing_offset, value_offset, existing_len)) {
     // Key exists - check if new value fits
     if (len <= existing_len) {
       // Overwrite in place (add HEADER_SIZE to convert from data-relative to absolute)
@@ -239,7 +240,6 @@ bool KeyValuePartition::set(const std::string &key, const uint8_t *value, size_t
   // Find end of storage (start after header)
   uint32_t write_offset = HEADER_SIZE;
   uint8_t marker;
-  bool is_first_entry = (write_offset == HEADER_SIZE);  // Track if this is the first entry
   while (write_offset < this->get_size()) {
     if (!this->read(write_offset, &marker, 1)) {
       break;
@@ -248,7 +248,6 @@ bool KeyValuePartition::set(const std::string &key, const uint8_t *value, size_t
       // Empty slot found
       break;
     }
-    is_first_entry = false;  // Found an existing entry, so not first time
     // Skip entry: key_len(1) + key + value_len(2) + value
     uint8_t key_len = marker;
     uint16_t value_len;
@@ -296,7 +295,7 @@ bool KeyValuePartition::erase(const std::string &key) {
   uint32_t offset, value_offset;
   uint16_t value_len;
 
-  if (!this->find_key(key, offset, value_offset, value_len)) {
+  if (!this->find_key_(key, offset, value_offset, value_len)) {
     ESP_LOGV(TAG, "KeyValue '%s' erase: key='%s' not found", this->get_id().c_str(), key.c_str());
     return false;  // Key not found
   }
@@ -312,7 +311,7 @@ bool KeyValuePartition::erase(const std::string &key) {
 bool KeyValuePartition::has_key(const std::string &key) {
   uint32_t offset, value_offset;
   uint16_t value_len;
-  return this->find_key(key, offset, value_offset, value_len);
+  return this->find_key_(key, offset, value_offset, value_len);
 }
 
 int KeyValuePartition::get_string(const std::string &key, char *buf, size_t buf_len, const char *default_value) {
@@ -353,8 +352,8 @@ bool KeyValuePartition::set_string(const std::string &key, const std::string &va
   return this->set(key, reinterpret_cast<const uint8_t *>(value.c_str()), value.size());
 }
 
-bool KeyValuePartition::find_key(const std::string &key, uint32_t &offset, uint32_t &value_offset,
-                                 uint16_t &value_len) {
+bool KeyValuePartition::find_key_(const std::string &key, uint32_t &offset, uint32_t &value_offset,
+                                  uint16_t &value_len) {
   // Start after header
   uint32_t current_offset = HEADER_SIZE;
 
@@ -393,7 +392,7 @@ bool KeyValuePartition::find_key(const std::string &key, uint32_t &offset, uint3
   return false;
 }
 
-void KeyValuePartition::compact() {
+void KeyValuePartition::compact_() {
   // TODO: Implement compaction to remove deleted entries
   // This would read all valid entries, erase the partition, and rewrite them
 }
@@ -918,7 +917,7 @@ uint32_t PreferencesPartition::calculate_pool_used_() {
     this->read(addr + 4, reinterpret_cast<uint8_t *>(&size), 4);
 
     // Invalid size - return current position
-    if (size > 1024 || size == 0xFFFFFFFF) {
+    if (size > 1024) {
       return addr;
     }
 
@@ -966,7 +965,7 @@ uint32_t NvmPreferenceBackend::find_key_(uint32_t key_hash) {
     this->partition_->read(addr + 4, reinterpret_cast<uint8_t *>(&size_from_nvm), 4);
 
     // Safety check: if size is unreasonably large, clear remaining pool and use this slot
-    if (size_from_nvm > 1024 || size_from_nvm == 0xFFFFFFFF) {
+    if (size_from_nvm > 1024) {
       ESP_LOGW(TAG, "Invalid size %u at offset %u, clearing remaining pool", size_from_nvm, addr);
       // Clear from this address to end of pool
       for (uint32_t i = addr; i < pool_size; i += 32) {

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/log.h"
 
 #include <array>
+#include <cinttypes>
 #include <cstring>
 #include <utility>
 
@@ -989,7 +990,9 @@ uint32_t NvmPreferenceBackend::find_key_(uint32_t key_hash) {
 }
 
 bool NvmPreferenceBackend::save(const uint8_t *data, size_t len) {
-  uint32_t key_hash = fnv1_hash(std::to_string(this->type_));
+  char type_buf[11];
+  snprintf(type_buf, sizeof(type_buf), "%" PRIu32, this->type_);
+  uint32_t key_hash = fnv1_hash(type_buf);
   ESP_LOGV(TAG, "Save: type=%u, key_hash=0x%08X, len=%u", this->type_, key_hash, len);
 
   uint32_t addr = this->find_key_(key_hash);
@@ -1052,7 +1055,9 @@ bool NvmPreferenceBackend::save(const uint8_t *data, size_t len) {
 }
 
 bool NvmPreferenceBackend::load(uint8_t *data, size_t len) {
-  uint32_t key_hash = fnv1_hash(std::to_string(this->type_));
+  char type_buf[11];
+  snprintf(type_buf, sizeof(type_buf), "%" PRIu32, this->type_);
+  uint32_t key_hash = fnv1_hash(type_buf);
   ESP_LOGV(TAG, "Load: type=%u, key_hash=0x%08X, len=%u", this->type_, key_hash, len);
 
   uint32_t addr = this->find_key_(key_hash);

--- a/esphome/components/nvm/nvm.cpp
+++ b/esphome/components/nvm/nvm.cpp
@@ -251,7 +251,7 @@ bool KeyValuePartition::set(const std::string &key, const uint8_t *value, size_t
     }
     // Skip entry: key_len(1) + key + value_len(2) + value
     uint8_t key_len = marker;
-    uint16_t value_len;
+    uint16_t value_len = 0;
     this->read(write_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&value_len), 2);
     write_offset += 1 + key_len + 2 + value_len;
   }
@@ -385,7 +385,7 @@ bool KeyValuePartition::find_key_(const std::string &key, uint32_t &offset, uint
     }
 
     // Skip to next entry
-    uint16_t entry_value_len;
+    uint16_t entry_value_len = 0;
     this->read(current_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&entry_value_len), 2);
     current_offset += 1 + key_len + 2 + entry_value_len;
   }
@@ -427,7 +427,7 @@ uint32_t KeyValuePartition::calculate_used_bytes_() {
     }
 
     // Read value length
-    uint16_t value_len;
+    uint16_t value_len = 0;
     this->read(current_offset + 1 + key_len, reinterpret_cast<uint8_t *>(&value_len), 2);
 
     // Add entry size: key_len(1) + key + value_len(2) + value
@@ -624,11 +624,7 @@ bool NvmDataPartition::validate_header_(PartitionType expected_type) {
 
   uint32_t stored_size = 0;
   this->read(OFF_SIZE, reinterpret_cast<uint8_t *>(&stored_size), 4);
-  if (stored_size != this->get_size()) {
-    return false;
-  }
-
-  return true;
+  return stored_size == this->get_size();
 }
 
 void NvmDataPartition::write_header_(uint32_t partition_size, PartitionType type, uint32_t first_free) {

--- a/esphome/components/nvm/nvm.h
+++ b/esphome/components/nvm/nvm.h
@@ -1,0 +1,403 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/preferences.h"
+#include <vector>
+#include <memory>
+
+namespace esphome {
+namespace nvm {
+
+/// RTC key for boot loop counter - used to delegate to NVS preferences
+/// TODO: Use safe_mode::RTC_KEY once PR #14121 is merged
+static const uint32_t RTC_KEY = 233825507UL;
+
+/// Partition types supported by NVM
+enum class PartitionType : uint8_t {
+  PREFERENCES = 0,  ///< ESPHome preferences backend
+  RAW = 1,          ///< Raw byte storage
+  KEY_VALUE = 2,    ///< Key-value store
+};
+
+/// Convert PartitionType to string for logging
+const char *partition_type_to_string(PartitionType type);
+
+/// Partition configuration
+struct PartitionConfig {
+  std::string id;      ///< User-defined partition ID
+  PartitionType type;  ///< Partition type
+  uint32_t offset;     ///< Offset in NVM device (auto-calculated if 0)
+  uint32_t size;       ///< Size in bytes
+};
+
+/// Forward declaration
+class NvmPlatform;
+
+/// Base class for NVM partitions
+///
+/// This class provides a logical view of a portion of an NVM device.
+/// Partitions are owned by an NvmPlatform and provide type-specific
+/// interfaces for accessing the underlying storage.
+class NvmPartition {
+ public:
+  NvmPartition(NvmPlatform *parent, const PartitionConfig &config);
+  virtual ~NvmPartition() = default;
+
+  /// Read data from partition
+  /// @param offset Offset within partition (not absolute NVM offset)
+  /// @param data Buffer to read into
+  /// @param len Number of bytes to read
+  /// @return true on success
+  bool read(uint32_t offset, uint8_t *data, size_t len);
+
+  /// Write data to partition
+  /// @param offset Offset within partition (not absolute NVM offset)
+  /// @param data Data to write
+  /// @param len Number of bytes to write
+  /// @return true on success
+  bool write(uint32_t offset, const uint8_t *data, size_t len);
+
+  /// Get partition ID
+  const std::string &get_id() const { return config_.id; }
+
+  /// Get partition type
+  PartitionType get_type() const { return config_.type; }
+
+  /// Get partition offset (absolute in NVM device)
+  uint32_t get_offset() const { return config_.offset; }
+
+  /// Get partition size
+  uint32_t get_size() const { return config_.size; }
+
+  /// Get parent NVM platform
+  NvmPlatform *get_parent() const { return parent_; }
+
+ protected:
+  friend class NvmPlatform;
+  NvmPlatform *parent_;
+  PartitionConfig config_;
+};
+
+/// Abstract base class for NVM platforms (FRAM, EEPROM, etc.)
+///
+/// This class defines the interface that all NVM platforms must implement.
+/// Platforms are responsible for the low-level read/write operations to
+/// the physical device. The base class handles partition management.
+///
+/// Platform implementations:
+/// - FramI2cPlatform: I2C FRAM devices (MB85RC series)
+/// - FramSpiPlatform: SPI FRAM devices (MB85RS series) - future
+/// - EepromI2cPlatform: I2C EEPROM devices (AT24C series) - future
+/// - EepromSpiPlatform: SPI EEPROM devices (AT25 series) - future
+class NvmPlatform : public Component {
+ public:
+  NvmPlatform() = default;
+  ~NvmPlatform() = default;
+
+  // ========== Abstract interface - must be implemented by platform ==========
+
+  /// Read bytes from NVM device
+  /// @param memaddr Absolute memory address
+  /// @param data Buffer to read into
+  /// @param len Number of bytes to read
+  /// @return true on success
+  virtual bool read_bytes(uint32_t memaddr, uint8_t *data, size_t len) = 0;
+
+  /// Write bytes to NVM device
+  /// @param memaddr Absolute memory address
+  /// @param data Data to write
+  /// @param len Number of bytes to write
+  /// @return true on success
+  virtual bool write_bytes(uint32_t memaddr, const uint8_t *data, size_t len) = 0;
+
+  /// Get total size of NVM device in bytes
+  virtual uint32_t get_total_size() const = 0;
+
+  // ========== Partition management ==========
+
+  /// Add a partition to this NVM device
+  /// @param config Partition configuration
+  /// @return Pointer to created partition, or nullptr on failure
+  NvmPartition *add_partition(const PartitionConfig &config);
+
+  /// Get partition by ID
+  /// @param id Partition ID
+  /// @return Pointer to partition, or nullptr if not found
+  NvmPartition *get_partition(const std::string &id);
+
+  /// Get all partitions
+  const std::vector<std::unique_ptr<NvmPartition>> &get_partitions() const { return partitions_; }
+
+  /// Validate partition configuration
+  /// @param config Partition configuration to validate
+  /// @return true if valid
+  bool validate_partition_config(const PartitionConfig &config);
+
+  // ========== Component methods ==========
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  std::vector<std::unique_ptr<NvmPartition>> partitions_;
+
+  /// Check for partition overlaps
+  bool check_partition_overlap(const PartitionConfig &config);
+
+  /// Calculate automatic offsets for partitions
+  void calculate_partition_offsets();
+};
+
+/// Base class for data partitions (Preferences and KeyValue)
+///
+/// This class provides common functionality for both partition types,
+/// including header management, validation, and usage tracking.
+class NvmDataPartition : public NvmPartition {
+ protected:
+  /// Header offsets
+  static const uint8_t OFF_MAGIC = 0;
+  static const uint8_t OFF_VERSION = 4;
+  static const uint8_t OFF_TYPE = 5;
+  static const uint8_t OFF_RESERVED = 6;
+  static const uint8_t OFF_SIZE = 8;
+  static const uint8_t OFF_FIRST_FREE = 12;
+
+  /// Header constants
+  static const uint32_t HEADER_SIZE = 16;  ///< magic(4) + version(1) + type(1) + reserved(2) + size(4) + first_free(4)
+  static const uint32_t MAGIC = 0x4B565354;  ///< "KVST" - unified magic for all NVM partitions
+  static const uint8_t VERSION = 1;          ///< Version 1 - unified across all partitions
+
+  /// Usage warning thresholds
+  static constexpr float WARNING_L1_PERCENT = 80.0f;
+  static constexpr float WARNING_L2_PERCENT = 90.0f;
+
+ public:
+  NvmDataPartition(NvmPlatform *parent, const PartitionConfig &config)
+      : NvmPartition(parent, config), initialized_(false), warned_L1_percent_(false) {}
+
+ protected:
+  /// Validate header and check if reinitialization is needed
+  /// @param expected_type The expected partition type
+  /// @return true if header is valid and matches expected type
+  bool validate_header_(PartitionType expected_type);
+
+  /// Write the header to the partition
+  /// @param partition_size Total size of the partition
+  /// @param type Partition type
+  /// @param first_free First free offset (usually HEADER_SIZE)
+  void write_header_(uint32_t partition_size, PartitionType type, uint32_t first_free);
+
+  /// Read first_free offset from header
+  /// @return First free offset, or HEADER_SIZE if not set
+  uint32_t read_first_free_();
+
+  /// Update first_free offset in header
+  /// @param first_free New first free offset
+  void update_first_free_(uint32_t first_free);
+
+  /// Check usage and warn if approaching capacity
+  /// @param used Number of bytes used
+  /// @param total Total partition size
+  void check_usage_warnings_(uint32_t used, uint32_t total);
+
+  /// Log a header mismatch
+  /// @param issue Description of the issue
+  /// @param actual Actual value found
+  /// @param expected Expected value
+  void log_mismatch_(const char *issue, uint32_t actual, uint32_t expected);
+
+ public:
+  virtual ~NvmDataPartition() = default;
+
+  /// Get the percentage of partition space used
+  /// @return Usage percentage (0-100)
+  float get_usage_percent();
+
+  bool initialized_;        ///< Track if partition has been initialized
+  bool warned_L1_percent_;  ///< Track if L1 warning was issued this boot
+};
+
+/// Specialized partition for preferences storage
+///
+/// This partition type integrates with ESPHome's preferences system,
+/// allowing global variables and other preferences to be stored in
+/// external NVM instead of flash.
+///
+/// When created, this partition automatically registers itself as the
+/// global preferences backend, replacing the default flash-based storage.
+class PreferencesPartition : public NvmDataPartition, public Component, public ESPPreferences {
+ public:
+  using NvmDataPartition::NvmDataPartition;
+
+  /// Setup the preferences backend
+  void setup() override;
+
+  /// Run after FRAM (IO) but before components that use preferences (BUS)
+  float get_setup_priority() const override { return setup_priority::BUS; }
+
+  /// Dump configuration
+  void dump_config() override;
+
+  // ========== ESPPreferences interface ==========
+  ESPPreferenceObject make_preference(size_t length, uint32_t type, bool in_flash) override;
+  ESPPreferenceObject make_preference(size_t length, uint32_t type) override;
+  bool sync() override;
+  bool reset() override;
+
+ protected:
+  friend class NvmPreferenceBackend;
+
+  /// Initialize the preferences pool
+  void ensure_initialized_();
+
+  /// Calculate pool usage
+  uint32_t calculate_pool_used_();
+
+  ESPPreferences *nvs_preferences_{nullptr};  ///< Original NVS preferences for delegated keys
+  bool pool_cleared_{false};
+  uint32_t pool_used_{0};
+};
+
+/// Backend for individual preference objects
+class NvmPreferenceBackend : public ESPPreferenceBackend {
+ public:
+  NvmPreferenceBackend(PreferencesPartition *partition, uint32_t type) : partition_(partition), type_(type) {}
+
+  bool save(const uint8_t *data, size_t len) override;
+  bool load(uint8_t *data, size_t len) override;
+
+ protected:
+  /// Find or allocate a key slot
+  uint32_t find_key_(uint32_t key_hash);
+
+  PreferencesPartition *partition_;
+  uint32_t type_;
+};
+
+/// Specialized partition for raw data storage
+///
+/// This partition type provides direct byte-level access to the storage.
+/// Users are responsible for managing the data structure and format.
+class RawPartition : public NvmPartition {
+ public:
+  using NvmPartition::NvmPartition;
+
+  /// Read a value from the partition at the specified offset
+  /// @tparam T Type of value to read
+  /// @param offset Byte offset within partition
+  /// @param value Reference to store the read value
+  /// @return true on success
+  template<typename T> bool read_value(uint32_t offset, T &value) {
+    return read(offset, reinterpret_cast<uint8_t *>(&value), sizeof(T));
+  }
+
+  /// Write a value to the partition at the specified offset
+  /// @tparam T Type of value to write
+  /// @param offset Byte offset within partition
+  /// @param value Value to write
+  /// @return true on success
+  template<typename T> bool write_value(uint32_t offset, const T &value) {
+    return write(offset, reinterpret_cast<const uint8_t *>(&value), sizeof(T));
+  }
+};
+
+/// Specialized partition for key-value storage
+///
+/// This partition type provides a simple key-value store where values
+/// can be stored and retrieved by string keys. The storage format is:
+/// Header (16 bytes): [magic: 4][version: 1][type: 1][reserved: 2][size: 4][first_free: 4]
+///   - magic: 0x4B565354 ("KVST")
+///   - version: format version (1)
+///   - type: PartitionType (2 = KEY_VALUE)
+///   - reserved: reserved for future use
+///   - size: partition size in bytes
+///   - first_free: offset of first free slot (for O(1) usage tracking)
+/// Entries: [key_len: 1 byte][key: N bytes][value_len: 2 bytes][value: M bytes]
+class KeyValuePartition : public NvmDataPartition, public Component {
+ public:
+  using NvmDataPartition::NvmDataPartition;
+
+  /// Dump configuration for debugging
+  void dump_config() override;
+
+  /// Get value by key
+  /// @param key Key to look up
+  /// @param value Buffer to store value
+  /// @param max_len Maximum bytes to read
+  /// @return Actual bytes read, or -1 on error
+  int get(const std::string &key, uint8_t *value, size_t max_len);
+
+  /// Set value by key
+  /// @param key Key to set
+  /// @param value Value to store
+  /// @param len Length of value
+  /// @return true on success
+  bool set(const std::string &key, const uint8_t *value, size_t len);
+
+  /// Delete key
+  /// @param key Key to delete
+  /// @return true on success
+  bool erase(const std::string &key);
+
+  /// Check if key exists
+  /// @param key Key to check
+  /// @return true if key exists
+  bool has_key(const std::string &key);
+
+  /// Get value as string into a buffer (no heap allocation)
+  /// @param key Key to look up
+  /// @param buf Buffer to store the string
+  /// @param buf_len Size of buffer
+  /// @param default_value Value to use if key not found
+  /// @return Actual length of string (excluding null terminator), or -1 on error
+  int get_string(const std::string &key, char *buf, size_t buf_len, const char *default_value = "");
+
+  /// Get value as string (heap-allocating, use sparingly)
+  /// @param key Key to look up
+  /// @param default_value Value to return if key not found
+  /// @return The stored value or default_value
+  /// @deprecated Use get_string(key, buf, buf_len, default) instead to avoid heap allocation
+  std::string get_string(const std::string &key, const std::string &default_value = "");
+
+  /// Set value as string
+  /// @param key Key to set
+  /// @param value String value to store
+  /// @return true on success
+  bool set_string(const std::string &key, const std::string &value);
+
+  /// Get the number of bytes used in the partition
+  /// @return Bytes used (including entry overhead)
+  uint32_t get_used_bytes();
+
+  /// Get the percentage of partition space used
+  /// @return Usage percentage (0-100)
+  float get_usage_percent();
+
+ protected:
+  /// Initialize partition header (lazy initialization)
+  void ensure_initialized_();
+
+  /// Clear partition and write new header
+  void clear_partition_();
+
+  /// Find key entry in storage
+  /// @param key Key to find
+  /// @param offset Output: offset where key starts (relative to data area)
+  /// @param value_offset Output: offset where value starts (relative to data area)
+  /// @param value_len Output: length of value
+  /// @return true if key found
+  bool find_key(const std::string &key, uint32_t &offset, uint32_t &value_offset, uint16_t &value_len);
+
+  /// Compact storage (remove deleted entries)
+  void compact();
+
+  /// Calculate used bytes by scanning all entries
+  /// @return Total bytes used (including header)
+  uint32_t calculate_used_bytes_();
+
+  /// Check usage and warn if approaching capacity
+  void check_usage_();
+};
+
+}  // namespace nvm
+}  // namespace esphome

--- a/esphome/components/nvm/nvm.h
+++ b/esphome/components/nvm/nvm.h
@@ -6,12 +6,7 @@
 #include <vector>
 #include <memory>
 
-namespace esphome {
-namespace nvm {
-
-/// RTC key for boot loop counter - used to delegate to NVS preferences
-/// TODO: Use safe_mode::RTC_KEY once PR #14121 is merged
-static const uint32_t RTC_KEY = 233825507UL;
+namespace esphome::nvm {
 
 /// Partition types supported by NVM
 enum class PartitionType : uint8_t {
@@ -241,6 +236,10 @@ template<typename Derived> class NvmPreferencesMixin {
   NvmPreferenceObject make_preference(uint32_t type) {
     return static_cast<Derived *>(this)->make_preference(sizeof(T), type);
   }
+
+ private:
+  NvmPreferencesMixin() = default;
+  friend Derived;
 };
 
 /// Specialized partition for preferences storage
@@ -436,5 +435,4 @@ class KeyValuePartition : public NvmDataPartition, public Component {
   void check_usage_();
 };
 
-}  // namespace nvm
-}  // namespace esphome
+}  // namespace esphome::nvm

--- a/esphome/components/nvm/nvm.h
+++ b/esphome/components/nvm/nvm.h
@@ -216,17 +216,44 @@ class NvmDataPartition : public NvmPartition {
   bool warned_L1_percent_;  ///< Track if L1 warning was issued this boot
 };
 
+class NvmPreferenceBackend;
+
+class NvmPreferenceObject {
+ public:
+  NvmPreferenceObject() = default;
+  explicit NvmPreferenceObject(NvmPreferenceBackend *backend) : backend_(backend) {}
+
+  template<typename T> bool save(const T *src);
+  template<typename T> bool load(T *dest);
+
+ protected:
+  NvmPreferenceBackend *backend_{nullptr};
+};
+
+template<typename Derived> class NvmPreferencesMixin {
+ public:
+  template<typename T, enable_if_t<is_trivially_copyable<T>::value, bool> = true>
+  NvmPreferenceObject make_preference(uint32_t type, bool in_flash) {
+    return static_cast<Derived *>(this)->make_preference(sizeof(T), type, in_flash);
+  }
+
+  template<typename T, enable_if_t<is_trivially_copyable<T>::value, bool> = true>
+  NvmPreferenceObject make_preference(uint32_t type) {
+    return static_cast<Derived *>(this)->make_preference(sizeof(T), type);
+  }
+};
+
 /// Specialized partition for preferences storage
 ///
-/// This partition type integrates with ESPHome's preferences system,
-/// allowing global variables and other preferences to be stored in
-/// external NVM instead of flash.
-///
-/// When created, this partition automatically registers itself as the
-/// global preferences backend, replacing the default flash-based storage.
-class PreferencesPartition : public NvmDataPartition, public Component, public ESPPreferences {
+/// This partition type acts as a standalone preferences system,
+/// allowing components specifically configured to use it to store
+/// preferences in external NVM instead of flash.
+class PreferencesPartition : public NvmDataPartition,
+                             public Component,
+                             public NvmPreferencesMixin<PreferencesPartition> {
  public:
   using NvmDataPartition::NvmDataPartition;
+  using NvmPreferencesMixin<PreferencesPartition>::make_preference;
 
   /// Setup the preferences backend
   void setup() override;
@@ -237,11 +264,11 @@ class PreferencesPartition : public NvmDataPartition, public Component, public E
   /// Dump configuration
   void dump_config() override;
 
-  // ========== ESPPreferences interface ==========
-  ESPPreferenceObject make_preference(size_t length, uint32_t type, bool in_flash) override;
-  ESPPreferenceObject make_preference(size_t length, uint32_t type) override;
-  bool sync() override;
-  bool reset() override;
+  // ========== NVM Preferences interface ==========
+  NvmPreferenceObject make_preference(size_t length, uint32_t type, bool in_flash);
+  NvmPreferenceObject make_preference(size_t length, uint32_t type);
+  bool sync();
+  bool reset();
 
  protected:
   friend class NvmPreferenceBackend;
@@ -252,18 +279,17 @@ class PreferencesPartition : public NvmDataPartition, public Component, public E
   /// Calculate pool usage
   uint32_t calculate_pool_used_();
 
-  ESPPreferences *nvs_preferences_{nullptr};  ///< Original NVS preferences for delegated keys
   bool pool_cleared_{false};
   uint32_t pool_used_{0};
 };
 
-/// Backend for individual preference objects
-class NvmPreferenceBackend : public ESPPreferenceBackend {
+/// Backend for individual preference objects (standalone, not inheriting from final class)
+class NvmPreferenceBackend {
  public:
   NvmPreferenceBackend(PreferencesPartition *partition, uint32_t type) : partition_(partition), type_(type) {}
 
-  bool save(const uint8_t *data, size_t len) override;
-  bool load(uint8_t *data, size_t len) override;
+  bool save(const uint8_t *data, size_t len);
+  bool load(uint8_t *data, size_t len);
 
  protected:
   /// Find or allocate a key slot
@@ -272,6 +298,18 @@ class NvmPreferenceBackend : public ESPPreferenceBackend {
   PreferencesPartition *partition_;
   uint32_t type_;
 };
+
+template<typename T> bool NvmPreferenceObject::save(const T *src) {
+  if (this->backend_ == nullptr)
+    return false;
+  return this->backend_->save(reinterpret_cast<const uint8_t *>(src), sizeof(T));
+}
+
+template<typename T> bool NvmPreferenceObject::load(T *dest) {
+  if (this->backend_ == nullptr)
+    return false;
+  return this->backend_->load(reinterpret_cast<uint8_t *>(dest), sizeof(T));
+}
 
 /// Specialized partition for raw data storage
 ///

--- a/esphome/components/nvm/nvm.h
+++ b/esphome/components/nvm/nvm.h
@@ -41,7 +41,7 @@ class NvmPlatform;
 /// interfaces for accessing the underlying storage.
 class NvmPartition {
  public:
-  NvmPartition(NvmPlatform *parent, const PartitionConfig &config);
+  NvmPartition(NvmPlatform *parent, PartitionConfig config);
   virtual ~NvmPartition() = default;
 
   /// Read data from partition
@@ -142,10 +142,10 @@ class NvmPlatform : public Component {
   std::vector<std::unique_ptr<NvmPartition>> partitions_;
 
   /// Check for partition overlaps
-  bool check_partition_overlap(const PartitionConfig &config);
+  bool check_partition_overlap_(const PartitionConfig &config);
 
   /// Calculate automatic offsets for partitions
-  void calculate_partition_offsets();
+  void calculate_partition_offsets_();
 };
 
 /// Base class for data partitions (Preferences and KeyValue)
@@ -153,16 +153,8 @@ class NvmPlatform : public Component {
 /// This class provides common functionality for both partition types,
 /// including header management, validation, and usage tracking.
 class NvmDataPartition : public NvmPartition {
- protected:
-  /// Header offsets
-  static const uint8_t OFF_MAGIC = 0;
-  static const uint8_t OFF_VERSION = 4;
-  static const uint8_t OFF_TYPE = 5;
-  static const uint8_t OFF_RESERVED = 6;
-  static const uint8_t OFF_SIZE = 8;
-  static const uint8_t OFF_FIRST_FREE = 12;
-
-  /// Header constants
+ public:
+  /// Header constants - public for use by backend classes
   static const uint32_t HEADER_SIZE = 16;  ///< magic(4) + version(1) + type(1) + reserved(2) + size(4) + first_free(4)
   static const uint32_t MAGIC = 0x4B565354;  ///< "KVST" - unified magic for all NVM partitions
   static const uint8_t VERSION = 1;          ///< Version 1 - unified across all partitions
@@ -171,9 +163,17 @@ class NvmDataPartition : public NvmPartition {
   static constexpr float WARNING_L1_PERCENT = 80.0f;
   static constexpr float WARNING_L2_PERCENT = 90.0f;
 
- public:
   NvmDataPartition(NvmPlatform *parent, const PartitionConfig &config)
       : NvmPartition(parent, config), initialized_(false), warned_L1_percent_(false) {}
+
+ protected:
+  /// Header offsets
+  static const uint8_t OFF_MAGIC = 0;
+  static const uint8_t OFF_VERSION = 4;
+  static const uint8_t OFF_TYPE = 5;
+  static const uint8_t OFF_RESERVED = 6;
+  static const uint8_t OFF_SIZE = 8;
+  static const uint8_t OFF_FIRST_FREE = 12;
 
  protected:
   /// Validate header and check if reinitialization is needed
@@ -207,7 +207,7 @@ class NvmDataPartition : public NvmPartition {
   void log_mismatch_(const char *issue, uint32_t actual, uint32_t expected);
 
  public:
-  virtual ~NvmDataPartition() = default;
+  ~NvmDataPartition() override = default;
 
   /// Get the percentage of partition space used
   /// @return Usage percentage (0-100)
@@ -386,10 +386,10 @@ class KeyValuePartition : public NvmDataPartition, public Component {
   /// @param value_offset Output: offset where value starts (relative to data area)
   /// @param value_len Output: length of value
   /// @return true if key found
-  bool find_key(const std::string &key, uint32_t &offset, uint32_t &value_offset, uint16_t &value_len);
+  bool find_key_(const std::string &key, uint32_t &offset, uint32_t &value_offset, uint16_t &value_len);
 
   /// Compact storage (remove deleted entries)
-  void compact();
+  void compact_();
 
   /// Calculate used bytes by scanning all entries
   /// @return Total bytes used (including header)

--- a/esphome/components/nvm/nvm.h
+++ b/esphome/components/nvm/nvm.h
@@ -175,7 +175,6 @@ class NvmDataPartition : public NvmPartition {
   static const uint8_t OFF_SIZE = 8;
   static const uint8_t OFF_FIRST_FREE = 12;
 
- protected:
   /// Validate header and check if reinitialization is needed
   /// @param expected_type The expected partition type
   /// @return true if header is valid and matches expected type

--- a/tests/component_tests/nvm/__init__.py
+++ b/tests/component_tests/nvm/__init__.py
@@ -1,0 +1,1 @@
+"""NVM component tests."""

--- a/tests/component_tests/nvm/conftest.py
+++ b/tests/component_tests/nvm/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures for NVM component tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+import sys
+
+import pytest
+
+# Add package root to python path
+here = Path(__file__).parent
+package_root = here.parent.parent.parent
+sys.path.insert(0, package_root.as_posix())
+
+from esphome.core import CORE  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_core() -> Generator[None]:
+    """Reset CORE state before and after each test."""
+    CORE.reset()
+    yield
+    CORE.reset()

--- a/tests/component_tests/nvm/test_validation.py
+++ b/tests/component_tests/nvm/test_validation.py
@@ -1,0 +1,158 @@
+"""Tests for NVM component validation.
+
+This module tests the configuration validation logic for the NVM component,
+ensuring that invalid configurations are properly rejected with helpful error messages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components import nvm
+from esphome.core import CORE
+
+
+class TestValidateNvmI2cAddress:
+    """Tests for validate_nvm_i2c_address function."""
+
+    def test_first_device_succeeds(self):
+        """Test that the first NVM device with an I2C address is accepted."""
+        config = {"id": "fram1", "address": 0x50}
+        result = nvm.validate_nvm_i2c_address(config)
+        assert result == config
+
+    def test_duplicate_address_same_bus_fails(self):
+        """Test that duplicate I2C address on same bus is rejected."""
+        # First device should succeed
+        config1 = {"id": "fram1", "address": 0x50}
+        nvm.validate_nvm_i2c_address(config1)
+
+        # Second device with same address should fail
+        config2 = {"id": "fram2", "address": 0x50}
+        with pytest.raises(cv.Invalid) as exc_info:
+            nvm.validate_nvm_i2c_address(config2)
+
+        error_msg = str(exc_info.value)
+        assert "Duplicate NVM I2C address" in error_msg
+        assert "0x50" in error_msg
+
+    def test_different_addresses_same_bus_succeeds(self):
+        """Test that different I2C addresses on same bus are allowed."""
+        config1 = {"id": "fram1", "address": 0x50}
+        nvm.validate_nvm_i2c_address(config1)
+
+        config2 = {"id": "fram2", "address": 0x51}
+        result = nvm.validate_nvm_i2c_address(config2)
+        assert result == config2
+
+    def test_same_address_different_buses_succeeds(self):
+        """Test that same I2C address on different buses is allowed."""
+        # Device on bus_a
+        config1 = {"id": "fram1", "address": 0x50, "i2c_id": "bus_a"}
+        nvm.validate_nvm_i2c_address(config1)
+
+        # Device on bus_b with same address should succeed
+        config2 = {"id": "fram2", "address": 0x50, "i2c_id": "bus_b"}
+        result = nvm.validate_nvm_i2c_address(config2)
+        assert result == config2
+
+    def test_address_none_succeeds(self):
+        """Test that config without address is accepted (non-I2C platform)."""
+        config = {"id": "fram1"}
+        result = nvm.validate_nvm_i2c_address(config)
+        assert result == config
+
+
+class TestValidatePreferencesPartitionCount:
+    """Tests for validate_preferences_partition_count function."""
+
+    def test_no_partitions_succeeds(self):
+        """Test that config with no partitions is accepted."""
+        config = {"id": "fram1", "partitions": []}
+        result = nvm.validate_preferences_partition_count(config)
+        assert result == config
+
+    def test_single_preferences_partition_succeeds(self):
+        """Test that a single preferences partition is accepted."""
+        config = {
+            "id": "fram1",
+            "partitions": [
+                {"id": "prefs", "type": "preferences", "size": 4096},
+            ],
+        }
+        result = nvm.validate_preferences_partition_count(config)
+        assert result == config
+
+    def test_multiple_preferences_partitions_fails(self):
+        """Test that multiple preferences partitions are rejected."""
+        # First config with preferences partition
+        config1 = {
+            "id": "fram1",
+            "partitions": [
+                {"id": "prefs1", "type": "preferences", "size": 4096},
+            ],
+        }
+        nvm.validate_preferences_partition_count(config1)
+
+        # Second config with preferences partition should fail
+        config2 = {
+            "id": "fram2",
+            "partitions": [
+                {"id": "prefs2", "type": "preferences", "size": 4096},
+            ],
+        }
+        with pytest.raises(cv.Invalid) as exc_info:
+            nvm.validate_preferences_partition_count(config2)
+
+        error_msg = str(exc_info.value)
+        assert "Only one preferences partition" in error_msg
+
+    def test_mixed_partition_types_succeeds(self):
+        """Test that mixed partition types (only one preferences) are accepted."""
+        config = {
+            "id": "fram1",
+            "partitions": [
+                {"id": "prefs", "type": "preferences", "size": 4096},
+                {"id": "raw", "type": "raw", "size": 8192},
+                {"id": "kv", "type": "key_value", "size": 2048},
+            ],
+        }
+        result = nvm.validate_preferences_partition_count(config)
+        assert result == config
+
+    def test_raw_partitions_only_succeeds(self):
+        """Test that multiple raw partitions are accepted."""
+        config = {
+            "id": "fram1",
+            "partitions": [
+                {"id": "raw1", "type": "raw", "size": 4096},
+                {"id": "raw2", "type": "raw", "size": 4096},
+            ],
+        }
+        result = nvm.validate_preferences_partition_count(config)
+        assert result == config
+
+
+class TestNvmData:
+    """Tests for NvmData state management."""
+
+    def test_data_stored_in_core_data(self):
+        """Test that NVM data is stored in CORE.data."""
+        data = nvm._get_data()
+        assert "nvm" in CORE.data
+        assert CORE.data["nvm"] is data
+
+    def test_data_is_reset_with_core(self):
+        """Test that NVM data is reset when CORE is reset."""
+        # Create some data
+        nvm._get_data().preferences_partition_count = 5
+        nvm._get_data().i2c_devices["test"] = "value"
+
+        # Reset CORE
+        CORE.reset()
+
+        # Data should be reset
+        data = nvm._get_data()
+        assert data.preferences_partition_count == 0
+        assert data.i2c_devices == {}

--- a/tests/components/nvm/test.esp32-idf.yaml
+++ b/tests/components/nvm/test.esp32-idf.yaml
@@ -1,0 +1,24 @@
+# Test configuration for NVM component with FRAM I2C platform
+#
+# This tests the NVM component with FRAM I2C platform and all partition types.
+
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+  scan: true
+
+nvm:
+  - platform: fram_i2c
+    id: test_fram
+    address: 0x50
+    model: MB85RC256
+    partitions:
+      - id: pref_partition
+        type: preferences
+        size: 4kB
+      - id: raw_partition
+        type: raw
+        size: 8kB
+      - id: kv_partition
+        type: key_value
+        size: 2kB

--- a/tests/components/nvm/test.esp8266-ard.yaml
+++ b/tests/components/nvm/test.esp8266-ard.yaml
@@ -1,0 +1,22 @@
+# Test configuration for NVM component with FRAM I2C platform on ESP8266
+
+i2c:
+  sda: GPIO4
+  scl: GPIO5
+  scan: true
+
+nvm:
+  - platform: fram_i2c
+    id: test_fram
+    address: 0x50
+    model: MB85RC256
+    partitions:
+      - id: pref_partition
+        type: preferences
+        size: 4kB
+      - id: raw_partition
+        type: raw
+        size: 8kB
+      - id: kv_partition
+        type: key_value
+        size: 2kB

--- a/tests/components/nvm/test.rp2040-ard.yaml
+++ b/tests/components/nvm/test.rp2040-ard.yaml
@@ -1,0 +1,22 @@
+# Test configuration for NVM component with FRAM I2C platform on RP2040
+
+i2c:
+  sda: GPIO0
+  scl: GPIO1
+  scan: true
+
+nvm:
+  - platform: fram_i2c
+    id: test_fram
+    address: 0x50
+    model: MB85RC256
+    partitions:
+      - id: pref_partition
+        type: preferences
+        size: 4kB
+      - id: raw_partition
+        type: raw
+        size: 8kB
+      - id: kv_partition
+        type: key_value
+        size: 2kB

--- a/tests/components/nvm/test_all_models.yaml
+++ b/tests/components/nvm/test_all_models.yaml
@@ -1,0 +1,74 @@
+# Test configuration for NVM component with all supported FRAM models
+#
+# This tests all five FRAM models to ensure they compile correctly:
+# - MB85RC64:   8KB  (13-bit addressing)
+# - MB85RC128: 16KB  (14-bit addressing)
+# - MB85RC256: 32KB  (15-bit addressing)
+# - MB85RC512: 64KB  (17-bit addressing)
+# - MB85RC1M: 128KB  (18-bit addressing)
+
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+  scan: true
+
+nvm:
+  - platform: fram_i2c
+    id: fram_64kb
+    address: 0x50
+    model: MB85RC64
+    partitions:
+      - id: prefs_64
+        type: preferences
+        size: 2kB
+      - id: raw_64
+        type: raw
+        size: 2kB
+
+  - platform: fram_i2c
+    id: fram_128kb
+    address: 0x51
+    model: MB85RC128
+    partitions:
+      - id: raw_128
+        type: raw
+        size: 4kB
+      - id: kv_128
+        type: key_value
+        size: 4kB
+
+  - platform: fram_i2c
+    id: fram_256kb
+    address: 0x52
+    model: MB85RC256
+    partitions:
+      - id: raw_256
+        type: raw
+        size: 8kB
+      - id: kv_256
+        type: key_value
+        size: 8kB
+
+  - platform: fram_i2c
+    id: fram_512kb
+    address: 0x53
+    model: MB85RC512
+    partitions:
+      - id: raw_512
+        type: raw
+        size: 16kB
+      - id: kv_512
+        type: key_value
+        size: 16kB
+
+  - platform: fram_i2c
+    id: fram_1mb
+    address: 0x54
+    model: MB85RC1M
+    partitions:
+      - id: raw_1m
+        type: raw
+        size: 32kB
+      - id: kv_1m
+        type: key_value
+        size: 32kB

--- a/tests/components/nvm/test_extended_addr.yaml
+++ b/tests/components/nvm/test_extended_addr.yaml
@@ -1,0 +1,34 @@
+# Test configuration for NVM component with extended address FRAM models
+#
+# This tests MB85RC512 (17-bit addressing) and MB85RC1M (18-bit addressing)
+# which require extended address handling in the I2C communication.
+
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+  scan: true
+
+nvm:
+  - platform: fram_i2c
+    id: fram_512kb
+    address: 0x50
+    model: MB85RC512
+    partitions:
+      - id: prefs_512
+        type: preferences
+        size: 32kB
+      - id: raw_512
+        type: raw
+        size: 16kB
+
+  - platform: fram_i2c
+    id: fram_1mb
+    address: 0x51
+    model: MB85RC1M
+    partitions:
+      - id: prefs_1m
+        type: raw
+        size: 64kB
+      - id: kv_1m
+        type: key_value
+        size: 32kB


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a new NVM (Non-Volatile Memory) component for ESPHome with FRAM I2C platform support, providing persistent storage capabilities with unlimited write cycles.

## NVM Component Features

- Generic NVM abstraction layer with platform support
- Three partition types: `preferences`, `raw`, and `key_value`

## FRAM I2C Platform Features

- I2C FRAM support for Fujitsu MB85RC series
- Unlimited write cycles (no wear)
- No write delays (instant writes)
- Fast read/write operations
- Non-volatile storage

### Supported FRAM Models

| Model | Size | Addressing |
|-------|------|------------|
| MB85RC64 | 8KB | 16-bit |
| MB85RC128 | 16KB | 16-bit |
| MB85RC256 | 32KB | 16-bit |
| MB85RC512 | 64KB | 17-bit extended |
| MB85RC1M | 128KB | 18-bit extended |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on PR #14121 (safe_mode RTC_KEY constant)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6130

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO21
  scl: GPIO22

nvm:
  - platform: fram_i2c
    id: my_fram
    address: 0x50
    model: MB85RC256
    partitions:
      - id: preferences
        type: preferences
        size: 4KB
      - id: sensor_cache
        type: raw
        size: 12KB
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).