### PR TITLE
[ecocomfort2] Add component for Fantini Cosmi VMC units via BLE

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -144,6 +144,7 @@ esphome/components/ds1307/* @badbadc0ffee
 esphome/components/ds2484/* @mrk-its
 esphome/components/dsmr/* @glmnet @PolarGoose
 esphome/components/duty_time/* @dudanov
+esphome/components/ecocomfort2/* @gledian
 esphome/components/ee895/* @Stock-M
 esphome/components/ektf2232/touchscreen/* @jesserockz
 esphome/components/emc2101/* @ellull

--- a/esphome/components/ecocomfort2/__init__.py
+++ b/esphome/components/ecocomfort2/__init__.py
@@ -1,0 +1,69 @@
+import esphome.codegen as cg
+from esphome.components import ble_client, button, fan, number, select, switch, time
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_TIME_ID
+
+from .const import CONF_ECOCOMFORT2_ID
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ble_client"]
+MULTI_CONF = True
+
+ecocomfort2_ns = cg.esphome_ns.namespace("ecocomfort2")
+Ecocomfort2Hub = ecocomfort2_ns.class_(
+    "Ecocomfort2Hub", ble_client.BLEClientNode, cg.PollingComponent
+)
+Ecocomfort2Fan = ecocomfort2_ns.class_("Ecocomfort2Fan", fan.Fan, cg.Component)
+Ecocomfort2Sensor = ecocomfort2_ns.class_("Ecocomfort2Sensor", cg.Component)
+Ecocomfort2BinarySensor = ecocomfort2_ns.class_("Ecocomfort2BinarySensor", cg.Component)
+Ecocomfort2TextSensor = ecocomfort2_ns.class_("Ecocomfort2TextSensor", cg.Component)
+Ecocomfort2SeasonSelect = ecocomfort2_ns.class_(
+    "Ecocomfort2SeasonSelect", select.Select, cg.Component
+)
+Ecocomfort2FreeCoolingSelect = ecocomfort2_ns.class_(
+    "Ecocomfort2FreeCoolingSelect", select.Select, cg.Component
+)
+Ecocomfort2ThresholdNumber = ecocomfort2_ns.class_(
+    "Ecocomfort2ThresholdNumber", number.Number, cg.Component
+)
+Ecocomfort2OffsetNumber = ecocomfort2_ns.class_(
+    "Ecocomfort2OffsetNumber", number.Number, cg.Component
+)
+Ecocomfort2AdvancedSwitch = ecocomfort2_ns.class_(
+    "Ecocomfort2AdvancedSwitch", switch.Switch, cg.Component
+)
+Ecocomfort2PairButton = ecocomfort2_ns.class_(
+    "Ecocomfort2PairButton", button.Button, cg.Component
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Ecocomfort2Hub),
+            cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+        }
+    )
+    .extend(ble_client.BLE_CLIENT_SCHEMA)
+    .extend(cv.polling_component_schema("30s"))
+)
+
+ECOCOMFORT2_CLIENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ECOCOMFORT2_ID): cv.use_id(Ecocomfort2Hub),
+    }
+)
+
+
+async def register_ecocomfort2_child(var, config):
+    parent = await cg.get_variable(config[CONF_ECOCOMFORT2_ID])
+    cg.add(parent.register_child(var))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await ble_client.register_ble_node(var, config)
+
+    if time_id := config.get(CONF_TIME_ID):
+        time_var = await cg.get_variable(time_id)
+        cg.add(var.set_time_id(time_var))

--- a/esphome/components/ecocomfort2/binary_sensor.py
+++ b/esphome/components/ecocomfort2/binary_sensor.py
@@ -1,0 +1,50 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+
+from . import (
+    ECOCOMFORT2_CLIENT_SCHEMA,
+    Ecocomfort2BinarySensor,
+    register_ecocomfort2_child,
+)
+from .const import CONF_BOOST, CONF_CONNECTED
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+SENSOR_TYPES = {
+    CONF_CONNECTED: binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_CONNECTIVITY,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_BOOST: binary_sensor.binary_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Ecocomfort2BinarySensor),
+        }
+    )
+    .extend({cv.Optional(type_): schema for type_, schema in SENSOR_TYPES.items()})
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ECOCOMFORT2_CLIENT_SCHEMA),
+    cv.has_at_least_one_key(*SENSOR_TYPES),
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await register_ecocomfort2_child(var, config)
+
+    if conf := config.get(CONF_CONNECTED):
+        sens = await binary_sensor.new_binary_sensor(conf)
+        cg.add(var.set_connected_sensor(sens))
+
+    if conf := config.get(CONF_BOOST):
+        sens = await binary_sensor.new_binary_sensor(conf)
+        cg.add(var.set_boost_sensor(sens))

--- a/esphome/components/ecocomfort2/button.py
+++ b/esphome/components/ecocomfort2/button.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+from esphome.components import button
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
+
+from . import (
+    ECOCOMFORT2_CLIENT_SCHEMA,
+    Ecocomfort2PairButton,
+    register_ecocomfort2_child,
+)
+from .const import CONF_PAIR
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.Optional(CONF_PAIR): button.button_schema(
+                Ecocomfort2PairButton,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+        }
+    )
+    .extend(ECOCOMFORT2_CLIENT_SCHEMA)
+    .add_extra(cv.has_at_least_one_key(CONF_PAIR))
+)
+
+
+async def to_code(config):
+    if conf := config.get(CONF_PAIR):
+        var = await button.new_button(conf)
+        await cg.register_component(var, conf)
+        await register_ecocomfort2_child(var, config)

--- a/esphome/components/ecocomfort2/const.py
+++ b/esphome/components/ecocomfort2/const.py
@@ -1,14 +1,5 @@
 CONF_ECOCOMFORT2_ID = "ecocomfort2_id"
 
-# BLE Service and Characteristic UUIDs
-SERVICE_UUID = "f4b827c3-e660-4bc8-bdf6-3c8e9b845e0d"
-C_INFO_UUID = "f5f56229-dd4f-480f-a829-9189269d8b37"
-C_STATE_UUID = "438d3433-7e5a-459a-a8e4-66343fad2bb0"
-C_SETTING_OPER_UUID = "b9d6f678-bc0d-4a73-90c8-60b0f07301f1"
-C_CONFIGURATION_UUID = "d3dac48e-b4e1-4f3a-8715-326ddf1da89a"
-C_SETTING_CLOCK_UUID = "82788997-49e4-4533-b949-7ed433678044"
-C_ADVANCED_UUID = "f8b2284e-61dd-44e3-a782-a93c9503ab2d"
-
 # Fan preset names
 PRESET_IN = "In"
 PRESET_OUT = "Out"
@@ -27,13 +18,8 @@ FREE_COOLING_MEDIUM = "Medium"
 FREE_COOLING_HIGH = "High"
 
 # Sensor types
-CONF_TEMPERATURE = "temperature"
-CONF_HUMIDITY = "humidity"
-CONF_VOC = "voc"
-CONF_DIRECTION = "direction"
 CONF_ACTUAL_MODE = "actual_mode"
 CONF_ACTUAL_SPEED = "actual_speed"
-CONF_ROLE = "role"
 CONF_TEMP_OFFSET = "temp_offset"
 CONF_HUMIDITY_OFFSET = "humidity_offset"
 

--- a/esphome/components/ecocomfort2/const.py
+++ b/esphome/components/ecocomfort2/const.py
@@ -1,0 +1,63 @@
+CONF_ECOCOMFORT2_ID = "ecocomfort2_id"
+
+# BLE Service and Characteristic UUIDs
+SERVICE_UUID = "f4b827c3-e660-4bc8-bdf6-3c8e9b845e0d"
+C_INFO_UUID = "f5f56229-dd4f-480f-a829-9189269d8b37"
+C_STATE_UUID = "438d3433-7e5a-459a-a8e4-66343fad2bb0"
+C_SETTING_OPER_UUID = "b9d6f678-bc0d-4a73-90c8-60b0f07301f1"
+C_CONFIGURATION_UUID = "d3dac48e-b4e1-4f3a-8715-326ddf1da89a"
+C_SETTING_CLOCK_UUID = "82788997-49e4-4533-b949-7ed433678044"
+C_ADVANCED_UUID = "f8b2284e-61dd-44e3-a782-a93c9503ab2d"
+
+# Fan preset names
+PRESET_IN = "In"
+PRESET_OUT = "Out"
+PRESET_IN_OUT = "In-Out"
+PRESET_SENSOR = "Sensor"
+PRESET_AUTO = "Auto"
+
+# Season options
+SEASON_WINTER = "Winter"
+SEASON_SUMMER = "Summer"
+
+# Free cooling options
+FREE_COOLING_OFF = "Off"
+FREE_COOLING_LOW = "Low"
+FREE_COOLING_MEDIUM = "Medium"
+FREE_COOLING_HIGH = "High"
+
+# Sensor types
+CONF_TEMPERATURE = "temperature"
+CONF_HUMIDITY = "humidity"
+CONF_VOC = "voc"
+CONF_DIRECTION = "direction"
+CONF_ACTUAL_MODE = "actual_mode"
+CONF_ACTUAL_SPEED = "actual_speed"
+CONF_ROLE = "role"
+CONF_TEMP_OFFSET = "temp_offset"
+CONF_HUMIDITY_OFFSET = "humidity_offset"
+
+# Binary sensor types
+CONF_CONNECTED = "connected"
+CONF_BOOST = "boost"
+
+# Number types
+CONF_HUMIDITY_THRESHOLD = "humidity_threshold"
+CONF_LUMINOSITY_THRESHOLD = "luminosity_threshold"
+CONF_VOC_THRESHOLD = "voc_threshold"
+CONF_TEMP_OFFSET_NUMBER = "temp_offset_number"
+CONF_HUMIDITY_OFFSET_NUMBER = "humidity_offset_number"
+
+# Switch types
+CONF_HUMIDITY_ADVANCED = "humidity_advanced"
+CONF_VOC_ADVANCED = "voc_advanced"
+
+# Select types
+CONF_SEASON = "season"
+CONF_FREE_COOLING = "free_cooling"
+
+# Button types
+CONF_PAIR = "pair"
+
+# Text sensor types
+CONF_FIRMWARE = "firmware"

--- a/esphome/components/ecocomfort2/ecocomfort2_binary_sensor.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_binary_sensor.cpp
@@ -1,0 +1,32 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_binary_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.binary_sensor";
+
+void Ecocomfort2BinarySensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Binary Sensor:");
+  LOG_BINARY_SENSOR("  ", "Connected", this->connected_sensor_);
+  LOG_BINARY_SENSOR("  ", "Boost", this->boost_sensor_);
+}
+
+void Ecocomfort2BinarySensor::on_status() {
+  if (this->parent_->has_oper_data() && this->boost_sensor_ != nullptr) {
+    this->boost_sensor_->publish_state(this->parent_->get_boost_active());
+  }
+}
+
+void Ecocomfort2BinarySensor::on_connect(bool connected) {
+  if (this->connected_sensor_ != nullptr) {
+    this->connected_sensor_->publish_state(connected);
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_binary_sensor.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_binary_sensor.h
@@ -1,0 +1,34 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2BinarySensor : public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  void set_connected_sensor(binary_sensor::BinarySensor *s) { this->connected_sensor_ = s; }
+  void set_boost_sensor(binary_sensor::BinarySensor *s) { this->boost_sensor_ = s; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override;
+  void on_config() override {}
+  void on_connect(bool connected) override;
+  const char *describe() const override { return "Ecocomfort2 Binary Sensor"; }
+
+ protected:
+  binary_sensor::BinarySensor *connected_sensor_{nullptr};
+  binary_sensor::BinarySensor *boost_sensor_{nullptr};
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_button.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_button.cpp
@@ -1,0 +1,29 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_button.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.button";
+
+void Ecocomfort2PairButton::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Pair Button:");
+  LOG_BUTTON("  ", "Pair", this);
+}
+
+void Ecocomfort2PairButton::press_action() {
+  if (!this->parent_->is_connected()) {
+    ESP_LOGW(TAG, "Not connected, cannot pair");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Pairing with VMC unit...");
+  this->parent_->pair();
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_button.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_button.h
@@ -1,0 +1,30 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2PairButton : public button::Button, public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override {}
+  void on_config() override {}
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Pair Button"; }
+
+ protected:
+  void press_action() override;
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_child.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_child.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+// Forward declare hub
+class Ecocomfort2Hub;
+
+class Ecocomfort2Client : public Parented<Ecocomfort2Hub> {
+ public:
+  virtual void on_status() = 0;
+  virtual void on_config() = 0;
+  virtual void on_connect(bool connected) = 0;
+
+ protected:
+  friend Ecocomfort2Hub;
+  virtual const char *describe() const = 0;
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome

--- a/esphome/components/ecocomfort2/ecocomfort2_fan.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_fan.cpp
@@ -11,13 +11,13 @@ namespace ecocomfort2 {
 static const char *const TAG = "ecocomfort2.fan";
 
 void Ecocomfort2Fan::setup() {
-  auto preset = this->parent_->get_desired_preset();
+  auto mode = this->parent_->get_desired_preset();
   auto speed = this->parent_->get_desired_speed();
-  bool auto_mode = this->parent_->get_desired_auto_mode();
+  bool auto_active = this->parent_->get_desired_auto_mode();
 
-  this->state = (preset != OPER_OFF);
+  this->state = (mode != OPER_OFF);
   this->speed = this->device_speed_to_fan_(speed);
-  const char *pm = this->mode_to_preset_name_(preset, auto_mode);
+  const char *pm = this->mode_to_preset_name_(mode, auto_active);
   if (pm != nullptr) {
     this->set_preset_mode_(pm);
   } else {
@@ -47,8 +47,9 @@ void Ecocomfort2Fan::control(const fan::FanCall &call) {
   }
 
   // Handle state change (on/off)
-  if (call.get_state().has_value()) {
-    this->state = *call.get_state();
+  auto opt_state = call.get_state();
+  if (opt_state.has_value()) {
+    this->state = *opt_state;
     if (!this->state) {
       // Turning off
       this->parent_->send_operation_command(OPER_OFF, SPEED_OFF, false);
@@ -68,8 +69,9 @@ void Ecocomfort2Fan::control(const fan::FanCall &call) {
     this->set_preset_mode_(preset_name);
   }
 
-  if (call.get_speed().has_value()) {
-    int fan_speed = *call.get_speed();
+  auto opt_speed = call.get_speed();
+  if (opt_speed.has_value()) {
+    int fan_speed = *opt_speed;
     speed = this->fan_speed_to_device_(fan_speed);
     this->speed = fan_speed;
 

--- a/esphome/components/ecocomfort2/ecocomfort2_fan.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_fan.cpp
@@ -1,0 +1,206 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_fan.h"
+#include "esphome/core/log.h"
+
+#include <cstring>
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.fan";
+
+void Ecocomfort2Fan::setup() {
+  auto preset = this->parent_->get_desired_preset();
+  auto speed = this->parent_->get_desired_speed();
+  bool auto_mode = this->parent_->get_desired_auto_mode();
+
+  this->state = (preset != OPER_OFF);
+  this->speed = this->device_speed_to_fan_(speed);
+  const char *pm = this->mode_to_preset_name_(preset, auto_mode);
+  if (pm != nullptr) {
+    this->set_preset_mode_(pm);
+  } else {
+    this->clear_preset_mode_();
+  }
+  // Wait for the first BLE readback before publishing a state guess.
+}
+
+void Ecocomfort2Fan::dump_config() { LOG_FAN("", "Ecocomfort2 Fan", this); }
+
+fan::FanTraits Ecocomfort2Fan::get_traits() {
+  fan::FanTraits traits;
+  traits.set_speed(true);
+  traits.set_supported_speed_count(4);  // Sleep, Vel1, Vel2, Vel3
+  traits.set_supported_preset_modes({PRESET_IN, PRESET_OUT, PRESET_IN_OUT, PRESET_SENSOR, PRESET_AUTO});
+  return traits;
+}
+
+void Ecocomfort2Fan::control(const fan::FanCall &call) {
+  // Skip-send guard: don't write back during readback updates
+  if (this->parent_->skip_send_)
+    return;
+
+  if (!this->parent_->is_ready()) {
+    ESP_LOGW(TAG, "Not ready, cannot handle control call");
+    return;
+  }
+
+  // Handle state change (on/off)
+  if (call.get_state().has_value()) {
+    this->state = *call.get_state();
+    if (!this->state) {
+      // Turning off
+      this->parent_->send_operation_command(OPER_OFF, SPEED_OFF, false);
+      this->publish_state();
+      return;
+    }
+  }
+
+  uint8_t preset = this->parent_->get_desired_preset();
+  uint8_t speed = this->parent_->get_desired_speed();
+  bool auto_mode = this->parent_->get_desired_auto_mode();
+
+  if (call.has_preset_mode()) {
+    const char *preset_name = call.get_preset_mode();
+    preset = this->preset_name_to_mode_(preset_name);
+    auto_mode = std::strcmp(preset_name, PRESET_AUTO) == 0;
+    this->set_preset_mode_(preset_name);
+  }
+
+  if (call.get_speed().has_value()) {
+    int fan_speed = *call.get_speed();
+    speed = this->fan_speed_to_device_(fan_speed);
+    this->speed = fan_speed;
+
+    if (preset == OPER_SENSOR_OR_AUTO && auto_mode) {
+      auto_mode = false;
+      this->set_preset_mode_(PRESET_SENSOR);
+    }
+  }
+
+  if (preset != OPER_SENSOR_OR_AUTO) {
+    auto_mode = false;
+  }
+
+  if (preset == OPER_SENSOR_OR_AUTO && !auto_mode && speed == 0) {
+    uint8_t fallback_speed = this->parent_->get_actual_speed();
+    if (fallback_speed == 0) {
+      fallback_speed = this->parent_->get_desired_speed();
+    }
+    if (fallback_speed == 0) {
+      fallback_speed = SPEED_VEL1;
+    }
+    speed = fallback_speed;
+    this->speed = this->device_speed_to_fan_(speed);
+  }
+
+  this->state = (preset != OPER_OFF);
+  this->parent_->send_operation_command(preset, speed, auto_mode);
+  this->publish_state();
+}
+
+void Ecocomfort2Fan::on_status() {
+  if (!this->parent_->has_oper_data()) {
+    return;
+  }
+
+  uint8_t mode = this->parent_->get_actual_mode();
+  uint8_t actual_speed = this->parent_->get_actual_speed();
+  bool boost = this->parent_->get_boost_active();
+
+  bool new_state = (mode != OPER_OFF);
+  int new_speed = new_state ? this->device_speed_to_fan_(actual_speed) : 0;
+  if (new_state && boost) {
+    new_speed = 4;  // Vel3
+  }
+
+  // Determine preset from readback using auto_active_ flag
+  bool auto_active = this->parent_->get_auto_active();
+  const char *new_preset = this->mode_to_preset_name_(mode, auto_active);
+
+  // Use skip-send guard to prevent feedback loop
+  this->parent_->skip_send_ = true;
+  this->state = new_state;
+  this->speed = new_speed;
+  if (new_preset != nullptr) {
+    this->set_preset_mode_(new_preset);
+  } else {
+    this->clear_preset_mode_();
+  }
+  this->publish_state();
+  this->parent_->skip_send_ = false;
+}
+
+void Ecocomfort2Fan::on_connect(bool connected) { (void) connected; }
+
+uint8_t Ecocomfort2Fan::preset_name_to_mode_(const char *preset) const {
+  if (preset == nullptr) {
+    return OPER_IN_OUT;
+  }
+  if (std::strcmp(preset, PRESET_IN) == 0)
+    return OPER_IN;
+  if (std::strcmp(preset, PRESET_OUT) == 0)
+    return OPER_OUT;
+  if (std::strcmp(preset, PRESET_IN_OUT) == 0)
+    return OPER_IN_OUT;
+  if (std::strcmp(preset, PRESET_SENSOR) == 0)
+    return OPER_SENSOR_OR_AUTO;
+  if (std::strcmp(preset, PRESET_AUTO) == 0)
+    return OPER_SENSOR_OR_AUTO;
+  return OPER_IN_OUT;
+}
+
+const char *Ecocomfort2Fan::mode_to_preset_name_(uint8_t mode, bool auto_active) const {
+  switch (mode) {
+    case OPER_OFF:
+      return nullptr;
+    case OPER_IN:
+      return PRESET_IN;
+    case OPER_OUT:
+      return PRESET_OUT;
+    case OPER_IN_OUT:
+      return PRESET_IN_OUT;
+    case OPER_SENSOR_OR_AUTO:
+      return auto_active ? PRESET_AUTO : PRESET_SENSOR;
+    default:
+      return PRESET_IN_OUT;
+  }
+}
+
+uint8_t Ecocomfort2Fan::fan_speed_to_device_(int speed) const {
+  switch (speed) {
+    case 1:
+      return SPEED_SLEEP;
+    case 2:
+      return SPEED_VEL1;
+    case 3:
+      return SPEED_VEL2;
+    case 4:
+      return SPEED_VEL3;
+    default:
+      return SPEED_VEL1;
+  }
+}
+
+int Ecocomfort2Fan::device_speed_to_fan_(uint8_t speed) const {
+  switch (speed) {
+    case SPEED_OFF:
+      return 0;
+    case SPEED_SLEEP:
+      return 1;
+    case SPEED_VEL1:
+      return 2;
+    case SPEED_VEL2:
+      return 3;
+    case SPEED_VEL3:
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_fan.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_fan.h
@@ -1,0 +1,43 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/fan/fan.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2Fan : public fan::Fan, public Ecocomfort2Client, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  fan::FanTraits get_traits() override;
+
+  // Ecocomfort2Client callbacks
+  void on_status() override;
+  void on_config() override {}
+  void on_connect(bool connected) override;
+  const char *describe() const override { return "Ecocomfort2 Fan"; }
+
+ protected:
+  void control(const fan::FanCall &call) override;
+
+ private:
+  /** Map preset name to OPER_* byte value. */
+  uint8_t preset_name_to_mode_(const char *preset) const;
+  /** Map OPER_* byte value to preset name. Returns nullptr if none. */
+  const char *mode_to_preset_name_(uint8_t mode, bool auto_active) const;
+  /** Map fan speed (1-4) to SPEED_* value. */
+  uint8_t fan_speed_to_device_(int speed) const;
+  /** Map SPEED_* value to fan speed (1-4). */
+  int device_speed_to_fan_(uint8_t speed) const;
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_hub.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_hub.cpp
@@ -200,8 +200,7 @@ void Ecocomfort2Hub::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if
       if (param->read.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%s] Error reading char at handle 0x%x, status=%d", this->log_id_(), param->read.handle,
                  param->read.status);
