### PR TITLE
[st25r] Add ST25R3916 NFC reader (SPI, ISO14443A)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -517,6 +517,8 @@ esphome/components/st7701s/* @clydebarrow
 esphome/components/st7735/* @SenexCrenshaw
 esphome/components/st7789v/* @kbx81
 esphome/components/st7920/* @marsjan155
+esphome/components/st25r/* @JohnMcLear
+esphome/components/st25r_spi/* @JohnMcLear
 esphome/components/statsd/* @Links2004
 esphome/components/stts22h/* @B48D81EFCC
 esphome/components/substitutions/* @esphome/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -509,6 +509,8 @@ esphome/components/ssd1331_base/* @kbx81
 esphome/components/ssd1331_spi/* @kbx81
 esphome/components/ssd1351_base/* @kbx81
 esphome/components/ssd1351_spi/* @kbx81
+esphome/components/st25r/* @JohnMcLear
+esphome/components/st25r_spi/* @JohnMcLear
 esphome/components/st7123/* @miniskipper
 esphome/components/st7567_base/* @latonita
 esphome/components/st7567_i2c/* @latonita
@@ -517,8 +519,6 @@ esphome/components/st7701s/* @clydebarrow
 esphome/components/st7735/* @SenexCrenshaw
 esphome/components/st7789v/* @kbx81
 esphome/components/st7920/* @marsjan155
-esphome/components/st25r/* @JohnMcLear
-esphome/components/st25r_spi/* @JohnMcLear
 esphome/components/statsd/* @Links2004
 esphome/components/stts22h/* @B48D81EFCC
 esphome/components/substitutions/* @esphome/core

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -47,7 +47,7 @@ ST25R_SCHEMA = cv.Schema(
 ).extend(cv.polling_component_schema("1s"))
 
 
-async def setup_st25r(var, config):
+async def setup_st25r(var: cg.Pvariable, config: dict) -> None:
     await cg.register_component(var, config)
 
     if CONF_IRQ_PIN in config:

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -2,12 +2,7 @@ from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import nfc
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_IRQ_PIN,
-    CONF_ON_TAG,
-    CONF_ON_TAG_REMOVED,
-    CONF_RESET_PIN,
-)
+from esphome.const import CONF_IRQ_PIN, CONF_ON_TAG, CONF_ON_TAG_REMOVED, CONF_RESET_PIN
 
 CODEOWNERS = ["@JohnMcLear"]
 AUTO_LOAD = ["nfc"]

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -7,7 +7,6 @@ from esphome.const import (
     CONF_ON_TAG,
     CONF_ON_TAG_REMOVED,
     CONF_RESET_PIN,
-    CONF_TRIGGER_ID,
 )
 
 CODEOWNERS = ["@JohnMcLear"]
@@ -20,29 +19,14 @@ CONF_RF_POWER = "rf_power"
 st25r_ns = cg.esphome_ns.namespace("st25r")
 ST25R = st25r_ns.class_("ST25R", nfc.Nfcc, cg.PollingComponent)
 
-ST25RTagTrigger = st25r_ns.class_(
-    "ST25RTagTrigger", automation.Trigger.template(cg.std_string)
-)
-ST25RTagRemovedTrigger = st25r_ns.class_(
-    "ST25RTagRemovedTrigger", automation.Trigger.template(cg.std_string)
-)
-
 ST25R_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(ST25R),
         cv.Optional(CONF_IRQ_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
-        cv.Optional(CONF_ON_TAG): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25RTagTrigger),
-            }
-        ),
-        cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25RTagRemovedTrigger),
-            }
-        ),
+        cv.Optional(CONF_ON_TAG): automation.validate_automation({}),
+        cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation({}),
     }
 ).extend(cv.polling_component_schema("1s"))
 
@@ -61,11 +45,11 @@ async def setup_st25r(var: cg.Pvariable, config: dict) -> None:
     cg.add(var.set_rf_power(config[CONF_RF_POWER]))
 
     for conf in config.get(CONF_ON_TAG, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        cg.add(var.register_on_tag_trigger(trigger))
-        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_callback_automation(
+            var, "add_on_tag_callback", [(cg.std_string, "x")], conf
+        )
 
     for conf in config.get(CONF_ON_TAG_REMOVED, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        cg.add(var.register_on_tag_removed_trigger(trigger))
-        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+        await automation.build_callback_automation(
+            var, "add_on_tag_removed_callback", [(cg.std_string, "x")], conf
+        )

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -2,13 +2,14 @@ from esphome import automation, pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
     CONF_IRQ_PIN,
     CONF_ON_TAG,
     CONF_ON_TAG_REMOVED,
     CONF_RESET_PIN,
     CONF_TRIGGER_ID,
 )
+
+from esphome.components import nfc
 
 CODEOWNERS = ["@JohnMcLear"]
 AUTO_LOAD = ["nfc"]
@@ -18,7 +19,7 @@ CONF_ST25R_ID = "st25r_id"
 CONF_RF_POWER = "rf_power"
 
 st25r_ns = cg.esphome_ns.namespace("st25r")
-ST25R = st25r_ns.class_("ST25R", cg.PollingComponent)
+ST25R = st25r_ns.class_("ST25R", nfc.Nfcc, cg.PollingComponent)
 
 ST25RTagTrigger = st25r_ns.class_(
     "ST25RTagTrigger", automation.Trigger.template(cg.std_string)

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -1,0 +1,77 @@
+from esphome import automation, pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_ON_TAG,
+    CONF_ON_TAG_REMOVED,
+    CONF_TRIGGER_ID,
+    CONF_IRQ_PIN,
+    CONF_RESET_PIN,
+)
+
+CODEOWNERS = ["@JohnMcLear"]
+AUTO_LOAD = ["nfc"]
+MULTI_CONF = True
+
+CONF_ST25R_ID = "st25r_id"
+CONF_RF_POWER = "rf_power"
+
+st25r_ns = cg.esphome_ns.namespace("st25r")
+ST25R = st25r_ns.class_("ST25R", cg.PollingComponent)
+
+ST25RTagTrigger = st25r_ns.class_(
+    "ST25RTagTrigger", automation.Trigger.template(cg.std_string)
+)
+ST25RTagRemovedTrigger = st25r_ns.class_(
+    "ST25RTagRemovedTrigger", automation.Trigger.template(cg.std_string)
+)
+
+ST25R_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(ST25R),
+        cv.Optional(CONF_IRQ_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
+        cv.Optional(CONF_ON_TAG): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25RTagTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                    ST25RTagRemovedTrigger
+                ),
+            }
+        ),
+    }
+).extend(cv.polling_component_schema("1s"))
+
+
+async def setup_st25r(var, config):
+    await cg.register_component(var, config)
+
+    if CONF_IRQ_PIN in config:
+        irq = await cg.gpio_pin_expression(config[CONF_IRQ_PIN])
+        cg.add(var.set_irq_pin(irq))
+
+    if CONF_RESET_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(reset))
+
+    cg.add(var.set_rf_power(config[CONF_RF_POWER]))
+
+    for conf in config.get(CONF_ON_TAG, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        cg.add(var.register_on_tag_trigger(trigger))
+        await automation.build_automation(
+            trigger, [(cg.std_string, "x")], conf
+        )
+
+    for conf in config.get(CONF_ON_TAG_REMOVED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        cg.add(var.register_on_tag_removed_trigger(trigger))
+        await automation.build_automation(
+            trigger, [(cg.std_string, "x")], conf
+        )

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -3,11 +3,11 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
+    CONF_IRQ_PIN,
     CONF_ON_TAG,
     CONF_ON_TAG_REMOVED,
-    CONF_TRIGGER_ID,
-    CONF_IRQ_PIN,
     CONF_RESET_PIN,
+    CONF_TRIGGER_ID,
 )
 
 CODEOWNERS = ["@JohnMcLear"]
@@ -40,9 +40,7 @@ ST25R_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
             {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                    ST25RTagRemovedTrigger
-                ),
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25RTagRemovedTrigger),
             }
         ),
     }
@@ -65,13 +63,9 @@ async def setup_st25r(var, config):
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.register_on_tag_trigger(trigger))
-        await automation.build_automation(
-            trigger, [(cg.std_string, "x")], conf
-        )
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_TAG_REMOVED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.register_on_tag_removed_trigger(trigger))
-        await automation.build_automation(
-            trigger, [(cg.std_string, "x")], conf
-        )
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -1,5 +1,6 @@
 from esphome import automation, pins
 import esphome.codegen as cg
+from esphome.components import nfc
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_IRQ_PIN,
@@ -8,8 +9,6 @@ from esphome.const import (
     CONF_RESET_PIN,
     CONF_TRIGGER_ID,
 )
-
-from esphome.components import nfc
 
 CODEOWNERS = ["@JohnMcLear"]
 AUTO_LOAD = ["nfc"]

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -3,6 +3,7 @@ import esphome.codegen as cg
 from esphome.components import nfc
 import esphome.config_validation as cv
 from esphome.const import CONF_IRQ_PIN, CONF_ON_TAG, CONF_ON_TAG_REMOVED, CONF_RESET_PIN
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@JohnMcLear"]
 AUTO_LOAD = ["nfc"]
@@ -26,7 +27,7 @@ ST25R_SCHEMA = cv.Schema(
 ).extend(cv.polling_component_schema("1s"))
 
 
-async def setup_st25r(var: cg.Pvariable, config: dict) -> None:
+async def setup_st25r(var: cg.Pvariable, config: ConfigType) -> None:
     await cg.register_component(var, config)
 
     if CONF_IRQ_PIN in config:

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -48,6 +48,7 @@ void ST25R::update() {
 
   this->write_register(OP_CONTROL, 0xC8);  // en=1, rx_en=1, tx_en=1
 
+  this->tag_found_this_scan_ = false;
   this->irq_triggered_ = false;
   this->write_command(ST25R_CMD_TRANSMIT_WUPA);
   this->state_ = STATE_WUPA;
@@ -58,7 +59,8 @@ bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t 
   return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
-bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                               uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
@@ -127,6 +129,16 @@ void ST25R::loop() {
   this->process_state();
 }
 
+// Append hex bytes to current_uid_ buffer without heap allocation
+void ST25R::uid_append_hex_(const uint8_t *data, uint8_t count) {
+  static constexpr char HEX[] = "0123456789ABCDEF";
+  for (uint8_t i = 0; i < count && this->current_uid_pos_ + 2 < MAX_UID_HEX; i++) {
+    this->current_uid_[this->current_uid_pos_++] = HEX[data[i] >> 4];
+    this->current_uid_[this->current_uid_pos_++] = HEX[data[i] & 0x0F];
+  }
+  this->current_uid_[this->current_uid_pos_] = '\0';
+}
+
 void ST25R::process_state() {
   switch (this->state_) {
     case STATE_IDLE:
@@ -135,7 +147,8 @@ void ST25R::process_state() {
     case STATE_WUPA: {
       if (this->irq_status_ & (IRQ_RXE | IRQ_COL)) {
         this->cascade_level_ = 0;
-        this->current_uid_ = "";
+        this->current_uid_pos_ = 0;
+        this->current_uid_[0] = '\0';
         this->send_anticol_frame();
         this->state_ = STATE_ANTICOL;
         this->last_state_change_ = millis();
@@ -168,7 +181,6 @@ void ST25R::process_state() {
       uint8_t f1 = this->read_fifo_status1();
 
       if (this->irq_status_ & IRQ_COL) {
-        // Collision: drain FIFO, scan will retry next update()
         if (f1 > 0) {
           uint8_t tmp[8];
           this->read_fifo(tmp, std::min(f1, (uint8_t) 8));
@@ -188,19 +200,11 @@ void ST25R::process_state() {
       uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
       uint8_t sel_pk[7] = {sel_cmds[this->cascade_level_], 0x70, resp[0], resp[1], resp[2], resp[3], bcc};
 
-      // Build UID string: skip cascade tag (0x88)
+      // Build UID: skip cascade tag (0x88)
       if (resp[0] == 0x88) {
-        for (int i = 1; i < 4; i++) {
-          char buf[3];
-          snprintf(buf, sizeof(buf), "%02X", resp[i]);
-          this->current_uid_ += buf;
-        }
+        this->uid_append_hex_(resp + 1, 3);
       } else {
-        for (int i = 0; i < 4; i++) {
-          char buf[3];
-          snprintf(buf, sizeof(buf), "%02X", resp[i]);
-          this->current_uid_ += buf;
-        }
+        this->uid_append_hex_(resp, 4);
       }
 
       this->pre_select();
@@ -216,7 +220,7 @@ void ST25R::process_state() {
       uint8_t sak = sak_buf[0];
       this->last_sak_ = sak;
 
-      if (sak & 0x04) {  // Cascade bit — need another level
+      if (sak & 0x04) {  // Cascade bit
         this->cascade_level_++;
         if (this->cascade_level_ > 2) {
           ESP_LOGE(TAG, "Too many cascade levels");
@@ -229,17 +233,16 @@ void ST25R::process_state() {
         this->last_state_change_ = millis();
       } else {
         // Tag fully selected
-        size_t uid_bytes_len = this->current_uid_.length() / 2;
-        if (uid_bytes_len != 4 && uid_bytes_len != 7 && uid_bytes_len != 10) {
-          ESP_LOGW(TAG, "Discarding invalid UID len=%zu", uid_bytes_len);
+        uint8_t uid_len = this->current_uid_pos_ / 2;
+        if (uid_len != 4 && uid_len != 7 && uid_len != 10) {
+          ESP_LOGW(TAG, "Discarding invalid UID len=%u", uid_len);
           this->state_ = STATE_IDLE;
           this->finalize_scan_();
           return;
         }
 
-        ESP_LOGI(TAG, "Tag selected: %s (SAK=0x%02X)", this->current_uid_.c_str(), sak);
-
-        this->tags_this_scan_.push_back(this->current_uid_);
+        ESP_LOGI(TAG, "Tag selected: %s (SAK=0x%02X)", this->current_uid_, sak);
+        this->tag_found_this_scan_ = true;
         this->send_halt();
         this->state_ = STATE_IDLE;
         this->finalize_scan_();
@@ -261,43 +264,44 @@ void ST25R::finalize_scan_() {
   // Remove stale tags; increment miss counters
   auto it = this->present_tags_.begin();
   while (it != this->present_tags_.end()) {
-    bool seen = false;
-    for (const auto &uid : this->tags_this_scan_) {
-      if (uid == it->uid) {
-        seen = true;
-        break;
-      }
-    }
+    bool seen = this->tag_found_this_scan_ && strcmp(it->uid, this->current_uid_) == 0;
     if (seen) {
       it->miss_count = 0;
       ++it;
     } else if (++it->miss_count >= this->miss_threshold_) {
-      ESP_LOGI(TAG, "Tag removed: %s", it->uid.c_str());
-      this->on_tag_removed_callback_.call(it->uid);
+      ESP_LOGI(TAG, "Tag removed: %s", it->uid);
+      this->on_tag_removed_callback_.call(std::string(it->uid));
       it = this->present_tags_.erase(it);
     } else {
       ++it;
     }
   }
 
-  // Fire on_tag for newly seen UIDs
-  for (const auto &uid : this->tags_this_scan_) {
+  // Fire on_tag if this is a new UID
+  if (this->tag_found_this_scan_) {
     bool found = false;
     for (const auto &entry : this->present_tags_) {
-      if (entry.uid == uid) {
+      if (strcmp(entry.uid, this->current_uid_) == 0) {
         found = true;
         break;
       }
     }
     if (!found) {
-      ESP_LOGI(TAG, "Tag detected: %s", uid.c_str());
+      ESP_LOGI(TAG, "Tag detected: %s", this->current_uid_);
+
+      // Parse hex UID to bytes (only on first detection)
       std::vector<uint8_t> uid_bytes;
-      for (size_t i = 0; i < uid.length(); i += 2)
-        uid_bytes.push_back((uint8_t) strtol(uid.substr(i, 2).c_str(), nullptr, 16));
+      for (uint8_t i = 0; i < this->current_uid_pos_; i += 2) {
+        uint8_t hi = (this->current_uid_[i] >= 'A') ? (this->current_uid_[i] - 'A' + 10) : (this->current_uid_[i] - '0');
+        uint8_t lo = (this->current_uid_[i + 1] >= 'A') ? (this->current_uid_[i + 1] - 'A' + 10) : (this->current_uid_[i + 1] - '0');
+        uid_bytes.push_back((hi << 4) | lo);
+      }
+
       TagEntry entry;
-      entry.uid = uid;
+      strncpy(entry.uid, this->current_uid_, MAX_UID_HEX);
       entry.tag = this->read_tag(uid_bytes);
-      this->on_tag_callback_.call(uid);
+
+      this->on_tag_callback_.call(std::string(this->current_uid_));
       if (entry.tag) {
         for (auto *listener : this->tag_listeners_)
           listener->tag_on(*entry.tag);
@@ -305,8 +309,6 @@ void ST25R::finalize_scan_() {
       this->present_tags_.push_back(std::move(entry));
     }
   }
-
-  this->tags_this_scan_.clear();
 }
 
 bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
@@ -415,7 +417,7 @@ void ST25R::reinitialize() {
 
 void ST25R::send_anticol_frame() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
-  uint8_t frame[2] = {sel_cmds[this->cascade_level_], 0x20};  // NVB=0x20: no prefix
+  uint8_t frame[2] = {sel_cmds[this->cascade_level_], 0x20};
 
   this->write_register(ISO14443A_CONF, 0x01);  // antcl=1
   this->write_command(ST25R_CMD_CLEAR_FIFO);
@@ -425,7 +427,7 @@ void ST25R::send_anticol_frame() {
   this->irq_triggered_ = false;
   this->write_fifo(frame, 2);
   this->write_register(NUM_TX_BYTES1, 0x00);
-  this->write_register(NUM_TX_BYTES2, 0x10);  // 2 bytes, 0 bits
+  this->write_register(NUM_TX_BYTES2, 0x10);
   this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
 }
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -278,8 +278,7 @@ void ST25R::finalize_scan_() {
   }
   for (const auto &uid : to_remove) {
     ESP_LOGI(TAG, "Tag removed: %s", uid.c_str());
-    for (auto *trigger : this->on_tag_removed_triggers_)
-      trigger->trigger(uid);
+    this->on_tag_removed_callback_.call(uid);
     this->tags_data_.erase(uid);
     this->present_tags_.erase(uid);
   }
@@ -288,8 +287,7 @@ void ST25R::finalize_scan_() {
   for (const auto &uid : this->tags_this_scan_) {
     if (!this->present_tags_.count(uid)) {
       this->present_tags_[uid] = 0;
-      for (auto *trigger : this->on_tag_triggers_)
-        trigger->trigger(uid);
+      this->on_tag_callback_.call(uid);
       if (this->tags_data_.count(uid) && this->tags_data_[uid]) {
         for (auto *listener : this->tag_listeners_)
           listener->tag_on(*this->tags_data_[uid]);

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -59,8 +59,7 @@ bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t 
   return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
-bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                               uint32_t timeout_ms) {
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -1,0 +1,626 @@
+#include "st25r.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/nfc/nfc_tag.h"
+#include <cinttypes>
+#include <algorithm>
+#include <cstring>
+
+namespace esphome {
+namespace st25r {
+
+static const char *const TAG = "st25r";
+
+void ST25R::isr(ST25R *arg) { arg->irq_triggered_ = true; }
+
+void ST25R::setup() {
+  ESP_LOGI(TAG, "Setting up ST25R...");
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(true);
+    delay(10);
+    this->reset_pin_->digital_write(false);
+    delay(10);
+  }
+
+  if (this->irq_pin_ != nullptr) {
+    this->irq_pin_->setup();
+    this->irq_pin_->attach_interrupt(ST25R::isr, this, gpio::INTERRUPT_RISING_EDGE);
+  }
+
+  if (!this->reset_chip()) {
+    ESP_LOGE(TAG, "Failed to reset chip");
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGI(TAG, "ST25R initialized successfully.");
+}
+
+void ST25R::update() {
+  if (this->is_failed() || this->state_ != STATE_IDLE)
+    return;
+
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->write_command(ST25R_CMD_RESET_RX_GAIN);
+
+  this->write_register(OP_CONTROL, 0xC8);  // en=1, rx_en=1, tx_en=1
+
+  this->saved_anticol_valid_ = false;
+  this->anticol_resume_ = false;
+
+  this->irq_triggered_ = false;
+  this->write_command(ST25R_CMD_TRANSMIT_WUPA);
+  this->state_ = STATE_WUPA;
+  this->last_state_change_ = millis();
+}
+
+bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                        uint32_t timeout_ms) {
+  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
+}
+
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                               uint32_t timeout_ms) {
+  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
+}
+
+bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc,
+                          uint32_t timeout_ms) {
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->write_command(ST25R_CMD_RESET_RX_GAIN);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+
+  this->write_register(NUM_TX_BYTES1, (len >> 8) & 0xFF);
+  if (with_crc) {
+    this->write_register(NUM_TX_BYTES2, (len & 0x1F) << 3);
+  } else {
+    this->write_register(NUM_TX_BYTES2, 0x00);
+  }
+
+  this->write_fifo(data, len);
+
+  this->irq_triggered_ = false;
+  if (with_crc) {
+    this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
+  } else {
+    this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
+  }
+
+  uint32_t start = millis();
+  resp_len = 0;
+  bool tx_done = false;
+
+  while (millis() - start < timeout_ms) {
+    uint8_t irq;
+    if (this->irq_triggered_) {
+      this->irq_triggered_ = false;
+      irq = this->read_register(IRQ_MAIN);
+    } else {
+      irq = this->read_register(IRQ_MAIN);
+    }
+    this->irq_status_ = irq;
+
+    if (irq & IRQ_TXE)
+      tx_done = true;
+
+    if (tx_done) {
+      uint8_t f1 = this->read_register(FIFO_STATUS1);
+      if (f1 > 0) {
+        uint8_t to_read = std::min((uint8_t) (64 - resp_len), f1);
+        this->read_fifo(resp + resp_len, to_read);
+        resp_len += to_read;
+        start = millis();
+      }
+      if (irq & IRQ_RXE) {
+        return resp_len > 0;
+      }
+    }
+    delay(1);
+  }
+  return resp_len > 0;
+}
+
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
+  nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+  return make_unique<nfc::NfcTag>(nfc_uid);
+}
+
+void ST25R::loop() {
+  if (this->is_failed())
+    return;
+
+  if (this->irq_triggered_) {
+    this->irq_triggered_ = false;
+    this->irq_status_ = this->read_register(IRQ_MAIN);
+  } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL || this->state_ == STATE_SELECT) {
+    this->irq_status_ = this->read_register(IRQ_MAIN);
+  } else {
+    this->irq_status_ = 0;
+  }
+
+  this->process_state();
+}
+
+void ST25R::process_state() {
+  switch (this->state_) {
+    case STATE_IDLE:
+      break;
+
+    case STATE_WUPA: {
+      if (this->irq_status_ & (IRQ_RXE | IRQ_COL)) {
+        this->cascade_level_ = 0;
+        this->current_uid_ = "";
+        if (!this->anticol_resume_) {
+          this->anticol_prefix_full_ = 0;
+          this->anticol_prefix_bits_ = 0;
+          this->anticol_col_pos_ = 0;
+          this->anticol_prefix_val_ = 0;
+        }
+        this->anticol_resume_ = false;
+
+        this->send_anticol_frame();
+        this->state_ = STATE_ANTICOL;
+        this->last_state_change_ = millis();
+      } else if (this->irq_status_ & IRQ_NRE) {
+        this->irq_status_ = 0;
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
+      } else if (millis() - this->last_state_change_ > 100) {
+        // Read all IRQ registers so pin goes LOW for next ISR edge
+        this->read_register(IRQ_TIMER);
+        this->read_register(IRQ_ERROR);
+        this->irq_status_ = 0;
+        this->irq_triggered_ = false;
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
+      }
+      break;
+    }
+
+    case STATE_ANTICOL: {
+      if (millis() - this->last_state_change_ > 20) {
+        uint8_t max_prefix_val = (1 << (this->anticol_col_pos_ + 1)) - 1;
+        if (this->anticol_col_pos_ > 0 && this->anticol_prefix_val_ < max_prefix_val) {
+          this->anticol_prefix_val_++;
+          this->apply_anticol_prefix_();
+          this->anticol_resume_ = true;
+          this->start_wupa();
+          this->state_ = STATE_WUPA;
+          this->last_state_change_ = millis();
+          return;
+        }
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
+        return;
+      }
+
+      if (this->irq_status_ != 0 && (this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE))) {
+        delay(5);
+        uint8_t f1 = this->read_fifo_status1();
+        bool has_collision = (this->irq_status_ & IRQ_COL) != 0;
+
+        if (has_collision) {
+          uint8_t col_raw = this->read_collision_display();
+          uint8_t c_byte = (col_raw >> 4) & 0x0F;
+          uint8_t c_bit = (col_raw >> 1) & 0x07;
+          int uid_col_pos = (int) (c_byte * 8 + c_bit) - 16;
+          if (uid_col_pos < 0)
+            uid_col_pos = 0;
+          if (f1 > 0) {
+            uint8_t tmp[8];
+            this->read_fifo(tmp, std::min(f1, (uint8_t) 8));
+          }
+
+          this->anticol_col_pos_ = uid_col_pos;
+          this->anticol_prefix_val_ = 0;
+          this->apply_anticol_prefix_();
+
+          this->send_anticol_frame();
+          this->last_state_change_ = millis();
+
+        } else if (f1 >= 5) {
+          uint8_t resp[5];
+          this->read_fifo(resp, 5);
+
+          // Reconstruct full UID by OR-ing prefix bits back in
+          uint8_t full_uid[4];
+          memcpy(full_uid, resp, 4);
+          for (int k = 0; k < (int) this->anticol_prefix_full_; k++) {
+            full_uid[k] = this->anticol_prefix_[k];
+          }
+          if (this->anticol_prefix_bits_ > 0) {
+            uint8_t mask = (uint8_t) ((1 << this->anticol_prefix_bits_) - 1);
+            full_uid[this->anticol_prefix_full_] =
+                (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
+                (resp[this->anticol_prefix_full_] & (uint8_t) (~mask));
+          }
+          uint8_t bcc = full_uid[0] ^ full_uid[1] ^ full_uid[2] ^ full_uid[3];
+
+          uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
+          uint8_t sel_pk[7] = {sel_cmds[this->cascade_level_], 0x70,       full_uid[0], full_uid[1],
+                               full_uid[2],                    full_uid[3], bcc};
+
+          if (full_uid[0] == 0x88) {
+            for (int i = 1; i < 4; i++) {
+              char buf[3];
+              snprintf(buf, sizeof(buf), "%02X", full_uid[i]);
+              this->current_uid_ += buf;
+            }
+          } else {
+            for (unsigned char i : full_uid) {
+              char buf[3];
+              snprintf(buf, sizeof(buf), "%02X", i);
+              this->current_uid_ += buf;
+            }
+          }
+
+          this->pre_select();
+
+          uint8_t sak_buf[3];
+          uint8_t sak_len = 0;
+          if (!this->transceive_(sel_pk, 7, sak_buf, sak_len) || sak_len == 0) {
+            ESP_LOGW(TAG, "SELECT failed (no SAK)");
+            this->state_ = STATE_IDLE;
+            this->finalize_scan_();
+            return;
+          }
+          uint8_t sak = sak_buf[0];
+          this->last_sak_ = sak;
+
+          if (sak & 0x04) {  // Cascade bit
+            if (this->cascade_level_ == 0) {
+              this->saved_col_pos_ = this->anticol_col_pos_;
+              this->saved_prefix_val_ = this->anticol_prefix_val_;
+              this->saved_anticol_valid_ =
+                  (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
+            }
+            this->cascade_level_++;
+            if (this->cascade_level_ > 2) {
+              ESP_LOGE(TAG, "Too many cascade levels");
+              this->state_ = STATE_IDLE;
+              this->finalize_scan_();
+              return;
+            }
+            this->anticol_prefix_full_ = 0;
+            this->anticol_prefix_bits_ = 0;
+            this->anticol_col_pos_ = 0;
+            this->anticol_prefix_val_ = 0;
+            this->send_anticol_frame();
+            this->state_ = STATE_ANTICOL;
+            this->last_state_change_ = millis();
+          } else {
+            // Tag fully selected - validate UID length
+            size_t uid_bytes_len = this->current_uid_.length() / 2;
+            if (uid_bytes_len != 4 && uid_bytes_len != 7 && uid_bytes_len != 10) {
+              ESP_LOGW(TAG, "Discarding invalid UID len=%zu", uid_bytes_len);
+              this->state_ = STATE_IDLE;
+              this->finalize_scan_();
+              return;
+            }
+
+            ESP_LOGI(TAG, "Tag selected: %s (SAK=0x%02X)", this->current_uid_.c_str(), sak);
+
+            if (!this->present_tags_.count(this->current_uid_)) {
+              std::vector<uint8_t> uid_bytes;
+              for (size_t i = 0; i < this->current_uid_.length(); i += 2)
+                uid_bytes.push_back(
+                    (uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
+              this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
+            }
+
+            this->tags_this_scan_.insert(this->current_uid_);
+            this->send_halt();
+
+            // Resume multi-tag tree traversal
+            uint8_t resume_col_pos;
+            uint8_t resume_prefix_val;
+            bool can_resume;
+            if (this->saved_anticol_valid_) {
+              resume_col_pos = this->saved_col_pos_;
+              resume_prefix_val = this->saved_prefix_val_;
+              can_resume = true;
+              this->saved_anticol_valid_ = false;
+            } else {
+              resume_col_pos = this->anticol_col_pos_;
+              resume_prefix_val = this->anticol_prefix_val_;
+              can_resume = (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
+            }
+
+            if (can_resume) {
+              this->cascade_level_ = 0;
+              this->current_uid_ = "";
+              this->anticol_col_pos_ = resume_col_pos;
+              this->anticol_prefix_val_ = resume_prefix_val + 1;
+              this->apply_anticol_prefix_();
+
+              uint8_t max_val = (1 << (resume_col_pos + 1)) - 1;
+              if (this->anticol_prefix_val_ > max_val) {
+                this->state_ = STATE_IDLE;
+                this->finalize_scan_();
+                return;
+              }
+              this->anticol_resume_ = true;
+              this->start_wupa();
+            } else {
+              this->state_ = STATE_IDLE;
+              this->finalize_scan_();
+              return;
+            }
+            this->state_ = STATE_WUPA;
+            this->last_state_change_ = millis();
+          }
+        }
+      }
+      break;
+    }
+
+    case STATE_REINITIALIZING:
+      this->reinitialize();
+      this->state_ = STATE_IDLE;
+      break;
+
+    case STATE_SELECT:
+    default:
+      break;
+  }
+}
+
+void ST25R::finalize_scan_() {
+  // Increment miss counters; fire on_tag_removed when threshold reached
+  std::vector<std::string> to_remove;
+  for (auto &kv : this->present_tags_) {
+    if (this->tags_this_scan_.count(kv.first)) {
+      kv.second = 0;
+    } else {
+      kv.second++;
+      if (kv.second >= this->miss_threshold_) {
+        to_remove.push_back(kv.first);
+      }
+    }
+  }
+  for (const auto &uid : to_remove) {
+    ESP_LOGI(TAG, "Tag removed: %s", uid.c_str());
+
+    std::vector<uint8_t> uid_bytes;
+    for (size_t i = 0; i < uid.length(); i += 2) {
+      uid_bytes.push_back((uint8_t) strtol(uid.substr(i, 2).c_str(), nullptr, 16));
+    }
+    nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
+    nfc::NfcTag nfc_tag(nfc_uid);
+    for (auto *listener : this->tag_listeners_) {
+      listener->tag_off(nfc_tag);
+    }
+    for (auto *trigger : this->on_tag_removed_triggers_) {
+      trigger->trigger(uid);
+    }
+    this->tags_data_.erase(uid);
+    this->present_tags_.erase(uid);
+  }
+
+  // Fire on_tag for newly seen UIDs
+  for (const auto &uid : this->tags_this_scan_) {
+    if (!this->present_tags_.count(uid)) {
+      this->present_tags_[uid] = 0;
+      for (auto *trigger : this->on_tag_triggers_) {
+        trigger->trigger(uid);
+      }
+      if (this->tags_data_.count(uid) && this->tags_data_[uid]) {
+        for (auto *listener : this->tag_listeners_) {
+          listener->tag_on(*this->tags_data_[uid]);
+        }
+      }
+    }
+  }
+
+  this->tags_this_scan_.clear();
+}
+
+bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
+  uint32_t start = millis();
+  while (millis() - start < timeout_ms) {
+    if (this->irq_triggered_)
+      return true;
+    delay(1);
+  }
+  return false;
+}
+
+bool ST25R::reset_chip() {
+  // Verify IC identity before SET_DEFAULT
+  uint8_t ic_identity = this->read_register(IC_IDENTITY);
+  uint8_t chip_type = ic_identity & 0xF8;
+  if (chip_type != 0x28 && chip_type != 0x30) {
+    ESP_LOGE(TAG, "IC identity mismatch: expected 0x28/0x30, got 0x%02X", chip_type);
+    return false;
+  }
+
+  this->write_command(ST25R_CMD_SET_DEFAULT);
+  delay(10);
+  this->is_b_version_ = (chip_type == 0x30);
+  this->has_aat_ = true;
+  ESP_LOGI(TAG, "IC: 0x%02X (ST25R3916%s)", ic_identity, this->is_b_version_ ? "B" : "");
+
+  // Enable oscillator
+  this->write_register(OP_CONTROL, 0x80);
+  delay(10);
+
+  // Measure VDD for supply voltage auto-detection
+  uint8_t reg_ctrl = this->read_register(REGULATOR_CONTROL);
+  this->write_register(REGULATOR_CONTROL, (reg_ctrl & ~0x07) | 0x00);
+  this->write_command(ST25R_CMD_MEASURE_VDD);
+  delay(5);
+  uint8_t vdd_raw = this->read_register(AD_CONV_RESULT);
+  bool sup3v;
+  if (vdd_raw == 0) {
+    sup3v = true;  // Default to 3.3V if measurement fails
+  } else {
+    uint16_t vdd_mv = (uint16_t) vdd_raw * 23U + (((uint16_t) vdd_raw * 4U + 5U) / 10U);
+    sup3v = (vdd_mv < 3600);
+    ESP_LOGI(TAG, "VDD: %u mV (sup3V=%s)", vdd_mv, sup3v ? "3.3V" : "5V");
+  }
+
+  // Configure registers (RFAL NFC-A 106 kbps profile)
+  this->write_register(IO_CONF1, 0x07);
+  uint8_t io_conf2 = sup3v ? 0x80 : 0x00;
+  io_conf2 |= 0x18;  // SPI pull-downs
+  if (this->has_aat_)
+    io_conf2 |= 0x20;  // Enable AAT module
+  this->write_register(IO_CONF2, io_conf2);
+  this->write_register(MODE, 0x08);
+  this->write_register(BIT_RATE, 0x00);
+  this->write_register(RX_CONF1, 0x08);
+  this->write_register(RX_CONF2, 0x2D);
+  this->write_register(RX_CONF3, 0x00);
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(MASK_MAIN, 0x00);
+  this->write_register(MASK_TIMER, 0x00);
+  this->write_register(ISO14443A_CONF, 0x00);
+
+  uint8_t d_res = (15 - this->rf_power_) & 0x0F;
+  this->write_register(TX_DRIVER_CONF, d_res);
+
+  if (this->has_aat_) {
+    this->write_register(ANT_TUNE_A, 0x80);
+    this->write_register(ANT_TUNE_B, 0x40);
+  }
+
+  // RFAL chip-init registers
+  this->write_register(AUX_MOD, 0x10);
+  this->write_register(RES_AM_MOD, 0x80);
+  this->write_register(FIELD_THRESHOLD_ACTV, 0x11);
+  this->write_register(FIELD_THRESHOLD_DEACTV, 0x00);
+  this->write_register(PASSIVE_TARGET, 0x50);
+  this->write_register(PT_MOD, 0x51);
+  this->write_register(EMD_SUP_CONF, 0x40);
+
+  // Overshoot/undershoot protection
+  this->write_register(OVERSHOOT_CONF1, 0x40);
+  this->write_register(OVERSHOOT_CONF2, 0x03);
+  this->write_register(UNDERSHOOT_CONF1, 0x40);
+  this->write_register(UNDERSHOOT_CONF2, 0x03);
+
+  // Correlator receiver
+  uint8_t aux_val = this->read_register(AUX);
+  this->write_register(AUX, aux_val & ~0x04);
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(CORR_CONF1, 0x51);
+  this->write_register(CORR_CONF2, 0x00);
+
+  this->field_on_();
+  delay(10);
+
+  return true;
+}
+
+void ST25R::reinitialize() {
+  ESP_LOGW(TAG, "Reinitializing ST25R...");
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(true);
+    delay(10);
+    this->reset_pin_->digital_write(false);
+    delay(10);
+  }
+  if (!this->reset_chip()) {
+    ESP_LOGE(TAG, "Reinitialize failed");
+    this->mark_failed();
+  }
+}
+
+void ST25R::apply_anticol_prefix_() {
+  int total_bits = this->anticol_col_pos_ + 1;
+  this->anticol_prefix_full_ = total_bits >> 3;
+  this->anticol_prefix_bits_ = total_bits & 7;
+  memset(this->anticol_prefix_, 0, sizeof(this->anticol_prefix_));
+  for (int i = 0; i < total_bits; i++) {
+    int byte_idx = i >> 3;
+    int bit_idx = i & 7;
+    if ((this->anticol_prefix_val_ >> i) & 1)
+      this->anticol_prefix_[byte_idx] |= (1 << bit_idx);
+  }
+}
+
+void ST25R::send_anticol_frame() {
+  uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
+  uint8_t sel = sel_cmds[this->cascade_level_];
+
+  uint8_t nvb_high = 2 + this->anticol_prefix_full_;
+  uint8_t nvb = (nvb_high << 4) | this->anticol_prefix_bits_;
+
+  uint8_t frame[7];
+  frame[0] = sel;
+  frame[1] = nvb;
+  uint8_t frame_len = 2;
+  for (int i = 0; i < this->anticol_prefix_full_; i++)
+    frame[frame_len++] = this->anticol_prefix_[i];
+  if (this->anticol_prefix_bits_ > 0)
+    frame[frame_len++] = this->anticol_prefix_[this->anticol_prefix_full_];
+
+  uint8_t ntx_n = 2 + this->anticol_prefix_full_;
+  uint8_t ntx_b = this->anticol_prefix_bits_;
+
+  this->write_register(ISO14443A_CONF, 0x01);  // antcl=1
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->irq_triggered_ = false;
+  this->write_fifo(frame, frame_len);
+  this->write_register(NUM_TX_BYTES1, ntx_n >> 5);
+  this->write_register(NUM_TX_BYTES2, ((ntx_n & 0x1F) << 3) | (ntx_b & 0x07));
+  this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
+}
+
+void ST25R::pre_select() { this->write_register(ISO14443A_CONF, 0x00); }
+
+uint8_t ST25R::read_fifo_status1() { return this->read_register(FIFO_STATUS1); }
+
+uint8_t ST25R::read_collision_display() { return this->read_register(COLLISION_DISPLAY); }
+
+void ST25R::send_halt() {
+  uint8_t halt_cmd[2] = {0x50, 0x00};
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->write_fifo(halt_cmd, 2);
+  this->write_register(NUM_TX_BYTES1, 0x00);
+  this->write_register(NUM_TX_BYTES2, 0x10);
+  this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
+  delay(10);
+}
+
+void ST25R::start_wupa() {
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->irq_triggered_ = false;
+  this->irq_status_ = 0;
+  this->write_command(ST25R_CMD_TRANSMIT_WUPA);
+}
+
+void ST25R::field_on_() {
+  this->write_register(OP_CONTROL, 0x88);  // en=1, tx_en=1
+  delay(10);
+  this->write_command(ST25R_CMD_FIELD_ON);
+  delay(10);
+  this->write_register(OP_CONTROL, 0xC8);  // en=1, rx_en=1, tx_en=1
+  this->write_command(ST25R_CMD_ADJUST_REGULATORS);
+}
+
+void ST25R::dump_config() {
+  ESP_LOGCONFIG(TAG, "ST25R:");
+  LOG_PIN("  IRQ Pin: ", this->irq_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGCONFIG(TAG, "  RF Power: %u", this->rf_power_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+}  // namespace st25r
+}  // namespace esphome

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -7,8 +7,7 @@
 #include <algorithm>
 #include <cstring>
 
-namespace esphome {
-namespace st25r {
+namespace esphome::st25r {
 
 static const char *const TAG = "st25r";
 
@@ -467,5 +466,4 @@ void ST25R::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace st25r
-}  // namespace esphome
+}  // namespace esphome::st25r

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -58,13 +58,11 @@ void ST25R::update() {
   this->last_state_change_ = millis();
 }
 
-bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                        uint32_t timeout_ms) {
+bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
-bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                               uint32_t timeout_ms) {
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
@@ -236,15 +234,14 @@ void ST25R::process_state() {
           }
           if (this->anticol_prefix_bits_ > 0) {
             uint8_t mask = (uint8_t) ((1 << this->anticol_prefix_bits_) - 1);
-            full_uid[this->anticol_prefix_full_] =
-                (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
-                (resp[this->anticol_prefix_full_] & (uint8_t) (~mask));
+            full_uid[this->anticol_prefix_full_] = (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
+                                                   (resp[this->anticol_prefix_full_] & (uint8_t) (~mask));
           }
           uint8_t bcc = full_uid[0] ^ full_uid[1] ^ full_uid[2] ^ full_uid[3];
 
           uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
-          uint8_t sel_pk[7] = {sel_cmds[this->cascade_level_], 0x70,       full_uid[0], full_uid[1],
-                               full_uid[2],                    full_uid[3], bcc};
+          uint8_t sel_pk[7] = {
+              sel_cmds[this->cascade_level_], 0x70, full_uid[0], full_uid[1], full_uid[2], full_uid[3], bcc};
 
           if (full_uid[0] == 0x88) {
             for (int i = 1; i < 4; i++) {
@@ -277,8 +274,7 @@ void ST25R::process_state() {
             if (this->cascade_level_ == 0) {
               this->saved_col_pos_ = this->anticol_col_pos_;
               this->saved_prefix_val_ = this->anticol_prefix_val_;
-              this->saved_anticol_valid_ =
-                  (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
+              this->saved_anticol_valid_ = (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
             }
             this->cascade_level_++;
             if (this->cascade_level_ > 2) {
@@ -309,8 +305,7 @@ void ST25R::process_state() {
             if (!this->present_tags_.count(this->current_uid_)) {
               std::vector<uint8_t> uid_bytes;
               for (size_t i = 0; i < this->current_uid_.length(); i += 2)
-                uid_bytes.push_back(
-                    (uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
+                uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
               this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
             }
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -130,10 +130,9 @@ void ST25R::loop() {
 
 // Append hex bytes to current_uid_ buffer without heap allocation
 void ST25R::uid_append_hex_(const uint8_t *data, uint8_t count) {
-  static constexpr char HEX[] = "0123456789ABCDEF";
   for (uint8_t i = 0; i < count && this->current_uid_pos_ + 2 < MAX_UID_HEX; i++) {
-    this->current_uid_[this->current_uid_pos_++] = HEX[data[i] >> 4];
-    this->current_uid_[this->current_uid_pos_++] = HEX[data[i] & 0x0F];
+    this->current_uid_[this->current_uid_pos_++] = format_hex_pretty_char(data[i] >> 4);
+    this->current_uid_[this->current_uid_pos_++] = format_hex_pretty_char(data[i] & 0x0F);
   }
   this->current_uid_[this->current_uid_pos_] = '\0';
 }

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -12,7 +12,7 @@ namespace st25r {
 
 static const char *const TAG = "st25r";
 
-void ST25R::isr(ST25R *arg) { arg->irq_triggered_ = true; }
+void IRAM_ATTR ST25R::isr(ST25R *arg) { arg->irq_triggered_ = true; }
 
 void ST25R::setup() {
   ESP_LOGI(TAG, "Setting up ST25R...");
@@ -183,7 +183,8 @@ void ST25R::process_state() {
 
     case STATE_ANTICOL: {
       if (millis() - this->last_state_change_ > 20) {
-        uint8_t max_prefix_val = (1 << (this->anticol_col_pos_ + 1)) - 1;
+        uint8_t capped_pos = std::min(this->anticol_col_pos_, (uint8_t) 7);
+        uint8_t max_prefix_val = (uint8_t) ((1u << (capped_pos + 1)) - 1);
         if (this->anticol_col_pos_ > 0 && this->anticol_prefix_val_ < max_prefix_val) {
           this->anticol_prefix_val_++;
           this->apply_anticol_prefix_();
@@ -210,6 +211,8 @@ void ST25R::process_state() {
           int uid_col_pos = (int) (c_byte * 8 + c_bit) - 16;
           if (uid_col_pos < 0)
             uid_col_pos = 0;
+          if (uid_col_pos > 31)
+            uid_col_pos = 31;  // Clamp to max UID bits per cascade level
           if (f1 > 0) {
             uint8_t tmp[8];
             this->read_fifo(tmp, std::min(f1, (uint8_t) 8));
@@ -334,7 +337,8 @@ void ST25R::process_state() {
               this->anticol_prefix_val_ = resume_prefix_val + 1;
               this->apply_anticol_prefix_();
 
-              uint8_t max_val = (1 << (resume_col_pos + 1)) - 1;
+              uint8_t capped_resume = std::min(resume_col_pos, (uint8_t) 7);
+              uint8_t max_val = (uint8_t) ((1u << (capped_resume + 1)) - 1);
               if (this->anticol_prefix_val_ > max_val) {
                 this->state_ = STATE_IDLE;
                 this->finalize_scan_();
@@ -528,7 +532,10 @@ void ST25R::reinitialize() {
 }
 
 void ST25R::apply_anticol_prefix_() {
+  // Clamp to protocol max: 4 UID bytes + 1 BCC = 40 bits per cascade level
   int total_bits = this->anticol_col_pos_ + 1;
+  if (total_bits > 40)
+    total_bits = 40;
   this->anticol_prefix_full_ = total_bits >> 3;
   this->anticol_prefix_bits_ = total_bits & 7;
   memset(this->anticol_prefix_, 0, sizeof(this->anticol_prefix_));

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -59,8 +59,7 @@ bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t 
   return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
-bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                               uint32_t timeout_ms) {
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
@@ -292,8 +291,10 @@ void ST25R::finalize_scan_() {
       // Parse hex UID to bytes (only on first detection)
       std::vector<uint8_t> uid_bytes;
       for (uint8_t i = 0; i < this->current_uid_pos_; i += 2) {
-        uint8_t hi = (this->current_uid_[i] >= 'A') ? (this->current_uid_[i] - 'A' + 10) : (this->current_uid_[i] - '0');
-        uint8_t lo = (this->current_uid_[i + 1] >= 'A') ? (this->current_uid_[i + 1] - 'A' + 10) : (this->current_uid_[i + 1] - '0');
+        uint8_t hi =
+            (this->current_uid_[i] >= 'A') ? (this->current_uid_[i] - 'A' + 10) : (this->current_uid_[i] - '0');
+        uint8_t lo = (this->current_uid_[i + 1] >= 'A') ? (this->current_uid_[i + 1] - 'A' + 10)
+                                                        : (this->current_uid_[i + 1] - '0');
         uid_bytes.push_back((hi << 4) | lo);
       }
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -49,9 +49,6 @@ void ST25R::update() {
 
   this->write_register(OP_CONTROL, 0xC8);  // en=1, rx_en=1, tx_en=1
 
-  this->saved_anticol_valid_ = false;
-  this->anticol_resume_ = false;
-
   this->irq_triggered_ = false;
   this->write_command(ST25R_CMD_TRANSMIT_WUPA);
   this->state_ = STATE_WUPA;
@@ -62,7 +59,8 @@ bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t 
   return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
-bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                               uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
@@ -75,33 +73,20 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
   this->read_register(IRQ_ERROR);
 
   this->write_register(NUM_TX_BYTES1, (len >> 8) & 0xFF);
-  if (with_crc) {
-    this->write_register(NUM_TX_BYTES2, (len & 0x1F) << 3);
-  } else {
-    this->write_register(NUM_TX_BYTES2, 0x00);
-  }
+  this->write_register(NUM_TX_BYTES2, with_crc ? ((len & 0x1F) << 3) : 0x00);
 
   this->write_fifo(data, len);
 
   this->irq_triggered_ = false;
-  if (with_crc) {
-    this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
-  } else {
-    this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
-  }
+  this->write_command(with_crc ? ST25R_CMD_TRANSMIT_WITH_CRC : ST25R_CMD_TRANSMIT_WITHOUT_CRC);
 
   uint32_t start = millis();
   resp_len = 0;
   bool tx_done = false;
 
   while (millis() - start < timeout_ms) {
-    uint8_t irq;
-    if (this->irq_triggered_) {
-      this->irq_triggered_ = false;
-      irq = this->read_register(IRQ_MAIN);
-    } else {
-      irq = this->read_register(IRQ_MAIN);
-    }
+    this->irq_triggered_ = false;
+    uint8_t irq = this->read_register(IRQ_MAIN);
     this->irq_status_ = irq;
 
     if (irq & IRQ_TXE)
@@ -115,9 +100,8 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
         resp_len += to_read;
         start = millis();
       }
-      if (irq & IRQ_RXE) {
+      if (irq & IRQ_RXE)
         return resp_len > 0;
-      }
     }
     delay(1);
   }
@@ -136,7 +120,7 @@ void ST25R::loop() {
   if (this->irq_triggered_) {
     this->irq_triggered_ = false;
     this->irq_status_ = this->read_register(IRQ_MAIN);
-  } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL || this->state_ == STATE_SELECT) {
+  } else if (this->state_ != STATE_IDLE) {
     this->irq_status_ = this->read_register(IRQ_MAIN);
   } else {
     this->irq_status_ = 0;
@@ -154,14 +138,6 @@ void ST25R::process_state() {
       if (this->irq_status_ & (IRQ_RXE | IRQ_COL)) {
         this->cascade_level_ = 0;
         this->current_uid_ = "";
-        if (!this->anticol_resume_) {
-          this->anticol_prefix_full_ = 0;
-          this->anticol_prefix_bits_ = 0;
-          this->anticol_col_pos_ = 0;
-          this->anticol_prefix_val_ = 0;
-        }
-        this->anticol_resume_ = false;
-
         this->send_anticol_frame();
         this->state_ = STATE_ANTICOL;
         this->last_state_change_ = millis();
@@ -170,7 +146,6 @@ void ST25R::process_state() {
         this->state_ = STATE_IDLE;
         this->finalize_scan_();
       } else if (millis() - this->last_state_change_ > 100) {
-        // Read all IRQ registers so pin goes LOW for next ISR edge
         this->read_register(IRQ_TIMER);
         this->read_register(IRQ_ERROR);
         this->irq_status_ = 0;
@@ -183,178 +158,100 @@ void ST25R::process_state() {
 
     case STATE_ANTICOL: {
       if (millis() - this->last_state_change_ > 20) {
-        uint8_t capped_pos = std::min(this->anticol_col_pos_, (uint8_t) 7);
-        uint8_t max_prefix_val = (uint8_t) ((1u << (capped_pos + 1)) - 1);
-        if (this->anticol_col_pos_ > 0 && this->anticol_prefix_val_ < max_prefix_val) {
-          this->anticol_prefix_val_++;
-          this->apply_anticol_prefix_();
-          this->anticol_resume_ = true;
-          this->start_wupa();
-          this->state_ = STATE_WUPA;
-          this->last_state_change_ = millis();
-          return;
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
+        return;
+      }
+
+      if (!(this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE)))
+        break;
+
+      delay(5);
+      uint8_t f1 = this->read_fifo_status1();
+
+      if (this->irq_status_ & IRQ_COL) {
+        // Collision: drain FIFO, scan will retry next update()
+        if (f1 > 0) {
+          uint8_t tmp[8];
+          this->read_fifo(tmp, std::min(f1, (uint8_t) 8));
         }
         this->state_ = STATE_IDLE;
         this->finalize_scan_();
         return;
       }
 
-      if (this->irq_status_ != 0 && (this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE))) {
-        delay(5);
-        uint8_t f1 = this->read_fifo_status1();
-        bool has_collision = (this->irq_status_ & IRQ_COL) != 0;
+      if (f1 < 5)
+        break;
 
-        if (has_collision) {
-          uint8_t col_raw = this->read_collision_display();
-          uint8_t c_byte = (col_raw >> 4) & 0x0F;
-          uint8_t c_bit = (col_raw >> 1) & 0x07;
-          int uid_col_pos = (int) (c_byte * 8 + c_bit) - 16;
-          if (uid_col_pos < 0)
-            uid_col_pos = 0;
-          if (uid_col_pos > 31)
-            uid_col_pos = 31;  // Clamp to max UID bits per cascade level
-          if (f1 > 0) {
-            uint8_t tmp[8];
-            this->read_fifo(tmp, std::min(f1, (uint8_t) 8));
-          }
+      uint8_t resp[5];
+      this->read_fifo(resp, 5);
+      uint8_t bcc = resp[0] ^ resp[1] ^ resp[2] ^ resp[3];
 
-          this->anticol_col_pos_ = uid_col_pos;
-          this->anticol_prefix_val_ = 0;
-          this->apply_anticol_prefix_();
+      uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
+      uint8_t sel_pk[7] = {sel_cmds[this->cascade_level_], 0x70, resp[0], resp[1], resp[2], resp[3], bcc};
 
-          this->send_anticol_frame();
-          this->last_state_change_ = millis();
-
-        } else if (f1 >= 5) {
-          uint8_t resp[5];
-          this->read_fifo(resp, 5);
-
-          // Reconstruct full UID by OR-ing prefix bits back in
-          uint8_t full_uid[4];
-          memcpy(full_uid, resp, 4);
-          for (int k = 0; k < (int) this->anticol_prefix_full_; k++) {
-            full_uid[k] = this->anticol_prefix_[k];
-          }
-          if (this->anticol_prefix_bits_ > 0) {
-            uint8_t mask = (uint8_t) ((1 << this->anticol_prefix_bits_) - 1);
-            full_uid[this->anticol_prefix_full_] = (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
-                                                   (resp[this->anticol_prefix_full_] & (uint8_t) (~mask));
-          }
-          uint8_t bcc = full_uid[0] ^ full_uid[1] ^ full_uid[2] ^ full_uid[3];
-
-          uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
-          uint8_t sel_pk[7] = {
-              sel_cmds[this->cascade_level_], 0x70, full_uid[0], full_uid[1], full_uid[2], full_uid[3], bcc};
-
-          if (full_uid[0] == 0x88) {
-            for (int i = 1; i < 4; i++) {
-              char buf[3];
-              snprintf(buf, sizeof(buf), "%02X", full_uid[i]);
-              this->current_uid_ += buf;
-            }
-          } else {
-            for (unsigned char i : full_uid) {
-              char buf[3];
-              snprintf(buf, sizeof(buf), "%02X", i);
-              this->current_uid_ += buf;
-            }
-          }
-
-          this->pre_select();
-
-          uint8_t sak_buf[3];
-          uint8_t sak_len = 0;
-          if (!this->transceive_(sel_pk, 7, sak_buf, sak_len) || sak_len == 0) {
-            ESP_LOGW(TAG, "SELECT failed (no SAK)");
-            this->state_ = STATE_IDLE;
-            this->finalize_scan_();
-            return;
-          }
-          uint8_t sak = sak_buf[0];
-          this->last_sak_ = sak;
-
-          if (sak & 0x04) {  // Cascade bit
-            if (this->cascade_level_ == 0) {
-              this->saved_col_pos_ = this->anticol_col_pos_;
-              this->saved_prefix_val_ = this->anticol_prefix_val_;
-              this->saved_anticol_valid_ = (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
-            }
-            this->cascade_level_++;
-            if (this->cascade_level_ > 2) {
-              ESP_LOGE(TAG, "Too many cascade levels");
-              this->state_ = STATE_IDLE;
-              this->finalize_scan_();
-              return;
-            }
-            this->anticol_prefix_full_ = 0;
-            this->anticol_prefix_bits_ = 0;
-            this->anticol_col_pos_ = 0;
-            this->anticol_prefix_val_ = 0;
-            this->send_anticol_frame();
-            this->state_ = STATE_ANTICOL;
-            this->last_state_change_ = millis();
-          } else {
-            // Tag fully selected - validate UID length
-            size_t uid_bytes_len = this->current_uid_.length() / 2;
-            if (uid_bytes_len != 4 && uid_bytes_len != 7 && uid_bytes_len != 10) {
-              ESP_LOGW(TAG, "Discarding invalid UID len=%zu", uid_bytes_len);
-              this->state_ = STATE_IDLE;
-              this->finalize_scan_();
-              return;
-            }
-
-            ESP_LOGI(TAG, "Tag selected: %s (SAK=0x%02X)", this->current_uid_.c_str(), sak);
-
-            if (!this->present_tags_.count(this->current_uid_)) {
-              std::vector<uint8_t> uid_bytes;
-              for (size_t i = 0; i < this->current_uid_.length(); i += 2)
-                uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
-              this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
-            }
-
-            this->tags_this_scan_.insert(this->current_uid_);
-            this->send_halt();
-
-            // Resume multi-tag tree traversal
-            uint8_t resume_col_pos;
-            uint8_t resume_prefix_val;
-            bool can_resume;
-            if (this->saved_anticol_valid_) {
-              resume_col_pos = this->saved_col_pos_;
-              resume_prefix_val = this->saved_prefix_val_;
-              can_resume = true;
-              this->saved_anticol_valid_ = false;
-            } else {
-              resume_col_pos = this->anticol_col_pos_;
-              resume_prefix_val = this->anticol_prefix_val_;
-              can_resume = (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
-            }
-
-            if (can_resume) {
-              this->cascade_level_ = 0;
-              this->current_uid_ = "";
-              this->anticol_col_pos_ = resume_col_pos;
-              this->anticol_prefix_val_ = resume_prefix_val + 1;
-              this->apply_anticol_prefix_();
-
-              uint8_t capped_resume = std::min(resume_col_pos, (uint8_t) 7);
-              uint8_t max_val = (uint8_t) ((1u << (capped_resume + 1)) - 1);
-              if (this->anticol_prefix_val_ > max_val) {
-                this->state_ = STATE_IDLE;
-                this->finalize_scan_();
-                return;
-              }
-              this->anticol_resume_ = true;
-              this->start_wupa();
-            } else {
-              this->state_ = STATE_IDLE;
-              this->finalize_scan_();
-              return;
-            }
-            this->state_ = STATE_WUPA;
-            this->last_state_change_ = millis();
-          }
+      // Build UID string: skip cascade tag (0x88)
+      if (resp[0] == 0x88) {
+        for (int i = 1; i < 4; i++) {
+          char buf[3];
+          snprintf(buf, sizeof(buf), "%02X", resp[i]);
+          this->current_uid_ += buf;
         }
+      } else {
+        for (int i = 0; i < 4; i++) {
+          char buf[3];
+          snprintf(buf, sizeof(buf), "%02X", resp[i]);
+          this->current_uid_ += buf;
+        }
+      }
+
+      this->pre_select();
+
+      uint8_t sak_buf[3];
+      uint8_t sak_len = 0;
+      if (!this->transceive_(sel_pk, 7, sak_buf, sak_len) || sak_len == 0) {
+        ESP_LOGW(TAG, "SELECT failed (no SAK)");
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
+        return;
+      }
+      uint8_t sak = sak_buf[0];
+      this->last_sak_ = sak;
+
+      if (sak & 0x04) {  // Cascade bit — need another level
+        this->cascade_level_++;
+        if (this->cascade_level_ > 2) {
+          ESP_LOGE(TAG, "Too many cascade levels");
+          this->state_ = STATE_IDLE;
+          this->finalize_scan_();
+          return;
+        }
+        this->send_anticol_frame();
+        this->state_ = STATE_ANTICOL;
+        this->last_state_change_ = millis();
+      } else {
+        // Tag fully selected
+        size_t uid_bytes_len = this->current_uid_.length() / 2;
+        if (uid_bytes_len != 4 && uid_bytes_len != 7 && uid_bytes_len != 10) {
+          ESP_LOGW(TAG, "Discarding invalid UID len=%zu", uid_bytes_len);
+          this->state_ = STATE_IDLE;
+          this->finalize_scan_();
+          return;
+        }
+
+        ESP_LOGI(TAG, "Tag selected: %s (SAK=0x%02X)", this->current_uid_.c_str(), sak);
+
+        if (!this->present_tags_.count(this->current_uid_)) {
+          std::vector<uint8_t> uid_bytes;
+          for (size_t i = 0; i < this->current_uid_.length(); i += 2)
+            uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
+          this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
+        }
+
+        this->tags_this_scan_.insert(this->current_uid_);
+        this->send_halt();
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
       }
       break;
     }
@@ -364,7 +261,6 @@ void ST25R::process_state() {
       this->state_ = STATE_IDLE;
       break;
 
-    case STATE_SELECT:
     default:
       break;
   }
@@ -378,26 +274,14 @@ void ST25R::finalize_scan_() {
       kv.second = 0;
     } else {
       kv.second++;
-      if (kv.second >= this->miss_threshold_) {
+      if (kv.second >= this->miss_threshold_)
         to_remove.push_back(kv.first);
-      }
     }
   }
   for (const auto &uid : to_remove) {
     ESP_LOGI(TAG, "Tag removed: %s", uid.c_str());
-
-    std::vector<uint8_t> uid_bytes;
-    for (size_t i = 0; i < uid.length(); i += 2) {
-      uid_bytes.push_back((uint8_t) strtol(uid.substr(i, 2).c_str(), nullptr, 16));
-    }
-    nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
-    nfc::NfcTag nfc_tag(nfc_uid);
-    for (auto *listener : this->tag_listeners_) {
-      listener->tag_off(nfc_tag);
-    }
-    for (auto *trigger : this->on_tag_removed_triggers_) {
+    for (auto *trigger : this->on_tag_removed_triggers_)
       trigger->trigger(uid);
-    }
     this->tags_data_.erase(uid);
     this->present_tags_.erase(uid);
   }
@@ -406,13 +290,11 @@ void ST25R::finalize_scan_() {
   for (const auto &uid : this->tags_this_scan_) {
     if (!this->present_tags_.count(uid)) {
       this->present_tags_[uid] = 0;
-      for (auto *trigger : this->on_tag_triggers_) {
+      for (auto *trigger : this->on_tag_triggers_)
         trigger->trigger(uid);
-      }
       if (this->tags_data_.count(uid) && this->tags_data_[uid]) {
-        for (auto *listener : this->tag_listeners_) {
+        for (auto *listener : this->tag_listeners_)
           listener->tag_on(*this->tags_data_[uid]);
-        }
       }
     }
   }
@@ -431,7 +313,6 @@ bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
 }
 
 bool ST25R::reset_chip() {
-  // Verify IC identity before SET_DEFAULT
   uint8_t ic_identity = this->read_register(IC_IDENTITY);
   uint8_t chip_type = ic_identity & 0xF8;
   if (chip_type != 0x28 && chip_type != 0x30) {
@@ -445,8 +326,7 @@ bool ST25R::reset_chip() {
   this->has_aat_ = true;
   ESP_LOGI(TAG, "IC: 0x%02X (ST25R3916%s)", ic_identity, this->is_b_version_ ? "B" : "");
 
-  // Enable oscillator
-  this->write_register(OP_CONTROL, 0x80);
+  this->write_register(OP_CONTROL, 0x80);  // Enable oscillator
   delay(10);
 
   // Measure VDD for supply voltage auto-detection
@@ -457,14 +337,14 @@ bool ST25R::reset_chip() {
   uint8_t vdd_raw = this->read_register(AD_CONV_RESULT);
   bool sup3v;
   if (vdd_raw == 0) {
-    sup3v = true;  // Default to 3.3V if measurement fails
+    sup3v = true;
   } else {
     uint16_t vdd_mv = (uint16_t) vdd_raw * 23U + (((uint16_t) vdd_raw * 4U + 5U) / 10U);
     sup3v = (vdd_mv < 3600);
     ESP_LOGI(TAG, "VDD: %u mV (sup3V=%s)", vdd_mv, sup3v ? "3.3V" : "5V");
   }
 
-  // Configure registers (RFAL NFC-A 106 kbps profile)
+  // RFAL NFC-A 106 kbps register profile
   this->write_register(IO_CONF1, 0x07);
   uint8_t io_conf2 = sup3v ? 0x80 : 0x00;
   io_conf2 |= 0x18;  // SPI pull-downs
@@ -489,7 +369,6 @@ bool ST25R::reset_chip() {
     this->write_register(ANT_TUNE_B, 0x40);
   }
 
-  // RFAL chip-init registers
   this->write_register(AUX_MOD, 0x10);
   this->write_register(RES_AM_MOD, 0x80);
   this->write_register(FIELD_THRESHOLD_ACTV, 0x11);
@@ -497,14 +376,11 @@ bool ST25R::reset_chip() {
   this->write_register(PASSIVE_TARGET, 0x50);
   this->write_register(PT_MOD, 0x51);
   this->write_register(EMD_SUP_CONF, 0x40);
-
-  // Overshoot/undershoot protection
   this->write_register(OVERSHOOT_CONF1, 0x40);
   this->write_register(OVERSHOOT_CONF2, 0x03);
   this->write_register(UNDERSHOOT_CONF1, 0x40);
   this->write_register(UNDERSHOOT_CONF2, 0x03);
 
-  // Correlator receiver
   uint8_t aux_val = this->read_register(AUX);
   this->write_register(AUX, aux_val & ~0x04);
   this->write_register(RX_CONF4, 0x00);
@@ -513,7 +389,6 @@ bool ST25R::reset_chip() {
 
   this->field_on_();
   delay(10);
-
   return true;
 }
 
@@ -531,40 +406,9 @@ void ST25R::reinitialize() {
   }
 }
 
-void ST25R::apply_anticol_prefix_() {
-  // Clamp to protocol max: 4 UID bytes + 1 BCC = 40 bits per cascade level
-  int total_bits = this->anticol_col_pos_ + 1;
-  if (total_bits > 40)
-    total_bits = 40;
-  this->anticol_prefix_full_ = total_bits >> 3;
-  this->anticol_prefix_bits_ = total_bits & 7;
-  memset(this->anticol_prefix_, 0, sizeof(this->anticol_prefix_));
-  for (int i = 0; i < total_bits; i++) {
-    int byte_idx = i >> 3;
-    int bit_idx = i & 7;
-    if ((this->anticol_prefix_val_ >> i) & 1)
-      this->anticol_prefix_[byte_idx] |= (1 << bit_idx);
-  }
-}
-
 void ST25R::send_anticol_frame() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
-  uint8_t sel = sel_cmds[this->cascade_level_];
-
-  uint8_t nvb_high = 2 + this->anticol_prefix_full_;
-  uint8_t nvb = (nvb_high << 4) | this->anticol_prefix_bits_;
-
-  uint8_t frame[7];
-  frame[0] = sel;
-  frame[1] = nvb;
-  uint8_t frame_len = 2;
-  for (int i = 0; i < this->anticol_prefix_full_; i++)
-    frame[frame_len++] = this->anticol_prefix_[i];
-  if (this->anticol_prefix_bits_ > 0)
-    frame[frame_len++] = this->anticol_prefix_[this->anticol_prefix_full_];
-
-  uint8_t ntx_n = 2 + this->anticol_prefix_full_;
-  uint8_t ntx_b = this->anticol_prefix_bits_;
+  uint8_t frame[2] = {sel_cmds[this->cascade_level_], 0x20};  // NVB=0x20: no prefix
 
   this->write_register(ISO14443A_CONF, 0x01);  // antcl=1
   this->write_command(ST25R_CMD_CLEAR_FIFO);
@@ -572,9 +416,9 @@ void ST25R::send_anticol_frame() {
   this->read_register(IRQ_TIMER);
   this->read_register(IRQ_ERROR);
   this->irq_triggered_ = false;
-  this->write_fifo(frame, frame_len);
-  this->write_register(NUM_TX_BYTES1, ntx_n >> 5);
-  this->write_register(NUM_TX_BYTES2, ((ntx_n & 0x1F) << 3) | (ntx_b & 0x07));
+  this->write_fifo(frame, 2);
+  this->write_register(NUM_TX_BYTES1, 0x00);
+  this->write_register(NUM_TX_BYTES2, 0x10);  // 2 bytes, 0 bits
   this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
 }
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -239,14 +239,7 @@ void ST25R::process_state() {
 
         ESP_LOGI(TAG, "Tag selected: %s (SAK=0x%02X)", this->current_uid_.c_str(), sak);
 
-        if (!this->present_tags_.count(this->current_uid_)) {
-          std::vector<uint8_t> uid_bytes;
-          for (size_t i = 0; i < this->current_uid_.length(); i += 2)
-            uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
-          this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
-        }
-
-        this->tags_this_scan_.insert(this->current_uid_);
+        this->tags_this_scan_.push_back(this->current_uid_);
         this->send_halt();
         this->state_ = STATE_IDLE;
         this->finalize_scan_();
@@ -265,33 +258,51 @@ void ST25R::process_state() {
 }
 
 void ST25R::finalize_scan_() {
-  // Increment miss counters; fire on_tag_removed when threshold reached
-  std::vector<std::string> to_remove;
-  for (auto &kv : this->present_tags_) {
-    if (this->tags_this_scan_.count(kv.first)) {
-      kv.second = 0;
-    } else {
-      kv.second++;
-      if (kv.second >= this->miss_threshold_)
-        to_remove.push_back(kv.first);
+  // Remove stale tags; increment miss counters
+  auto it = this->present_tags_.begin();
+  while (it != this->present_tags_.end()) {
+    bool seen = false;
+    for (const auto &uid : this->tags_this_scan_) {
+      if (uid == it->uid) {
+        seen = true;
+        break;
+      }
     }
-  }
-  for (const auto &uid : to_remove) {
-    ESP_LOGI(TAG, "Tag removed: %s", uid.c_str());
-    this->on_tag_removed_callback_.call(uid);
-    this->tags_data_.erase(uid);
-    this->present_tags_.erase(uid);
+    if (seen) {
+      it->miss_count = 0;
+      ++it;
+    } else if (++it->miss_count >= this->miss_threshold_) {
+      ESP_LOGI(TAG, "Tag removed: %s", it->uid.c_str());
+      this->on_tag_removed_callback_.call(it->uid);
+      it = this->present_tags_.erase(it);
+    } else {
+      ++it;
+    }
   }
 
   // Fire on_tag for newly seen UIDs
   for (const auto &uid : this->tags_this_scan_) {
-    if (!this->present_tags_.count(uid)) {
-      this->present_tags_[uid] = 0;
-      this->on_tag_callback_.call(uid);
-      if (this->tags_data_.count(uid) && this->tags_data_[uid]) {
-        for (auto *listener : this->tag_listeners_)
-          listener->tag_on(*this->tags_data_[uid]);
+    bool found = false;
+    for (const auto &entry : this->present_tags_) {
+      if (entry.uid == uid) {
+        found = true;
+        break;
       }
+    }
+    if (!found) {
+      ESP_LOGI(TAG, "Tag detected: %s", uid.c_str());
+      std::vector<uint8_t> uid_bytes;
+      for (size_t i = 0; i < uid.length(); i += 2)
+        uid_bytes.push_back((uint8_t) strtol(uid.substr(i, 2).c_str(), nullptr, 16));
+      TagEntry entry;
+      entry.uid = uid;
+      entry.tag = this->read_tag(uid_bytes);
+      this->on_tag_callback_.call(uid);
+      if (entry.tag) {
+        for (auto *listener : this->tag_listeners_)
+          listener->tag_on(*entry.tag);
+      }
+      this->present_tags_.push_back(std::move(entry));
     }
   }
 

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -138,7 +138,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   volatile bool irq_triggered_{false};
   volatile uint8_t irq_status_{0};
 
-  // Max UID hex string: 10-byte UID = 20 hex chars + null
+  // Max UID hex string: 20 hex chars + null terminator
   static constexpr uint8_t MAX_UID_HEX = 21;
 
   // Tag tracking — small linear containers (typically 0-3 tags)

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -115,9 +115,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void set_rf_power(uint8_t power) { this->rf_power_ = power; }
 
   void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
-  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) {
-    this->on_tag_removed_triggers_.push_back(trig);
-  }
+  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) { this->on_tag_removed_triggers_.push_back(trig); }
 
   bool is_tag_present() const { return !this->present_tags_.empty(); }
 
@@ -145,10 +143,8 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void finalize_scan_();
   void apply_anticol_prefix_();
   bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
-  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                   uint32_t timeout_ms = 150);
-  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                          uint32_t timeout_ms = 150);
+  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
+  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   static void isr(ST25R *arg);
 
   GPIOPin *reset_pin_{nullptr};

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -99,7 +99,6 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
     STATE_IDLE,
     STATE_WUPA,
     STATE_ANTICOL,
-    STATE_SELECT,
     STATE_REINITIALIZING,
   };
 
@@ -115,7 +114,9 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void set_rf_power(uint8_t power) { this->rf_power_ = power; }
 
   void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
-  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) { this->on_tag_removed_triggers_.push_back(trig); }
+  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) {
+    this->on_tag_removed_triggers_.push_back(trig);
+  }
 
   bool is_tag_present() const { return !this->present_tags_.empty(); }
 
@@ -141,7 +142,6 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
 
   void field_on_();
   void finalize_scan_();
-  void apply_anticol_prefix_();
   bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
@@ -158,7 +158,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   volatile bool irq_triggered_{false};
   volatile uint8_t irq_status_{0};
 
-  // Multi-tag tracking
+  // Tag tracking
   std::map<std::string, uint8_t> present_tags_;
   std::set<std::string> tags_this_scan_;
   std::map<std::string, std::unique_ptr<nfc::NfcTag>> tags_data_;
@@ -174,19 +174,6 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   uint8_t cascade_level_{0};
   std::string current_uid_;
   uint8_t last_sak_{0};
-
-  // Anticollision state
-  uint8_t anticol_prefix_[5]{};
-  uint8_t anticol_prefix_full_;
-  uint8_t anticol_prefix_bits_;
-  uint8_t anticol_col_pos_{0};
-  uint8_t anticol_prefix_val_{0};
-
-  // Saved CL1 state for cascade CL2 resume
-  uint8_t saved_col_pos_{0};
-  uint8_t saved_prefix_val_{0};
-  bool saved_anticol_valid_{false};
-  bool anticol_resume_{false};
 
   std::vector<ST25RTagTrigger *> on_tag_triggers_;
   std::vector<ST25RTagRemovedTrigger *> on_tag_removed_triggers_;

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -74,24 +74,6 @@ enum ST25RCommand : uint8_t {
   ST25R_CMD_MEASURE_VDD = 0xDF,
 };
 
-class ST25R;
-
-class ST25RTagTrigger : public Trigger<std::string> {
- public:
-  explicit ST25RTagTrigger(ST25R *parent) : parent_(parent) {}
-
- protected:
-  ST25R *parent_;
-};
-
-class ST25RTagRemovedTrigger : public Trigger<std::string> {
- public:
-  explicit ST25RTagRemovedTrigger(ST25R *parent) : parent_(parent) {}
-
- protected:
-  ST25R *parent_;
-};
-
 class ST25R : public PollingComponent, public nfc::Nfcc {
  public:
   enum State {
@@ -112,8 +94,10 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void set_irq_pin(InternalGPIOPin *irq_pin) { this->irq_pin_ = irq_pin; }
   void set_rf_power(uint8_t power) { this->rf_power_ = power; }
 
-  void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
-  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) { this->on_tag_removed_triggers_.push_back(trig); }
+  template<typename F> void add_on_tag_callback(F &&callback) { this->on_tag_callback_.add(std::forward<F>(callback)); }
+  template<typename F> void add_on_tag_removed_callback(F &&callback) {
+    this->on_tag_removed_callback_.add(std::forward<F>(callback));
+  }
 
   bool is_tag_present() const { return !this->present_tags_.empty(); }
 
@@ -172,8 +156,8 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   std::string current_uid_;
   uint8_t last_sak_{0};
 
-  std::vector<ST25RTagTrigger *> on_tag_triggers_;
-  std::vector<ST25RTagRemovedTrigger *> on_tag_removed_triggers_;
+  CallbackManager<void(std::string)> on_tag_callback_;
+  CallbackManager<void(std::string)> on_tag_removed_callback_;
 };
 
 }  // namespace esphome::st25r

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -121,6 +121,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
 
   void field_on_();
   void finalize_scan_();
+  void uid_append_hex_(const uint8_t *data, uint8_t count);
   bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
@@ -137,14 +138,16 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   volatile bool irq_triggered_{false};
   volatile uint8_t irq_status_{0};
 
+  // Max UID hex string: 10-byte UID = 20 hex chars + null
+  static constexpr uint8_t MAX_UID_HEX = 21;
+
   // Tag tracking — small linear containers (typically 0-3 tags)
   struct TagEntry {
-    std::string uid;
+    char uid[MAX_UID_HEX]{};
     uint8_t miss_count{0};
     std::unique_ptr<nfc::NfcTag> tag;
   };
   std::vector<TagEntry> present_tags_;
-  std::vector<std::string> tags_this_scan_;
 
   // IRQ_MAIN bit definitions
   static constexpr uint8_t IRQ_RXE = 0x10;
@@ -155,8 +158,10 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   State state_{STATE_IDLE};
   uint32_t last_state_change_{0};
   uint8_t cascade_level_{0};
-  std::string current_uid_;
+  char current_uid_[MAX_UID_HEX]{};
+  uint8_t current_uid_pos_{0};
   uint8_t last_sak_{0};
+  bool tag_found_this_scan_{false};
 
   CallbackManager<void(std::string)> on_tag_callback_;
   CallbackManager<void(std::string)> on_tag_removed_callback_;

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -114,9 +114,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void set_rf_power(uint8_t power) { this->rf_power_ = power; }
 
   void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
-  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) {
-    this->on_tag_removed_triggers_.push_back(trig);
-  }
+  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) { this->on_tag_removed_triggers_.push_back(trig); }
 
   bool is_tag_present() const { return !this->present_tags_.empty(); }
 

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -145,7 +145,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
-  static void isr(ST25R *arg);
+  static void IRAM_ATTR isr(ST25R *arg);
 
   GPIOPin *reset_pin_{nullptr};
   InternalGPIOPin *irq_pin_{nullptr};

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -4,8 +4,6 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/nfc/nfc.h"
-#include <map>
-#include <set>
 #include <vector>
 #include <string>
 
@@ -139,10 +137,14 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   volatile bool irq_triggered_{false};
   volatile uint8_t irq_status_{0};
 
-  // Tag tracking
-  std::map<std::string, uint8_t> present_tags_;
-  std::set<std::string> tags_this_scan_;
-  std::map<std::string, std::unique_ptr<nfc::NfcTag>> tags_data_;
+  // Tag tracking — small linear containers (typically 0-3 tags)
+  struct TagEntry {
+    std::string uid;
+    uint8_t miss_count{0};
+    std::unique_ptr<nfc::NfcTag> tag;
+  };
+  std::vector<TagEntry> present_tags_;
+  std::vector<std::string> tags_this_scan_;
 
   // IRQ_MAIN bit definitions
   static const uint8_t IRQ_RXE = 0x10;

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -147,10 +147,10 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   std::vector<std::string> tags_this_scan_;
 
   // IRQ_MAIN bit definitions
-  static const uint8_t IRQ_RXE = 0x10;
-  static const uint8_t IRQ_TXE = 0x08;
-  static const uint8_t IRQ_COL = 0x04;
-  static const uint8_t IRQ_NRE = 0x01;
+  static constexpr uint8_t IRQ_RXE = 0x10;
+  static constexpr uint8_t IRQ_TXE = 0x08;
+  static constexpr uint8_t IRQ_COL = 0x04;
+  static constexpr uint8_t IRQ_NRE = 0x01;
 
   State state_{STATE_IDLE};
   uint32_t last_state_change_{0};

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -9,8 +9,7 @@
 #include <vector>
 #include <string>
 
-namespace esphome {
-namespace st25r {
+namespace esphome::st25r {
 
 // ST25R Register Definitions
 enum ST25RRegister : uint8_t {
@@ -177,5 +176,4 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   std::vector<ST25RTagRemovedTrigger *> on_tag_removed_triggers_;
 };
 
-}  // namespace st25r
-}  // namespace esphome
+}  // namespace esphome::st25r

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/nfc/nfc.h"
+#include <map>
+#include <set>
+#include <vector>
+#include <string>
+
+namespace esphome {
+namespace st25r {
+
+// ST25R Register Definitions
+enum ST25RRegister : uint8_t {
+  IO_CONF1 = 0x00,
+  IO_CONF2 = 0x01,
+  OP_CONTROL = 0x02,
+  MODE = 0x03,
+  BIT_RATE = 0x04,
+  ISO14443A_CONF = 0x05,
+  PASSIVE_TARGET = 0x08,
+  STREAM_MODE = 0x09,
+  AUX = 0x0A,
+  RX_CONF1 = 0x0B,
+  RX_CONF2 = 0x0C,
+  RX_CONF3 = 0x0D,
+  RX_CONF4 = 0x0E,
+  MASK_MAIN = 0x16,
+  MASK_TIMER = 0x17,
+  IRQ_MAIN = 0x1A,
+  IRQ_TIMER = 0x1B,
+  IRQ_ERROR = 0x1C,
+  FIFO_STATUS1 = 0x1E,
+  FIFO_STATUS2 = 0x1F,
+  COLLISION_DISPLAY = 0x20,
+  NUM_TX_BYTES1 = 0x22,
+  NUM_TX_BYTES2 = 0x23,
+  AD_CONV_RESULT = 0x25,
+  ANT_TUNE_A = 0x26,
+  ANT_TUNE_B = 0x27,
+  TX_DRIVER_CONF = 0x28,
+  PT_MOD = 0x29,
+  FIELD_THRESHOLD_ACTV = 0x2A,
+  FIELD_THRESHOLD_DEACTV = 0x2B,
+  REGULATOR_CONTROL = 0x2C,
+  IC_IDENTITY = 0x3F,
+  // Space B registers (bit 0x40 set -> SPI prefix 0xFB before address)
+  EMD_SUP_CONF = 0x45,
+  CORR_CONF1 = 0x4C,
+  CORR_CONF2 = 0x4D,
+  AUX_MOD = 0x68,
+  RES_AM_MOD = 0x6A,
+  OVERSHOOT_CONF1 = 0x70,
+  OVERSHOOT_CONF2 = 0x71,
+  UNDERSHOOT_CONF1 = 0x72,
+  UNDERSHOOT_CONF2 = 0x73,
+};
+
+// ST25R Commands
+enum ST25RCommand : uint8_t {
+  ST25R_CMD_SET_DEFAULT = 0xC1,
+  ST25R_CMD_STOP_ALL = 0xC2,
+  ST25R_CMD_CLEAR_FIFO = 0xC3,
+  ST25R_CMD_TRANSMIT_WITH_CRC = 0xC4,
+  ST25R_CMD_TRANSMIT_WITHOUT_CRC = 0xC5,
+  ST25R_CMD_TRANSMIT_REQA = 0xC6,
+  ST25R_CMD_TRANSMIT_WUPA = 0xC7,
+  ST25R_CMD_FIELD_ON = 0xC8,
+  ST25R_CMD_FIELD_OFF = 0xC9,
+  ST25R_CMD_MEASURE_AMPLITUDE = 0xD3,
+  ST25R_CMD_RESET_RX_GAIN = 0xD5,
+  ST25R_CMD_ADJUST_REGULATORS = 0xD6,
+  ST25R_CMD_MEASURE_VDD = 0xDF,
+};
+
+class ST25R;
+
+class ST25RTagTrigger : public Trigger<std::string> {
+ public:
+  explicit ST25RTagTrigger(ST25R *parent) : parent_(parent) {}
+
+ protected:
+  ST25R *parent_;
+};
+
+class ST25RTagRemovedTrigger : public Trigger<std::string> {
+ public:
+  explicit ST25RTagRemovedTrigger(ST25R *parent) : parent_(parent) {}
+
+ protected:
+  ST25R *parent_;
+};
+
+class ST25R : public PollingComponent, public nfc::Nfcc {
+ public:
+  enum State {
+    STATE_IDLE,
+    STATE_WUPA,
+    STATE_ANTICOL,
+    STATE_SELECT,
+    STATE_REINITIALIZING,
+  };
+
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  void loop() override;
+  void process_state();
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
+  void set_irq_pin(InternalGPIOPin *irq_pin) { this->irq_pin_ = irq_pin; }
+  void set_rf_power(uint8_t power) { this->rf_power_ = power; }
+
+  void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
+  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) {
+    this->on_tag_removed_triggers_.push_back(trig);
+  }
+
+  bool is_tag_present() const { return !this->present_tags_.empty(); }
+
+ protected:
+  virtual uint8_t read_register(uint8_t reg) = 0;
+  virtual void write_register(uint8_t reg, uint8_t value) = 0;
+  virtual void write_command(uint8_t command) = 0;
+  virtual void write_fifo(const uint8_t *data, size_t len) = 0;
+  virtual void read_fifo(uint8_t *data, size_t len) = 0;
+
+  virtual bool reset_chip();
+  virtual void reinitialize();
+  virtual void send_anticol_frame();
+  virtual bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc,
+                             uint32_t timeout_ms);
+  virtual std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid);
+
+  virtual void send_halt();
+  virtual void start_wupa();
+  virtual void pre_select();
+  virtual uint8_t read_fifo_status1();
+  virtual uint8_t read_collision_display();
+
+  void field_on_();
+  void finalize_scan_();
+  void apply_anticol_prefix_();
+  bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
+  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                   uint32_t timeout_ms = 150);
+  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                          uint32_t timeout_ms = 150);
+  static void isr(ST25R *arg);
+
+  GPIOPin *reset_pin_{nullptr};
+  InternalGPIOPin *irq_pin_{nullptr};
+
+  uint8_t rf_power_{15};
+  uint8_t miss_threshold_{3};
+  bool is_b_version_{false};
+  bool has_aat_{false};
+
+  volatile bool irq_triggered_{false};
+  volatile uint8_t irq_status_{0};
+
+  // Multi-tag tracking
+  std::map<std::string, uint8_t> present_tags_;
+  std::set<std::string> tags_this_scan_;
+  std::map<std::string, std::unique_ptr<nfc::NfcTag>> tags_data_;
+
+  // IRQ_MAIN bit definitions
+  static const uint8_t IRQ_RXE = 0x10;
+  static const uint8_t IRQ_TXE = 0x08;
+  static const uint8_t IRQ_COL = 0x04;
+  static const uint8_t IRQ_NRE = 0x01;
+
+  State state_{STATE_IDLE};
+  uint32_t last_state_change_{0};
+  uint8_t cascade_level_{0};
+  std::string current_uid_;
+  uint8_t last_sak_{0};
+
+  // Anticollision state
+  uint8_t anticol_prefix_[5]{};
+  uint8_t anticol_prefix_full_;
+  uint8_t anticol_prefix_bits_;
+  uint8_t anticol_col_pos_{0};
+  uint8_t anticol_prefix_val_{0};
+
+  // Saved CL1 state for cascade CL2 resume
+  uint8_t saved_col_pos_{0};
+  uint8_t saved_prefix_val_{0};
+  bool saved_anticol_valid_{false};
+  bool anticol_resume_{false};
+
+  std::vector<ST25RTagTrigger *> on_tag_triggers_;
+  std::vector<ST25RTagRemovedTrigger *> on_tag_removed_triggers_;
+};
+
+}  // namespace st25r
+}  // namespace esphome

--- a/esphome/components/st25r_spi/__init__.py
+++ b/esphome/components/st25r_spi/__init__.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+from esphome.components import st25r, spi
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["st25r"]
+CODEOWNERS = ["@JohnMcLear"]
+DEPENDENCIES = ["spi"]
+MULTI_CONF = True
+
+st25r_spi_ns = cg.esphome_ns.namespace("st25r_spi")
+ST25RSpi = st25r_spi_ns.class_("ST25RSpi", st25r.ST25R, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.All(
+    st25r.ST25R_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ST25RSpi),
+        }
+    ).extend(spi.spi_device_schema(cs_pin_required=True))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await st25r.setup_st25r(var, config)
+    await spi.register_spi_device(var, config)

--- a/esphome/components/st25r_spi/__init__.py
+++ b/esphome/components/st25r_spi/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import spi, st25r
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["st25r"]
 CODEOWNERS = ["@JohnMcLear"]
@@ -20,7 +21,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config: dict) -> None:
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await st25r.setup_st25r(var, config)
     await spi.register_spi_device(var, config)

--- a/esphome/components/st25r_spi/__init__.py
+++ b/esphome/components/st25r_spi/__init__.py
@@ -20,7 +20,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: dict) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await st25r.setup_st25r(var, config)
     await spi.register_spi_device(var, config)

--- a/esphome/components/st25r_spi/__init__.py
+++ b/esphome/components/st25r_spi/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import st25r, spi
+from esphome.components import spi, st25r
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 

--- a/esphome/components/st25r_spi/st25r_spi.cpp
+++ b/esphome/components/st25r_spi/st25r_spi.cpp
@@ -1,0 +1,65 @@
+#include "st25r_spi.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace st25r_spi {
+
+static const char *const TAG = "st25r_spi";
+
+void ST25RSpi::setup() {
+  this->spi_setup();
+  st25r::ST25R::setup();
+}
+
+void ST25RSpi::dump_config() {
+  st25r::ST25R::dump_config();
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+uint8_t ST25RSpi::read_register(uint8_t reg) {
+  this->enable();
+  if (reg & 0x40) {
+    this->write_byte(0xFB);  // Space B prefix
+  }
+  this->write_byte(0x40 | (reg & 0x3F));
+  uint8_t value = this->read_byte();
+  this->disable();
+  return value;
+}
+
+void ST25RSpi::write_register(uint8_t reg, uint8_t value) {
+  this->enable();
+  if (reg & 0x40) {
+    this->write_byte(0xFB);  // Space B prefix
+  }
+  this->write_byte(0x00 | (reg & 0x3F));
+  this->write_byte(value);
+  this->disable();
+}
+
+void ST25RSpi::write_command(uint8_t command) {
+  this->enable();
+  this->write_byte(command);
+  this->disable();
+}
+
+void ST25RSpi::write_fifo(const uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(0x80);
+  for (size_t i = 0; i < len; i++) {
+    this->write_byte(data[i]);
+  }
+  this->disable();
+}
+
+void ST25RSpi::read_fifo(uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(0x9F);
+  for (size_t i = 0; i < len; i++) {
+    data[i] = this->read_byte();
+  }
+  this->disable();
+}
+
+}  // namespace st25r_spi
+}  // namespace esphome

--- a/esphome/components/st25r_spi/st25r_spi.cpp
+++ b/esphome/components/st25r_spi/st25r_spi.cpp
@@ -1,8 +1,7 @@
 #include "st25r_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace st25r_spi {
+namespace esphome::st25r_spi {
 
 static const char *const TAG = "st25r_spi";
 
@@ -61,5 +60,4 @@ void ST25RSpi::read_fifo(uint8_t *data, size_t len) {
   this->disable();
 }
 
-}  // namespace st25r_spi
-}  // namespace esphome
+}  // namespace esphome::st25r_spi

--- a/esphome/components/st25r_spi/st25r_spi.h
+++ b/esphome/components/st25r_spi/st25r_spi.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/st25r/st25r.h"
+
+namespace esphome {
+namespace st25r_spi {
+
+class ST25RSpi : public st25r::ST25R,
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                       spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  uint8_t read_register(uint8_t reg) override;
+  void write_register(uint8_t reg, uint8_t value) override;
+  void write_command(uint8_t command) override;
+  void write_fifo(const uint8_t *data, size_t len) override;
+  void read_fifo(uint8_t *data, size_t len) override;
+};
+
+}  // namespace st25r_spi
+}  // namespace esphome

--- a/esphome/components/st25r_spi/st25r_spi.h
+++ b/esphome/components/st25r_spi/st25r_spi.h
@@ -4,8 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/st25r/st25r.h"
 
-namespace esphome {
-namespace st25r_spi {
+namespace esphome::st25r_spi {
 
 class ST25RSpi : public st25r::ST25R,
                  public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING,
@@ -22,5 +21,4 @@ class ST25RSpi : public st25r::ST25R,
   void read_fifo(uint8_t *data, size_t len) override;
 };
 
-}  // namespace st25r_spi
-}  // namespace esphome
+}  // namespace esphome::st25r_spi

--- a/esphome/components/st25r_spi/st25r_spi.h
+++ b/esphome/components/st25r_spi/st25r_spi.h
@@ -8,8 +8,8 @@ namespace esphome {
 namespace st25r_spi {
 
 class ST25RSpi : public st25r::ST25R,
-                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                       spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING,
+                                       spi::DATA_RATE_200KHZ> {
  public:
   void setup() override;
   void dump_config() override;

--- a/tests/components/st25r_spi/common.yaml
+++ b/tests/components/st25r_spi/common.yaml
@@ -1,0 +1,3 @@
+st25r_spi:
+  id: st25r_nfcc_spi
+  cs_pin: ${cs_pin}

--- a/tests/components/st25r_spi/test.esp32-idf.yaml
+++ b/tests/components/st25r_spi/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  cs_pin: GPIO12
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
## What does this implement/fix?

New component for STMicroelectronics ST25R3916 NFC reader IC over SPI. Detects ISO 14443A (NFC-A) tags and fires `on_tag`/`on_tag_removed` triggers.

This is PR 1 of 7, split from #15082 per reviewer feedback. Each subsequent PR adds one feature layer:

1. **This PR**: ST25R3916 SPI + ISO14443A single-tag UID detection (4/7/10-byte UIDs, cascade CL1-CL3)
2. Multi-tag anticollision + I2C transport + binary sensor
3. NFC-V (ISO 15693) + NFC-B (ISO 14443B)
4. NDEF read (Type 2 + Type 5)
5. Mifare Classic auth + NDEF write
6. ST25R300 variant + AAT (Automatic Antenna Tuning)
7. Health check

## Hardware

- ST25R3916 / ST25R3916B (IC identity 0x28 / 0x30)
- SPI Mode 1 (CPOL=0, CPHA=1), 200 kHz
- VDD auto-detection via cmd 0xDF
- RFAL NFC-A 106 kbps analog profile

## Example config

``` yaml
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19

st25r_spi:
  cs_pin: GPIO5
  irq_pin: GPIO4
  on_tag:
    then:
      - logger.log:
          format: "Tag: %s"
          args: ['x.c_str()']
  on_tag_removed:
    then:
      - logger.log: "Tag removed"
```

## Documentation

esphome/esphome-docs#6428

## Test plan

- [x] ESP32-IDF compile test (\`tests/components/st25r_spi/test.esp32-idf.yaml\`)
- [x] Hardware verified on Elechouse ST25R3916 module (NTAG216, Mifare Classic, NFC ring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)