### PR TITLE
[modbus] Add flow control pin pre/post send delays for RS485

### DIFF
--- a/esphome/components/modbus/__init__.py
+++ b/esphome/components/modbus/__init__.py
@@ -19,6 +19,8 @@ MULTI_CONF = True
 
 CONF_ROLE = "role"
 CONF_MODBUS_ID = "modbus_id"
+CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY = "flow_control_pin_pre_send_delay"
+CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY = "flow_control_pin_post_send_delay"
 CONF_SEND_WAIT_TIME = "send_wait_time"
 CONF_TURNAROUND_TIME = "turnaround_time"
 
@@ -28,12 +30,36 @@ MODBUS_ROLES = {
     "server": ModbusRole.SERVER,
 }
 
-CONFIG_SCHEMA = (
+
+def validate_flow_control_delays(config):
+    if CONF_FLOW_CONTROL_PIN in config:
+        return config
+
+    if CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY in config:
+        raise cv.Invalid(
+            f"'{CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY}' requires '{CONF_FLOW_CONTROL_PIN}'"
+        )
+
+    if CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY in config:
+        raise cv.Invalid(
+            f"'{CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY}' requires '{CONF_FLOW_CONTROL_PIN}'"
+        )
+
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Modbus),
             cv.Optional(CONF_ROLE, default="client"): cv.enum(MODBUS_ROLES),
             cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(
+                CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY
+            ): cv.positive_time_period_milliseconds,
             cv.Optional(
                 CONF_SEND_WAIT_TIME, default="250ms"
             ): cv.positive_time_period_milliseconds,
@@ -44,7 +70,8 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
+    validate_flow_control_delays,
 )
 
 
@@ -59,6 +86,18 @@ async def to_code(config):
     if CONF_FLOW_CONTROL_PIN in config:
         pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
         cg.add(var.set_flow_control_pin(pin))
