### PR TITLE
[valve] New platform time_based

### DIFF
--- a/esphome/components/time_based/valve/__init__.py
+++ b/esphome/components/time_based/valve/__init__.py
@@ -1,13 +1,45 @@
+from esphome import automation
 import esphome.codegen as cg
 from esphome.components import valve
 import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CLOSE_ACTION,
+    CONF_DURATION,
+    CONF_OPEN_ACTION,
+    CONF_STOP_ACTION,
+)
 
 time_based_ns = cg.esphome_ns.namespace("time_based")
 TimeBasedValve = time_based_ns.class_("TimeBasedValve", valve.Valve, cg.Component)
 
-CONFIG_SCHEMA = valve.valve_schema(TimeBasedValve).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    valve.valve_schema(TimeBasedValve)
+    .extend(
+        {
+            cv.Required(CONF_OPEN_ACTION): automation.validate_automation(single=True),
+            cv.Required(CONF_CLOSE_ACTION): automation.validate_automation(single=True),
+            cv.Required(CONF_STOP_ACTION): automation.validate_automation(single=True),
+            cv.Required(CONF_DURATION): cv.positive_time_period_milliseconds,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):
     var = await valve.new_valve(config)
     await cg.register_component(var, config)
+
+    await automation.build_automation(
+        var.get_open_trigger(), [], config[CONF_OPEN_ACTION]
+    )
+
+    await automation.build_automation(
+        var.get_close_trigger(), [], config[CONF_CLOSE_ACTION]
+    )
+
+    await automation.build_automation(
+        var.get_stop_trigger(), [], config[CONF_STOP_ACTION]
+    )
+
+    cg.add(var.set_duration(config[CONF_DURATION]))

--- a/esphome/components/time_based/valve/__init__.py
+++ b/esphome/components/time_based/valve/__init__.py
@@ -6,11 +6,20 @@ from esphome.const import (
     CONF_CLOSE_ACTION,
     CONF_DURATION,
     CONF_OPEN_ACTION,
+    CONF_RESTORE_MODE,
     CONF_STOP_ACTION,
 )
 
 time_based_ns = cg.esphome_ns.namespace("time_based")
 TimeBasedValve = time_based_ns.class_("TimeBasedValve", valve.Valve, cg.Component)
+
+TimeBasedValveRestoreMode = time_based_ns.enum("TimeBasedValveRestoreMode")
+RESTORE_MODES = {
+    "NO_RESTORE": TimeBasedValveRestoreMode.VALVE_NO_RESTORE,
+    "RESTORE": TimeBasedValveRestoreMode.VALVE_RESTORE,
+    "ALWAYS_OPEN": TimeBasedValveRestoreMode.VALVE_ALWAYS_OPEN,
+    "ALWAYS_CLOSED": TimeBasedValveRestoreMode.VALVE_ALWAYS_CLOSED,
+}
 
 CONFIG_SCHEMA = (
     valve.valve_schema(TimeBasedValve)
@@ -20,6 +29,9 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_CLOSE_ACTION): automation.validate_automation(single=True),
             cv.Required(CONF_STOP_ACTION): automation.validate_automation(single=True),
             cv.Required(CONF_DURATION): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_RESTORE_MODE, default="NO_RESTORE"): cv.enum(
+                RESTORE_MODES, upper=True
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -29,17 +41,14 @@ CONFIG_SCHEMA = (
 async def to_code(config):
     var = await valve.new_valve(config)
     await cg.register_component(var, config)
-
     await automation.build_automation(
         var.get_open_trigger(), [], config[CONF_OPEN_ACTION]
     )
-
     await automation.build_automation(
         var.get_close_trigger(), [], config[CONF_CLOSE_ACTION]
     )
-
     await automation.build_automation(
         var.get_stop_trigger(), [], config[CONF_STOP_ACTION]
     )
-
     cg.add(var.set_duration(config[CONF_DURATION]))
+    cg.add(var.set_restore_mode(config[CONF_RESTORE_MODE]))

--- a/esphome/components/time_based/valve/__init__.py
+++ b/esphome/components/time_based/valve/__init__.py
@@ -10,7 +10,8 @@ from esphome.const import (
     CONF_STOP_ACTION,
 )
 
-time_based_ns = cg.esphome_ns.namespace("time_based")
+from .. import time_based_ns
+
 TimeBasedValve = time_based_ns.class_("TimeBasedValve", valve.Valve, cg.Component)
 
 TimeBasedValveRestoreMode = time_based_ns.enum("TimeBasedValveRestoreMode")

--- a/esphome/components/time_based/valve/__init__.py
+++ b/esphome/components/time_based/valve/__init__.py
@@ -1,0 +1,13 @@
+import esphome.codegen as cg
+from esphome.components import valve
+import esphome.config_validation as cv
+
+time_based_ns = cg.esphome_ns.namespace("time_based")
+TimeBasedValve = time_based_ns.class_("TimeBasedValve", valve.Valve, cg.Component)
+
+CONFIG_SCHEMA = valve.valve_schema(TimeBasedValve).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = await valve.new_valve(config)
+    await cg.register_component(var, config)

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -6,11 +6,10 @@ using namespace esphome::valve;
 
 static const char *const TAG = "time_based.valve";
 
-TimeBasedValve::TimeBasedValve() = default;
-
 void TimeBasedValve::setup() {
   switch (this->restore_mode_) {
     case VALVE_NO_RESTORE:
+      this->position = NAN;
       break;
     case VALVE_RESTORE: {
       auto restore = this->restore_state_();
@@ -69,6 +68,12 @@ ValveTraits TimeBasedValve::get_traits() {
   traits.set_supports_toggle(true);
   traits.set_supports_position(true);
   return traits;
+}
+
+void TimeBasedValve::reset_position() {
+  this->measured_position_ = 0;
+  this->measured_position_min_ = 0;
+  this->measured_position_max_ = 0;
 }
 
 void TimeBasedValve::stop_prev_trigger_() {
@@ -133,7 +138,6 @@ void TimeBasedValve::start_direction_(ValveOperation dir) {
   this->current_operation = dir;
 
   const uint32_t now = millis();
-  this->start_dir_time_ = now;
   this->last_recompute_time_ = now;
 
   this->stop_prev_trigger_();
@@ -170,10 +174,27 @@ void TimeBasedValve::recompute_position_() {
   }
 
   const uint32_t now = millis();
-  this->position += dir * (now - this->last_recompute_time_) / this->duration_;
-  this->position = clamp(this->position, 0.0f, 1.0f);
-
+  float distance = dir * (now - this->last_recompute_time_) / this->duration_;
   this->last_recompute_time_ = now;
+
+  bool duration_traveled = (this->measured_position_max_ - this->measured_position_min_) >= this->duration_;
+  if (!duration_traveled) {
+    this->measured_position_ += distance;
+    if (this->measured_position_ > this->measured_position_max_) {
+      this->measured_position_max_ = this->measured_position_;
+    }
+    if (this->measured_position_ < this->measured_position_min_) {
+      this->measured_position_min_ = this->measured_position_;
+    }
+    return;
+  }
+
+  if (this->position == NAN) {
+    this->position = dir > 0 ? 1 : 0;
+  } else {
+    this->position += distance;
+    this->position = clamp(this->position, 0.0f, 1.0f);
+  }
 }
 
 }  // namespace esphome::time_based

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -78,6 +78,10 @@ void TimeBasedValve::reset_position() {
   this->measured_position_max_ = 0;
 }
 
+bool TimeBasedValve::is_endstop_reached() {
+  return (this->measured_position_max_ - this->measured_position_min_) >= 1.0f;
+}
+
 void TimeBasedValve::set_position(float position, bool relative) {
   ValveOperation op;
 
@@ -205,10 +209,9 @@ void TimeBasedValve::recompute_position_() {
   } else if (this->measured_position_ < this->measured_position_min_) {
     this->measured_position_min_ = this->measured_position_;
   }
-  bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= 1.0f;
 
   this->position += distance;
-  if (endstop_reached) {
+  if (this->is_endstop_reached()) {
     this->position = clamp(this->position, 0.0f, 1.0f);
   } else {
     // Full duration not traveled yet -> keep value 1% off end

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -1,5 +1,4 @@
 #include "time_based_valve.h"
-#include "esphome/core/log.h"
 
 namespace esphome::time_based {
 
@@ -27,99 +26,154 @@ void TimeBasedValve::setup() {
       break;
     }
   }
-  if (!this->state_f_.has_value())
-    this->disable_loop();
 }
 
 void TimeBasedValve::loop() {
-  bool changed = false;
+  if (this->current_operation == VALVE_OPERATION_IDLE)
+    return;
 
-  auto s = this->state_f_();
-  if (s.has_value()) {
-    auto pos = clamp(*s, 0.0f, 1.0f);
-    if (pos != this->position) {
-      this->position = pos;
-      changed = true;
+  const uint32_t now = App.get_loop_component_start_time();
+
+  // Recompute position every loop cycle
+  this->recompute_position_();
+
+  if (this->is_at_target_()) {
+    if (this->target_position_ == VALVE_OPEN || this->target_position_ == VALVE_CLOSED) {
+      this->current_operation = VALVE_OPERATION_IDLE;
     }
+    this->publish_state();
   }
 
-  if (changed)
-    this->publish_state();
+  // Send current position every second
+  if (now - this->last_publish_time_ > 1000) {
+    this->publish_state(false);
+    this->last_publish_time_ = now;
+  }
 }
 
-void TimeBasedValve::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-void TimeBasedValve::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 float TimeBasedValve::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 Trigger<> *TimeBasedValve::get_open_trigger() { return &this->open_trigger_; }
 Trigger<> *TimeBasedValve::get_close_trigger() { return &this->close_trigger_; }
 Trigger<> *TimeBasedValve::get_stop_trigger() { return &this->stop_trigger_; }
-Trigger<> *TimeBasedValve::get_toggle_trigger() { return &this->toggle_trigger_; }
 
 void TimeBasedValve::dump_config() {
-  LOG_VALVE("", "Template Valve", this);
-  ESP_LOGCONFIG(TAG,
-                "  Has position: %s\n"
-                "  Optimistic: %s",
-                YESNO(this->has_position_), YESNO(this->optimistic_));
-}
-
-void TimeBasedValve::control(const ValveCall &call) {
-  if (call.get_stop()) {
-    this->stop_prev_trigger_();
-    this->stop_trigger_.trigger();
-    this->prev_command_trigger_ = &this->stop_trigger_;
-    this->publish_state();
-  }
-  if (call.get_toggle().has_value()) {
-    this->stop_prev_trigger_();
-    this->toggle_trigger_.trigger();
-    this->prev_command_trigger_ = &this->toggle_trigger_;
-    this->publish_state();
-  }
-  auto pos_val = call.get_position();
-  if (pos_val.has_value()) {
-    auto pos = *pos_val;
-    this->stop_prev_trigger_();
-
-    if (pos == VALVE_OPEN) {
-      this->open_trigger_.trigger();
-      this->prev_command_trigger_ = &this->open_trigger_;
-    } else if (pos == VALVE_CLOSED) {
-      this->close_trigger_.trigger();
-      this->prev_command_trigger_ = &this->close_trigger_;
-    } else {
-      this->position_trigger_.trigger(pos);
-    }
-
-    if (this->optimistic_) {
-      this->position = pos;
-    }
-  }
-
-  this->publish_state();
+  LOG_VALVE("", "Time Based Valve", this);
+  ESP_LOGCONFIG(TAG, "  Duration: %.1fs", this->duration_ / 1e3f);
 }
 
 ValveTraits TimeBasedValve::get_traits() {
   auto traits = ValveTraits();
-  traits.set_is_assumed_state(this->assumed_state_);
-  traits.set_supports_stop(this->has_stop_);
-  traits.set_supports_toggle(this->has_toggle_);
-  traits.set_supports_position(this->has_position_);
+  traits.set_is_assumed_state(true);
+  traits.set_supports_stop(true);
+  traits.set_supports_toggle(true);
+  traits.set_supports_position(true);
   return traits;
 }
-
-Trigger<float> *TimeBasedValve::get_position_trigger() { return &this->position_trigger_; }
-
-void TimeBasedValve::set_has_stop(bool has_stop) { this->has_stop_ = has_stop; }
-void TimeBasedValve::set_has_toggle(bool has_toggle) { this->has_toggle_ = has_toggle; }
-void TimeBasedValve::set_has_position(bool has_position) { this->has_position_ = has_position; }
 
 void TimeBasedValve::stop_prev_trigger_() {
   if (this->prev_command_trigger_ != nullptr) {
     this->prev_command_trigger_->stop_action();
     this->prev_command_trigger_ = nullptr;
   }
+}
+
+void TimeBasedValve::control(const ValveCall &call) {
+  if (call.get_stop()) {
+    this->start_direction_(VALVE_OPERATION_IDLE);
+    this->publish_state();
+  }
+  if (call.get_toggle().has_value()) {
+    if (this->current_operation != VALVE_OPERATION_IDLE) {
+      this->start_direction_(VALVE_OPERATION_IDLE);
+      this->publish_state();
+    } else {
+      if (this->position == VALVE_CLOSED || this->last_operation_ == VALVE_OPERATION_CLOSING) {
+        this->target_position_ = VALVE_OPEN;
+        this->start_direction_(VALVE_OPERATION_OPENING);
+      } else {
+        this->target_position_ = VALVE_CLOSED;
+        this->start_direction_(VALVE_OPERATION_CLOSING);
+      }
+    }
+  }
+  auto pos_val = call.get_position();
+  if (pos_val.has_value()) {
+    auto pos = *pos_val;
+    if (pos != this->position) {
+      auto op = pos < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+      this->target_position_ = pos;
+      this->start_direction_(op);
+    }
+  }
+}
+
+void TimeBasedValve::start_direction_(ValveOperation dir) {
+  if (dir == this->current_operation && dir != VALVE_OPERATION_IDLE)
+    return;
+
+  this->recompute_position_();
+  Trigger<> *trig;
+  switch (dir) {
+    case VALVE_OPERATION_IDLE:
+      trig = &this->stop_trigger_;
+      break;
+    case VALVE_OPERATION_OPENING:
+      this->last_operation_ = dir;
+      trig = &this->open_trigger_;
+      break;
+    case VALVE_OPERATION_CLOSING:
+      this->last_operation_ = dir;
+      trig = &this->close_trigger_;
+      break;
+    default:
+      return;
+  }
+
+  this->current_operation = dir;
+
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
+  this->last_recompute_time_ = now;
+
+  this->stop_prev_trigger_();
+  trig->trigger();
+  this->prev_command_trigger_ = trig;
+}
+
+bool TimeBasedValve::is_at_target_() const {
+  switch (this->current_operation) {
+    case VALVE_OPERATION_OPENING:
+      return this->position >= this->target_position_;
+    case VALVE_OPERATION_CLOSING:
+      return this->position <= this->target_position_;
+    case VALVE_OPERATION_IDLE:
+    default:
+      return true;
+  }
+}
+
+void TimeBasedValve::recompute_position_() {
+  if (this->current_operation == VALVE_OPERATION_IDLE)
+    return;
+
+  float dir;
+  switch (this->current_operation) {
+    case VALVE_OPERATION_OPENING:
+      dir = 1.0f;
+      break;
+    case VALVE_OPERATION_CLOSING:
+      dir = -1.0f;
+      break;
+    default:
+      return;
+  }
+
+  const uint32_t now = millis();
+  this->position += dir * (now - this->last_recompute_time_) / this->duration_;
+  this->position = clamp(this->position, 0.0f, 1.0f);
+
+  this->last_recompute_time_ = now;
 }
 
 }  // namespace esphome::time_based

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -7,9 +7,9 @@ using namespace esphome::valve;
 static const char *const TAG = "time_based.valve";
 
 void TimeBasedValve::setup() {
+  this->position = NAN;
   switch (this->restore_mode_) {
     case VALVE_NO_RESTORE:
-      this->position = NAN;
       break;
     case VALVE_RESTORE: {
       auto restore = this->restore_state_();
@@ -17,13 +17,12 @@ void TimeBasedValve::setup() {
         restore->apply(this);
       break;
     }
-    case VALVE_RESTORE_AND_CALL: {
-      auto restore = this->restore_state_();
-      if (restore.has_value()) {
-        restore->to_call(this).perform();
-      }
+    case VALVE_ALWAYS_OPEN:
+      this->start_direction_(VALVE_OPERATION_OPENING);
       break;
-    }
+    case VALVE_ALWAYS_CLOSED:
+      this->start_direction_(VALVE_OPERATION_CLOSING);
+      break;
   }
 }
 
@@ -52,8 +51,6 @@ void TimeBasedValve::loop() {
              this->measured_position_max_);
   }
 }
-
-float TimeBasedValve::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 Trigger<> *TimeBasedValve::get_open_trigger() { return &this->open_trigger_; }
 Trigger<> *TimeBasedValve::get_close_trigger() { return &this->close_trigger_; }
@@ -192,8 +189,8 @@ void TimeBasedValve::recompute_position_() {
   float distance = dir * (now - this->last_recompute_time_);
   this->last_recompute_time_ = now;
 
-  bool duration_traveled = (this->measured_position_max_ - this->measured_position_min_) >= this->duration_;
-  if (!duration_traveled) {
+  bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= this->duration_;
+  if (!endstop_reached) {
     this->measured_position_ += distance;
     if (this->measured_position_ > this->measured_position_max_) {
       this->measured_position_max_ = this->measured_position_;
@@ -201,14 +198,22 @@ void TimeBasedValve::recompute_position_() {
     if (this->measured_position_ < this->measured_position_min_) {
       this->measured_position_min_ = this->measured_position_;
     }
-    return;
   }
 
-  if (std::isnan(this->position)) {
+  if (endstop_reached && std::isnan(this->position)) {
+    // Full duration traveled -> position is now known
     this->position = dir > 0 ? VALVE_OPEN : VALVE_CLOSED;
-  } else {
-    this->position += distance / this->duration_;
+    return;
+  }
+  if (std::isnan(this->position))
+    return;
+
+  this->position += distance / this->duration_;
+  if (endstop_reached) {
     this->position = clamp(this->position, 0.0f, 1.0f);
+  } else {
+    // Full duration not traveled yet -> keep value below target
+    this->position = clamp(this->position, 0.01f, 0.99f);
   }
 }
 

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -36,9 +36,7 @@ void TimeBasedValve::loop() {
   this->recompute_position_();
 
   if (this->is_at_target_()) {
-    if (this->target_position_ == VALVE_OPEN || this->target_position_ == VALVE_CLOSED) {
-      this->start_direction_(VALVE_OPERATION_IDLE);
-    }
+    this->start_direction_(VALVE_OPERATION_IDLE);
     this->publish_state();
   }
 
@@ -47,7 +45,7 @@ void TimeBasedValve::loop() {
     this->publish_state(false);
     this->last_publish_time_ = now;
 
-    ESP_LOGV(TAG, "Pos: %.1f Min: %.1f Max: %.1f", this->measured_position_, this->measured_position_min_,
+    ESP_LOGV(TAG, "Pos: %.2f Min: %.2f Max: %.2f", this->measured_position_, this->measured_position_min_,
              this->measured_position_max_);
   }
 }
@@ -77,11 +75,32 @@ void TimeBasedValve::reset_position() {
   this->measured_position_max_ = 0;
 }
 
-void TimeBasedValve::stop_prev_trigger_() {
-  if (this->prev_command_trigger_ != nullptr) {
-    this->prev_command_trigger_->stop_action();
-    this->prev_command_trigger_ = nullptr;
+void TimeBasedValve::set_position(float position, bool relative) {
+  if (position == this->position && !relative)
+    return;
+  this->target_position_relative_ = relative;
+
+  ValveOperation op;
+  if (relative) {
+    op = position < 0 ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+  } else {
+    if (std::isnan(this->position)) {
+      // If current position is unknown, only full open and close are possible
+      if (position != VALVE_CLOSED && position != VALVE_OPEN)
+        return;
+      op = position == VALVE_CLOSED ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+    } else {
+      op = position < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+    }
   }
+
+  if (this->current_operation != VALVE_OPERATION_IDLE && this->current_operation != op) {
+    // Stop before direction change
+    this->start_direction_(VALVE_OPERATION_IDLE);
+  }
+
+  this->target_position_ = relative ? this->measured_position_ + position : position;
+  this->start_direction_(op);
 }
 
 void TimeBasedValve::control(const ValveCall &call) {
@@ -95,34 +114,23 @@ void TimeBasedValve::control(const ValveCall &call) {
       this->publish_state();
     } else {
       if (this->position == VALVE_CLOSED || this->last_operation_ == VALVE_OPERATION_CLOSING) {
-        this->target_position_ = VALVE_OPEN;
-        this->start_direction_(VALVE_OPERATION_OPENING);
+        this->set_position(VALVE_OPEN);
       } else {
-        this->target_position_ = VALVE_CLOSED;
-        this->start_direction_(VALVE_OPERATION_CLOSING);
+        this->set_position(VALVE_CLOSED);
       }
     }
   }
   auto pos_val = call.get_position();
   if (pos_val.has_value()) {
     auto pos = *pos_val;
-    if (pos != this->position) {
-      ValveOperation op;
-      if (std::isnan(this->position)) {
-        // If current position is unknown, only full open and close are possible
-        if (pos != VALVE_CLOSED && pos != VALVE_OPEN)
-          return;
-        op = pos == VALVE_CLOSED ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
-      } else {
-        op = pos < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
-      }
-      if (this->current_operation != VALVE_OPERATION_IDLE && this->current_operation != op) {
-        // Stop before direction change
-        this->start_direction_(VALVE_OPERATION_IDLE);
-      }
-      this->target_position_ = pos;
-      this->start_direction_(op);
-    }
+    this->set_position(pos);
+  }
+}
+
+void TimeBasedValve::stop_prev_trigger_() {
+  if (this->prev_command_trigger_ != nullptr) {
+    this->prev_command_trigger_->stop_action();
+    this->prev_command_trigger_ = nullptr;
   }
 }
 
@@ -159,11 +167,12 @@ void TimeBasedValve::start_direction_(ValveOperation dir) {
 }
 
 bool TimeBasedValve::is_at_target_() const {
+  float position = this->target_position_relative_ ? this->measured_position_ : this->position;
   switch (this->current_operation) {
     case VALVE_OPERATION_OPENING:
-      return this->position >= this->target_position_;
+      return position >= this->target_position_ || this->position == VALVE_OPEN;
     case VALVE_OPERATION_CLOSING:
-      return this->position <= this->target_position_;
+      return position <= this->target_position_ || this->position == VALVE_CLOSED;
     case VALVE_OPERATION_IDLE:
     default:
       return true;
@@ -187,12 +196,13 @@ void TimeBasedValve::recompute_position_() {
   }
 
   const uint32_t now = millis();
-  float distance = dir * (now - this->last_recompute_time_);
+  float distance = dir * (now - this->last_recompute_time_) / this->duration_;
   this->last_recompute_time_ = now;
 
-  bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= this->duration_;
+  bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= 1;
+  this->measured_position_ += distance;
+  clamp(this->measured_position_, -1.0f, 1.0f);
   if (!endstop_reached) {
-    this->measured_position_ += distance;
     if (this->measured_position_ > this->measured_position_max_) {
       this->measured_position_max_ = this->measured_position_;
     }
@@ -209,7 +219,7 @@ void TimeBasedValve::recompute_position_() {
   if (std::isnan(this->position))
     return;
 
-  this->position += distance / this->duration_;
+  this->position += distance;
   if (endstop_reached) {
     this->position = clamp(this->position, 0.0f, 1.0f);
   } else {

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -76,14 +76,16 @@ void TimeBasedValve::reset_position() {
 }
 
 void TimeBasedValve::set_position(float position, bool relative) {
-  if (position == this->position && !relative)
-    return;
-  this->target_position_relative_ = relative;
-
   ValveOperation op;
+
   if (relative) {
     op = position < 0 ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+    if (op == VALVE_OPERATION_CLOSING && this->position == VALVE_CLOSED ||
+        op == VALVE_OPERATION_OPENING && this->position == VALVE_OPEN)
+      return;
   } else {
+    if (position == this->position)
+      return;
     if (std::isnan(this->position)) {
       // If current position is unknown, only full open and close are possible
       if (position != VALVE_CLOSED && position != VALVE_OPEN)
@@ -99,6 +101,7 @@ void TimeBasedValve::set_position(float position, bool relative) {
     this->start_direction_(VALVE_OPERATION_IDLE);
   }
 
+  this->target_position_relative_ = relative;
   this->target_position_ = relative ? this->measured_position_ + position : position;
   this->start_direction_(op);
 }
@@ -201,7 +204,7 @@ void TimeBasedValve::recompute_position_() {
 
   bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= 1;
   this->measured_position_ += distance;
-  clamp(this->measured_position_, -1.0f, 1.0f);
+  this->measured_position_ = clamp(this->measured_position_, -1.0f, 1.0f);
   if (!endstop_reached) {
     if (this->measured_position_ > this->measured_position_max_) {
       this->measured_position_max_ = this->measured_position_;

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -87,8 +87,8 @@ void TimeBasedValve::set_position(float position, bool relative) {
 
   if (relative) {
     op = position < 0 ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
-    if (op == VALVE_OPERATION_CLOSING && this->position == VALVE_CLOSED ||
-        op == VALVE_OPERATION_OPENING && this->position == VALVE_OPEN)
+    if ((op == VALVE_OPERATION_CLOSING && this->position == VALVE_CLOSED) ||
+        (op == VALVE_OPERATION_OPENING && this->position == VALVE_OPEN))
       return;
   } else {
     if (position == this->position)

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -69,7 +69,7 @@ ValveTraits TimeBasedValve::get_traits() {
 }
 
 void TimeBasedValve::reset_position() {
-  this->position = NAN;
+  this->position = 0.5f;
   this->measured_position_ = 0;
   this->measured_position_min_ = 0;
   this->measured_position_max_ = 0;
@@ -86,14 +86,7 @@ void TimeBasedValve::set_position(float position, bool relative) {
   } else {
     if (position == this->position)
       return;
-    if (std::isnan(this->position)) {
-      // If current position is unknown, only full open and close are possible
-      if (position != VALVE_CLOSED && position != VALVE_OPEN)
-        return;
-      op = position == VALVE_CLOSED ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
-    } else {
-      op = position < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
-    }
+    op = position < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
   }
 
   if (this->current_operation != VALVE_OPERATION_IDLE && this->current_operation != op) {
@@ -211,19 +204,11 @@ void TimeBasedValve::recompute_position_() {
   }
   bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= 1.0f;
 
-  if (endstop_reached && std::isnan(this->position)) {
-    // Full duration traveled -> position is now known
-    this->position = dir > 0 ? VALVE_OPEN : VALVE_CLOSED;
-    return;
-  }
-  if (std::isnan(this->position))
-    return;
-
   this->position += distance;
   if (endstop_reached) {
     this->position = clamp(this->position, 0.0f, 1.0f);
   } else {
-    // Full duration not traveled yet -> keep value below target
+    // Full duration not traveled yet -> keep value 1% off end
     this->position = clamp(this->position, 0.01f, 0.99f);
   }
 }

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -1,0 +1,125 @@
+#include "time_based_valve.h"
+#include "esphome/core/log.h"
+
+namespace esphome::time_based {
+
+using namespace esphome::valve;
+
+static const char *const TAG = "time_based.valve";
+
+TimeBasedValve::TimeBasedValve() = default;
+
+void TimeBasedValve::setup() {
+  switch (this->restore_mode_) {
+    case VALVE_NO_RESTORE:
+      break;
+    case VALVE_RESTORE: {
+      auto restore = this->restore_state_();
+      if (restore.has_value())
+        restore->apply(this);
+      break;
+    }
+    case VALVE_RESTORE_AND_CALL: {
+      auto restore = this->restore_state_();
+      if (restore.has_value()) {
+        restore->to_call(this).perform();
+      }
+      break;
+    }
+  }
+  if (!this->state_f_.has_value())
+    this->disable_loop();
+}
+
+void TimeBasedValve::loop() {
+  bool changed = false;
+
+  auto s = this->state_f_();
+  if (s.has_value()) {
+    auto pos = clamp(*s, 0.0f, 1.0f);
+    if (pos != this->position) {
+      this->position = pos;
+      changed = true;
+    }
+  }
+
+  if (changed)
+    this->publish_state();
+}
+
+void TimeBasedValve::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
+void TimeBasedValve::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
+float TimeBasedValve::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+Trigger<> *TimeBasedValve::get_open_trigger() { return &this->open_trigger_; }
+Trigger<> *TimeBasedValve::get_close_trigger() { return &this->close_trigger_; }
+Trigger<> *TimeBasedValve::get_stop_trigger() { return &this->stop_trigger_; }
+Trigger<> *TimeBasedValve::get_toggle_trigger() { return &this->toggle_trigger_; }
+
+void TimeBasedValve::dump_config() {
+  LOG_VALVE("", "Template Valve", this);
+  ESP_LOGCONFIG(TAG,
+                "  Has position: %s\n"
+                "  Optimistic: %s",
+                YESNO(this->has_position_), YESNO(this->optimistic_));
+}
+
+void TimeBasedValve::control(const ValveCall &call) {
+  if (call.get_stop()) {
+    this->stop_prev_trigger_();
+    this->stop_trigger_.trigger();
+    this->prev_command_trigger_ = &this->stop_trigger_;
+    this->publish_state();
+  }
+  if (call.get_toggle().has_value()) {
+    this->stop_prev_trigger_();
+    this->toggle_trigger_.trigger();
+    this->prev_command_trigger_ = &this->toggle_trigger_;
+    this->publish_state();
+  }
+  auto pos_val = call.get_position();
+  if (pos_val.has_value()) {
+    auto pos = *pos_val;
+    this->stop_prev_trigger_();
+
+    if (pos == VALVE_OPEN) {
+      this->open_trigger_.trigger();
+      this->prev_command_trigger_ = &this->open_trigger_;
+    } else if (pos == VALVE_CLOSED) {
+      this->close_trigger_.trigger();
+      this->prev_command_trigger_ = &this->close_trigger_;
+    } else {
+      this->position_trigger_.trigger(pos);
+    }
+
+    if (this->optimistic_) {
+      this->position = pos;
+    }
+  }
+
+  this->publish_state();
+}
+
+ValveTraits TimeBasedValve::get_traits() {
+  auto traits = ValveTraits();
+  traits.set_is_assumed_state(this->assumed_state_);
+  traits.set_supports_stop(this->has_stop_);
+  traits.set_supports_toggle(this->has_toggle_);
+  traits.set_supports_position(this->has_position_);
+  return traits;
+}
+
+Trigger<float> *TimeBasedValve::get_position_trigger() { return &this->position_trigger_; }
+
+void TimeBasedValve::set_has_stop(bool has_stop) { this->has_stop_ = has_stop; }
+void TimeBasedValve::set_has_toggle(bool has_toggle) { this->has_toggle_ = has_toggle; }
+void TimeBasedValve::set_has_position(bool has_position) { this->has_position_ = has_position; }
+
+void TimeBasedValve::stop_prev_trigger_() {
+  if (this->prev_command_trigger_ != nullptr) {
+    this->prev_command_trigger_->stop_action();
+    this->prev_command_trigger_ = nullptr;
+  }
+}
+
+}  // namespace esphome::time_based

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -6,8 +6,9 @@ using namespace esphome::valve;
 
 static const char *const TAG = "time_based.valve";
 
+TimeBasedValve::TimeBasedValve() { this->reset_position(); }
+
 void TimeBasedValve::setup() {
-  this->reset_position();
   switch (this->restore_mode_) {
     case VALVE_NO_RESTORE:
       break;
@@ -15,6 +16,8 @@ void TimeBasedValve::setup() {
       auto restore = this->restore_state_();
       if (restore.has_value())
         restore->apply(this);
+      // Prevent end locations on restore so valve can still be moved
+      this->position = clamp(this->position, 0.01f, 0.99f);
       break;
     }
     case VALVE_ALWAYS_OPEN:

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -161,7 +161,7 @@ void TimeBasedValve::start_direction_(ValveOperation dir) {
 
   this->current_operation = dir;
 
-  const uint32_t now = millis();
+  const uint32_t now = this->get_millis();
   this->last_recompute_time_ = now;
 
   this->stop_prev_trigger_();
@@ -198,21 +198,18 @@ void TimeBasedValve::recompute_position_() {
       return;
   }
 
-  const uint32_t now = millis();
+  const uint32_t now = this->get_millis();
   float distance = dir * (now - this->last_recompute_time_) / this->duration_;
   this->last_recompute_time_ = now;
 
-  bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= 1;
   this->measured_position_ += distance;
   this->measured_position_ = clamp(this->measured_position_, -1.0f, 1.0f);
-  if (!endstop_reached) {
-    if (this->measured_position_ > this->measured_position_max_) {
-      this->measured_position_max_ = this->measured_position_;
-    }
-    if (this->measured_position_ < this->measured_position_min_) {
-      this->measured_position_min_ = this->measured_position_;
-    }
+  if (this->measured_position_ > this->measured_position_max_) {
+    this->measured_position_max_ = this->measured_position_;
+  } else if (this->measured_position_ < this->measured_position_min_) {
+    this->measured_position_min_ = this->measured_position_;
   }
+  bool endstop_reached = (this->measured_position_max_ - this->measured_position_min_) >= 1.0f;
 
   if (endstop_reached && std::isnan(this->position)) {
     // Full duration traveled -> position is now known

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -38,7 +38,7 @@ void TimeBasedValve::loop() {
 
   if (this->is_at_target_()) {
     if (this->target_position_ == VALVE_OPEN || this->target_position_ == VALVE_CLOSED) {
-      this->current_operation = VALVE_OPERATION_IDLE;
+      this->start_direction_(VALVE_OPERATION_IDLE);
     }
     this->publish_state();
   }
@@ -47,6 +47,9 @@ void TimeBasedValve::loop() {
   if (now - this->last_publish_time_ > 1000) {
     this->publish_state(false);
     this->last_publish_time_ = now;
+
+    ESP_LOGV(TAG, "Pos: %.1f Min: %.1f Max: %.1f", this->measured_position_, this->measured_position_min_,
+             this->measured_position_max_);
   }
 }
 
@@ -106,7 +109,19 @@ void TimeBasedValve::control(const ValveCall &call) {
   if (pos_val.has_value()) {
     auto pos = *pos_val;
     if (pos != this->position) {
-      auto op = pos < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+      ValveOperation op;
+      if (std::isnan(this->position)) {
+        // If current position is unknown, only full open and close are possible
+        if (pos != VALVE_CLOSED && pos != VALVE_OPEN)
+          return;
+        op = pos == VALVE_CLOSED ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+      } else {
+        op = pos < this->position ? VALVE_OPERATION_CLOSING : VALVE_OPERATION_OPENING;
+      }
+      if (this->current_operation != VALVE_OPERATION_IDLE && this->current_operation != op) {
+        // Stop before direction change
+        this->start_direction_(VALVE_OPERATION_IDLE);
+      }
       this->target_position_ = pos;
       this->start_direction_(op);
     }
@@ -174,7 +189,7 @@ void TimeBasedValve::recompute_position_() {
   }
 
   const uint32_t now = millis();
-  float distance = dir * (now - this->last_recompute_time_) / this->duration_;
+  float distance = dir * (now - this->last_recompute_time_);
   this->last_recompute_time_ = now;
 
   bool duration_traveled = (this->measured_position_max_ - this->measured_position_min_) >= this->duration_;
@@ -189,10 +204,10 @@ void TimeBasedValve::recompute_position_() {
     return;
   }
 
-  if (this->position == NAN) {
-    this->position = dir > 0 ? 1 : 0;
+  if (std::isnan(this->position)) {
+    this->position = dir > 0 ? VALVE_OPEN : VALVE_CLOSED;
   } else {
-    this->position += distance;
+    this->position += distance / this->duration_;
     this->position = clamp(this->position, 0.0f, 1.0f);
   }
 }

--- a/esphome/components/time_based/valve/time_based_valve.cpp
+++ b/esphome/components/time_based/valve/time_based_valve.cpp
@@ -7,7 +7,7 @@ using namespace esphome::valve;
 static const char *const TAG = "time_based.valve";
 
 void TimeBasedValve::setup() {
-  this->position = NAN;
+  this->reset_position();
   switch (this->restore_mode_) {
     case VALVE_NO_RESTORE:
       break;
@@ -71,6 +71,7 @@ ValveTraits TimeBasedValve::get_traits() {
 }
 
 void TimeBasedValve::reset_position() {
+  this->position = NAN;
   this->measured_position_ = 0;
   this->measured_position_min_ = 0;
   this->measured_position_max_ = 0;

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -26,6 +26,7 @@ class TimeBasedValve final : public valve::Valve, public Component {
   Trigger<> *get_stop_trigger();
   void set_duration(uint32_t duration) { this->duration_ = duration; }
   void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
+  void set_position(float position, bool relative = false);
   void reset_position();
 
  protected:
@@ -43,6 +44,7 @@ class TimeBasedValve final : public valve::Valve, public Component {
   uint32_t last_recompute_time_{0};
   valve::ValveOperation last_operation_{valve::VALVE_OPERATION_OPENING};
   float target_position_{0};
+  bool target_position_relative_{0};
   float measured_position_{0};
   float measured_position_max_{0};
   float measured_position_min_{0};

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -24,6 +24,7 @@ class TimeBasedValve final : public valve::Valve, public Component {
   Trigger<> *get_open_trigger();
   Trigger<> *get_close_trigger();
   Trigger<> *get_stop_trigger();
+  void set_duration(uint32_t duration) { this->duration_ = duration; }
   void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
   void reset_position();
 

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/template_lambda.h"
+#include "esphome/components/valve/valve.h"
+
+namespace esphome::time_based {
+
+enum TimeBasedValveRestoreMode {
+  VALVE_NO_RESTORE,
+  VALVE_RESTORE,
+  VALVE_RESTORE_AND_CALL,
+};
+
+class TimeBasedValve final : public valve::Valve, public Component {
+ public:
+  TimeBasedValve();
+
+  template<typename F> void set_state_lambda(F &&f) { this->state_f_.set(std::forward<F>(f)); }
+  Trigger<> *get_open_trigger();
+  Trigger<> *get_close_trigger();
+  Trigger<> *get_stop_trigger();
+  Trigger<> *get_toggle_trigger();
+  Trigger<float> *get_position_trigger();
+  void set_optimistic(bool optimistic);
+  void set_assumed_state(bool assumed_state);
+  void set_has_stop(bool has_stop);
+  void set_has_position(bool has_position);
+  void set_has_toggle(bool has_toggle);
+  void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
+
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override;
+
+ protected:
+  void control(const valve::ValveCall &call) override;
+  valve::ValveTraits get_traits() override;
+  void stop_prev_trigger_();
+
+  TimeBasedValveRestoreMode restore_mode_{VALVE_NO_RESTORE};
+  TemplateLambda<float> state_f_;
+  bool assumed_state_{false};
+  bool optimistic_{false};
+  Trigger<> open_trigger_;
+  Trigger<> close_trigger_;
+  bool has_stop_{false};
+  bool has_toggle_{false};
+  Trigger<> stop_trigger_;
+  Trigger<> toggle_trigger_;
+  Trigger<> *prev_command_trigger_{nullptr};
+  Trigger<float> position_trigger_;
+  bool has_position_{false};
+};
+
+}  // namespace esphome::time_based

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -30,6 +30,7 @@ class TimeBasedValve : public valve::Valve, public Component {
   void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
   void set_position(float position, bool relative = false);
   void reset_position();
+  bool is_endstop_reached();
 
  protected:
   void control(const valve::ValveCall &call) override;

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -25,6 +25,7 @@ class TimeBasedValve final : public valve::Valve, public Component {
   Trigger<> *get_close_trigger();
   Trigger<> *get_stop_trigger();
   void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
+  void reset_position();
 
  protected:
   void control(const valve::ValveCall &call) override;
@@ -40,8 +41,10 @@ class TimeBasedValve final : public valve::Valve, public Component {
   uint32_t last_publish_time_{0};
   uint32_t last_recompute_time_{0};
   valve::ValveOperation last_operation_{valve::VALVE_OPERATION_OPENING};
-  uint32_t start_dir_time_{0};
   float target_position_{0};
+  float measured_position_{0};
+  float measured_position_max_{0};
+  float measured_position_min_{0};
   Trigger<> open_trigger_;
   Trigger<> close_trigger_;
   Trigger<> stop_trigger_;

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -11,7 +11,8 @@ namespace esphome::time_based {
 enum TimeBasedValveRestoreMode {
   VALVE_NO_RESTORE,
   VALVE_RESTORE,
-  VALVE_RESTORE_AND_CALL,
+  VALVE_ALWAYS_OPEN,
+  VALVE_ALWAYS_CLOSED,
 };
 
 class TimeBasedValve final : public valve::Valve, public Component {
@@ -19,7 +20,6 @@ class TimeBasedValve final : public valve::Valve, public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   Trigger<> *get_open_trigger();
   Trigger<> *get_close_trigger();

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -17,6 +17,8 @@ enum TimeBasedValveRestoreMode {
 
 class TimeBasedValve : public valve::Valve, public Component {
  public:
+  explicit TimeBasedValve();
+
   void setup() override;
   void loop() override;
   void dump_config() override;

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -15,7 +15,7 @@ enum TimeBasedValveRestoreMode {
   VALVE_ALWAYS_CLOSED,
 };
 
-class TimeBasedValve final : public valve::Valve, public Component {
+class TimeBasedValve : public valve::Valve, public Component {
  public:
   void setup() override;
   void loop() override;
@@ -37,6 +37,7 @@ class TimeBasedValve final : public valve::Valve, public Component {
   void start_direction_(valve::ValveOperation dir);
   bool is_at_target_() const;
   void recompute_position_();
+  virtual uint32_t get_millis() { return millis(); }
 
   TimeBasedValveRestoreMode restore_mode_{VALVE_NO_RESTORE};
   uint32_t duration_;

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "esphome/core/component.h"
+#include "esphome/core/application.h"
 #include "esphome/core/automation.h"
-#include "esphome/core/template_lambda.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
 #include "esphome/components/valve/valve.h"
 
 namespace esphome::time_based {
@@ -15,45 +16,36 @@ enum TimeBasedValveRestoreMode {
 
 class TimeBasedValve final : public valve::Valve, public Component {
  public:
-  TimeBasedValve();
-
-  template<typename F> void set_state_lambda(F &&f) { this->state_f_.set(std::forward<F>(f)); }
-  Trigger<> *get_open_trigger();
-  Trigger<> *get_close_trigger();
-  Trigger<> *get_stop_trigger();
-  Trigger<> *get_toggle_trigger();
-  Trigger<float> *get_position_trigger();
-  void set_optimistic(bool optimistic);
-  void set_assumed_state(bool assumed_state);
-  void set_has_stop(bool has_stop);
-  void set_has_position(bool has_position);
-  void set_has_toggle(bool has_toggle);
-  void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
-
   void setup() override;
   void loop() override;
   void dump_config() override;
-
   float get_setup_priority() const override;
+
+  Trigger<> *get_open_trigger();
+  Trigger<> *get_close_trigger();
+  Trigger<> *get_stop_trigger();
+  void set_restore_mode(TimeBasedValveRestoreMode restore_mode) { restore_mode_ = restore_mode; }
 
  protected:
   void control(const valve::ValveCall &call) override;
   valve::ValveTraits get_traits() override;
+
   void stop_prev_trigger_();
+  void start_direction_(valve::ValveOperation dir);
+  bool is_at_target_() const;
+  void recompute_position_();
 
   TimeBasedValveRestoreMode restore_mode_{VALVE_NO_RESTORE};
-  TemplateLambda<float> state_f_;
-  bool assumed_state_{false};
-  bool optimistic_{false};
+  uint32_t duration_;
+  uint32_t last_publish_time_{0};
+  uint32_t last_recompute_time_{0};
+  valve::ValveOperation last_operation_{valve::VALVE_OPERATION_OPENING};
+  uint32_t start_dir_time_{0};
+  float target_position_{0};
   Trigger<> open_trigger_;
   Trigger<> close_trigger_;
-  bool has_stop_{false};
-  bool has_toggle_{false};
   Trigger<> stop_trigger_;
-  Trigger<> toggle_trigger_;
   Trigger<> *prev_command_trigger_{nullptr};
-  Trigger<float> position_trigger_;
-  bool has_position_{false};
 };
 
 }  // namespace esphome::time_based

--- a/esphome/components/time_based/valve/time_based_valve.h
+++ b/esphome/components/time_based/valve/time_based_valve.h
@@ -48,7 +48,7 @@ class TimeBasedValve : public valve::Valve, public Component {
   uint32_t last_recompute_time_{0};
   valve::ValveOperation last_operation_{valve::VALVE_OPERATION_OPENING};
   float target_position_{0};
-  bool target_position_relative_{0};
+  bool target_position_relative_{false};
   float measured_position_{0};
   float measured_position_max_{0};
   float measured_position_min_{0};

--- a/tests/components/time_based/common.yaml
+++ b/tests/components/time_based/common.yaml
@@ -10,3 +10,15 @@ cover:
     close_action:
       - logger.log: close_action
     close_duration: 4.5min
+
+valve:
+  - platform: time_based
+    name: Time Based Valve
+    id: time_based_valve
+    duration: 10s
+    stop_action:
+      - logger.log: stop_action
+    open_action:
+      - logger.log: open_action
+    close_action:
+      - logger.log: close_action

--- a/tests/components/time_based/dummy.h
+++ b/tests/components/time_based/dummy.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/components/time_based/valve/common.h
+++ b/tests/components/time_based/valve/common.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "esphome/core/base_automation.h"
 #include "esphome/components/time_based/valve/time_based_valve.h"
 
 namespace esphome::time_based::testing {
@@ -19,6 +20,11 @@ class TestableTimeBasedValve : public TimeBasedValve {
 
  protected:
   uint32_t get_millis() override { return mock_millis; }
+};
+
+class MockAction : public Action<> {
+ public:
+  MOCK_METHOD(void, play, (), (override));
 };
 
 }  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/common.h
+++ b/tests/components/time_based/valve/common.h
@@ -27,4 +27,11 @@ class MockAction : public Action<> {
   MOCK_METHOD(void, play, (), (override));
 };
 
+class MockESPPreferences : public ESPPreferences {
+  MOCK_METHOD(ESPPreferenceObject, make_preference, (size_t length, uint32_t type), (override));
+  MOCK_METHOD(ESPPreferenceObject, make_preference, (size_t length, uint32_t type, bool in_flash), (override));
+  MOCK_METHOD(bool, sync, (), (override));
+  MOCK_METHOD(bool, reset, (), (override));
+};
+
 }  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/common.h
+++ b/tests/components/time_based/valve/common.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "esphome/components/time_based/valve/time_based_valve.h"
+
+namespace esphome::time_based::testing {
+
+// Expose protected members for testing.
+class TestableTimeBasedValve : public TimeBasedValve {
+ public:
+  using TimeBasedValve::target_position_;
+  using TimeBasedValve::last_recompute_time_;
+  using TimeBasedValve::measured_position_;
+  uint32_t mock_millis = 0;
+
+ protected:
+  uint32_t get_millis() override { return mock_millis; }
+};
+
+}  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/common.h
+++ b/tests/components/time_based/valve/common.h
@@ -13,6 +13,7 @@ class TestableTimeBasedValve : public TimeBasedValve {
  public:
   using TimeBasedValve::target_position_;
   using TimeBasedValve::last_recompute_time_;
+  using TimeBasedValve::current_operation;
   using TimeBasedValve::measured_position_;
   uint32_t mock_millis = 0;
 

--- a/tests/components/time_based/valve/common.h
+++ b/tests/components/time_based/valve/common.h
@@ -27,11 +27,4 @@ class MockAction : public Action<> {
   MOCK_METHOD(void, play, (), (override));
 };
 
-class MockESPPreferences : public ESPPreferences {
-  MOCK_METHOD(ESPPreferenceObject, make_preference, (size_t length, uint32_t type), (override));
-  MOCK_METHOD(ESPPreferenceObject, make_preference, (size_t length, uint32_t type, bool in_flash), (override));
-  MOCK_METHOD(bool, sync, (), (override));
-  MOCK_METHOD(bool, reset, (), (override));
-};
-
 }  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/time_based_valve_position.cpp
+++ b/tests/components/time_based/valve/time_based_valve_position.cpp
@@ -15,12 +15,20 @@ class TimeBasedValvePositionTest : public ::testing::Test {
   TestableTimeBasedValve valve;
 };
 
-TEST_F(TimeBasedValvePositionTest, StopIsCalled) {
+TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
   auto stop_action = MockAction();
   auto stop_automation = Automation<>(valve.get_stop_trigger());
   stop_automation.add_action(&stop_action);
+  auto open_action = MockAction();
+  auto open_automation = Automation<>(valve.get_open_trigger());
+  open_automation.add_action(&open_action);
+  auto close_action = MockAction();
+  auto close_automation = Automation<>(valve.get_close_trigger());
+  close_automation.add_action(&close_action);
 
   EXPECT_CALL(stop_action, play()).Times(0);
+  EXPECT_CALL(open_action, play()).Times(1);
+  EXPECT_CALL(close_action, play()).Times(0);
   auto call = valve.make_call();
   call.set_command_open();
   call.perform();
@@ -28,7 +36,11 @@ TEST_F(TimeBasedValvePositionTest, StopIsCalled) {
 
   // Direction change
   ::testing::Mock::VerifyAndClearExpectations(&stop_action);
+  ::testing::Mock::VerifyAndClearExpectations(&open_action);
+  ::testing::Mock::VerifyAndClearExpectations(&close_action);
   EXPECT_CALL(stop_action, play()).Times(1);
+  EXPECT_CALL(open_action, play()).Times(0);
+  EXPECT_CALL(close_action, play()).Times(1);
   valve.mock_millis += 1000;
   call = valve.make_call();
   call.set_command_close();
@@ -36,7 +48,11 @@ TEST_F(TimeBasedValvePositionTest, StopIsCalled) {
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
 
   ::testing::Mock::VerifyAndClearExpectations(&stop_action);
+  ::testing::Mock::VerifyAndClearExpectations(&open_action);
+  ::testing::Mock::VerifyAndClearExpectations(&close_action);
   EXPECT_CALL(stop_action, play()).Times(1);
+  EXPECT_CALL(open_action, play()).Times(0);
+  EXPECT_CALL(close_action, play()).Times(0);
   valve.mock_millis += 1000;
   call = valve.make_call();
   call.set_command_stop();
@@ -54,6 +70,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 0.6f);
   EXPECT_EQ(valve.position, 0.99f);
+  EXPECT_FALSE(valve.is_fully_open());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Full duration now traveled
@@ -63,6 +80,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 1.0f);
   EXPECT_EQ(valve.position, VALVE_OPEN);
+  EXPECT_TRUE(valve.is_fully_open());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Further open is ignored
@@ -93,6 +111,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.5f);
   EXPECT_EQ(valve.position, 0.01f);
+  EXPECT_FALSE(valve.is_fully_closed());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Close fully
@@ -102,6 +121,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.9f);
   EXPECT_EQ(valve.position, VALVE_CLOSED);
+  EXPECT_TRUE(valve.is_fully_closed());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Further close is ignored

--- a/tests/components/time_based/valve/time_based_valve_position.cpp
+++ b/tests/components/time_based/valve/time_based_valve_position.cpp
@@ -7,6 +7,7 @@ namespace esphome::time_based::testing {
 class TimeBasedValvePositionTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    valve.mock_millis = 1000;
     valve.set_duration(10000);
     valve.setup();
   }
@@ -15,7 +16,6 @@ class TimeBasedValvePositionTest : public ::testing::Test {
 };
 
 TEST_F(TimeBasedValvePositionTest, SetPosition) {
-  valve.mock_millis = 1000;
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   valve.set_position(-0.1, true);

--- a/tests/components/time_based/valve/time_based_valve_position.cpp
+++ b/tests/components/time_based/valve/time_based_valve_position.cpp
@@ -15,20 +15,89 @@ class TimeBasedValvePositionTest : public ::testing::Test {
   TestableTimeBasedValve valve;
 };
 
+TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
+  valve.position = 0.5f;
+
+  // Should be open, but full duration not traveled yet
+  valve.set_position(0.6, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  valve.mock_millis += 6000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 0.6f);
+  EXPECT_EQ(valve.position, 0.99f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+
+  // Full duration now traveled
+  valve.set_position(0.5, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  valve.mock_millis += 5000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 1.0f);
+  EXPECT_EQ(valve.position, VALVE_OPEN);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+
+  // Further open is ignored
+  valve.set_position(0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  valve.mock_millis += 1000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 1.0f);
+  EXPECT_EQ(valve.position, VALVE_OPEN);
+}
+
+TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
+  valve.position = 0.5f;
+
+  // Open a little
+  valve.set_position(0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  valve.mock_millis += 1000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 0.1f);
+  EXPECT_EQ(valve.position, 0.6f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+
+  // Almost close
+  valve.set_position(-0.6f, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  valve.mock_millis += 6000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, -0.5f);
+  EXPECT_EQ(valve.position, 0.01f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+
+  // Close fully
+  valve.set_position(-0.4, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  valve.mock_millis += 4000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, -0.9f);
+  EXPECT_EQ(valve.position, VALVE_CLOSED);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+
+  // Further close is ignored
+  valve.set_position(-0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  valve.mock_millis += 1000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, -0.9f);
+  EXPECT_EQ(valve.position, VALVE_CLOSED);
+}
+
 TEST_F(TimeBasedValvePositionTest, SetPosition) {
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   valve.set_position(-0.1, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
-  valve.mock_millis = 2000;
+  valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.1f);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
-  // Position should still be null because not entire duration traveled
+  // Position should still be NaN because not entire duration traveled
   valve.set_position(-0.4, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
-  valve.mock_millis = 6000;
+  valve.mock_millis += 4000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.5f);
   EXPECT_TRUE(std::isnan(valve.position));
@@ -37,23 +106,23 @@ TEST_F(TimeBasedValvePositionTest, SetPosition) {
   // Move -0.1 over endstop to check clamping and position now available
   valve.set_position(-0.6, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
-  valve.mock_millis = 12000;
+  valve.mock_millis += 6000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -1.0f);
-  EXPECT_EQ(valve.position, 0.0f);
+  EXPECT_EQ(valve.position, VALVE_CLOSED);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Check if not triggered at endstop
   valve.set_position(-0.1, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
-  valve.mock_millis = 13000;
+  valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.last_recompute_time_, 12000);
 
   // Move to other end
   valve.set_position(1, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
-  valve.mock_millis = 23000;
+  valve.mock_millis += 10000;
   valve.loop();
   EXPECT_EQ(valve.position, VALVE_OPEN);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
@@ -61,7 +130,7 @@ TEST_F(TimeBasedValvePositionTest, SetPosition) {
   // Move to middle absolute
   valve.set_position(0.5);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
-  valve.mock_millis = 28000;
+  valve.mock_millis += 5000;
   valve.loop();
   EXPECT_EQ(valve.position, 0.5f);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
@@ -69,11 +138,11 @@ TEST_F(TimeBasedValvePositionTest, SetPosition) {
   // Open and close a little relative
   valve.set_position(0.1, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
-  valve.mock_millis = 29000;
+  valve.mock_millis += 1000;
   valve.loop();
   valve.set_position(-0.3, true);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
-  valve.mock_millis = 32000;
+  valve.mock_millis += 3000;
   valve.loop();
   EXPECT_EQ(valve.position, 0.3f);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
@@ -81,7 +150,7 @@ TEST_F(TimeBasedValvePositionTest, SetPosition) {
   // Fully close
   valve.set_position(0);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
-  valve.mock_millis = 35000;
+  valve.mock_millis += 3000;
   valve.loop();
   EXPECT_EQ(valve.position, VALVE_CLOSED);
   EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);

--- a/tests/components/time_based/valve/time_based_valve_position.cpp
+++ b/tests/components/time_based/valve/time_based_valve_position.cpp
@@ -1,5 +1,7 @@
 #include "common.h"
 
+using namespace esphome::valve;
+
 namespace esphome::time_based::testing {
 
 class TimeBasedValvePositionTest : public ::testing::Test {
@@ -14,58 +16,75 @@ class TimeBasedValvePositionTest : public ::testing::Test {
 
 TEST_F(TimeBasedValvePositionTest, SetPosition) {
   valve.mock_millis = 1000;
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   valve.set_position(-0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
   valve.mock_millis = 2000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.1f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Position should still be null because not entire duration traveled
   valve.set_position(-0.4, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
   valve.mock_millis = 6000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.5f);
   EXPECT_TRUE(std::isnan(valve.position));
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Move -0.1 over endstop to check clamping and position now available
   valve.set_position(-0.6, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
   valve.mock_millis = 12000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -1.0f);
   EXPECT_EQ(valve.position, 0.0f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Check if not triggered at endstop
   valve.set_position(-0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
   valve.mock_millis = 13000;
   valve.loop();
   EXPECT_EQ(valve.last_recompute_time_, 12000);
 
   // Move to other end
   valve.set_position(1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
   valve.mock_millis = 23000;
   valve.loop();
-  EXPECT_EQ(valve.position, 1.0f);
+  EXPECT_EQ(valve.position, VALVE_OPEN);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Move to middle absolute
   valve.set_position(0.5);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
   valve.mock_millis = 28000;
   valve.loop();
   EXPECT_EQ(valve.position, 0.5f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Open and close a little relative
   valve.set_position(0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
   valve.mock_millis = 29000;
   valve.loop();
   valve.set_position(-0.3, true);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
   valve.mock_millis = 32000;
   valve.loop();
   EXPECT_EQ(valve.position, 0.3f);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 
   // Fully close
   valve.set_position(0);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
   valve.mock_millis = 35000;
   valve.loop();
-  EXPECT_EQ(valve.position, 0.0f);
+  EXPECT_EQ(valve.position, VALVE_CLOSED);
+  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
 }
 
 }  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/time_based_valve_position.cpp
+++ b/tests/components/time_based/valve/time_based_valve_position.cpp
@@ -15,30 +15,59 @@ class TimeBasedValvePositionTest : public ::testing::Test {
   TestableTimeBasedValve valve;
 };
 
+TEST_F(TimeBasedValvePositionTest, StopIsCalled) {
+  auto stop_action = MockAction();
+  auto stop_automation = Automation<>(valve.get_stop_trigger());
+  stop_automation.add_action(&stop_action);
+
+  EXPECT_CALL(stop_action, play()).Times(0);
+  auto call = valve.make_call();
+  call.set_command_open();
+  call.perform();
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
+
+  // Direction change
+  ::testing::Mock::VerifyAndClearExpectations(&stop_action);
+  EXPECT_CALL(stop_action, play()).Times(1);
+  valve.mock_millis += 1000;
+  call = valve.make_call();
+  call.set_command_close();
+  call.perform();
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
+
+  ::testing::Mock::VerifyAndClearExpectations(&stop_action);
+  EXPECT_CALL(stop_action, play()).Times(1);
+  valve.mock_millis += 1000;
+  call = valve.make_call();
+  call.set_command_stop();
+  call.perform();
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+}
+
 TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
   valve.position = 0.5f;
 
   // Should be open, but full duration not traveled yet
   valve.set_position(0.6, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
   valve.mock_millis += 6000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 0.6f);
   EXPECT_EQ(valve.position, 0.99f);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Full duration now traveled
   valve.set_position(0.5, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
   valve.mock_millis += 5000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 1.0f);
   EXPECT_EQ(valve.position, VALVE_OPEN);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Further open is ignored
   valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 1.0f);
@@ -50,34 +79,34 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
 
   // Open a little
   valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 0.1f);
   EXPECT_EQ(valve.position, 0.6f);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Almost close
   valve.set_position(-0.6f, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 6000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.5f);
   EXPECT_EQ(valve.position, 0.01f);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Close fully
   valve.set_position(-0.4, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 4000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.9f);
   EXPECT_EQ(valve.position, VALVE_CLOSED);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Further close is ignored
   valve.set_position(-0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.9f);
@@ -85,75 +114,75 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
 }
 
 TEST_F(TimeBasedValvePositionTest, SetPosition) {
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   valve.set_position(-0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.1f);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Position should still be NaN because not entire duration traveled
   valve.set_position(-0.4, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 4000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.5f);
   EXPECT_TRUE(std::isnan(valve.position));
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Move -0.1 over endstop to check clamping and position now available
   valve.set_position(-0.6, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 6000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -1.0f);
   EXPECT_EQ(valve.position, VALVE_CLOSED);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Check if not triggered at endstop
   valve.set_position(-0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.last_recompute_time_, 12000);
 
   // Move to other end
   valve.set_position(1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
   valve.mock_millis += 10000;
   valve.loop();
   EXPECT_EQ(valve.position, VALVE_OPEN);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Move to middle absolute
   valve.set_position(0.5);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 5000;
   valve.loop();
   EXPECT_EQ(valve.position, 0.5f);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Open and close a little relative
   valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_OPENING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
   valve.mock_millis += 1000;
   valve.loop();
   valve.set_position(-0.3, true);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 3000;
   valve.loop();
   EXPECT_EQ(valve.position, 0.3f);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Fully close
   valve.set_position(0);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 3000;
   valve.loop();
   EXPECT_EQ(valve.position, VALVE_CLOSED);
-  EXPECT_EQ((int) valve.current_operation, (int) ValveOperation::VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 }
 
 }  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/time_based_valve_position.cpp
+++ b/tests/components/time_based/valve/time_based_valve_position.cpp
@@ -1,0 +1,71 @@
+#include "common.h"
+
+namespace esphome::time_based::testing {
+
+class TimeBasedValvePositionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    valve.set_duration(10000);
+    valve.setup();
+  }
+
+  TestableTimeBasedValve valve;
+};
+
+TEST_F(TimeBasedValvePositionTest, SetPosition) {
+  valve.mock_millis = 1000;
+
+  valve.set_position(-0.1, true);
+  valve.mock_millis = 2000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, -0.1f);
+
+  // Position should still be null because not entire duration traveled
+  valve.set_position(-0.4, true);
+  valve.mock_millis = 6000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, -0.5f);
+  EXPECT_TRUE(std::isnan(valve.position));
+
+  // Move -0.1 over endstop to check clamping and position now available
+  valve.set_position(-0.6, true);
+  valve.mock_millis = 12000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, -1.0f);
+  EXPECT_EQ(valve.position, 0.0f);
+
+  // Check if not triggered at endstop
+  valve.set_position(-0.1, true);
+  valve.mock_millis = 13000;
+  valve.loop();
+  EXPECT_EQ(valve.last_recompute_time_, 12000);
+
+  // Move to other end
+  valve.set_position(1, true);
+  valve.mock_millis = 23000;
+  valve.loop();
+  EXPECT_EQ(valve.position, 1.0f);
+
+  // Move to middle absolute
+  valve.set_position(0.5);
+  valve.mock_millis = 28000;
+  valve.loop();
+  EXPECT_EQ(valve.position, 0.5f);
+
+  // Open and close a little relative
+  valve.set_position(0.1, true);
+  valve.mock_millis = 29000;
+  valve.loop();
+  valve.set_position(-0.3, true);
+  valve.mock_millis = 32000;
+  valve.loop();
+  EXPECT_EQ(valve.position, 0.3f);
+
+  // Fully close
+  valve.set_position(0);
+  valve.mock_millis = 35000;
+  valve.loop();
+  EXPECT_EQ(valve.position, 0.0f);
+}
+
+}  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/time_based_valve_test.cpp
+++ b/tests/components/time_based/valve/time_based_valve_test.cpp
@@ -70,6 +70,27 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionFullyClosed) {
   EXPECT_EQ(valve.position, 0.01f);
 }
 
+TEST_F(TimeBasedValvePositionTest, OpenWhileOpening) {
+  valve.set_position(0.4, true);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve.mock_millis += 2000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 0.2f);
+
+  // Open while still opening
+  valve.set_position(0.1, true);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve.mock_millis += 3000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 0.5f);
+
+  // Should have stopped
+  valve.mock_millis += 1000;
+  valve.loop();
+  EXPECT_EQ(valve.measured_position_, 0.5f);
+  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+}
+
 TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
   valve.position = 0.7f;
 

--- a/tests/components/time_based/valve/time_based_valve_test.cpp
+++ b/tests/components/time_based/valve/time_based_valve_test.cpp
@@ -61,22 +61,22 @@ TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
-  valve.position = 0.5f;
+  valve.position = 0.7f;
 
   // Should be open, but full duration not traveled yet
-  valve.set_position(0.6, true);
+  valve.set_position(0.4, true);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 6000;
+  valve.mock_millis += 4000;
   valve.loop();
-  EXPECT_EQ(valve.measured_position_, 0.6f);
+  EXPECT_EQ(valve.measured_position_, 0.4f);
   EXPECT_EQ(valve.position, 0.99f);
   EXPECT_FALSE(valve.is_fully_open());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Full duration now traveled
-  valve.set_position(0.5, true);
+  valve.set_position(0.7, true);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 5000;
+  valve.mock_millis += 7000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 1.0f);
   EXPECT_EQ(valve.position, VALVE_OPEN);
@@ -93,7 +93,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
-  valve.position = 0.5f;
+  valve.position = 0.7f;
 
   // Open a little
   valve.set_position(0.1, true);
@@ -101,23 +101,23 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 0.1f);
-  EXPECT_EQ(valve.position, 0.6f);
+  EXPECT_EQ(valve.position, 0.8f);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Almost close
-  valve.set_position(-0.6f, true);
+  valve.set_position(-0.8f, true);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 6000;
+  valve.mock_millis += 8000;
   valve.loop();
-  EXPECT_EQ(valve.measured_position_, -0.5f);
+  EXPECT_EQ(valve.measured_position_, -0.7f);
   EXPECT_EQ(valve.position, 0.01f);
   EXPECT_FALSE(valve.is_fully_closed());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Close fully
-  valve.set_position(-0.4, true);
+  valve.set_position(-0.2, true);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 4000;
+  valve.mock_millis += 2000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.9f);
   EXPECT_EQ(valve.position, VALVE_CLOSED);
@@ -141,15 +141,16 @@ TEST_F(TimeBasedValvePositionTest, SetPosition) {
   valve.mock_millis += 1000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.1f);
+  EXPECT_EQ(valve.position, 0.4f);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
-  // Position should still be NaN because not entire duration traveled
+  // Position should be 0.01 because not entire duration traveled
   valve.set_position(-0.4, true);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
   valve.mock_millis += 4000;
   valve.loop();
   EXPECT_EQ(valve.measured_position_, -0.5f);
-  EXPECT_TRUE(std::isnan(valve.position));
+  EXPECT_EQ(valve.position, 0.01f);
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Move -0.1 over endstop to check clamping and position now available

--- a/tests/components/time_based/valve/time_based_valve_test.cpp
+++ b/tests/components/time_based/valve/time_based_valve_test.cpp
@@ -7,6 +7,7 @@ namespace esphome::time_based::testing {
 class TimeBasedValvePositionTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    EXPECT_EQ(valve.position, 0.5f);
     valve.mock_millis = 1000;
     valve.set_duration(10000);
     valve.setup();
@@ -58,6 +59,15 @@ TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
   call.set_command_stop();
   call.perform();
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+}
+
+TEST_F(TimeBasedValvePositionTest, RestoredPositionFullyClosed) {
+  auto mock_ESPPreferences = MockESPPreferences();
+  global_preferences = &mock_ESPPreferences;
+  valve.position = 0;
+  valve.set_restore_mode(VALVE_RESTORE);
+  valve.setup();
+  EXPECT_EQ(valve.position, 0.01f);
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {

--- a/tests/components/time_based/valve/time_based_valve_test.cpp
+++ b/tests/components/time_based/valve/time_based_valve_test.cpp
@@ -7,33 +7,33 @@ namespace esphome::time_based::testing {
 class TimeBasedValvePositionTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    EXPECT_EQ(valve.position, 0.5f);
-    valve.mock_millis = 1000;
-    valve.set_duration(10000);
-    valve.setup();
+    EXPECT_EQ(valve_.position, 0.5f);
+    valve_.mock_millis = 1000;
+    valve_.set_duration(10000);
+    valve_.setup();
   }
 
-  TestableTimeBasedValve valve;
+  TestableTimeBasedValve valve_;
 };
 
 TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
   auto stop_action = MockAction();
-  auto stop_automation = Automation<>(valve.get_stop_trigger());
+  auto stop_automation = Automation<>(valve_.get_stop_trigger());
   stop_automation.add_action(&stop_action);
   auto open_action = MockAction();
-  auto open_automation = Automation<>(valve.get_open_trigger());
+  auto open_automation = Automation<>(valve_.get_open_trigger());
   open_automation.add_action(&open_action);
   auto close_action = MockAction();
-  auto close_automation = Automation<>(valve.get_close_trigger());
+  auto close_automation = Automation<>(valve_.get_close_trigger());
   close_automation.add_action(&close_action);
 
   EXPECT_CALL(stop_action, play()).Times(0);
   EXPECT_CALL(open_action, play()).Times(1);
   EXPECT_CALL(close_action, play()).Times(0);
-  auto call = valve.make_call();
+  auto call = valve_.make_call();
   call.set_command_open();
   call.perform();
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
 
   // Direction change
   ::testing::Mock::VerifyAndClearExpectations(&stop_action);
@@ -42,11 +42,11 @@ TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
   EXPECT_CALL(stop_action, play()).Times(1);
   EXPECT_CALL(open_action, play()).Times(0);
   EXPECT_CALL(close_action, play()).Times(1);
-  valve.mock_millis += 1000;
-  call = valve.make_call();
+  valve_.mock_millis += 1000;
+  call = valve_.make_call();
   call.set_command_close();
   call.perform();
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
 
   ::testing::Mock::VerifyAndClearExpectations(&stop_action);
   ::testing::Mock::VerifyAndClearExpectations(&open_action);
@@ -54,187 +54,187 @@ TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
   EXPECT_CALL(stop_action, play()).Times(1);
   EXPECT_CALL(open_action, play()).Times(0);
   EXPECT_CALL(close_action, play()).Times(0);
-  valve.mock_millis += 1000;
-  call = valve.make_call();
+  valve_.mock_millis += 1000;
+  call = valve_.make_call();
   call.set_command_stop();
   call.perform();
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionFullyClosed) {
-  valve.position = 0;
-  valve.set_restore_mode(VALVE_RESTORE);
-  valve.setup();
-  EXPECT_EQ(valve.position, 0.01f);
+  valve_.position = 0;
+  valve_.set_restore_mode(VALVE_RESTORE);
+  valve_.setup();
+  EXPECT_EQ(valve_.position, 0.01f);
 }
 
 TEST_F(TimeBasedValvePositionTest, OpenWhileOpening) {
-  valve.set_position(0.4, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 2000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 0.2f);
+  valve_.set_position(0.4, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 2000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 0.2f);
 
   // Open while still opening
-  valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 3000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 0.5f);
+  valve_.set_position(0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 3000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 0.5f);
 
   // Should have stopped
-  valve.mock_millis += 1000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 0.5f);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 0.5f);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
-  valve.position = 0.7f;
+  valve_.position = 0.7f;
 
   // Should be open, but full duration not traveled yet
-  valve.set_position(0.4, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 4000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 0.4f);
-  EXPECT_EQ(valve.position, 0.99f);
-  EXPECT_FALSE(valve.is_endstop_reached());
-  EXPECT_FALSE(valve.is_fully_open());
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(0.4, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 4000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 0.4f);
+  EXPECT_EQ(valve_.position, 0.99f);
+  EXPECT_FALSE(valve_.is_endstop_reached());
+  EXPECT_FALSE(valve_.is_fully_open());
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Full duration now traveled
-  valve.set_position(0.7, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 7000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 1.0f);
-  EXPECT_EQ(valve.position, VALVE_OPEN);
-  EXPECT_TRUE(valve.is_endstop_reached());
-  EXPECT_TRUE(valve.is_fully_open());
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(0.7, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 7000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 1.0f);
+  EXPECT_EQ(valve_.position, VALVE_OPEN);
+  EXPECT_TRUE(valve_.is_endstop_reached());
+  EXPECT_TRUE(valve_.is_fully_open());
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Further open is ignored
-  valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
-  valve.mock_millis += 1000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 1.0f);
-  EXPECT_EQ(valve.position, VALVE_OPEN);
+  valve_.set_position(0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 1.0f);
+  EXPECT_EQ(valve_.position, VALVE_OPEN);
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionClose) {
-  valve.position = 0.7f;
+  valve_.position = 0.7f;
 
   // Open a little
-  valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 1000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, 0.1f);
-  EXPECT_EQ(valve.position, 0.8f);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, 0.1f);
+  EXPECT_EQ(valve_.position, 0.8f);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Almost close
-  valve.set_position(-0.8f, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 8000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, -0.7f);
-  EXPECT_EQ(valve.position, 0.01f);
-  EXPECT_FALSE(valve.is_fully_closed());
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(-0.8f, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 8000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, -0.7f);
+  EXPECT_EQ(valve_.position, 0.01f);
+  EXPECT_FALSE(valve_.is_fully_closed());
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Close fully
-  valve.set_position(-0.2, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 2000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, -0.9f);
-  EXPECT_EQ(valve.position, VALVE_CLOSED);
-  EXPECT_TRUE(valve.is_fully_closed());
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(-0.2, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 2000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, -0.9f);
+  EXPECT_EQ(valve_.position, VALVE_CLOSED);
+  EXPECT_TRUE(valve_.is_fully_closed());
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Further close is ignored
-  valve.set_position(-0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
-  valve.mock_millis += 1000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, -0.9f);
-  EXPECT_EQ(valve.position, VALVE_CLOSED);
+  valve_.set_position(-0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, -0.9f);
+  EXPECT_EQ(valve_.position, VALVE_CLOSED);
 }
 
 TEST_F(TimeBasedValvePositionTest, SetPosition) {
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
-  valve.set_position(-0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 1000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, -0.1f);
-  EXPECT_EQ(valve.position, 0.4f);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(-0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, -0.1f);
+  EXPECT_EQ(valve_.position, 0.4f);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Position should be 0.01 because not entire duration traveled
-  valve.set_position(-0.4, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 4000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, -0.5f);
-  EXPECT_EQ(valve.position, 0.01f);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(-0.4, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 4000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, -0.5f);
+  EXPECT_EQ(valve_.position, 0.01f);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Move -0.1 over endstop to check clamping and position now available
-  valve.set_position(-0.6, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 6000;
-  valve.loop();
-  EXPECT_EQ(valve.measured_position_, -1.0f);
-  EXPECT_EQ(valve.position, VALVE_CLOSED);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(-0.6, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 6000;
+  valve_.loop();
+  EXPECT_EQ(valve_.measured_position_, -1.0f);
+  EXPECT_EQ(valve_.position, VALVE_CLOSED);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Check if not triggered at endstop
-  valve.set_position(-0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
-  valve.mock_millis += 1000;
-  valve.loop();
-  EXPECT_EQ(valve.last_recompute_time_, 12000);
+  valve_.set_position(-0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  EXPECT_EQ(valve_.last_recompute_time_, 12000);
 
   // Move to other end
-  valve.set_position(1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 10000;
-  valve.loop();
-  EXPECT_EQ(valve.position, VALVE_OPEN);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 10000;
+  valve_.loop();
+  EXPECT_EQ(valve_.position, VALVE_OPEN);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Move to middle absolute
-  valve.set_position(0.5);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 5000;
-  valve.loop();
-  EXPECT_EQ(valve.position, 0.5f);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(0.5);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 5000;
+  valve_.loop();
+  EXPECT_EQ(valve_.position, 0.5f);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Open and close a little relative
-  valve.set_position(0.1, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_OPENING);
-  valve.mock_millis += 1000;
-  valve.loop();
-  valve.set_position(-0.3, true);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 3000;
-  valve.loop();
-  EXPECT_EQ(valve.position, 0.3f);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(0.1, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_OPENING);
+  valve_.mock_millis += 1000;
+  valve_.loop();
+  valve_.set_position(-0.3, true);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 3000;
+  valve_.loop();
+  EXPECT_EQ(valve_.position, 0.3f);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 
   // Fully close
-  valve.set_position(0);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_CLOSING);
-  valve.mock_millis += 3000;
-  valve.loop();
-  EXPECT_EQ(valve.position, VALVE_CLOSED);
-  EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
+  valve_.set_position(0);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_CLOSING);
+  valve_.mock_millis += 3000;
+  valve_.loop();
+  EXPECT_EQ(valve_.position, VALVE_CLOSED);
+  EXPECT_EQ((int) valve_.current_operation, (int) VALVE_OPERATION_IDLE);
 }
 
 }  // namespace esphome::time_based::testing

--- a/tests/components/time_based/valve/time_based_valve_test.cpp
+++ b/tests/components/time_based/valve/time_based_valve_test.cpp
@@ -62,8 +62,6 @@ TEST_F(TimeBasedValvePositionTest, TriggersAreCalled) {
 }
 
 TEST_F(TimeBasedValvePositionTest, RestoredPositionFullyClosed) {
-  auto mock_ESPPreferences = MockESPPreferences();
-  global_preferences = &mock_ESPPreferences;
   valve.position = 0;
   valve.set_restore_mode(VALVE_RESTORE);
   valve.setup();

--- a/tests/components/time_based/valve/time_based_valve_test.cpp
+++ b/tests/components/time_based/valve/time_based_valve_test.cpp
@@ -101,6 +101,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 0.4f);
   EXPECT_EQ(valve.position, 0.99f);
+  EXPECT_FALSE(valve.is_endstop_reached());
   EXPECT_FALSE(valve.is_fully_open());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 
@@ -111,6 +112,7 @@ TEST_F(TimeBasedValvePositionTest, RestoredPositionOpen) {
   valve.loop();
   EXPECT_EQ(valve.measured_position_, 1.0f);
   EXPECT_EQ(valve.position, VALVE_OPEN);
+  EXPECT_TRUE(valve.is_endstop_reached());
   EXPECT_TRUE(valve.is_fully_open());
   EXPECT_EQ((int) valve.current_operation, (int) VALVE_OPERATION_IDLE);
 


### PR DESCRIPTION
# What does this implement/fix?

This PR introduces a new time based valve component. It is similar to the time based cover component adding more safety by measuring the current position since boot to accurately detect the endstops.

I use this component to control the valve of my central heating. To ensure proper operation various unit tests were added.
The component is running since Apr 9 without issues 24/7.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <https://github.com/esphome/feature-requests/issues/2720>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6426

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
valve:
  - platform: time_based
    name: "Time-Based Valve"
    duration: 10s
    open_action:
      - switch.turn_on: open_valve_switch
    close_action:
      - switch.turn_on: close_valve_switch
    stop_action:
      - switch.turn_off: open_valve_switch
      - switch.turn_off: close_valve_switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