-        if ((param->read.status == ESP_GATT_INSUF_ENCRYPTION ||
-             param->read.status == ESP_GATT_INSUF_AUTHENTICATION) &&
+        if ((param->read.status == ESP_GATT_INSUF_ENCRYPTION || param->read.status == ESP_GATT_INSUF_AUTHENTICATION) &&
             this->ready_) {
           this->ready_ = false;
           this->status_set_warning();

--- a/esphome/components/ecocomfort2/ecocomfort2_hub.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_hub.cpp
@@ -1,0 +1,679 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_hub.h"
+#include "ecocomfort2_child.h"
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <esp_gap_ble_api.h>
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2";
+
+void Ecocomfort2Hub::setup() {
+  char pref_key[40];
+  if (this->parent_ != nullptr) {
+    snprintf(pref_key, sizeof(pref_key), "ecocomfort2_%s", this->parent_->address_str());
+  } else {
+    snprintf(pref_key, sizeof(pref_key), "ecocomfort2");
+  }
+
+  this->pref_ = global_preferences->make_preference<Ecocomfort2PersistedState>(fnv1_hash(pref_key));
+  if (this->pref_.load(&this->persisted_)) {
+    ESP_LOGD(TAG, "Restored state: preset=%d, speed=%d, auto=%d", this->persisted_.preset, this->persisted_.speed,
+             this->persisted_.auto_mode);
+  } else {
+    ESP_LOGD(TAG, "No saved state, using defaults: preset=%d, speed=%d, auto=%d", this->persisted_.preset,
+             this->persisted_.speed, this->persisted_.auto_mode);
+  }
+
+  if (this->persisted_.speed == 0) {
+    this->persisted_.speed = SPEED_VEL1;
+  }
+
+  esp_ble_auth_req_t auth_req = ESP_LE_AUTH_REQ_SC_BOND;
+  esp_ble_io_cap_t io_cap = ESP_IO_CAP_NONE;
+  uint8_t key_size = 16;
+  uint8_t init_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+  uint8_t rsp_key = ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK;
+
+  auto set_security_param = [this](esp_ble_sm_param_t param, void *value, uint8_t len, const char *name) {
+    auto err = esp_ble_gap_set_security_param(param, value, len);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "[%s] Failed to set BLE security param %s, err=%d", this->log_id_(), name, err);
+    }
+  };
+
+  set_security_param(ESP_BLE_SM_AUTHEN_REQ_MODE, &auth_req, static_cast<uint8_t>(sizeof(auth_req)), "auth_req");
+  set_security_param(ESP_BLE_SM_IOCAP_MODE, &io_cap, static_cast<uint8_t>(sizeof(io_cap)), "io_cap");
+  set_security_param(ESP_BLE_SM_MAX_KEY_SIZE, &key_size, static_cast<uint8_t>(sizeof(key_size)), "key_size");
+  set_security_param(ESP_BLE_SM_SET_INIT_KEY, &init_key, static_cast<uint8_t>(sizeof(init_key)), "init_key");
+  set_security_param(ESP_BLE_SM_SET_RSP_KEY, &rsp_key, static_cast<uint8_t>(sizeof(rsp_key)), "rsp_key");
+}
+
+void Ecocomfort2Hub::loop() {
+  if (!this->is_ready()) {
+    return;
+  }
+
+  uint32_t now = millis();
+  uint32_t retry_interval = this->last_clock_sync_ == 0 ? CLOCK_SYNC_RETRY_INTERVAL : CLOCK_SYNC_INTERVAL;
+  if (this->last_clock_attempt_ != 0 && (now - this->last_clock_attempt_) <= retry_interval) {
+    return;
+  }
+
+  this->last_clock_attempt_ = now;
+  if (this->send_clock()) {
+    this->last_clock_sync_ = now;
+  }
+}
+
+void Ecocomfort2Hub::update() {
+  if (!this->is_ready()) {
+    ESP_LOGD(TAG, "[%s] Not ready (connected=%d, ready=%d), skipping update", this->log_id_(), this->is_connected(),
+             this->ready_);
+    return;
+  }
+
+  auto read_char = [this](uint16_t handle, const char *name) {
+    if (handle == 0) {
+      return;
+    }
+
+    auto status = esp_ble_gattc_read_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), handle,
+                                          ESP_GATT_AUTH_REQ_NONE);
+    if (status != ESP_GATT_OK) {
+      ESP_LOGW(TAG, "[%s] Read request failed for %s handle 0x%x, status=%d", this->log_id_(), name, handle, status);
+    }
+  };
+
+  read_char(this->char_handle_state_, "C_STATE");
+  read_char(this->char_handle_oper_, "C_OPER");
+  read_char(this->char_handle_config_, "C_CONFIG");
+  read_char(this->char_handle_advanced_, "C_ADVANCED");
+  if (!this->firmware_read_) {
+    read_char(this->char_handle_info_, "C_INFO");
+  }
+}
+
+void Ecocomfort2Hub::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Hub:");
+  if (this->parent_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Address: %s", this->parent_->address_str());
+  }
+  LOG_UPDATE_INTERVAL(this);
+  ESP_LOGCONFIG(TAG, "  Child components (%u):", static_cast<unsigned>(this->children_.size()));
+  for (auto *child : this->children_) {
+    ESP_LOGCONFIG(TAG, "    - %s", child->describe());
+  }
+}
+
+bool Ecocomfort2Hub::discover_characteristics_() {
+  bool result = true;
+  esphome::ble_client::BLECharacteristic *chr;
+
+  auto find_char = [&](const espbt::ESPBTUUID &uuid, uint16_t &handle, const char *name) {
+    if (handle != 0) {
+      return;
+    }
+    chr = this->parent_->get_characteristic(ECOCOMFORT2_SERVICE_UUID, uuid);
+    if (chr == nullptr) {
+      ESP_LOGW(TAG, "[%s] No %s characteristic found", this->log_id_(), name);
+      result = false;
+    } else {
+      handle = chr->handle;
+    }
+  };
+
+  find_char(ECOCOMFORT2_C_INFO_UUID, this->char_handle_info_, "C_INFO");
+  find_char(ECOCOMFORT2_C_STATE_UUID, this->char_handle_state_, "C_STATE");
+  find_char(ECOCOMFORT2_C_OPER_UUID, this->char_handle_oper_, "C_OPER");
+  find_char(ECOCOMFORT2_C_CONFIG_UUID, this->char_handle_config_, "C_CONFIG");
+  find_char(ECOCOMFORT2_C_CLOCK_UUID, this->char_handle_clock_, "C_CLOCK");
+  find_char(ECOCOMFORT2_C_ADVANCED_UUID, this->char_handle_advanced_, "C_ADVANCED");
+
+  ESP_LOGI(TAG, "[%s] Discovered characteristics: INFO=0x%x STATE=0x%x OPER=0x%x CONFIG=0x%x CLOCK=0x%x ADVANCED=0x%x",
+           this->log_id_(), this->char_handle_info_, this->char_handle_state_, this->char_handle_oper_,
+           this->char_handle_config_, this->char_handle_clock_, this->char_handle_advanced_);
+
+  return result;
+}
+
+void Ecocomfort2Hub::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                                         esp_ble_gattc_cb_param_t *param) {
+  switch (event) {
+    case ESP_GATTC_DISCONNECT_EVT: {
+      ESP_LOGD(TAG, "[%s] Disconnected: reason=%d", this->log_id_(), param->disconnect.reason);
+      this->cancel_timeout("send_cmd");
+      this->cancel_timeout("connect_encrypt");
+      this->cancel_timeout("connect_auth_timeout");
+      this->cancel_timeout("post_auth_sync");
+      this->status_set_warning();
+      this->node_state = espbt::ClientState::IDLE;
+      this->char_handle_info_ = 0;
+      this->char_handle_state_ = 0;
+      this->char_handle_oper_ = 0;
+      this->char_handle_config_ = 0;
+      this->char_handle_clock_ = 0;
+      this->char_handle_advanced_ = 0;
+      this->firmware_read_ = false;
+      this->ready_ = false;
+      this->state_valid_ = false;
+      this->oper_valid_ = false;
+      this->config_valid_ = false;
+      this->advanced_valid_ = false;
+      this->last_clock_sync_ = 0;
+      this->last_clock_attempt_ = 0;
+      this->encryption_retries_ = 0;
+      this->dispatch_connect_(false);
+      break;
+    }
+    case ESP_GATTC_SEARCH_CMPL_EVT: {
+      if (!this->discover_characteristics_()) {
+        ESP_LOGW(TAG, "[%s] Failed to discover characteristics — disconnecting to retry", this->log_id_());
+        this->parent_->disconnect();
+        break;
+      }
+
+      ESP_LOGD(TAG, "[%s] Service discovery complete", this->log_id_());
+      this->node_state = espbt::ClientState::ESTABLISHED;
+      this->ready_ = false;
+      this->state_valid_ = false;
+      this->oper_valid_ = false;
+      this->config_valid_ = false;
+      this->advanced_valid_ = false;
+      this->status_set_warning();
+      this->dispatch_connect_(false);
+
+      this->set_timeout("connect_encrypt", 500, [this]() { this->request_encryption_("initial connect"); });
+      break;
+    }
+    case ESP_GATTC_READ_CHAR_EVT: {
+      if (param->read.conn_id != this->parent_->get_conn_id()) {
+        break;
+      }
+      if (param->read.status != ESP_GATT_OK) {
+        ESP_LOGW(TAG, "[%s] Error reading char at handle 0x%x, status=%d", this->log_id_(), param->read.handle,
+                 param->read.status);
+        if ((param->read.status == ESP_GATT_INSUF_ENCRYPTION ||
+             param->read.status == ESP_GATT_INSUF_AUTHENTICATION) &&
+            this->ready_) {
+          this->ready_ = false;
+          this->status_set_warning();
+          this->dispatch_connect_(false);
+          if (++this->encryption_retries_ >= MAX_ENCRYPTION_RETRIES) {
+            ESP_LOGW(TAG, "[%s] Encryption lost, max retries reached — disconnecting", this->log_id_());
+            this->parent_->disconnect();
+          } else {
+            ESP_LOGW(TAG, "[%s] Encryption lost, retry %d/%d", this->log_id_(), this->encryption_retries_,
+                     MAX_ENCRYPTION_RETRIES);
+            this->set_timeout("connect_encrypt", 500, [this]() { this->request_encryption_("encryption lost"); });
+          }
+        }
+        break;
+      }
+
+      if (param->read.handle == this->char_handle_state_) {
+        if (this->parse_state_(param->read.value, param->read.value_len)) {
+          this->state_valid_ = true;
+          this->dispatch_status_();
+        }
+      } else if (param->read.handle == this->char_handle_oper_) {
+        if (this->parse_oper_(param->read.value, param->read.value_len)) {
+          this->oper_valid_ = true;
+          this->dispatch_status_();
+        }
+      } else if (param->read.handle == this->char_handle_config_) {
+        if (this->parse_config_(param->read.value, param->read.value_len)) {
+          this->config_valid_ = true;
+          this->dispatch_config_();
+        }
+      } else if (param->read.handle == this->char_handle_advanced_) {
+        if (this->parse_advanced_(param->read.value, param->read.value_len)) {
+          this->advanced_valid_ = true;
+          this->dispatch_config_();
+        }
+      } else if (param->read.handle == this->char_handle_info_) {
+        if (this->parse_info_(param->read.value, param->read.value_len)) {
+          this->firmware_read_ = true;
+          this->dispatch_status_();
+        }
+      }
+      break;
+    }
+    case ESP_GATTC_WRITE_CHAR_EVT: {
+      if (param->write.status != ESP_GATT_OK) {
+        ESP_LOGW(TAG, "[%s] Error writing char at handle 0x%x, status=%d", this->log_id_(), param->write.handle,
+                 param->write.status);
+        if ((param->write.status == ESP_GATT_INSUF_ENCRYPTION ||
+             param->write.status == ESP_GATT_INSUF_AUTHENTICATION) &&
+            this->ready_) {
+          this->ready_ = false;
+          this->status_set_warning();
+          this->dispatch_connect_(false);
+          if (++this->encryption_retries_ >= MAX_ENCRYPTION_RETRIES) {
+            ESP_LOGW(TAG, "[%s] Encryption lost, max retries reached — disconnecting", this->log_id_());
+            this->parent_->disconnect();
+          } else {
+            ESP_LOGW(TAG, "[%s] Encryption lost, retry %d/%d", this->log_id_(), this->encryption_retries_,
+                     MAX_ENCRYPTION_RETRIES);
+            this->set_timeout("connect_encrypt", 500, [this]() { this->request_encryption_("encryption lost"); });
+          }
+        }
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void Ecocomfort2Hub::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+  switch (event) {
+    case ESP_GAP_BLE_AUTH_CMPL_EVT: {
+      if (std::memcmp(param->ble_security.auth_cmpl.bd_addr, this->parent_->get_remote_bda(), sizeof(esp_bd_addr_t)) !=
+          0) {
+        return;
+      }
+      if (!this->is_connected()) {
+        return;
+      }
+      if (!param->ble_security.auth_cmpl.success) {
+        this->cancel_timeout("connect_auth_timeout");
+        this->ready_ = false;
+        this->status_set_warning();
+        ESP_LOGW(TAG, "[%s] BLE authentication failed, reason=%d — disconnecting to retry", this->log_id_(),
+                 param->ble_security.auth_cmpl.fail_reason);
+        this->parent_->disconnect();
+        return;
+      }
+
+      this->on_encryption_ready_();
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+bool Ecocomfort2Hub::parse_state_(const uint8_t *data, uint16_t len) {
+  if (len < 9) {
+    ESP_LOGW(TAG, "C_STATE too short: %d bytes", len);
+    return false;
+  }
+
+  this->direction_ = data[2];
+
+  int16_t temp_raw = (static_cast<int16_t>(data[3]) << 8) | data[4];
+  this->temperature_ = temp_raw / 100.0f;
+
+  uint16_t hum_raw = (static_cast<uint16_t>(data[5]) << 8) | data[6];
+  this->humidity_ = hum_raw / 100.0f;
+
+  uint16_t voc_raw = (static_cast<uint16_t>(data[7]) << 8) | data[8];
+  this->voc_ = voc_raw;
+
+  ESP_LOGD(TAG, "[%s] State: temp=%.1f C, humidity=%.1f%%, VOC=%d ppb, dir=%d", this->log_id_(), this->temperature_,
+           this->humidity_, this->voc_, this->direction_);
+  return true;
+}
+
+bool Ecocomfort2Hub::parse_oper_(const uint8_t *data, uint16_t len) {
+  if (len < 2) {
+    ESP_LOGW(TAG, "C_SETTING_OPER too short: %d bytes", len);
+    return false;
+  }
+
+  this->actual_mode_ = data[0];
+  uint8_t speed_byte = data[1];
+
+  this->boost_active_ = (speed_byte & FLAG_BOOST) != 0;
+  this->night_active_ = (speed_byte & FLAG_NIGHT) != 0;
+  this->auto_active_ = (speed_byte & FLAG_AUTO) != 0;
+
+  uint8_t base_speed = speed_byte & 0x0F;
+
+  if (this->boost_active_) {
+    this->actual_speed_ = SPEED_VEL3;
+  } else if (this->night_active_) {
+    this->actual_speed_ = SPEED_SLEEP;
+  } else {
+    this->actual_speed_ = base_speed;
+  }
+
+  ESP_LOGD(TAG, "[%s] Oper: mode=%d, speed=%d, boost=%d, night=%d, auto=%d", this->log_id_(), this->actual_mode_,
+           this->actual_speed_, this->boost_active_, this->night_active_, this->auto_active_);
+  return true;
+}
+
+bool Ecocomfort2Hub::parse_config_(const uint8_t *data, uint16_t len) {
+  if (len < 5) {
+    ESP_LOGW(TAG, "C_CONFIGURATION too short: %d bytes", len);
+    return false;
+  }
+
+  this->role_ = data[0];
+  this->humidity_threshold_ = data[1] & 0x7F;
+  this->humidity_advanced_ = (data[1] & 0x80) != 0;
+  this->luminosity_threshold_ = data[2] & 0x7F;
+  this->voc_threshold_ = data[3] & 0x7F;
+  this->voc_advanced_ = (data[3] & 0x80) != 0;
+  this->season_summer_ = (data[4] & 0x08) != 0;
+  this->free_cooling_level_ = data[4] & 0x03;
+
+  ESP_LOGD(TAG, "[%s] Config: role=%d, hum_thr=%d(%s), lum_thr=%d, voc_thr=%d(%s), season=%s, fc=%d", this->log_id_(),
+           this->role_, this->humidity_threshold_, this->humidity_advanced_ ? "adv" : "std",
+           this->luminosity_threshold_, this->voc_threshold_, this->voc_advanced_ ? "adv" : "std",
+           this->season_summer_ ? "summer" : "winter", this->free_cooling_level_);
+  return true;
+}
+
+bool Ecocomfort2Hub::parse_advanced_(const uint8_t *data, uint16_t len) {
+  if (len < 4) {
+    ESP_LOGW(TAG, "C_ADVANCED too short: %d bytes", len);
+    return false;
+  }
+
+  this->temp_offset_raw_ = (static_cast<int16_t>(data[0]) << 8) | data[1];
+  this->humidity_offset_raw_ = (static_cast<int16_t>(data[2]) << 8) | data[3];
+
+  ESP_LOGD(TAG, "[%s] Advanced: temp_offset=%.2f C, hum_offset=%.2f%%", this->log_id_(),
+           this->temp_offset_raw_ / 100.0f, this->humidity_offset_raw_ / 100.0f);
+  return true;
+}
+
+bool Ecocomfort2Hub::parse_info_(const uint8_t *data, uint16_t len) {
+  if (len < 2) {
+    ESP_LOGW(TAG, "C_INFO too short: %d bytes", len);
+    return false;
+  }
+
+  uint8_t major = (data[0] >> 4) & 0x0F;
+  uint16_t field = (static_cast<uint16_t>(data[0] & 0x0F) << 8) | data[1];
+  uint8_t minor = field >> 6;
+  uint8_t patch = field & 0x3F;
+
+  snprintf(this->firmware_version_, sizeof(this->firmware_version_), "%u.%u.%u", major, minor, patch);
+
+  ESP_LOGI(TAG, "[%s] Firmware: %s", this->log_id_(), this->firmware_version_);
+  return true;
+}
+
+void Ecocomfort2Hub::send_operation_command(uint8_t preset, uint8_t speed, bool auto_mode) {
+  this->pending_preset_ = preset;
+  this->pending_speed_ = speed;
+  this->pending_auto_mode_ = auto_mode;
+
+  if (preset != OPER_OFF) {
+    this->persisted_.preset = preset;
+    this->persisted_.auto_mode = auto_mode;
+    if (speed != 0) {
+      this->persisted_.speed = speed;
+    }
+    this->pref_.save(&this->persisted_);
+  }
+
+  this->set_timeout("send_cmd", 100, [this]() { this->do_send_operation_command_(); });
+}
+
+void Ecocomfort2Hub::do_send_operation_command_() {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "[%s] Not ready, cannot send operation command", this->log_id_());
+    return;
+  }
+
+  uint8_t data[2];
+  data[0] = this->pending_preset_;
+  data[1] = this->pending_auto_mode_ ? FLAG_AUTO : this->pending_speed_;
+
+  ESP_LOGD(TAG, "[%s] Sending operation: preset=0x%02x, speed=0x%02x, auto=%d", this->log_id_(), data[0], data[1],
+           this->pending_auto_mode_);
+  this->write_characteristic_(this->char_handle_oper_, data, 2);
+}
+
+void Ecocomfort2Hub::write_season(bool is_summer) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "[%s] Not ready, cannot write season", this->log_id_());
+    return;
+  }
+  if (!this->config_valid_) {
+    ESP_LOGW(TAG, "[%s] Configuration not loaded yet, cannot write season", this->log_id_());
+    return;
+  }
+
+  this->season_summer_ = is_summer;
+
+  uint8_t data[12];
+  memset(data, CONFIG_PRESERVE, sizeof(data));
+  data[4] = (is_summer ? 0x08 : 0x00) | (this->free_cooling_level_ & 0x03);
+
+  ESP_LOGD(TAG, "[%s] Writing season: %s (byte4=0x%02x)", this->log_id_(), is_summer ? "summer" : "winter", data[4]);
+  this->write_characteristic_(this->char_handle_config_, data, 12);
+}
+
+void Ecocomfort2Hub::write_free_cooling(uint8_t level) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "[%s] Not ready, cannot write free cooling", this->log_id_());
+    return;
+  }
+  if (!this->config_valid_) {
+    ESP_LOGW(TAG, "[%s] Configuration not loaded yet, cannot write free cooling", this->log_id_());
+    return;
+  }
+
+  this->free_cooling_level_ = level;
+
+  uint8_t data[12];
+  memset(data, CONFIG_PRESERVE, sizeof(data));
+  data[4] = (this->season_summer_ ? 0x08 : 0x00) | (level & 0x03);
+
+  ESP_LOGD(TAG, "[%s] Writing free cooling: %d (byte4=0x%02x)", this->log_id_(), level, data[4]);
+  this->write_characteristic_(this->char_handle_config_, data, 12);
+}
+
+void Ecocomfort2Hub::write_thresholds(uint8_t humidity, uint8_t luminosity, uint8_t voc) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "[%s] Not ready, cannot write thresholds", this->log_id_());
+    return;
+  }
+  if (!this->config_valid_) {
+    ESP_LOGW(TAG, "[%s] Configuration not loaded yet, cannot write thresholds", this->log_id_());
+    return;
+  }
+
+  this->humidity_threshold_ = humidity;
+  this->luminosity_threshold_ = luminosity;
+  this->voc_threshold_ = voc;
+
+  uint8_t data[12];
+  memset(data, CONFIG_PRESERVE, sizeof(data));
+  data[1] = humidity + (this->humidity_advanced_ ? 128 : 0);
+  data[2] = luminosity;
+  data[3] = voc + (this->voc_advanced_ ? 128 : 0);
+
+  ESP_LOGD(TAG, "[%s] Writing thresholds: hum=%d, lum=%d, voc=%d", this->log_id_(), humidity, luminosity, voc);
+  this->write_characteristic_(this->char_handle_config_, data, 12);
+}
+
+void Ecocomfort2Hub::write_offsets(int16_t temp_offset_raw, int16_t humidity_offset_raw) {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "[%s] Not ready, cannot write offsets", this->log_id_());
+    return;
+  }
+  if (!this->advanced_valid_) {
+    ESP_LOGW(TAG, "[%s] Advanced settings not loaded yet, cannot write offsets", this->log_id_());
+    return;
+  }
+
+  this->temp_offset_raw_ = temp_offset_raw;
+  this->humidity_offset_raw_ = humidity_offset_raw;
+
+  uint8_t data[4];
+  data[0] = (temp_offset_raw >> 8) & 0xFF;
+  data[1] = temp_offset_raw & 0xFF;
+  data[2] = (humidity_offset_raw >> 8) & 0xFF;
+  data[3] = humidity_offset_raw & 0xFF;
+
+  ESP_LOGD(TAG, "[%s] Writing offsets: temp=%.2f, hum=%.2f", this->log_id_(), temp_offset_raw / 100.0f,
+           humidity_offset_raw / 100.0f);
+  this->write_characteristic_(this->char_handle_advanced_, data, 4);
+}
+
+void Ecocomfort2Hub::pair() {
+  if (!this->is_connected()) {
+    return;
+  }
+  if (this->ready_) {
+    ESP_LOGI(TAG, "[%s] BLE link is already ready", this->log_id_());
+    return;
+  }
+
+  this->request_encryption_("manual pair");
+}
+
+bool Ecocomfort2Hub::send_clock() {
+  if (!this->is_ready()) {
+    return false;
+  }
+
+#ifdef USE_TIME
+  if (this->time_id_ == nullptr) {
+    ESP_LOGD(TAG, "[%s] No time source configured, skipping clock sync", this->log_id_());
+    return false;
+  }
+
+  ESPTime now = this->time_id_->now();
+  if (!now.is_valid()) {
+    ESP_LOGW(TAG, "[%s] Time not valid yet, skipping clock sync", this->log_id_());
+    return false;
+  }
+
+  uint8_t data[8];
+  data[0] = now.hour;
+  data[1] = now.minute;
+  data[2] = now.second;
+
+  uint8_t dow = now.day_of_week;
+  if (dow == 1) {
+    dow = 6;
+  } else {
+    dow = dow - 2;
+  }
+  data[3] = dow;
+  data[4] = now.day_of_month;
+  data[5] = now.month;
+  data[6] = (now.year >> 8) & 0xFF;
+  data[7] = now.year & 0xFF;
+
+  ESP_LOGD(TAG, "[%s] Syncing clock: %02d:%02d:%02d", this->log_id_(), now.hour, now.minute, now.second);
+  return this->write_characteristic_(this->char_handle_clock_, data, 8);
+#endif
+
+  return false;
+}
+
+bool Ecocomfort2Hub::write_characteristic_(uint16_t handle, const uint8_t *data, uint16_t len) {
+  if (handle == 0) {
+    ESP_LOGW(TAG, "[%s] Cannot write: handle not discovered", this->log_id_());
+    return false;
+  }
+
+  auto status =
+      esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), handle, len,
+                               const_cast<uint8_t *>(data), ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
+  if (status != ESP_GATT_OK) {
+    ESP_LOGW(TAG, "[%s] Write failed for handle 0x%x, status=%d", this->log_id_(), handle, status);
+    return false;
+  }
+
+  return true;
+}
+
+void Ecocomfort2Hub::request_encryption_(const char *reason) {
+  if (!this->is_connected() || this->ready_) {
+    return;
+  }
+
+  this->cancel_timeout("connect_auth_timeout");
+  this->cancel_timeout("connect_encrypt");
+  ESP_LOGI(TAG, "[%s] Requesting BLE encryption (%s)", this->log_id_(), reason);
+  auto err = this->parent_->pair();
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "[%s] BLE pair request failed, err=%d — disconnecting to retry", this->log_id_(), err);
+    this->parent_->disconnect();
+    return;
+  }
+
+  this->set_timeout("connect_auth_timeout", ENCRYPTION_TIMEOUT_MS, [this]() {
+    if (!this->is_connected() || this->ready_) {
+      return;
+    }
+    this->status_set_warning();
+    ESP_LOGW(TAG, "[%s] BLE authentication timed out — disconnecting to retry", this->log_id_());
+    this->parent_->disconnect();
+  });
+}
+
+const char *Ecocomfort2Hub::log_id_() const {
+  if (this->parent_ != nullptr) {
+    return this->parent_->address_str();
+  }
+  return "ecocomfort2";
+}
+
+void Ecocomfort2Hub::on_encryption_ready_() {
+  if (!this->is_connected() || this->ready_) {
+    return;
+  }
+
+  this->cancel_timeout("connect_encrypt");
+  this->cancel_timeout("connect_auth_timeout");
+  this->ready_ = true;
+  this->encryption_retries_ = 0;
+  this->status_clear_warning();
+  ESP_LOGI(TAG, "[%s] Encryption confirmed, device ready", this->log_id_());
+  this->dispatch_connect_(true);
+  this->set_timeout("post_auth_sync", 0, [this]() {
+    if (!this->is_ready()) {
+      return;
+    }
+    this->last_clock_attempt_ = millis();
+    if (this->send_clock()) {
+      this->last_clock_sync_ = this->last_clock_attempt_;
+    }
+    this->update();
+  });
+}
+
+void Ecocomfort2Hub::dispatch_status_() {
+  for (auto *child : this->children_) {
+    child->on_status();
+  }
+}
+
+void Ecocomfort2Hub::dispatch_config_() {
+  for (auto *child : this->children_) {
+    child->on_config();
+  }
+}
+
+void Ecocomfort2Hub::dispatch_connect_(bool connected) {
+  for (auto *child : this->children_) {
+    child->on_connect(connected);
+  }
+}
+
+void Ecocomfort2Hub::register_child(Ecocomfort2Client *obj) {
+  this->children_.push_back(obj);
+  obj->set_parent(this);
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_hub.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_hub.h
@@ -1,0 +1,275 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+#include "ecocomfort2_child.h"
+
+#include <vector>
+
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+#include "esphome/core/time.h"
+#endif
+
+#include <esp_gattc_api.h>
+
+namespace esphome {
+namespace ecocomfort2 {
+
+namespace espbt = esphome::esp32_ble_tracker;
+
+// Forward declare
+class Ecocomfort2Client;
+
+// BLE UUIDs
+static const espbt::ESPBTUUID ECOCOMFORT2_SERVICE_UUID =
+    espbt::ESPBTUUID::from_raw("f4b827c3-e660-4bc8-bdf6-3c8e9b845e0d");
+static const espbt::ESPBTUUID ECOCOMFORT2_C_INFO_UUID =
+    espbt::ESPBTUUID::from_raw("f5f56229-dd4f-480f-a829-9189269d8b37");
+static const espbt::ESPBTUUID ECOCOMFORT2_C_STATE_UUID =
+    espbt::ESPBTUUID::from_raw("438d3433-7e5a-459a-a8e4-66343fad2bb0");
+static const espbt::ESPBTUUID ECOCOMFORT2_C_OPER_UUID =
+    espbt::ESPBTUUID::from_raw("b9d6f678-bc0d-4a73-90c8-60b0f07301f1");
+static const espbt::ESPBTUUID ECOCOMFORT2_C_CONFIG_UUID =
+    espbt::ESPBTUUID::from_raw("d3dac48e-b4e1-4f3a-8715-326ddf1da89a");
+static const espbt::ESPBTUUID ECOCOMFORT2_C_CLOCK_UUID =
+    espbt::ESPBTUUID::from_raw("82788997-49e4-4533-b949-7ed433678044");
+static const espbt::ESPBTUUID ECOCOMFORT2_C_ADVANCED_UUID =
+    espbt::ESPBTUUID::from_raw("f8b2284e-61dd-44e3-a782-a93c9503ab2d");
+
+// Operating mode byte values
+static const uint8_t OPER_OFF = 0x00;
+static const uint8_t OPER_IN = 0x01;
+static const uint8_t OPER_OUT = 0x02;
+static const uint8_t OPER_IN_OUT = 0x03;
+static const uint8_t OPER_SENSOR_OR_AUTO = 0x04;
+
+// Speed constants
+static const uint8_t SPEED_OFF = 0x00;
+static const uint8_t SPEED_SLEEP = 0x01;
+static const uint8_t SPEED_VEL1 = 0x02;
+static const uint8_t SPEED_VEL2 = 0x03;
+static const uint8_t SPEED_VEL3 = 0x04;
+
+// Speed flags
+static const uint8_t FLAG_AUTO = 0x10;
+static const uint8_t FLAG_BOOST = 0x40;
+static const uint8_t FLAG_NIGHT = 0x80;
+
+// Configuration write special values
+static const uint8_t CONFIG_PRESERVE = 0x7F;
+
+// Preset names
+static const char *const PRESET_IN = "In";
+static const char *const PRESET_OUT = "Out";
+static const char *const PRESET_IN_OUT = "In-Out";
+static const char *const PRESET_SENSOR = "Sensor";
+static const char *const PRESET_AUTO = "Auto";
+
+// Persisted state structure
+struct Ecocomfort2PersistedState {
+  uint8_t preset;  // OPER_* value
+  uint8_t speed;   // SPEED_* value for the last non-auto command
+  bool auto_mode;  // true when the desired preset is Auto
+};
+
+/** Hub component for Ecocomfort 2.0 VMC via BLE. */
+class Ecocomfort2Hub : public esphome::ble_client::BLEClientNode, public PollingComponent {
+ public:
+  void setup() override;
+  void loop() override;
+  void update() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::BLUETOOTH; }
+
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
+  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
+
+  /** Register a child component. */
+  void register_child(Ecocomfort2Client *obj);
+
+  /** @return true if BLE connection is established. */
+  bool is_connected() const { return this->node_state == espbt::ClientState::ESTABLISHED; }
+  /** @return true if BLE connection and encryption are both established. */
+  bool is_ready() const { return this->is_connected() && this->ready_; }
+  bool has_state_data() const { return this->state_valid_; }
+  bool has_oper_data() const { return this->oper_valid_; }
+  bool has_config_data() const { return this->config_valid_; }
+  bool has_advanced_data() const { return this->advanced_valid_; }
+
+  // --- Write commands (called by child entities) ---
+
+  /** Send operating mode command (preset + speed). Debounced by 100ms. */
+  void send_operation_command(uint8_t preset, uint8_t speed, bool auto_mode);
+
+  /** Write season to C_CONFIGURATION. */
+  void write_season(bool is_summer);
+
+  /** Write free cooling level (0-3) to C_CONFIGURATION. */
+  void write_free_cooling(uint8_t level);
+
+  /** Write all three thresholds to C_CONFIGURATION.
+   *  Threshold values should be plain (0-3). Advanced flags are read from internal state.
+   */
+  void write_thresholds(uint8_t humidity, uint8_t luminosity, uint8_t voc);
+
+  /** Set humidity advanced flag (used by switch before calling write_thresholds). */
+  void set_humidity_advanced(bool advanced) { this->humidity_advanced_ = advanced; }
+  /** Set VOC advanced flag (used by switch before calling write_thresholds). */
+  void set_voc_advanced(bool advanced) { this->voc_advanced_ = advanced; }
+
+  /** Write calibration offsets to C_ADVANCED. */
+  void write_offsets(int16_t temp_offset_raw, int16_t humidity_offset_raw);
+
+  /** Send BLE pairing request. */
+  void pair();
+
+  /** Send clock sync. */
+  bool send_clock();
+
+#ifdef USE_TIME
+  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
+#endif
+
+  // --- Current state accessors (for child entities) ---
+
+  // State from C_STATE readback
+  float get_temperature() const { return this->temperature_; }
+  float get_humidity() const { return this->humidity_; }
+  uint16_t get_voc() const { return this->voc_; }
+  uint8_t get_direction() const { return this->direction_; }
+
+  // State from C_SETTING_OPER readback
+  uint8_t get_actual_mode() const { return this->actual_mode_; }
+  uint8_t get_actual_speed() const { return this->actual_speed_; }
+  bool get_boost_active() const { return this->boost_active_; }
+  bool get_night_active() const { return this->night_active_; }
+  bool get_auto_active() const { return this->auto_active_; }
+
+  // State from C_CONFIGURATION readback
+  uint8_t get_role() const { return this->role_; }
+  uint8_t get_humidity_threshold() const { return this->humidity_threshold_; }
+  uint8_t get_luminosity_threshold() const { return this->luminosity_threshold_; }
+  uint8_t get_voc_threshold() const { return this->voc_threshold_; }
+  bool get_humidity_advanced() const { return this->humidity_advanced_; }
+  bool get_voc_advanced() const { return this->voc_advanced_; }
+  bool get_season_summer() const { return this->season_summer_; }
+  uint8_t get_free_cooling_level() const { return this->free_cooling_level_; }
+
+  // State from C_ADVANCED readback
+  int16_t get_temp_offset_raw() const { return this->temp_offset_raw_; }
+  int16_t get_humidity_offset_raw() const { return this->humidity_offset_raw_; }
+
+  // Firmware version from C_INFO
+  static constexpr uint8_t FIRMWARE_VERSION_SIZE = 16;
+  const char *get_firmware_version() const { return this->firmware_version_; }
+
+  // Desired state (persisted)
+  uint8_t get_desired_preset() const { return this->persisted_.preset; }
+  uint8_t get_desired_speed() const { return this->persisted_.speed; }
+  bool get_desired_auto_mode() const { return this->persisted_.auto_mode; }
+
+  /** Skip-send guard: set to true during readback to prevent feedback loops. */
+  bool skip_send_{false};
+
+ protected:
+  std::vector<Ecocomfort2Client *> children_;
+  void dispatch_status_();
+  void dispatch_config_();
+  void dispatch_connect_(bool connected);
+
+  bool discover_characteristics_();
+
+  // BLE characteristic handles
+  uint16_t char_handle_info_{0};
+  uint16_t char_handle_state_{0};
+  uint16_t char_handle_oper_{0};
+  uint16_t char_handle_config_{0};
+  uint16_t char_handle_clock_{0};
+  uint16_t char_handle_advanced_{0};
+
+  // Write helpers
+  bool write_characteristic_(uint16_t handle, const uint8_t *data, uint16_t len);
+  void do_send_operation_command_();
+  void request_encryption_(const char *reason);
+  const char *log_id_() const;
+
+  void on_encryption_ready_();
+
+  // Parsed state from readbacks
+  // C_STATE
+  float temperature_{0};
+  float humidity_{0};
+  uint16_t voc_{0};
+  uint8_t direction_{0};
+
+  // C_SETTING_OPER
+  uint8_t actual_mode_{0};
+  uint8_t actual_speed_{0};
+  bool boost_active_{false};
+  bool night_active_{false};
+  bool auto_active_{false};
+
+  // C_CONFIGURATION
+  uint8_t role_{0};
+  uint8_t humidity_threshold_{0};
+  uint8_t luminosity_threshold_{0};
+  uint8_t voc_threshold_{0};
+  bool humidity_advanced_{false};
+  bool voc_advanced_{false};
+  bool season_summer_{false};
+  uint8_t free_cooling_level_{0};
+
+  // C_ADVANCED
+  int16_t temp_offset_raw_{0};
+  int16_t humidity_offset_raw_{0};
+
+  // C_INFO
+  char firmware_version_[FIRMWARE_VERSION_SIZE]{};
+  bool firmware_read_{false};
+
+  // Persisted desired state
+  Ecocomfort2PersistedState persisted_{OPER_IN_OUT, SPEED_VEL1, false};
+  ESPPreferenceObject pref_;
+
+  // Debounce
+  uint8_t pending_preset_{0};
+  uint8_t pending_speed_{0};
+  bool pending_auto_mode_{false};
+
+  // Clock sync tracking
+  uint32_t last_clock_sync_{0};
+  uint32_t last_clock_attempt_{0};
+  static const uint32_t CLOCK_SYNC_INTERVAL = 3600000;      // 1 hour in ms
+  static const uint32_t CLOCK_SYNC_RETRY_INTERVAL = 60000;  // 1 minute in ms
+  static const uint32_t ENCRYPTION_TIMEOUT_MS = 10000;
+  static const uint8_t MAX_ENCRYPTION_RETRIES = 3;
+
+  // Connection state tracking
+  bool ready_{false};  // true once BLE authentication/encryption is confirmed
+  uint8_t encryption_retries_{0};
+  bool state_valid_{false};
+  bool oper_valid_{false};
+  bool config_valid_{false};
+  bool advanced_valid_{false};
+
+#ifdef USE_TIME
+  time::RealTimeClock *time_id_{nullptr};
+#endif
+
+  // Parse readback data
+  bool parse_state_(const uint8_t *data, uint16_t len);
+  bool parse_oper_(const uint8_t *data, uint16_t len);
+  bool parse_config_(const uint8_t *data, uint16_t len);
+  bool parse_advanced_(const uint8_t *data, uint16_t len);
+  bool parse_info_(const uint8_t *data, uint16_t len);
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_number.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_number.cpp
@@ -1,0 +1,127 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_number.h"
+#include "esphome/core/log.h"
+
+#include <cmath>
+#include <cstring>
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.number";
+
+// --- Threshold Number ---
+
+void Ecocomfort2ThresholdNumber::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "Ecocomfort2 Threshold Number (%s):", this->threshold_type_ != nullptr ? this->threshold_type_ : "?");
+  LOG_NUMBER("  ", "Threshold", this);
+}
+
+void Ecocomfort2ThresholdNumber::control(float value) {
+  if (!this->parent_->is_ready()) {
+    ESP_LOGW(TAG, "Not ready, cannot change threshold");
+    return;
+  }
+  if (!this->parent_->has_config_data()) {
+    ESP_LOGW(TAG, "Configuration not loaded yet, cannot change threshold");
+    return;
+  }
+
+  // Read current values and write all three together
+  uint8_t humidity = this->parent_->get_humidity_threshold();
+  uint8_t luminosity = this->parent_->get_luminosity_threshold();
+  uint8_t voc = this->parent_->get_voc_threshold();
+
+  uint8_t new_val = static_cast<uint8_t>(value);
+
+  if (this->threshold_type_ != nullptr && std::strcmp(this->threshold_type_, "humidity") == 0) {
+    humidity = new_val;
+  } else if (this->threshold_type_ != nullptr && std::strcmp(this->threshold_type_, "luminosity") == 0) {
+    luminosity = new_val;
+  } else if (this->threshold_type_ != nullptr && std::strcmp(this->threshold_type_, "voc") == 0) {
+    voc = new_val;
+  }
+
+  this->parent_->write_thresholds(humidity, luminosity, voc);
+  this->publish_state(value);
+}
+
+void Ecocomfort2ThresholdNumber::on_config() {
+  if (!this->parent_->has_config_data()) {
+    return;
+  }
+
+  float value;
+  if (this->threshold_type_ != nullptr && std::strcmp(this->threshold_type_, "humidity") == 0) {
+    value = this->parent_->get_humidity_threshold();
+  } else if (this->threshold_type_ != nullptr && std::strcmp(this->threshold_type_, "luminosity") == 0) {
+    value = this->parent_->get_luminosity_threshold();
+  } else if (this->threshold_type_ != nullptr && std::strcmp(this->threshold_type_, "voc") == 0) {
+    value = this->parent_->get_voc_threshold();
+  } else {
+    return;
+  }
+
+  if (!this->has_state() || this->state != value) {
+    this->publish_state(value);
+  }
+}
+
+// --- Offset Number ---
+
+void Ecocomfort2OffsetNumber::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Offset Number (%s):", this->offset_type_ != nullptr ? this->offset_type_ : "?");
+  LOG_NUMBER("  ", "Offset", this);
+}
+
+void Ecocomfort2OffsetNumber::control(float value) {
+  if (!this->parent_->is_ready()) {
+    ESP_LOGW(TAG, "Not ready, cannot change offset");
+    return;
+  }
+  if (!this->parent_->has_advanced_data()) {
+    ESP_LOGW(TAG, "Advanced settings not loaded yet, cannot change offset");
+    return;
+  }
+
+  // Read current values and write both together
+  int16_t temp_raw = this->parent_->get_temp_offset_raw();
+  int16_t hum_raw = this->parent_->get_humidity_offset_raw();
+
+  int16_t new_raw = static_cast<int16_t>(std::lroundf(value * 100.0f));
+
+  if (this->offset_type_ != nullptr && std::strcmp(this->offset_type_, "temperature") == 0) {
+    temp_raw = new_raw;
+  } else if (this->offset_type_ != nullptr && std::strcmp(this->offset_type_, "humidity") == 0) {
+    hum_raw = new_raw;
+  }
+
+  this->parent_->write_offsets(temp_raw, hum_raw);
+  this->publish_state(value);
+}
+
+void Ecocomfort2OffsetNumber::on_config() {
+  if (!this->parent_->has_advanced_data()) {
+    return;
+  }
+
+  float value;
+  if (this->offset_type_ != nullptr && std::strcmp(this->offset_type_, "temperature") == 0) {
+    value = this->parent_->get_temp_offset_raw() / 100.0f;
+  } else if (this->offset_type_ != nullptr && std::strcmp(this->offset_type_, "humidity") == 0) {
+    value = this->parent_->get_humidity_offset_raw() / 100.0f;
+  } else {
+    return;
+  }
+
+  if (!this->has_state() || this->state != value) {
+    this->publish_state(value);
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_number.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_number.h
@@ -1,0 +1,51 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2ThresholdNumber : public number::Number, public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  void set_threshold_type(const char *type) { this->threshold_type_ = type; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override {}
+  void on_config() override;
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Threshold Number"; }
+
+ protected:
+  void control(float value) override;
+  const char *threshold_type_{nullptr};
+};
+
+class Ecocomfort2OffsetNumber : public number::Number, public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  void set_offset_type(const char *type) { this->offset_type_ = type; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override {}
+  void on_config() override;
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Offset Number"; }
+
+ protected:
+  void control(float value) override;
+  const char *offset_type_{nullptr};
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_select.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_select.cpp
@@ -1,0 +1,111 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_select.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.select";
+
+// --- Season Select ---
+
+void Ecocomfort2SeasonSelect::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Season Select:");
+  LOG_SELECT("  ", "Season", this);
+}
+
+void Ecocomfort2SeasonSelect::control(size_t index) {
+  if (!this->parent_->is_ready()) {
+    ESP_LOGW(TAG, "Not ready, cannot change season");
+    return;
+  }
+  if (!this->parent_->has_config_data()) {
+    ESP_LOGW(TAG, "Configuration not loaded yet, cannot change season");
+    return;
+  }
+
+  bool is_summer = index == 1;
+  const char *value = is_summer ? "Summer" : "Winter";
+  this->parent_->write_season(is_summer);
+  this->publish_state(value);
+}
+
+void Ecocomfort2SeasonSelect::on_config() {
+  if (!this->parent_->has_config_data()) {
+    return;
+  }
+
+  bool is_summer = this->parent_->get_season_summer();
+  const char *value = is_summer ? "Summer" : "Winter";
+  if (!this->has_state() || this->current_option() != value) {
+    this->publish_state(value);
+  }
+}
+
+// --- Free Cooling Select ---
+
+void Ecocomfort2FreeCoolingSelect::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Free Cooling Select:");
+  LOG_SELECT("  ", "Free Cooling", this);
+}
+
+void Ecocomfort2FreeCoolingSelect::control(size_t index) {
+  if (!this->parent_->is_ready()) {
+    ESP_LOGW(TAG, "Not ready, cannot change free cooling");
+    return;
+  }
+  if (!this->parent_->has_config_data()) {
+    ESP_LOGW(TAG, "Configuration not loaded yet, cannot change free cooling");
+    return;
+  }
+
+  uint8_t level = static_cast<uint8_t>(index);
+  const char *value = "Off";
+  switch (level) {
+    case 1:
+      value = "Low";
+      break;
+    case 2:
+      value = "Medium";
+      break;
+    case 3:
+      value = "High";
+      break;
+    default:
+      break;
+  }
+
+  this->parent_->write_free_cooling(level);
+  this->publish_state(value);
+}
+
+void Ecocomfort2FreeCoolingSelect::on_config() {
+  if (!this->parent_->has_config_data()) {
+    return;
+  }
+
+  uint8_t level = this->parent_->get_free_cooling_level();
+  const char *value = "Off";
+  switch (level) {
+    case 1:
+      value = "Low";
+      break;
+    case 2:
+      value = "Medium";
+      break;
+    case 3:
+      value = "High";
+      break;
+    default:
+      break;
+  }
+  if (!this->has_state() || this->current_option() != value) {
+    this->publish_state(value);
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_select.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_select.h
@@ -1,0 +1,45 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/select/select.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2SeasonSelect : public select::Select, public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override {}
+  void on_config() override;
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Season Select"; }
+
+ protected:
+  void control(size_t index) override;
+};
+
+class Ecocomfort2FreeCoolingSelect : public select::Select, public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override {}
+  void on_config() override;
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Free Cooling Select"; }
+
+ protected:
+  void control(size_t index) override;
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_sensor.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_sensor.cpp
@@ -1,0 +1,60 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.sensor";
+
+void Ecocomfort2Sensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Sensor:");
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
+  LOG_SENSOR("  ", "VOC", this->voc_sensor_);
+  LOG_SENSOR("  ", "Direction", this->direction_sensor_);
+  LOG_SENSOR("  ", "Actual Mode", this->actual_mode_sensor_);
+  LOG_SENSOR("  ", "Actual Speed", this->actual_speed_sensor_);
+  LOG_SENSOR("  ", "Role", this->role_sensor_);
+  LOG_SENSOR("  ", "Temp Offset", this->temp_offset_sensor_);
+  LOG_SENSOR("  ", "Humidity Offset", this->humidity_offset_sensor_);
+}
+
+void Ecocomfort2Sensor::on_status() {
+  if (this->parent_->has_state_data() && this->temperature_sensor_ != nullptr) {
+    this->temperature_sensor_->publish_state(this->parent_->get_temperature());
+  }
+  if (this->parent_->has_state_data() && this->humidity_sensor_ != nullptr) {
+    this->humidity_sensor_->publish_state(this->parent_->get_humidity());
+  }
+  if (this->parent_->has_state_data() && this->voc_sensor_ != nullptr) {
+    this->voc_sensor_->publish_state(this->parent_->get_voc());
+  }
+  if (this->parent_->has_state_data() && this->direction_sensor_ != nullptr) {
+    this->direction_sensor_->publish_state(this->parent_->get_direction());
+  }
+  if (this->parent_->has_oper_data() && this->actual_mode_sensor_ != nullptr) {
+    this->actual_mode_sensor_->publish_state(this->parent_->get_actual_mode());
+  }
+  if (this->parent_->has_oper_data() && this->actual_speed_sensor_ != nullptr) {
+    this->actual_speed_sensor_->publish_state(this->parent_->get_actual_speed());
+  }
+}
+
+void Ecocomfort2Sensor::on_config() {
+  if (this->parent_->has_config_data() && this->role_sensor_ != nullptr) {
+    this->role_sensor_->publish_state(this->parent_->get_role());
+  }
+  if (this->parent_->has_advanced_data() && this->temp_offset_sensor_ != nullptr) {
+    this->temp_offset_sensor_->publish_state(this->parent_->get_temp_offset_raw() / 100.0f);
+  }
+  if (this->parent_->has_advanced_data() && this->humidity_offset_sensor_ != nullptr) {
+    this->humidity_offset_sensor_->publish_state(this->parent_->get_humidity_offset_raw() / 100.0f);
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_sensor.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_sensor.h
@@ -1,0 +1,48 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2Sensor : public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  void set_temperature_sensor(sensor::Sensor *s) { this->temperature_sensor_ = s; }
+  void set_humidity_sensor(sensor::Sensor *s) { this->humidity_sensor_ = s; }
+  void set_voc_sensor(sensor::Sensor *s) { this->voc_sensor_ = s; }
+  void set_direction_sensor(sensor::Sensor *s) { this->direction_sensor_ = s; }
+  void set_actual_mode_sensor(sensor::Sensor *s) { this->actual_mode_sensor_ = s; }
+  void set_actual_speed_sensor(sensor::Sensor *s) { this->actual_speed_sensor_ = s; }
+  void set_role_sensor(sensor::Sensor *s) { this->role_sensor_ = s; }
+  void set_temp_offset_sensor(sensor::Sensor *s) { this->temp_offset_sensor_ = s; }
+  void set_humidity_offset_sensor(sensor::Sensor *s) { this->humidity_offset_sensor_ = s; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override;
+  void on_config() override;
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Sensor"; }
+
+ protected:
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
+  sensor::Sensor *voc_sensor_{nullptr};
+  sensor::Sensor *direction_sensor_{nullptr};
+  sensor::Sensor *actual_mode_sensor_{nullptr};
+  sensor::Sensor *actual_speed_sensor_{nullptr};
+  sensor::Sensor *role_sensor_{nullptr};
+  sensor::Sensor *temp_offset_sensor_{nullptr};
+  sensor::Sensor *humidity_offset_sensor_{nullptr};
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_switch.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_switch.cpp
@@ -1,0 +1,64 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_switch.h"
+#include "esphome/core/log.h"
+
+#include <cstring>
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.switch";
+
+void Ecocomfort2AdvancedSwitch::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Advanced Switch (%s):", this->advanced_type_ != nullptr ? this->advanced_type_ : "?");
+  LOG_SWITCH("  ", "Advanced", this);
+}
+
+void Ecocomfort2AdvancedSwitch::write_state(bool state) {
+  if (!this->parent_->is_ready()) {
+    ESP_LOGW(TAG, "Not ready, cannot change advanced mode");
+    return;
+  }
+  if (!this->parent_->has_config_data()) {
+    ESP_LOGW(TAG, "Configuration not loaded yet, cannot change advanced mode");
+    return;
+  }
+
+  // Update hub's internal advanced flag, then write thresholds
+  // write_thresholds() reads advanced flags from the hub's internal state
+  if (this->advanced_type_ != nullptr && std::strcmp(this->advanced_type_, "humidity") == 0) {
+    this->parent_->set_humidity_advanced(state);
+  } else if (this->advanced_type_ != nullptr && std::strcmp(this->advanced_type_, "voc") == 0) {
+    this->parent_->set_voc_advanced(state);
+  }
+
+  this->parent_->write_thresholds(this->parent_->get_humidity_threshold(), this->parent_->get_luminosity_threshold(),
+                                  this->parent_->get_voc_threshold());
+
+  this->publish_state(state);
+}
+
+void Ecocomfort2AdvancedSwitch::on_config() {
+  if (!this->parent_->has_config_data()) {
+    return;
+  }
+
+  bool state;
+  if (this->advanced_type_ != nullptr && std::strcmp(this->advanced_type_, "humidity") == 0) {
+    state = this->parent_->get_humidity_advanced();
+  } else if (this->advanced_type_ != nullptr && std::strcmp(this->advanced_type_, "voc") == 0) {
+    state = this->parent_->get_voc_advanced();
+  } else {
+    return;
+  }
+
+  if (!this->has_state() || this->state != state) {
+    this->publish_state(state);
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_switch.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_switch.h
@@ -1,0 +1,33 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2AdvancedSwitch : public switch_::Switch, public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  void set_advanced_type(const char *type) { this->advanced_type_ = type; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override {}
+  void on_config() override;
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Advanced Switch"; }
+
+ protected:
+  void write_state(bool state) override;
+  const char *advanced_type_{nullptr};
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_text_sensor.cpp
+++ b/esphome/components/ecocomfort2/ecocomfort2_text_sensor.cpp
@@ -1,0 +1,32 @@
+#ifdef USE_ESP32
+
+#include "ecocomfort2_text_sensor.h"
+#include "esphome/core/log.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace esphome {
+namespace ecocomfort2 {
+
+static const char *const TAG = "ecocomfort2.text_sensor";
+
+void Ecocomfort2TextSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Ecocomfort2 Text Sensor:");
+  LOG_TEXT_SENSOR("  ", "Firmware", this->firmware_sensor_);
+}
+
+void Ecocomfort2TextSensor::on_status() {
+  if (this->firmware_sensor_ != nullptr) {
+    const char *fw = this->parent_->get_firmware_version();
+    if (fw[0] != '\0' && std::strcmp(fw, this->last_firmware_) != 0) {
+      snprintf(this->last_firmware_, sizeof(this->last_firmware_), "%s", fw);
+      this->firmware_sensor_->publish_state(fw);
+    }
+  }
+}
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/ecocomfort2_text_sensor.h
+++ b/esphome/components/ecocomfort2/ecocomfort2_text_sensor.h
@@ -1,0 +1,33 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/component.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "ecocomfort2_child.h"
+#include "ecocomfort2_hub.h"
+
+namespace esphome {
+namespace ecocomfort2 {
+
+class Ecocomfort2TextSensor : public Ecocomfort2Client, public Component {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  void set_firmware_sensor(text_sensor::TextSensor *s) { this->firmware_sensor_ = s; }
+
+  // Ecocomfort2Client callbacks
+  void on_status() override;
+  void on_config() override {}
+  void on_connect(bool) override {}
+  const char *describe() const override { return "Ecocomfort2 Text Sensor"; }
+
+ protected:
+  text_sensor::TextSensor *firmware_sensor_{nullptr};
+  char last_firmware_[Ecocomfort2Hub::FIRMWARE_VERSION_SIZE]{};
+};
+
+}  // namespace ecocomfort2
+}  // namespace esphome
+
+#endif

--- a/esphome/components/ecocomfort2/fan.py
+++ b/esphome/components/ecocomfort2/fan.py
@@ -1,0 +1,20 @@
+import esphome.codegen as cg
+from esphome.components import fan
+import esphome.config_validation as cv
+
+from . import ECOCOMFORT2_CLIENT_SCHEMA, Ecocomfort2Fan, register_ecocomfort2_child
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+CONFIG_SCHEMA = (
+    fan.fan_schema(Ecocomfort2Fan)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ECOCOMFORT2_CLIENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = await fan.new_fan(config)
+    await cg.register_component(var, config)
+    await register_ecocomfort2_child(var, config)

--- a/esphome/components/ecocomfort2/number.py
+++ b/esphome/components/ecocomfort2/number.py
@@ -1,0 +1,91 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
+
+from . import (
+    ECOCOMFORT2_CLIENT_SCHEMA,
+    Ecocomfort2OffsetNumber,
+    Ecocomfort2ThresholdNumber,
+    register_ecocomfort2_child,
+)
+from .const import (
+    CONF_HUMIDITY_OFFSET_NUMBER,
+    CONF_HUMIDITY_THRESHOLD,
+    CONF_LUMINOSITY_THRESHOLD,
+    CONF_TEMP_OFFSET_NUMBER,
+    CONF_VOC_THRESHOLD,
+)
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+NUMBER_TYPES = {
+    CONF_HUMIDITY_THRESHOLD: {
+        "class": Ecocomfort2ThresholdNumber,
+        "min_value": 0,
+        "max_value": 3,
+        "step": 1,
+        "kind": "humidity",
+        "setter": "set_threshold_type",
+    },
+    CONF_LUMINOSITY_THRESHOLD: {
+        "class": Ecocomfort2ThresholdNumber,
+        "min_value": 0,
+        "max_value": 3,
+        "step": 1,
+        "kind": "luminosity",
+        "setter": "set_threshold_type",
+    },
+    CONF_VOC_THRESHOLD: {
+        "class": Ecocomfort2ThresholdNumber,
+        "min_value": 0,
+        "max_value": 3,
+        "step": 1,
+        "kind": "voc",
+        "setter": "set_threshold_type",
+    },
+    CONF_TEMP_OFFSET_NUMBER: {
+        "class": Ecocomfort2OffsetNumber,
+        "min_value": -5.0,
+        "max_value": 5.0,
+        "step": 0.01,
+        "kind": "temperature",
+        "setter": "set_offset_type",
+    },
+    CONF_HUMIDITY_OFFSET_NUMBER: {
+        "class": Ecocomfort2OffsetNumber,
+        "min_value": -10.0,
+        "max_value": 10.0,
+        "step": 0.01,
+        "kind": "humidity",
+        "setter": "set_offset_type",
+    },
+}
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(key): number.number_schema(
+                spec["class"],
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            )
+            for key, spec in NUMBER_TYPES.items()
+        }
+    ).extend(ECOCOMFORT2_CLIENT_SCHEMA),
+    cv.has_at_least_one_key(*NUMBER_TYPES),
+)
+
+
+async def to_code(config):
+    for key, spec in NUMBER_TYPES.items():
+        if conf := config.get(key):
+            var = await number.new_number(
+                conf,
+                min_value=spec["min_value"],
+                max_value=spec["max_value"],
+                step=spec["step"],
+            )
+            await cg.register_component(var, conf)
+            cg.add(getattr(var, spec["setter"])(spec["kind"]))
+            await register_ecocomfort2_child(var, config)

--- a/esphome/components/ecocomfort2/select.py
+++ b/esphome/components/ecocomfort2/select.py
@@ -1,0 +1,60 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
+
+from . import (
+    ECOCOMFORT2_CLIENT_SCHEMA,
+    Ecocomfort2FreeCoolingSelect,
+    Ecocomfort2SeasonSelect,
+    register_ecocomfort2_child,
+)
+from .const import (
+    CONF_FREE_COOLING,
+    CONF_SEASON,
+    FREE_COOLING_HIGH,
+    FREE_COOLING_LOW,
+    FREE_COOLING_MEDIUM,
+    FREE_COOLING_OFF,
+    SEASON_SUMMER,
+    SEASON_WINTER,
+)
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_SEASON): select.select_schema(
+                Ecocomfort2SeasonSelect,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+            cv.Optional(CONF_FREE_COOLING): select.select_schema(
+                Ecocomfort2FreeCoolingSelect,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
+        }
+    ).extend(ECOCOMFORT2_CLIENT_SCHEMA),
+    cv.has_at_least_one_key(CONF_SEASON, CONF_FREE_COOLING),
+)
+
+
+async def to_code(config):
+    if conf := config.get(CONF_SEASON):
+        var = await select.new_select(conf, options=[SEASON_WINTER, SEASON_SUMMER])
+        await cg.register_component(var, conf)
+        await register_ecocomfort2_child(var, config)
+
+    if conf := config.get(CONF_FREE_COOLING):
+        var = await select.new_select(
+            conf,
+            options=[
+                FREE_COOLING_OFF,
+                FREE_COOLING_LOW,
+                FREE_COOLING_MEDIUM,
+                FREE_COOLING_HIGH,
+            ],
+        )
+        await cg.register_component(var, conf)
+        await register_ecocomfort2_child(var, config)

--- a/esphome/components/ecocomfort2/sensor.py
+++ b/esphome/components/ecocomfort2/sensor.py
@@ -1,0 +1,100 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_PARTS_PER_BILLION,
+    UNIT_PERCENT,
+)
+
+from . import ECOCOMFORT2_CLIENT_SCHEMA, Ecocomfort2Sensor, register_ecocomfort2_child
+from .const import (
+    CONF_ACTUAL_MODE,
+    CONF_ACTUAL_SPEED,
+    CONF_DIRECTION,
+    CONF_HUMIDITY,
+    CONF_HUMIDITY_OFFSET,
+    CONF_ROLE,
+    CONF_TEMP_OFFSET,
+    CONF_TEMPERATURE,
+    CONF_VOC,
+)
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+SENSOR_TYPES = {
+    CONF_TEMPERATURE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_HUMIDITY: sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_HUMIDITY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_VOC: sensor.sensor_schema(
+        unit_of_measurement=UNIT_PARTS_PER_BILLION,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_DIRECTION: sensor.sensor_schema(
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_ACTUAL_MODE: sensor.sensor_schema(
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_ACTUAL_SPEED: sensor.sensor_schema(
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_ROLE: sensor.sensor_schema(
+        accuracy_decimals=0,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_TEMP_OFFSET: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_HUMIDITY_OFFSET: sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=2,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Ecocomfort2Sensor),
+        }
+    )
+    .extend({cv.Optional(type_): schema for type_, schema in SENSOR_TYPES.items()})
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ECOCOMFORT2_CLIENT_SCHEMA),
+    cv.has_at_least_one_key(*SENSOR_TYPES),
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await register_ecocomfort2_child(var, config)
+
+    for key in SENSOR_TYPES:
+        if conf := config.get(key):
+            sens = await sensor.new_sensor(conf)
+            cg.add(getattr(var, f"set_{key}_sensor")(sens))

--- a/esphome/components/ecocomfort2/sensor.py
+++ b/esphome/components/ecocomfort2/sensor.py
@@ -2,7 +2,11 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_DIRECTION,
+    CONF_HUMIDITY,
     CONF_ID,
+    CONF_TEMPERATURE,
+    CONF_VOC,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
@@ -17,13 +21,8 @@ from . import ECOCOMFORT2_CLIENT_SCHEMA, Ecocomfort2Sensor, register_ecocomfort2
 from .const import (
     CONF_ACTUAL_MODE,
     CONF_ACTUAL_SPEED,
-    CONF_DIRECTION,
-    CONF_HUMIDITY,
     CONF_HUMIDITY_OFFSET,
-    CONF_ROLE,
     CONF_TEMP_OFFSET,
-    CONF_TEMPERATURE,
-    CONF_VOC,
 )
 
 CODEOWNERS = ["@gledian"]
@@ -60,7 +59,7 @@ SENSOR_TYPES = {
         accuracy_decimals=0,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
-    CONF_ROLE: sensor.sensor_schema(
+    "role": sensor.sensor_schema(
         accuracy_decimals=0,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),

--- a/esphome/components/ecocomfort2/switch.py
+++ b/esphome/components/ecocomfort2/switch.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_CONFIG
+
+from . import (
+    ECOCOMFORT2_CLIENT_SCHEMA,
+    Ecocomfort2AdvancedSwitch,
+    register_ecocomfort2_child,
+)
+from .const import CONF_HUMIDITY_ADVANCED, CONF_VOC_ADVANCED
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+SWITCH_TYPES = {
+    CONF_HUMIDITY_ADVANCED: "humidity",
+    CONF_VOC_ADVANCED: "voc",
+}
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(key): switch.switch_schema(
+                Ecocomfort2AdvancedSwitch,
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            )
+            for key in SWITCH_TYPES
+        }
+    ).extend(ECOCOMFORT2_CLIENT_SCHEMA),
+    cv.has_at_least_one_key(*SWITCH_TYPES),
+)
+
+
+async def to_code(config):
+    for key, kind in SWITCH_TYPES.items():
+        if conf := config.get(key):
+            var = await switch.new_switch(conf)
+            await cg.register_component(var, conf)
+            cg.add(var.set_advanced_type(kind))
+            await register_ecocomfort2_child(var, config)

--- a/esphome/components/ecocomfort2/text_sensor.py
+++ b/esphome/components/ecocomfort2/text_sensor.py
@@ -1,0 +1,38 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
+
+from . import (
+    ECOCOMFORT2_CLIENT_SCHEMA,
+    Ecocomfort2TextSensor,
+    register_ecocomfort2_child,
+)
+from .const import CONF_FIRMWARE
+
+CODEOWNERS = ["@gledian"]
+DEPENDENCIES = ["ecocomfort2"]
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Ecocomfort2TextSensor),
+            cv.Optional(CONF_FIRMWARE): text_sensor.text_sensor_schema(
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ECOCOMFORT2_CLIENT_SCHEMA)
+    .add_extra(cv.has_at_least_one_key(CONF_FIRMWARE))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await register_ecocomfort2_child(var, config)
+
+    if conf := config.get(CONF_FIRMWARE):
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(var.set_firmware_sensor(sens))

--- a/tests/components/ecocomfort2/common.yaml
+++ b/tests/components/ecocomfort2/common.yaml
@@ -1,0 +1,106 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+time:
+  - platform: sntp
+    id: sntp_time
+    servers:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 192.168.178.1
+
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: 01:02:03:04:05:06
+    id: ecocomfort2_ble_1
+  - mac_address: 01:02:03:04:05:07
+    id: ecocomfort2_ble_2
+
+ecocomfort2:
+  - id: ecocomfort2_hub_1
+    ble_client_id: ecocomfort2_ble_1
+    time_id: sntp_time
+  - id: ecocomfort2_hub_2
+    ble_client_id: ecocomfort2_ble_2
+
+fan:
+  - platform: ecocomfort2
+    name: Ecocomfort2 Fan 1
+    ecocomfort2_id: ecocomfort2_hub_1
+  - platform: ecocomfort2
+    name: Ecocomfort2 Fan 2
+    ecocomfort2_id: ecocomfort2_hub_2
+
+sensor:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    temperature:
+      name: Ecocomfort2 Temperature
+    humidity:
+      name: Ecocomfort2 Humidity
+    voc:
+      name: Ecocomfort2 VOC
+    direction:
+      name: Ecocomfort2 Direction
+    actual_mode:
+      name: Ecocomfort2 Actual Mode
+    actual_speed:
+      name: Ecocomfort2 Actual Speed
+    role:
+      name: Ecocomfort2 Role
+    temp_offset:
+      name: Ecocomfort2 Temp Offset
+    humidity_offset:
+      name: Ecocomfort2 Humidity Offset
+
+binary_sensor:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    connected:
+      name: Ecocomfort2 Connected
+    boost:
+      name: Ecocomfort2 Boost
+
+text_sensor:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    firmware:
+      name: Ecocomfort2 Firmware
+
+select:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    season:
+      name: Ecocomfort2 Season
+    free_cooling:
+      name: Ecocomfort2 Free Cooling
+
+number:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    humidity_threshold:
+      name: Ecocomfort2 Humidity Threshold
+    luminosity_threshold:
+      name: Ecocomfort2 Luminosity Threshold
+    voc_threshold:
+      name: Ecocomfort2 VOC Threshold
+    temp_offset_number:
+      name: Ecocomfort2 Temp Offset Number
+    humidity_offset_number:
+      name: Ecocomfort2 Humidity Offset Number
+
+switch:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    humidity_advanced:
+      name: Ecocomfort2 Humidity Advanced
+    voc_advanced:
+      name: Ecocomfort2 VOC Advanced
+
+button:
+  - platform: ecocomfort2
+    ecocomfort2_id: ecocomfort2_hub_1
+    pair:
+      name: Ecocomfort2 Pair

--- a/tests/components/ecocomfort2/test.esp32-idf.yaml
+++ b/tests/components/ecocomfort2/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  ble: !include ../../test_build_components/common/ble/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add a new `ecocomfort2` component for controlling [Fantini Cosmi Aspirvelo Air Ecocomfort 2.0 Smart](https://www.fantinicosmi.it/prodotto/aspirvelo-air-ecocomfort-2-0-smart/) VMC (Mechanical Ventilation with Heat Recovery) units over BLE using ESP32.

The component uses a hub architecture: one `ecocomfort2` hub per VMC unit, with platform entities registered as children. A single ESP32 can control multiple VMC units simultaneously.

**Platforms:**
- **fan** — on/off, speed (1–4), preset modes (In, Out, In-Out, Sensor, Auto)
- **sensor** — temperature, humidity, VOC, direction, mode, speed, role, calibration offsets
- **binary_sensor** — BLE connection status, boost mode
- **text_sensor** — firmware version
- **select** — season (Summer/Winter), free cooling level
- **number** — humidity/luminosity/VOC thresholds, temperature/humidity calibration offsets
- **switch** — advanced humidity/VOC sensing algorithms
- **button** — manual BLE pairing trigger

**BLE features:**
- Secure Connections bonding with automatic bond recovery
- Automatic re-encryption on `INSUF_ENCRYPTION` / `INSUF_AUTHENTICATION` errors with retry limit
- Automatic disconnect and reconnect on unrecoverable failures (discovery failure, pair failure, auth timeout)
- Clock synchronization with configurable time source

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6385

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble_tracker:

ble_client:
  - mac_address: "AA:BB:CC:DD:EE:FF"
    id: vmc_ble

ecocomfort2:
  - id: vmc_hub
    ble_client_id: vmc_ble
    time_id: sntp_time

fan:
  - platform: ecocomfort2
    name: "VMC Fan"
    ecocomfort2_id: vmc_hub

sensor:
  - platform: ecocomfort2
    ecocomfort2_id: vmc_hub
    temperature:
      name: "VMC Temperature"
    humidity:
      name: "VMC Humidity"
    voc:
      name: "VMC VOC"

binary_sensor:
  - platform: ecocomfort2
    ecocomfort2_id: vmc_hub
    connected:
      name: "VMC Connected"

select:
  - platform: ecocomfort2
    ecocomfort2_id: vmc_hub
    season:
      name: "VMC Season"

button:
  - platform: ecocomfort2
    ecocomfort2_id: vmc_hub
    pair:
      name: "VMC Pair"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).