### PR TITLE
[modbus_server] Add error path on registrer reads for modbus_server

### DIFF
--- a/esphome/components/modbus_server/__init__.py
+++ b/esphome/components/modbus_server/__init__.py
@@ -103,7 +103,7 @@ async def to_code(config):
                     await cg.process_lambda(
                         server_register[CONF_READ_LAMBDA],
                         [(cg.uint16, "address")],
-                        return_type=cpp_type,
+                        return_type=cg.optional.template(cpp_type),
                     ),
                 )
             )

--- a/esphome/components/modbus_server/modbus_server.cpp
+++ b/esphome/components/modbus_server/modbus_server.cpp
@@ -29,14 +29,20 @@ void ModbusServer::on_modbus_read_registers(uint8_t function_code, uint16_t star
         if (!server_register->read_lambda) {
           break;
         }
-        int64_t value = server_register->read_lambda();
+        optional<int64_t> value = server_register->read_lambda();
+        if (!value.has_value()) {
+          ESP_LOGW(TAG, "Matched register at 0x%02X but read lambda returned no value. Sending exception response.",
+                   server_register->address);
+          this->send_error(function_code, ModbusExceptionCode::SERVICE_DEVICE_FAILURE);
+          return;
+        }
         ESP_LOGV(TAG, "Matched register. Address: 0x%02X. Value type: %zu. Register count: %u. Value: %s.",
                  server_register->address, static_cast<size_t>(server_register->value_type),
-                 server_register->register_count, server_register->format_value(value).c_str());
+                 server_register->register_count, server_register->format_value(value.value()).c_str());
 
         std::vector<uint16_t> payload;
         payload.reserve(server_register->register_count * 2);
-        modbus::helpers::number_to_payload(payload, value, server_register->value_type);
+        modbus::helpers::number_to_payload(payload, value.value(), server_register->value_type);
         sixteen_bit_response.insert(sixteen_bit_response.end(), payload.cbegin(), payload.cend());
         current_address += server_register->register_count;
         found = true;

--- a/esphome/components/modbus_server/modbus_server.h
+++ b/esphome/components/modbus_server/modbus_server.h
@@ -5,6 +5,7 @@
 #include "esphome/components/modbus/modbus.h"
 #include "esphome/components/modbus/modbus_helpers.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/optional.h"
 
 #include <utility>
 #include <vector>
@@ -20,7 +21,7 @@ struct ServerCourtesyResponse {
 };
 
 class ServerRegister {
-  using ReadLambda = std::function<int64_t()>;
+  using ReadLambda = std::function<optional<int64_t>()>;
   using WriteLambda = std::function<bool(int64_t value)>;
 
  public:
@@ -30,13 +31,16 @@ class ServerRegister {
     this->register_count = register_count;
   }
 
-  template<typename T> void set_read_lambda(const std::function<T(uint16_t address)> &&user_read_lambda) {
-    this->read_lambda = [this, user_read_lambda]() -> int64_t {
-      T user_value = user_read_lambda(this->address);
+  template<typename T> void set_read_lambda(const std::function<optional<T>(uint16_t address)> &&user_read_lambda) {
+    this->read_lambda = [this, user_read_lambda]() -> optional<int64_t> {
+      optional<T> user_value = user_read_lambda(this->address);
+      if (!user_value.has_value()) {
+        return nullopt;
+      }
       if constexpr (std::is_same_v<T, float>) {
-        return bit_cast<uint32_t>(user_value);
+        return bit_cast<uint32_t>(user_value.value());
       } else {
-        return static_cast<int64_t>(user_value);
+        return static_cast<int64_t>(user_value.value());
       }
     };
   }

--- a/tests/components/modbus_server/common.yaml
+++ b/tests/components/modbus_server/common.yaml
@@ -39,3 +39,7 @@ modbus_server:
         value_type: U_WORD
         read_lambda: |-
           return (random_uint32() % 100);
+      - address: 0x7
+        value_type: U_WORD
+        read_lambda: |-
+          return {};


### PR DESCRIPTION
# What does this implement/fix?

This adds an error path when reading modbus registers on the `modbus_controller` component. Reading registers has a similar path, so it's only natural to allow reads to also fail. The error path is triggered by returning `std::nullopt` from the read lambda, which will send a `ModbusExceptionCode::SERVICE_DEVICE_FAILURE` exception response, similarly to the behaviour implemented for writing registers.

My understanding is that the types we're working with will be implicitly converted into an std::option containing the bare returned value, thus why the current tests pass. Therefore this should be considered a non breaking change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None that I could find

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

https://github.com/esphome/esphome-docs/pull/6348

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
modbus_controller:
- address: 0x1
  modbus_id: inverter_modbus_rtu
  server_registers:
  - address: 0x0033
    value_type: U_WORD
    read_lambda: |-
      const &auto soc_soh = id(pcs_all_decoded_soc_soh).value();
      if (soc_soh.has_value()) {
        return soc_soh.value().battery_soc_percent;
      }
      return {};
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
