### PR TITLE
[modbus] Rewrite RTU parser with buffered sliding resync

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -53,8 +53,17 @@ void Modbus::loop() {
   // If we use a cached value in place of millis() and last_modbus_byte_ is updated inside our loop
   // then the comparison is backwards (small negative which wraps to large positive) and will cause a false timeout
   // So in this component we don't use any cached timestamp values to avoid these annoying bugs
-  if (millis() - this->last_modbus_byte_ > timeout) {
-    this->clear_rx_buffer_(LOG_STR("timeout after partial response"), true);
+  if (!this->rx_buffer_.empty() && millis() - this->last_modbus_byte_ > timeout) {
+    // Interframe gap expired. Try one last resync - a valid frame may be
+    // buried after leading noise bytes that prevented extraction earlier.
+    this->try_extract_frame_();
+    if (!this->rx_buffer_.empty()) {
+      const size_t dump_size = std::min(this->rx_buffer_.size(), MODBUS_MAX_LOG_BYTES);
+      char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
+      ESP_LOGD(TAG, "Timeout buffer (%zu bytes) %" PRIu32 "ms after last send: %s", this->rx_buffer_.size(),
+               millis() - this->last_send_, format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), dump_size));
+      this->clear_rx_buffer_(LOG_STR("timeout after partial response"), true);
+    }
   }
 
   // If we're past the send_wait_time timeout and response buffer doesn't have the start of the expected response