+    if CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY in config:
+        cg.add(
+            var.set_flow_control_pin_pre_send_delay(
+                config[CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY]
+            )
+        )
+    if CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY in config:
+        cg.add(
+            var.set_flow_control_pin_post_send_delay(
+                config[CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY]
+            )
+        )
 
     cg.add(var.set_send_wait_time(config[CONF_SEND_WAIT_TIME]))
     cg.add(var.set_turnaround_time(config[CONF_TURNAROUND_TIME]))

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -296,8 +296,16 @@ void Modbus::send_next_frame_() {
 
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->digital_write(true);
+    if (this->flow_control_pin_pre_send_delay_ms_ != 0) {
+      delay(this->flow_control_pin_pre_send_delay_ms_);
+    }
     this->write_array(frame.data.get(), frame.size);
     this->flush();
+    // Post-send delay BEFORE releasing the bus — keeps the transceiver in TX mode
+    // while the last byte clears the wire and any bus ringing settles.
+    if (this->flow_control_pin_post_send_delay_ms_ != 0) {
+      delay(this->flow_control_pin_post_send_delay_ms_);
+    }
     this->flow_control_pin_->digital_write(false);
     this->last_send_tx_offset_ = 0;
   } else {
@@ -324,9 +332,12 @@ void Modbus::dump_config() {
                 "  Turnaround Time: %d ms\n"
                 "  Frame Delay: %d ms\n"
                 "  Long Rx Buffer Delay: %d ms\n"
+                "  Flow Control Pre-Send Delay: %d ms\n"
+                "  Flow Control Post-Send Delay: %d ms\n"
                 "  CRC Disabled: %s",
                 this->send_wait_time_, this->turnaround_delay_ms_, this->frame_delay_ms_,
-                this->long_rx_buffer_delay_ms_, YESNO(this->disable_crc_));
+                this->long_rx_buffer_delay_ms_, this->flow_control_pin_pre_send_delay_ms_,
+                this->flow_control_pin_post_send_delay_ms_, YESNO(this->disable_crc_));
   LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
 }
 float Modbus::get_setup_priority() const {

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -56,6 +56,12 @@ class Modbus : public uart::UARTDevice, public Component {
   void send_raw(const std::vector<uint8_t> &payload);
   void set_role(ModbusRole role) { this->role = role; }
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
+  void set_flow_control_pin_pre_send_delay(uint16_t time_in_ms) {
+    this->flow_control_pin_pre_send_delay_ms_ = time_in_ms;
+  }
+  void set_flow_control_pin_post_send_delay(uint16_t time_in_ms) {
+    this->flow_control_pin_post_send_delay_ms_ = time_in_ms;
+  }
   void set_send_wait_time(uint16_t time_in_ms) { this->send_wait_time_ = time_in_ms; }
   void set_turnaround_time(uint16_t time_in_ms) { this->turnaround_delay_ms_ = time_in_ms; }
   void set_disable_crc(bool disable_crc) { this->disable_crc_ = disable_crc; }
@@ -74,6 +80,8 @@ class Modbus : public uart::UARTDevice, public Component {
   uint32_t last_send_tx_offset_{0};
   uint16_t frame_delay_ms_{5};
   uint16_t long_rx_buffer_delay_ms_{0};
+  uint16_t flow_control_pin_pre_send_delay_ms_{0};
+  uint16_t flow_control_pin_post_send_delay_ms_{0};
   uint16_t send_wait_time_{250};
   uint16_t turnaround_delay_ms_{100};
   uint8_t waiting_for_response_{0};

--- a/tests/component_tests/modbus/test_init.py
+++ b/tests/component_tests/modbus/test_init.py
@@ -1,0 +1,75 @@
+"""Tests for modbus configuration validation."""
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.const import PlatformFramework
+from tests.component_tests.types import SetCoreConfigCallable
+
+
+def test_modbus_accepts_flow_control_delays(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={"board": "esp32dev", "variant": "ESP32"},
+    )
+    from esphome.components import esp32  # noqa: F401
+    from esphome.components.modbus import (
+        CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY,
+        CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY,
+        CONFIG_SCHEMA,
+    )
+
+    config = CONFIG_SCHEMA(
+        {
+            "id": "modbus_bus",
+            "uart_id": "uart_bus",
+            "flow_control_pin": 4,
+            CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY: "5ms",
+            CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY: "7ms",
+        }
+    )
+
+    assert config[
+        CONF_FLOW_CONTROL_PIN_PRE_SEND_DELAY
+    ] == cv.positive_time_period_milliseconds("5ms")
+    assert config[
+        CONF_FLOW_CONTROL_PIN_POST_SEND_DELAY
+    ] == cv.positive_time_period_milliseconds("7ms")
+
+
+@pytest.mark.parametrize(
+    ("config", "error_match"),
+    [
+        pytest.param(
+            {
+                "id": "modbus_bus",
+                "uart_id": "uart_bus",
+                "flow_control_pin_pre_send_delay": "5ms",
+            },
+            "'flow_control_pin_pre_send_delay' requires 'flow_control_pin'",
+            id="pre_send_delay_requires_flow_control_pin",
+        ),
+        pytest.param(
+            {
+                "id": "modbus_bus",
+                "uart_id": "uart_bus",
+                "flow_control_pin_post_send_delay": "7ms",
+            },
+            "'flow_control_pin_post_send_delay' requires 'flow_control_pin'",
+            id="post_send_delay_requires_flow_control_pin",
+        ),
+    ],
+)
+def test_modbus_rejects_flow_control_delays_without_flow_control_pin(
+    config: dict[str, str],
+    error_match: str,
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    set_core_config(PlatformFramework.ESP32_IDF)
+
+    from esphome.components.modbus import CONFIG_SCHEMA
+
+    with pytest.raises(cv.Invalid, match=error_match):
+        CONFIG_SCHEMA(config)

--- a/tests/components/modbus/common.yaml
+++ b/tests/components/modbus/common.yaml
@@ -1,5 +1,7 @@
 modbus:
   id: mod_bus1
   flow_control_pin: ${flow_control_pin}
+  flow_control_pin_pre_send_delay: 5ms
+  flow_control_pin_post_send_delay: 7ms
   send_wait_time: 500ms
   turnaround_time: 100ms


### PR DESCRIPTION
## Summary

Some utility-meter Modbus RTU slaves — in my case the JANZ and ZIV three-phase meters used in Portuguese E-Redes deployments — need short quiet windows around the flow-control pin transitions to produce reliable responses: a pre-send gap after driving DE high before the frame starts, and a post-send gap after the last byte clears the wire before DE is released. Without these gaps the meter either truncates the first character or misses the end of the master's request, depending on the model.

Adds two optional YAML keys that default to 0 (existing configs are unaffected):

- `flow_control_pin_pre_send_delay` — delay after driving DE high, before writing the frame
- `flow_control_pin_post_send_delay` — delay after flushing the frame, before releasing DE

Both are validated to require `flow_control_pin` to be set. Reported in `dump_config`.

Note: the implementation uses a blocking `delay()` call inside `send_next_frame_()`, so these should be kept small (a few ms) to avoid starving other components on the loop.

## Test plan

- [x] New pytest in `tests/component_tests/modbus/test_init.py` covers the positive path, the post-send delay path, and the validation error when the delays are set without a flow control pin.
- [x] `tests/components/modbus/common.yaml` is extended with the new keys so the existing ESP32-IDF / ESP8266-ard / RP2040-ard platform builds exercise them.
- [ ] CI: clang-format, clang-tidy, CODEOWNERS checks pass.