### PR TITLE
[modbus] Add configurable rx_buffer_delay override

### DIFF
--- a/esphome/components/modbus/__init__.py
+++ b/esphome/components/modbus/__init__.py
@@ -19,6 +19,7 @@ MULTI_CONF = True
 
 CONF_ROLE = "role"
 CONF_MODBUS_ID = "modbus_id"
+CONF_RX_BUFFER_DELAY = "rx_buffer_delay"
 CONF_SEND_WAIT_TIME = "send_wait_time"
 CONF_TURNAROUND_TIME = "turnaround_time"
 
@@ -40,6 +41,7 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_TURNAROUND_TIME, default="100ms"
             ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_RX_BUFFER_DELAY): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_DISABLE_CRC, default=False): cv.boolean,
         }
     )
@@ -62,6 +64,8 @@ async def to_code(config):
 
     cg.add(var.set_send_wait_time(config[CONF_SEND_WAIT_TIME]))
     cg.add(var.set_turnaround_time(config[CONF_TURNAROUND_TIME]))
+    if CONF_RX_BUFFER_DELAY in config:
+        cg.add(var.set_rx_buffer_delay(config[CONF_RX_BUFFER_DELAY]))
     cg.add(var.set_disable_crc(config[CONF_DISABLE_CRC]))
 
 

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -43,11 +43,18 @@ void Modbus::loop() {
 
   // If the response frame is finished (including interframe delay) - we timeout.
   // The long_rx_buffer_delay accounts for long responses (larger than the UART rx_full_threshold) to avoid timeouts
-  // when the buffer is filling the back half of the response
-  const uint16_t timeout = std::max(
-      (uint16_t) this->frame_delay_ms_,
-      (uint16_t) (this->rx_buffer_.size() >= this->parent_->get_rx_full_threshold() ? this->long_rx_buffer_delay_ms_
-                                                                                    : 0));
+  // when the buffer is filling the back half of the response.
+  // rx_buffer_delay_override_ms_, when non-zero, replaces the auto-calculated long_rx_buffer_delay_ms_
+  // for devices whose effective per-frame delay is not well modelled by rx_full_threshold.
+  // uint32_t so rx_buffer_delay_override_ms_ is not silently truncated when a user sets a
+  // delay larger than uint16_t can hold (positive_time_period_milliseconds accepts up to
+  // 2^32 - 1 ms).
+  uint32_t timeout = this->frame_delay_ms_;
+  if (this->rx_buffer_delay_override_ms_ != 0) {
+    timeout = std::max(timeout, this->rx_buffer_delay_override_ms_);
+  } else if (this->rx_buffer_.size() >= this->parent_->get_rx_full_threshold()) {
+    timeout = std::max(timeout, static_cast<uint32_t>(this->long_rx_buffer_delay_ms_));
+  }
   // We use millis() here and elsewhere instead of App.get_loop_component_start_time() to avoid stale timestamps
   // It's critical in all timestamp comparisons that the left timestamp comes before the right one in time
   // If we use a cached value in place of millis() and last_modbus_byte_ is updated inside our loop
@@ -324,9 +331,10 @@ void Modbus::dump_config() {
                 "  Turnaround Time: %d ms\n"
                 "  Frame Delay: %d ms\n"
                 "  Long Rx Buffer Delay: %d ms\n"
+                "  Rx Buffer Delay Override: %" PRIu32 " ms\n"
                 "  CRC Disabled: %s",
                 this->send_wait_time_, this->turnaround_delay_ms_, this->frame_delay_ms_,
-                this->long_rx_buffer_delay_ms_, YESNO(this->disable_crc_));
+                this->long_rx_buffer_delay_ms_, this->rx_buffer_delay_override_ms_, YESNO(this->disable_crc_));
   LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
 }
 float Modbus::get_setup_priority() const {

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -58,6 +58,7 @@ class Modbus : public uart::UARTDevice, public Component {
   void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
   void set_send_wait_time(uint16_t time_in_ms) { this->send_wait_time_ = time_in_ms; }
   void set_turnaround_time(uint16_t time_in_ms) { this->turnaround_delay_ms_ = time_in_ms; }
+  void set_rx_buffer_delay(uint32_t time_in_ms) { this->rx_buffer_delay_override_ms_ = time_in_ms; }
   void set_disable_crc(bool disable_crc) { this->disable_crc_ = disable_crc; }
 
   ModbusRole role;
@@ -74,6 +75,7 @@ class Modbus : public uart::UARTDevice, public Component {
   uint32_t last_send_tx_offset_{0};
   uint16_t frame_delay_ms_{5};
   uint16_t long_rx_buffer_delay_ms_{0};
+  uint32_t rx_buffer_delay_override_ms_{0};
   uint16_t send_wait_time_{250};
   uint16_t turnaround_delay_ms_{100};
   uint8_t waiting_for_response_{0};

--- a/tests/component_tests/modbus/test_init.py
+++ b/tests/component_tests/modbus/test_init.py
@@ -1,0 +1,23 @@
+"""Tests for modbus configuration validation."""
+
+from esphome import config_validation as cv
+from esphome.const import PlatformFramework
+from tests.component_tests.types import SetCoreConfigCallable
+
+
+def test_modbus_accepts_rx_buffer_delay(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    set_core_config(PlatformFramework.ESP32_IDF)
+
+    from esphome.components.modbus import CONF_RX_BUFFER_DELAY, CONFIG_SCHEMA
+
+    config = CONFIG_SCHEMA(
+        {
+            "id": "modbus_bus",
+            "uart_id": "uart_bus",
+            CONF_RX_BUFFER_DELAY: "25ms",
+        }
+    )
+
+    assert config[CONF_RX_BUFFER_DELAY] == cv.positive_time_period_milliseconds("25ms")


### PR DESCRIPTION
## Summary

The long-RX-buffer timeout in `Modbus::loop()` is auto-derived from the UART's `rx_full_threshold` on the assumption that the slave's per-frame response shape is predictable from that threshold. Some utility-meter Modbus RTU slaves — the JANZ and ZIV three-phase meters used in Portuguese E-Redes deployments — don't match that model: their responses need a longer settled window regardless of the UART FIFO threshold, and on ESP-IDF 5.5.x with the wake-on-RX loop enabled the auto-calculated value is not sufficient to avoid truncating long frames.

Add an optional `rx_buffer_delay` YAML key (`positive_time_period_milliseconds`). When non-zero it replaces the auto-calculated `long_rx_buffer_delay_ms_` in the per-loop timeout computation. Zero (the default) keeps existing behavior untouched, so no current config is affected.

Reported in `dump_config` alongside the existing Long Rx Buffer Delay line so users can see which one is in effect.

## Test plan

- [x] New pytest in `tests/component_tests/modbus/test_init.py` asserts the schema accepts a `25ms` value and parses it to the expected `TimePeriod`.
- [ ] CI: existing modbus platform YAML suites continue to compile.