### PR TITLE
[modbus_controller] Validate response payload length against queued command

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
+#include <algorithm>
+
 namespace esphome {
 namespace modbus_controller {
 
@@ -65,6 +67,18 @@ void ModbusController::on_modbus_data(const std::vector<uint8_t> &data) {
   }
   auto &current_command = this->command_queue_.front();
   if (current_command != nullptr) {
+    if (!this->validate_command_response_(*current_command, data)) {
+      // A response arrived but its payload length did not match the queued command.
+      // The retry path only advances on timeouts, so leaving the command at the front
+      // of the queue would stall every subsequent range until max_cmd_retries_ was
+      // exhausted via artificial timeouts. Pop the command so the queue keeps moving;
+      // the WARN logged by validate_command_response_ already captured the diagnostic.
+      ESP_LOGW(TAG, "Invalid modbus response for device=%d register=0x%02X - removed from send queue", this->address_,
+               current_command->register_address);
+      this->command_queue_.pop_front();
+      return;
+    }
+
     if (this->module_offline_) {
       ESP_LOGW(TAG, "Modbus device=%d back online", this->address_);
 
@@ -273,20 +287,81 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
   this->send_raw(response);
 }
 
-SensorSet ModbusController::find_sensors_(ModbusRegisterType register_type, uint16_t start_address) const {
+const RegisterRange *ModbusController::find_register_range_(ModbusRegisterType register_type,
+                                                            uint16_t start_address) const {
   auto reg_it = std::find_if(
       std::begin(this->register_ranges_), std::end(this->register_ranges_),
-      [=](RegisterRange const &r) { return (r.start_address == start_address && r.register_type == register_type); });
+      [=](const RegisterRange &r) { return r.start_address == start_address && r.register_type == register_type; });
 
   if (reg_it == this->register_ranges_.end()) {
+    return nullptr;
+  }
+
+  return &(*reg_it);
+}
+
+SensorSet ModbusController::find_sensors_(ModbusRegisterType register_type, uint16_t start_address) const {
+  const RegisterRange *range = this->find_register_range_(register_type, start_address);
+  if (range == nullptr) {
     ESP_LOGE(TAG, "No matching range for sensor found - start_address : 0x%X", start_address);
   } else {
-    return reg_it->sensors;
+    return range->sensors;
   }
 
   // not found
   return {};
 }
+
+size_t ModbusController::get_register_range_size_(const RegisterRange &range) const {
+  size_t expected_size = 0;
+  for (auto *sensor : range.sensors) {
+    expected_size = std::max(expected_size, size_t(sensor->offset) + sensor->get_register_size());
+  }
+  return expected_size;
+}
+
+bool ModbusController::validate_command_response_(const ModbusCommandItem &command,
+                                                  const std::vector<uint8_t> &data) const {
+  size_t expected_size = 0;
+
+  switch (command.function_code) {
+    case ModbusFunctionCode::READ_COILS:
+    case ModbusFunctionCode::READ_DISCRETE_INPUTS:
+      expected_size = (command.register_count + 7) / 8;
+      break;
+    case ModbusFunctionCode::READ_HOLDING_REGISTERS:
+    case ModbusFunctionCode::READ_INPUT_REGISTERS:
+    case ModbusFunctionCode::CUSTOM: {
+      const RegisterRange *range = this->find_register_range_(command.register_type, command.register_address);
+      if (range != nullptr) {
+        expected_size = this->get_register_range_size_(*range);
+      }
+      break;
+    }
+    case ModbusFunctionCode::WRITE_SINGLE_COIL:
+    case ModbusFunctionCode::WRITE_SINGLE_REGISTER:
+    case ModbusFunctionCode::WRITE_MULTIPLE_COILS:
+    case ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS:
+      expected_size = 4;
+      break;
+    default:
+      return true;
+  }
+
+  // expected_size == 0 means we could not determine an expected length (unknown function code,
+  // no matching register range, or a CUSTOM command with no registered size). In that case we
+  // pass the response through so existing behavior is preserved for unvalidatable commands.
+  if (expected_size == 0 || data.size() == expected_size) {
+    return true;
+  }
+
+  ESP_LOGW(TAG,
+           "Ignoring invalid response payload for device=%d register=0x%X function=0x%X: expected %zu bytes, got %zu",
+           this->address_, command.register_address, static_cast<uint8_t>(command.function_code), expected_size,
+           data.size());
+  return false;
+}
+
 void ModbusController::on_register_data(ModbusRegisterType register_type, uint16_t start_address,
                                         const std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "data for register address : 0x%X : ", start_address);

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -423,8 +423,14 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
  protected:
   /// parse sensormap_ and create range of sequential addresses
   size_t create_register_ranges_();
+  /// find register range. Returns nullptr if not found.
+  const RegisterRange *find_register_range_(ModbusRegisterType register_type, uint16_t start_address) const;
   // find register in sensormap. Returns iterator with all registers having the same start address
   SensorSet find_sensors_(ModbusRegisterType register_type, uint16_t start_address) const;
+  /// get the maximum response size across all sensors in a register range
+  size_t get_register_range_size_(const RegisterRange &range) const;
+  /// validate that a modbus response payload matches the queued command
+  bool validate_command_response_(const ModbusCommandItem &command, const std::vector<uint8_t> &data) const;
   /// submit the read command for the address range to the send queue
   void update_range_(RegisterRange &r);
   /// parse incoming modbus data

--- a/tests/components/modbus_controller/modbus_controller_test.cpp
+++ b/tests/components/modbus_controller/modbus_controller_test.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+
+#include "esphome/components/modbus/modbus.h"
+#include "esphome/components/modbus_controller/modbus_controller.h"
+
+namespace esphome::modbus_controller::testing {
+
+class DummySensorItem : public SensorItem {
+ public:
+  void parse_and_publish(const std::vector<uint8_t> &data) override { (void) data; }
+};
+
+class TestModbusController : public ModbusController {
+ public:
+  using ModbusController::create_register_ranges_;
+  using ModbusController::validate_command_response_;
+};
+
+TEST(ModbusControllerTest, RejectsInvalidReadPayloadLength) {
+  modbus::Modbus bus;
+  bus.set_role(modbus::ModbusRole::CLIENT);
+
+  TestModbusController controller;
+  controller.set_parent(&bus);
+  controller.set_address(0x01);
+  bus.register_device(&controller);
+
+  DummySensorItem sensor;
+  sensor.register_type = modbus::ModbusRegisterType::HOLDING;
+  sensor.start_address = 0x0010;
+  sensor.register_count = 1;
+  controller.add_sensor_item(&sensor);
+
+  ASSERT_EQ(controller.create_register_ranges_(), 1);
+
+  auto command = ModbusCommandItem::create_read_command(&controller, modbus::ModbusRegisterType::HOLDING, 0x0010, 1);
+
+  EXPECT_TRUE(controller.validate_command_response_(command, {0x12, 0x34}));
+  EXPECT_FALSE(controller.validate_command_response_(command, {0x12, 0x34, 0x56, 0x78}));
+}
+
+TEST(ModbusControllerTest, UsesResponseSizeOverrideForCustomPayloadValidation) {
+  modbus::Modbus bus;
+  bus.set_role(modbus::ModbusRole::CLIENT);
+
+  TestModbusController controller;
+  controller.set_parent(&bus);
+  controller.set_address(0x01);
+  bus.register_device(&controller);
+
+  DummySensorItem sensor;
+  sensor.register_type = modbus::ModbusRegisterType::CUSTOM;
+  sensor.start_address = 0x0B56;
+  sensor.register_count = 1;
+  sensor.response_bytes = 14;
+  controller.add_sensor_item(&sensor);
+
+  ASSERT_EQ(controller.create_register_ranges_(), 1);
+
+  auto command = ModbusCommandItem::create_custom_command(&controller, std::vector<uint8_t>{0x44, 0xCE, 0xAA});
+  command.register_type = modbus::ModbusRegisterType::CUSTOM;
+  command.register_address = 0x0B56;
+  command.register_count = 1;
+
+  EXPECT_TRUE(controller.validate_command_response_(command, std::vector<uint8_t>(14, 0x00)));
+  EXPECT_FALSE(controller.validate_command_response_(command, std::vector<uint8_t>(8, 0x00)));
+}
+
+}  // namespace esphome::modbus_controller::testing

--- a/tests/integration/fixtures/uart_mock_modbus.yaml
+++ b/tests/integration/fixtures/uart_mock_modbus.yaml
@@ -39,6 +39,8 @@ uart_mock:
         inject_rx: [] # No response, should cause timeout
       - expect_tx: [0x01, 0x03, 0x00, 0x0A, 0x00, 0x01, 0xA4, 0x08] # Read holding register A on device 1 (exception_response)
         inject_rx: [0x01, 0x83, 0x02, 0xC0, 0xF1] # Exception response with code 2 (illegal data address)
+      - expect_tx: [0x01, 0x03, 0x00, 0x20, 0x00, 0x01, 0x85, 0xC0] # Read holding register 20 on device 1 (invalid_length_response)
+        inject_rx: [0x01, 0x03, 0x04, 0x00, 0x01, 0x02, 0x03, 0xEA, 0x92] # Wrong-length response: 4 bytes instead of 2
 
 modbus:
   uart_id: virtual_uart_dev
@@ -83,6 +85,11 @@ sensor:
   - platform: modbus_controller
     name: "exception_response"
     address: 0x0A
+    register_type: holding
+    modbus_controller_id: modbus_controller_ok
+  - platform: modbus_controller
+    name: "invalid_length_response"
+    address: 0x20
     register_type: holding
     modbus_controller_id: modbus_controller_ok
 

--- a/tests/integration/test_uart_mock_modbus.py
+++ b/tests/integration/test_uart_mock_modbus.py
@@ -90,6 +90,7 @@ async def test_uart_mock_modbus(
             "late_response",
             "no_response",
             "exception_response",
+            "invalid_length_response",
         ]
     )
     basic_register_changed = tracker.expect("basic_register", 259.0)
@@ -99,6 +100,7 @@ async def test_uart_mock_modbus(
     late_response_changed = tracker.expect_any("late_response")
     no_response_changed = tracker.expect_any("no_response")
     exception_response_changed = tracker.expect_any("exception_response")
+    invalid_length_response_changed = tracker.expect_any("invalid_length_response")
 
     async with (
         run_compiled(yaml_config),
@@ -115,6 +117,9 @@ async def test_uart_mock_modbus(
             tracker.await_must_not_change(no_response_changed, "no_response"),
             tracker.await_must_not_change(
                 exception_response_changed, "exception_response"
+            ),
+            tracker.await_must_not_change(
+                invalid_length_response_changed, "invalid_length_response"
             ),
         )
 


### PR DESCRIPTION
## Summary

When a Modbus slave returns a malformed response (wrong byte count for the queued function code or register range), `ModbusController` currently dispatches it to sensors and produces garbage values. Add `validate_command_response_()` that cross-checks payload length against the expected size before dispatch:

- Read coils / discrete inputs: `(register_count + 7) / 8`
- Read holding / input / custom registers: aggregate size of all sensors in the matching register range (new `get_register_range_size_` helper)
- Write single / multiple: constant 4 bytes

Mismatched responses are dropped with a WARN log that includes the device address, register, function code, expected size, and actual size. Unknown function codes and unvalidatable CUSTOM commands (no registered size) pass through so existing behavior is preserved for configs the controller cannot reason about — this is documented inline.

Also factors a `find_register_range_()` helper out of the existing `find_sensors_()` so both the new validator and the original sensor lookup share the range search.

## Test plan

- [x] New C++ unit tests in `tests/components/modbus_controller/modbus_controller_test.cpp` cover both a standard read-register case and a custom command with `response_bytes` override.
- [x] New `invalid_length_response` case added to `tests/integration/test_uart_mock_modbus.py` — injects a 4-byte response where 2 are expected and asserts the sensor value never updates.
- [ ] CI: existing modbus / modbus_controller platform YAML suites continue to compile.