@@ -90,79 +99,242 @@ bool Modbus::tx_blocked() {
 bool Modbus::tx_buffer_empty() { return this->tx_buffer_.empty(); }
 
 void Modbus::receive_and_parse_modbus_bytes_() {
-  // Read all available bytes in batches to reduce UART call overhead.
   size_t avail = this->available();
+  if (avail == 0)
+    return;
+
+  // Batch-read all available bytes into rx_buffer_.
+  bool was_empty = this->rx_buffer_.empty();
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(avail, sizeof(buf));
-    if (!this->read_array(buf, to_read)) {
+    if (!this->read_array(buf, to_read))
+      break;
+    this->rx_buffer_.insert(this->rx_buffer_.end(), buf, buf + to_read);
+    avail -= to_read;
+  }
+  this->last_modbus_byte_ = millis();
+
+  if (was_empty && !this->rx_buffer_.empty()) {
+    const uint8_t first = this->rx_buffer_[0];
+    ESP_LOGV(TAG, "Received first byte %" PRIu8 " (0X%x) %" PRIu32 "ms after last send", first, first,
+             millis() - this->last_send_);
+  }
+
+  // Guard against unbounded growth from continuous noise
+  if (this->rx_buffer_.size() > MAX_FRAME_SIZE) {
+    size_t excess = this->rx_buffer_.size() - MAX_FRAME_SIZE;
+    ESP_LOGW(TAG, "Rx buffer overflow (%zu bytes), discarding oldest %zu", this->rx_buffer_.size(), excess);
+    this->rx_buffer_.erase(this->rx_buffer_.begin(), this->rx_buffer_.begin() + excess);
+  }
+
+  this->drop_impossible_leading_bytes_();
+  this->try_extract_frame_();
+}
+
+void Modbus::drop_impossible_leading_bytes_() {
+  while (!this->rx_buffer_.empty()) {
+    const uint8_t first = this->rx_buffer_.front();
+    bool impossible = false;
+
+    if (this->waiting_for_response_ != 0) {
+      // While a response is pending, any leading byte that does not match the expected
+      // device address cannot begin a valid RTU response frame.
+      impossible = first != this->waiting_for_response_;
+    } else {
+      // With no response pending, only trim explicit NUL noise eagerly.
+      impossible = first == 0x00;
+    }
+
+    if (!impossible) {
       break;
     }
-    avail -= to_read;
-    for (size_t i = 0; i < to_read; i++) {
-      if (this->rx_buffer_.empty()) {
-        ESP_LOGV(TAG, "Received first byte %" PRIu8 " (0X%x) %" PRIu32 "ms after last send", buf[i], buf[i],
-                 millis() - this->last_send_);
-      } else {
-        ESP_LOGVV(TAG, "Received byte %" PRIu8 " (0X%x) %" PRIu32 "ms after last send", buf[i], buf[i],
-                  millis() - this->last_send_);
-      }
 
-      // If the bytes in the rx buffer do not parse, clear out the buffer
-      if (!this->parse_modbus_byte_(buf[i])) {
-        this->clear_rx_buffer_(LOG_STR("parse failed"), true);
-      }
-      this->last_modbus_byte_ = millis();
-    }
+    // ESP_LOGV, not ESP_LOGD: on a continuously noisy bus this fires once per byte and
+    // would flood the default log. Operators enable V when they need to investigate.
+    ESP_LOGV(TAG, "Dropping impossible leading byte 0x%02X while waiting for addr=%" PRIu8, first,
+             this->waiting_for_response_);
+    this->rx_buffer_.erase(this->rx_buffer_.begin());
   }
 }
 
-bool Modbus::parse_modbus_byte_(uint8_t byte) {
-  size_t at = this->rx_buffer_.size();
-  this->rx_buffer_.push_back(byte);
-  const uint8_t *raw = &this->rx_buffer_[0];
+// Examine rx_buffer_ starting at byte 0 for a complete, valid Modbus RTU frame.
+// Returns:
+//   > 0  total frame length (including CRC) - valid frame ready to dispatch
+//     0  incomplete frame, need more bytes
+//    -1  CRC failure or implausible header - caller should resync
+int Modbus::check_frame_() const {
+  const size_t len = this->rx_buffer_.size();
+  // Absolute minimum: addr(1) + FC(1) + CRC(2) = 4 bytes. Standard FCs need more than this
+  // and the check further down handles their lengths; user-defined FCs can legally be this short.
+  if (len < 4)
+    return 0;
 
-  // Byte 0: modbus address (match all)
-  if (at == 0)
-    return true;
-  // Byte 1: function code
-  if (at == 1)
-    return true;
-  // Byte 2: Size (with modbus rtu function code 4/3)
-  // See also https://en.wikipedia.org/wiki/Modbus
-  if (at == 2)
-    return true;
-
-  uint8_t address = raw[0];
+  const uint8_t *raw = this->rx_buffer_.data();
   uint8_t function_code = raw[1];
 
-  uint8_t data_len = raw[2];
-  uint8_t data_offset = 3;
-
-  // Per https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf Ch 5 User-Defined function codes
+  // --- User-defined function codes: unknown payload length, speculative CRC ---
+  // Per https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf Ch 5
   if (((function_code >= FUNCTION_CODE_USER_DEFINED_SPACE_1_INIT) &&
        (function_code <= FUNCTION_CODE_USER_DEFINED_SPACE_1_END)) ||
       ((function_code >= FUNCTION_CODE_USER_DEFINED_SPACE_2_INIT) &&
        (function_code <= FUNCTION_CODE_USER_DEFINED_SPACE_2_END))) {
-    // Handle user-defined function, since we don't know how big this ought to be,
-    // ideally we should delegate the entire length detection to whatever handler is
-    // installed, but wait, there is the CRC, and if we get a hit there is a good
-    // chance that this is a complete message ... admittedly there is a small chance is
-    // isn't but that is quite small given the purpose of the CRC in the first place
+    // Try CRC at every possible frame end (min 4 bytes: addr+FC+CRC_L+CRC_H)
+    for (size_t try_len = 4; try_len <= len && try_len <= MAX_FRAME_SIZE; try_len++) {
+      size_t crc_pos = try_len - 2;
+      uint16_t computed = crc16(raw, crc_pos);
+      uint16_t remote = uint16_t(raw[crc_pos]) | (uint16_t(raw[crc_pos + 1]) << 8);
+      if (computed == remote)
+        return static_cast<int>(try_len);
+    }
+    return (len < MAX_FRAME_SIZE) ? 0 : -1;
+  }
 
-    data_len = at - 2;
-    data_offset = 1;
+  // Standard function codes need at least an exception-response shape:
+  // addr(1) + FC(1) + exception(1) + CRC(2) = 5 bytes.
+  if (len < 5)
+    return 0;
 
-    uint16_t computed_crc = crc16(raw, data_offset + data_len);
-    uint16_t remote_crc = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
+  // --- Standard function codes: deterministic frame length ---
+  uint8_t data_offset = 3;
+  uint8_t data_len = raw[2];
 
-    if (computed_crc != remote_crc)
-      return true;
-
-    ESP_LOGD(TAG, "User-defined function %02X found", function_code);
-
-  } else {
+  // See also https://en.wikipedia.org/wiki/Modbus
+  if (this->role == ModbusRole::SERVER) {
     // data starts at 2 and length is 4 for read registers commands
+    if (function_code == ModbusFunctionCode::READ_COILS || function_code == ModbusFunctionCode::READ_DISCRETE_INPUTS ||
+        function_code == ModbusFunctionCode::READ_HOLDING_REGISTERS ||
+        function_code == ModbusFunctionCode::READ_INPUT_REGISTERS ||
+        function_code == ModbusFunctionCode::WRITE_SINGLE_REGISTER) {
+      data_offset = 2;
+      data_len = 4;
+    } else if (function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
+      if (len < 7)
+        return 0;  // Need raw[6] for byte count
+      data_offset = 2;
+      // starting address (2 bytes) + quantity of registers (2 bytes) + byte count itself (1 byte) + actual byte count
+      data_len = 2 + 2 + 1 + raw[6];
+    }
+  } else {
+    // CLIENT mode - the response for write command mirrors the requests and data starts at offset 2 instead of 3 for
+    // read commands
+    if (function_code == ModbusFunctionCode::WRITE_SINGLE_COIL ||
+        function_code == ModbusFunctionCode::WRITE_SINGLE_REGISTER ||
+        function_code == ModbusFunctionCode::WRITE_MULTIPLE_COILS ||
+        function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
+      data_offset = 2;
+      data_len = 4;
+    }
+    // else: read response - data_offset=3, data_len=raw[2] (defaults)
+  }
+
+  // Error ( msb indicates error ) overrides any previous layout
+  // response format:  Byte[0] = device address, Byte[1] function code | 0x80 , Byte[2] exception code, Byte[3-4] crc
+  if ((function_code & FUNCTION_CODE_EXCEPTION_MASK) == FUNCTION_CODE_EXCEPTION_MASK) {
+    data_offset = 2;
+    data_len = 1;
+  }
+
+  size_t frame_len = static_cast<size_t>(data_offset) + data_len + 2;
+
+  // Implausible length - noise probably corrupted the header
+  if (frame_len > MAX_FRAME_SIZE)
+    return -1;
+
+  // Not enough bytes yet
+  if (len < frame_len)
+    return 0;
+
+  // CRC validation
+  uint16_t computed = crc16(raw, data_offset + data_len);
+  uint16_t remote = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
+
+  if (computed != remote) {
+    if (this->disable_crc_) {
+      ESP_LOGD(TAG, "CRC check failed %" PRIu32 "ms after last send; ignoring", millis() - this->last_send_);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+      char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
+#endif
+      ESP_LOGVV(TAG, "  (%02X != %02X)  %s", computed, remote,
+                format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
+      return static_cast<int>(frame_len);
+    }
+    {
+      const size_t dump_size = std::min(this->rx_buffer_.size(), MODBUS_MAX_LOG_BYTES);
+      char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
+      ESP_LOGD(TAG, "CRC check failed %" PRIu32 "ms after last send (%04X != %04X) %zu bytes: %s",
+               millis() - this->last_send_, computed, remote, this->rx_buffer_.size(),
+               format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), dump_size));
+    }
+    return -1;
+  }
+
+  return static_cast<int>(frame_len);
+}
+
+void Modbus::try_extract_frame_() {
+  // Standard Modbus RTU frames are at least 5 bytes, but user-defined function
+  // codes can legally have no payload and therefore be only 4 bytes
+  // (addr + function + CRC16).
+  static constexpr size_t MIN_FRAME_SIZE = 4;
+  // Upper bound on how much leading noise we will skip before giving up and clearing
+  // the buffer. 16 bytes covers the common "a few stray bits before the real frame"
+  // case without risking unbounded CPU on a line that is just continuously garbage.
+  static constexpr size_t MAX_RESYNC_DROPS = 16;
+  size_t drops = 0;
+
+  while (this->rx_buffer_.size() >= MIN_FRAME_SIZE) {
+    int frame_len = this->check_frame_();
+
+    if (frame_len > 0) {
+      // Valid frame found
+      if (drops > 0) {
+        ESP_LOGD(TAG, "Resync: recovered frame after dropping %zu noise byte(s)", drops);
+      }
+      this->dispatch_frame_(static_cast<size_t>(frame_len));
+      this->rx_buffer_.erase(this->rx_buffer_.begin(), this->rx_buffer_.begin() + frame_len);
+      drops = 0;
+      continue;  // Check for another frame in remaining bytes
+    }
+
+    if (frame_len == 0) {
+      return;  // Incomplete - wait for more bytes
+    }
+
+    // frame_len == -1: CRC failure or bad header - try resync by dropping byte 0
+    if (drops >= MAX_RESYNC_DROPS) {
+      ESP_LOGW(TAG, "Resync exhausted after dropping %zu bytes, clearing buffer", drops);
+      this->clear_rx_buffer_(LOG_STR("resync exhausted"), true);
+      return;
+    }
+    // ESP_LOGV for per-byte drops - the recovery summary at ESP_LOGD covers the useful signal.
+    ESP_LOGV(TAG, "Resync: dropping leading byte 0x%02X (%zu bytes remain)", this->rx_buffer_[0],
+             this->rx_buffer_.size() - 1);
+    this->rx_buffer_.erase(this->rx_buffer_.begin());
+    drops++;
+  }
+}
+
+void Modbus::dispatch_frame_(size_t frame_len) {
+  const uint8_t *raw = this->rx_buffer_.data();
+  uint8_t address = raw[0];
+  uint8_t function_code = raw[1];
+
+  uint8_t data_offset;
+  uint8_t data_len;
+
+  // Determine data layout (mirrors check_frame_ logic)
+  if (((function_code >= FUNCTION_CODE_USER_DEFINED_SPACE_1_INIT) &&
+       (function_code <= FUNCTION_CODE_USER_DEFINED_SPACE_1_END)) ||
+      ((function_code >= FUNCTION_CODE_USER_DEFINED_SPACE_2_INIT) &&
+       (function_code <= FUNCTION_CODE_USER_DEFINED_SPACE_2_END))) {
+    data_offset = 1;
+    data_len = static_cast<uint8_t>(frame_len - 3);  // frame minus addr(1) and CRC(2)
+    ESP_LOGD(TAG, "User-defined function %02X found", function_code);
+  } else {
+    data_offset = 3;
+    data_len = raw[2];
+
     if (this->role == ModbusRole::SERVER) {
       if (function_code == ModbusFunctionCode::READ_COILS ||
           function_code == ModbusFunctionCode::READ_DISCRETE_INPUTS ||
@@ -172,15 +344,10 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
         data_offset = 2;
         data_len = 4;
       } else if (function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
-        if (at < 6) {
-          return true;
-        }
         data_offset = 2;
-        // starting address (2 bytes) + quantity of registers (2 bytes) + byte count itself (1 byte) + actual byte count
         data_len = 2 + 2 + 1 + raw[6];
       }
     } else {
-      // the response for write command mirrors the requests and data starts at offset 2 instead of 3 for read commands
       if (function_code == ModbusFunctionCode::WRITE_SINGLE_COIL ||
           function_code == ModbusFunctionCode::WRITE_SINGLE_REGISTER ||
           function_code == ModbusFunctionCode::WRITE_MULTIPLE_COILS ||
@@ -190,44 +357,13 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
       }
     }
 
-    // Error ( msb indicates error )
-    // response format:  Byte[0] = device address, Byte[1] function code | 0x80 , Byte[2] exception code, Byte[3-4] crc
     if ((function_code & FUNCTION_CODE_EXCEPTION_MASK) == FUNCTION_CODE_EXCEPTION_MASK) {
       data_offset = 2;
       data_len = 1;
     }
-
-    // Byte data_offset..data_offset+data_len-1: Data
-    if (at < data_offset + data_len)
-      return true;
-
-    // Byte 3+data_len: CRC_LO (over all bytes)
-    if (at == data_offset + data_len)
-      return true;
-
-    // Byte data_offset+len+1: CRC_HI (over all bytes)
-    uint16_t computed_crc = crc16(raw, data_offset + data_len);
-    uint16_t remote_crc = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
-    if (computed_crc != remote_crc) {
-      if (this->disable_crc_) {
-        ESP_LOGD(TAG, "CRC check failed %" PRIu32 "ms after last send; ignoring", millis() - this->last_send_);
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
-        char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
-#endif
-        ESP_LOGVV(TAG, "  (%02X != %02X)  %s", computed_crc, remote_crc,
-                  format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
-      } else {
-        ESP_LOGW(TAG, "CRC check failed %" PRIu32 "ms after last send", millis() - this->last_send_);
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
-        char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
-#endif
-        ESP_LOGVV(TAG, "  (%02X != %02X) %s", computed_crc, remote_crc,
-                  format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
-        return false;
-      }
-    }
   }
-  std::vector<uint8_t> data(this->rx_buffer_.begin() + data_offset, this->rx_buffer_.begin() + data_offset + data_len);
+
+  std::vector<uint8_t> data(raw + data_offset, raw + data_offset + data_len);
   bool found = false;
   for (auto *device : this->devices_) {
     if (device->address_ == address) {
@@ -273,12 +409,8 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
              millis() - this->last_send_);
   }
 
-  this->clear_rx_buffer_(LOG_STR("parse succeeded"));
-
   if (this->waiting_for_response_ == address)
     this->waiting_for_response_ = 0;
-
-  return true;
 }
 
 void Modbus::send_next_frame_() {

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -63,11 +63,14 @@ class Modbus : public uart::UARTDevice, public Component {
   ModbusRole role;
 
  protected:
-  bool parse_modbus_byte_(uint8_t byte);
+  int check_frame_() const;
+  void try_extract_frame_();
+  void dispatch_frame_(size_t frame_len);
   void receive_and_parse_modbus_bytes_();
   void clear_rx_buffer_(const LogString *reason, bool warn = false);
   void send_next_frame_();
   void queue_raw_(const uint8_t *data, uint16_t len);
+  void drop_impossible_leading_bytes_();
 
   uint32_t last_modbus_byte_{0};
   uint32_t last_send_{0};

--- a/tests/components/modbus/modbus_test.cpp
+++ b/tests/components/modbus/modbus_test.cpp
@@ -1,35 +1,48 @@
 #include <gtest/gtest.h>
+
 #include "esphome/components/modbus/modbus.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome::modbus {
 
-// Exposes protected methods for testing.
 class TestModbus : public Modbus {
  public:
-  bool test_parse_modbus_byte(uint8_t byte) { return this->parse_modbus_byte_(byte); }
-  void test_clear_rx_buffer() { this->rx_buffer_.clear(); }
+  void append_rx_bytes(const std::vector<uint8_t> &bytes) {
+    this->rx_buffer_.insert(this->rx_buffer_.end(), bytes.begin(), bytes.end());
+  }
+  void run_drop_impossible() { this->drop_impossible_leading_bytes_(); }
+  void run_extract() { this->try_extract_frame_(); }
   void set_waiting(uint8_t addr) { this->waiting_for_response_ = addr; }
+  size_t rx_buffer_size() const { return this->rx_buffer_.size(); }
 };
 
 class MockDevice : public ModbusDevice {
  public:
-  void on_modbus_data(const std::vector<uint8_t> &data) override { this->data_received = true; }
-  bool data_received{false};
+  void on_modbus_data(const std::vector<uint8_t> &data) override { this->payloads.push_back(data); }
+
+  std::vector<std::vector<uint8_t>> payloads;
 };
 
-TEST(ModbusTest, TwoByteRegressionTest) {
-  TestModbus modbus;
-  modbus.set_role(ModbusRole::CLIENT);
-  // First byte (at=0)
-  EXPECT_TRUE(modbus.test_parse_modbus_byte(0x01));
-  // Second byte (at=1)
-  // This used to reach raw[2] because it skipped the if(at==2) check, causing a
-  // buffer overflow.
-  EXPECT_TRUE(modbus.test_parse_modbus_byte(0x03));
+static std::vector<uint8_t> make_rtu_frame(const std::vector<uint8_t> &frame_data) {
+  std::vector<uint8_t> frame = frame_data;
+  uint16_t crc = esphome::crc16(frame.data(), frame.size());
+  frame.push_back(crc & 0xFF);
+  frame.push_back((crc >> 8) & 0xFF);
+  return frame;
 }
 
-TEST(ModbusTest, TestValidFrame) {
+TEST(ModbusTest, TruncatedHeaderRemainsBuffered) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  modbus.append_rx_bytes({0x01, 0x03});
+  modbus.run_extract();
+
+  // Incomplete frame must stay buffered so subsequent bytes can complete it.
+  EXPECT_EQ(modbus.rx_buffer_size(), 2);
+}
+
+TEST(ModbusTest, StandardFrameDispatchesFromBufferedParser) {
   TestModbus modbus;
   modbus.set_role(ModbusRole::CLIENT);
 
@@ -39,21 +52,110 @@ TEST(ModbusTest, TestValidFrame) {
   modbus.register_device(&device);
   modbus.set_waiting(0x01);
 
-  // Address 1, Function 3, Length 2, Data 0x1234
-  uint8_t frame_data[] = {0x01, 0x03, 0x02, 0x12, 0x34};
-  uint16_t crc = esphome::crc16(frame_data, sizeof(frame_data));
+  modbus.append_rx_bytes(make_rtu_frame({0x01, 0x03, 0x02, 0x12, 0x34}));
+  modbus.run_extract();
 
-  std::vector<uint8_t> frame;
-  for (uint8_t b : frame_data)
-    frame.push_back(b);
-  frame.push_back(crc & 0xFF);
-  frame.push_back((crc >> 8) & 0xFF);
+  ASSERT_EQ(device.payloads.size(), 1);
+  EXPECT_EQ(device.payloads[0], (std::vector<uint8_t>{0x12, 0x34}));
+  EXPECT_EQ(modbus.rx_buffer_size(), 0);
+}
 
-  for (size_t i = 0; i < frame.size(); i++) {
-    bool result = modbus.test_parse_modbus_byte(frame[i]);
-    EXPECT_TRUE(result) << "Failed at byte " << i << " (0x" << std::hex << (int) frame[i] << ")";
-  }
-  EXPECT_TRUE(device.data_received);
+TEST(ModbusTest, UserDefinedFourByteFrameDispatches) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  // User-defined function code 0x44 with no payload (4-byte frame: addr+FC+CRC16).
+  modbus.append_rx_bytes(make_rtu_frame({0x01, 0x44}));
+  modbus.run_extract();
+
+  ASSERT_EQ(device.payloads.size(), 1);
+  EXPECT_EQ(device.payloads[0], (std::vector<uint8_t>{0x44}));
+  EXPECT_EQ(modbus.rx_buffer_size(), 0);
+}
+
+TEST(ModbusTest, SlidingResyncRecoversValidFrameAfterNoise) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  std::vector<uint8_t> frame = make_rtu_frame({0x01, 0x03, 0x02, 0x12, 0x34});
+  // This test exercises the sliding CRC resync in isolation. In production flow
+  // receive_and_parse_modbus_bytes_() calls drop_impossible_leading_bytes_() first, which
+  // would discard 0xAA/0xBB while waiting for address 0x01. Here we skip that pass and
+  // verify that try_extract_frame_() alone still recovers the valid frame.
+  std::vector<uint8_t> noisy_frame = {0xAA, 0xBB};
+  noisy_frame.insert(noisy_frame.end(), frame.begin(), frame.end());
+
+  modbus.append_rx_bytes(noisy_frame);
+  modbus.run_extract();
+
+  ASSERT_EQ(device.payloads.size(), 1);
+  EXPECT_EQ(device.payloads[0], (std::vector<uint8_t>{0x12, 0x34}));
+  EXPECT_EQ(modbus.rx_buffer_size(), 0);
+}
+
+TEST(ModbusTest, FastDropRemovesAddressMismatchedLeadingByteWhenWaiting) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  std::vector<uint8_t> frame = make_rtu_frame({0x01, 0x03, 0x02, 0x12, 0x34});
+  std::vector<uint8_t> with_noise = {0x00};
+  with_noise.insert(with_noise.end(), frame.begin(), frame.end());
+
+  modbus.append_rx_bytes(with_noise);
+  // The fast-drop path must remove the leading 0x00 before any CRC work happens;
+  // after drop_impossible the buffer should start with the valid frame.
+  modbus.run_drop_impossible();
+  EXPECT_EQ(modbus.rx_buffer_size(), frame.size());
+
+  modbus.run_extract();
+  ASSERT_EQ(device.payloads.size(), 1);
+  EXPECT_EQ(device.payloads[0], (std::vector<uint8_t>{0x12, 0x34}));
+  EXPECT_EQ(modbus.rx_buffer_size(), 0);
+}
+
+TEST(ModbusTest, FastDropIgnoresNonNulLeadingByteWhenNotWaiting) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  std::vector<uint8_t> frame = make_rtu_frame({0x01, 0x03, 0x02, 0x12, 0x34});
+  std::vector<uint8_t> with_noise = {0xAA};
+  with_noise.insert(with_noise.end(), frame.begin(), frame.end());
+
+  modbus.append_rx_bytes(with_noise);
+  // Drop-pass invariant under test: when no response is pending, the fast-drop path must
+  // not consume arbitrary non-NUL bytes (unlike the waiting path, which drops any leading
+  // non-address byte). Only NUL noise is trimmed here; 0xAA must remain.
+  modbus.run_drop_impossible();
+  EXPECT_EQ(modbus.rx_buffer_size(), with_noise.size());
+
+  // Recovery still works - try_extract_frame_ uses the sliding CRC resync to drop the
+  // 0xAA and extract the valid frame. Not checking device.payloads here because CLIENT
+  // mode requires set_waiting() for dispatch, which is a separate concern from this test.
+  modbus.run_extract();
+  EXPECT_EQ(modbus.rx_buffer_size(), 0);
 }
 
 }  // namespace esphome::modbus


### PR DESCRIPTION
## Summary

The byte-at-a-time `parse_modbus_byte_` state machine cannot recover from a single dropped or spurious byte on an RS485 line — any parse failure clears the whole `rx_buffer_` and discards any valid frame that might have been buried in it. This is disruptive with utility-meter Modbus RTU slaves (JANZ and ZIV meters in Portuguese E-Redes deployments) whose lines occasionally carry stray leading bytes, after which every subsequent response is dropped.

Replace the per-byte state machine with a batched buffer-based parser:

- `receive_and_parse_modbus_bytes_()` reads all available UART bytes in one pass, guards against `rx_buffer_` growing past `MAX_FRAME_SIZE`, then runs the new fast-drop and frame-extraction passes.
- `drop_impossible_leading_bytes_()` is a cheap fast path. While a response is pending, any leading byte that does not match the expected slave address is discarded; with no response pending only explicit NUL noise is discarded. Avoids burning resync budget on obvious garbage.
- `check_frame_()` examines `rx_buffer_` from byte 0 and returns `> 0` (full frame length), `0` (incomplete), or `-1` (CRC failure or implausible header). Supports user-defined function codes with no payload (4-byte frames: `addr + FC + CRC16`) by trying a speculative CRC at every possible frame end.
- `try_extract_frame_()` drives the resync: on CRC failure it drops byte 0 and retries, up to `MAX_RESYNC_DROPS = 16` bytes, then gives up and clears. On success it dispatches, erases the frame, and continues to look for another frame in the remaining bytes.
- `dispatch_frame_()` hosts the logic that used to be inline at the end of `parse_modbus_byte_`.

Per-byte resync and fast-drop events log at `ESP_LOGV` so noisy buses don't flood default logs; the once-per-recovery summary stays at `ESP_LOGD`. If the interframe-gap timeout finds a non-empty buffer, the new code tries one last resync before clearing — a valid frame may be buried after leading noise.

## Test plan

- [x] `tests/components/modbus/modbus_test.cpp` rewritten: 6 GoogleTest cases covering (1) truncated header stays buffered, (2) standard read-holding-registers dispatch, (3) user-defined 4-byte frame dispatch, (4) CRC resync recovers through 2 leading noise bytes, (5) fast-drop removes address-mismatched leading byte while waiting, (6) fast-drop leaves non-NUL leading byte alone when not waiting.
- [ ] CI: `script/cpp_unit_test.py modbus` passes.
- [ ] CI: existing `tests/components/modbus/` and `tests/components/modbus_controller/` platform YAML suites continue to compile against the new parser.
- [ ] CI: clang-format, clang-tidy, CODEOWNERS checks pass.