### PR TITLE
[mqtt] Add MQTT over WebSocket transport for ESP32 IDF

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -58,6 +58,7 @@ from esphome.const import (
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_RTL87XX,
+    Framework,
     PlatformFramework,
 )
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
@@ -75,6 +76,12 @@ def AUTO_LOAD():
 CONF_DISCOVER_IP = "discover_ip"
 CONF_IDF_SEND_ASYNC = "idf_send_async"
 CONF_WAIT_FOR_CONNECTION = "wait_for_connection"
+CONF_TRANSPORT = "transport"
+CONF_WS_PATH = "ws_path"
+
+MQTT_TRANSPORT_TCP = "tcp"
+MQTT_TRANSPORT_WS = "ws"
+MQTT_TRANSPORT_WSS = "wss"
 
 # Max lengths for stack-based topic building.
 # These values are used in cv.Length() validators below to ensure the C++ code
@@ -168,8 +175,61 @@ MQTT_DISCOVERY_OBJECT_ID_GENERATOR_OPTIONS = {
     "device_name": MQTTDiscoveryObjectIdGenerator.MQTT_DEVICE_NAME_OBJECT_ID_GENERATOR,
 }
 
+# WebSocket / WSS support is provided by ESP-IDF's esp-mqtt component. The
+# other MQTT backends (AsyncMqttClient on ESP8266/LibreTiny) do not implement
+# the MQTT-over-WebSocket framing in MQTT 3.1.1 §6, so the transport selector
+# is currently restricted to the ESP32 IDF build.
+MQTTTransport = mqtt_ns.enum("MQTTTransport", is_class=True)
+MQTT_TRANSPORT_OPTIONS = {
+    MQTT_TRANSPORT_TCP: MQTTTransport.TCP,
+    MQTT_TRANSPORT_WS: MQTTTransport.WS,
+    MQTT_TRANSPORT_WSS: MQTTTransport.WSS,
+}
+
+
+def _validate_transport(value):
+    value = cv.enum(MQTT_TRANSPORT_OPTIONS, lower=True)(value)
+    if value in (MQTT_TRANSPORT_WS, MQTT_TRANSPORT_WSS):
+        if not CORE.is_esp32:
+            raise cv.Invalid(
+                f"transport '{value}' is currently only supported on ESP32"
+            )
+        if CORE.target_framework != Framework.ESP_IDF:
+            raise cv.Invalid(
+                f"transport '{value}' requires the esp-idf framework "
+                f"(esp-mqtt's WebSocket support is not available under Arduino)"
+            )
+    return value
+
 
 def validate_config(value):
+    # Plain ws is unencrypted. Pairing it with a CA certificate is almost
+    # certainly a mistake — the user probably meant wss. Flagging this here
+    # (rather than silently dropping the cert in C++) catches the typo at
+    # config-validation time.
+    if value.get(CONF_TRANSPORT) == MQTT_TRANSPORT_WS and (
+        CONF_CERTIFICATE_AUTHORITY in value or CONF_CLIENT_CERTIFICATE in value
+    ):
+        raise cv.Invalid(
+            "transport 'ws' is unencrypted; remove the certificate options "
+            "or switch to transport 'wss'"
+        )
+
+    # ws_path only applies to the WebSocket transports. Reject it elsewhere
+    # (e.g. transport: tcp, or any non-ESP32-IDF target) so a misplaced ws_path
+    # is a clear error at validation time rather than silently ignored in C++.
+    if (
+        value.get(CONF_TRANSPORT)
+        not in (
+            MQTT_TRANSPORT_WS,
+            MQTT_TRANSPORT_WSS,
+        )
+        and CONF_WS_PATH in value
+    ):
+        raise cv.Invalid(
+            f"'{CONF_WS_PATH}' is only valid when 'transport' is 'ws' or 'wss'"
+        )
+
     # Populate default fields
     out = value.copy()
     topic_prefix = value[CONF_TOPIC_PREFIX]
@@ -235,6 +295,10 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PASSWORD, default=""): cv.sensitive(),
             cv.Optional(CONF_CLEAN_SESSION, default=False): cv.boolean,
             cv.Optional(CONF_CLIENT_ID): cv.string,
+            cv.Optional(
+                CONF_TRANSPORT, default=MQTT_TRANSPORT_TCP
+            ): _validate_transport,
+            cv.Optional(CONF_WS_PATH): cv.string,
             cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32=False): cv.All(
                 cv.boolean, cv.only_on_esp32
             ),
@@ -446,6 +510,29 @@ async def to_code(config):
         # prevent error -0x428e
         # See https://github.com/espressif/esp-idf/issues/139
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_HARDWARE_MPI", False)
+
+    if CORE.is_esp32:
+        transport = config[CONF_TRANSPORT]
+        if transport != MQTT_TRANSPORT_TCP:
+            cg.add(var.set_transport(transport))
+        if transport in (MQTT_TRANSPORT_WS, MQTT_TRANSPORT_WSS):
+            cg.add(var.set_ws_path(config.get(CONF_WS_PATH, "/mqtt")))
+            # esp-mqtt's WebSocket transports default to enabled in ESP-IDF, but
+            # enable them explicitly so the feature does not depend on a Kconfig
+            # default that could change underneath us.
+            add_idf_sdkconfig_option("CONFIG_MQTT_TRANSPORT_WEBSOCKET", True)
+            if transport == MQTT_TRANSPORT_WSS:
+                add_idf_sdkconfig_option("CONFIG_MQTT_TRANSPORT_WEBSOCKET_SECURE", True)
+        # wss with no explicit CA falls back to ESP-IDF's bundled root CAs.
+        # Enable the bundle in sdkconfig so esp_crt_bundle_attach is available;
+        # mirrors what http_request does for the same reason.
+        if transport == MQTT_TRANSPORT_WSS and CONF_CERTIFICATE_AUTHORITY not in config:
+            add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+            # wss performs a full TLS handshake even without an explicit CA, so it
+            # needs the same -0x428e hardware-MPI workaround the classic CA/SSL
+            # path applies above (the CA branch handles the wss-with-CA case).
+            # See https://github.com/espressif/esp-idf/issues/139
+            add_idf_sdkconfig_option("CONFIG_MBEDTLS_HARDWARE_MPI", False)
 
     if CONF_IDF_SEND_ASYNC in config and config[CONF_IDF_SEND_ASYNC]:
         cg.add_define("USE_MQTT_IDF_ENQUEUE")

--- a/esphome/components/mqtt/mqtt_backend.h
+++ b/esphome/components/mqtt/mqtt_backend.h
@@ -20,6 +20,16 @@ enum class MQTTClientDisconnectReason : int8_t {
   DNS_RESOLVE_ERROR = 8
 };
 
+/// Transport selected for the MQTT connection.
+/// TCP keeps the existing behavior (SSL is auto-derived when a CA cert is set).
+/// WS and WSS are only honored by backends that support them (currently the
+/// ESP-IDF backend, via esp-mqtt's MQTT_TRANSPORT_OVER_WS/WSS).
+enum class MQTTTransport : uint8_t {
+  TCP = 0,
+  WS = 1,
+  WSS = 2,
+};
+
 /// internal struct for MQTT messages.
 struct MQTTMessage {
   std::string topic;

--- a/esphome/components/mqtt/mqtt_backend_esp32.cpp
+++ b/esphome/components/mqtt/mqtt_backend_esp32.cpp
@@ -8,6 +8,10 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#include "esp_crt_bundle.h"
+#endif
+
 namespace esphome::mqtt {
 
 static const char *const TAG = "mqtt.idf";
@@ -39,17 +43,52 @@ bool MQTTBackendESP32::initialize_() {
   if (!this->client_id_.empty()) {
     mqtt_cfg_.credentials.client_id = this->client_id_.c_str();
   }
-  if (ca_certificate_.has_value()) {
-    mqtt_cfg_.broker.verification.certificate = ca_certificate_.value().c_str();
-    mqtt_cfg_.broker.verification.skip_cert_common_name_check = skip_cert_cn_check_;
-    mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_SSL;
 
+  // Select the underlying transport. WS/WSS are honored as-is; for plain TCP we
+  // keep the historical behavior of auto-upgrading to SSL when a CA certificate
+  // is configured, so existing YAML keeps working without setting `transport:`.
+  bool uses_tls = false;
+  switch (this->transport_) {
+    case MQTTTransport::WS:
+      mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_WS;
+      break;
+    case MQTTTransport::WSS:
+      mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_WSS;
+      uses_tls = true;
+      break;
+    case MQTTTransport::TCP:
+    default:
+      if (this->ca_certificate_.has_value()) {
+        mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_SSL;
+        uses_tls = true;
+      } else {
+        mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_TCP;
+      }
+      break;
+  }
+
+  // The WebSocket path on the broker (e.g. "/mqtt"). Only meaningful for ws/wss.
+  if ((this->transport_ == MQTTTransport::WS || this->transport_ == MQTTTransport::WSS) && !this->ws_path_.empty()) {
+    mqtt_cfg_.broker.address.path = this->ws_path_.c_str();
+  }
+
+  if (uses_tls) {
+    if (this->ca_certificate_.has_value()) {
+      mqtt_cfg_.broker.verification.certificate = this->ca_certificate_.value().c_str();
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+    } else {
+      // No explicit CA configured — fall back to the global certificate bundle.
+      // This matches what `http_request` does and is what lets `wss` connect to
+      // brokers fronted by Cloudflare / Let's Encrypt / etc. without the user
+      // having to paste a CA into YAML.
+      mqtt_cfg_.broker.verification.crt_bundle_attach = esp_crt_bundle_attach;
+#endif
+    }
+    mqtt_cfg_.broker.verification.skip_cert_common_name_check = this->skip_cert_cn_check_;
     if (this->cl_certificate_.has_value() && this->cl_key_.has_value()) {
       mqtt_cfg_.credentials.authentication.certificate = this->cl_certificate_.value().c_str();
       mqtt_cfg_.credentials.authentication.key = this->cl_key_.value().c_str();
     }
-  } else {
-    mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_TCP;
   }
 
   auto *mqtt_client = esp_mqtt_client_init(&mqtt_cfg_);
@@ -59,8 +98,12 @@ bool MQTTBackendESP32::initialize_() {
     esp_mqtt_client_register_event(mqtt_client, MQTT_EVENT_ANY, mqtt_event_handler, this);
 #if defined(USE_MQTT_IDF_ENQUEUE)
     // Create the task only after MQTT client is initialized successfully
-    // Use larger stack size when TLS is enabled
-    size_t stack_size = this->ca_certificate_.has_value() ? TASK_STACK_SIZE_TLS : TASK_STACK_SIZE;
+    // Use larger stack size when TLS is enabled. TLS is in use either when a CA
+    // certificate is configured (the classic SSL case) or when the user picked
+    // `wss` (which always goes through TLS regardless of whether a CA cert was
+    // provided — the bundle path uses TLS too).
+    const bool tls_active = this->ca_certificate_.has_value() || this->transport_ == MQTTTransport::WSS;
+    size_t stack_size = tls_active ? TASK_STACK_SIZE_TLS : TASK_STACK_SIZE;
     xTaskCreate(esphome_mqtt_task, "esphome_mqtt", stack_size, (void *) this, TASK_PRIORITY, &this->task_handle_);
     if (this->task_handle_ == nullptr) {
       ESP_LOGE(TAG, "Failed to create MQTT task");

--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -218,6 +218,8 @@ class MQTTBackendESP32 final : public MQTTBackend {
   void set_cl_certificate(const std::string &cert) { cl_certificate_ = cert; }
   void set_cl_key(const std::string &key) { cl_key_ = key; }
   void set_skip_cert_cn_check(bool skip_check) { skip_cert_cn_check_ = skip_check; }
+  void set_transport(MQTTTransport transport) { this->transport_ = transport; }
+  void set_ws_path(const std::string &path) { this->ws_path_ = path; }
 
   // No destructor needed: ESPHome components live for the entire device runtime.
   // The MQTT task and queue will run until the device reboots or loses power,
@@ -256,6 +258,8 @@ class MQTTBackendESP32 final : public MQTTBackend {
   optional<std::string> cl_certificate_;
   optional<std::string> cl_key_;
   bool skip_cert_cn_check_{false};
+  MQTTTransport transport_{MQTTTransport::TCP};
+  std::string ws_path_;
 #if defined(USE_MQTT_IDF_ENQUEUE)
   static void esphome_mqtt_task(void *params);
   // Pool sized to queue capacity (SIZE-1) — see mqtt_event_pool_ comment.

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -142,6 +142,8 @@ class MQTTClientComponent : public Component {
   void set_cl_certificate(const char *cert) { this->mqtt_backend_.set_cl_certificate(cert); }
   void set_cl_key(const char *key) { this->mqtt_backend_.set_cl_key(key); }
   void set_skip_cert_cn_check(bool skip_check) { this->mqtt_backend_.set_skip_cert_cn_check(skip_check); }
+  void set_transport(MQTTTransport transport) { this->mqtt_backend_.set_transport(transport); }
+  void set_ws_path(const std::string &path) { this->mqtt_backend_.set_ws_path(path); }
 #endif
   const Availability &get_availability();
 

--- a/tests/component_tests/mqtt/test_transport_validation.py
+++ b/tests/component_tests/mqtt/test_transport_validation.py
@@ -1,0 +1,81 @@
+"""Validation tests for the mqtt ws/wss transport options."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome.components.mqtt import (
+    CONF_TRANSPORT,
+    CONF_WS_PATH,
+    MQTT_TRANSPORT_TCP,
+    MQTT_TRANSPORT_WS,
+    MQTT_TRANSPORT_WSS,
+    _validate_transport,
+    validate_config,
+)
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CERTIFICATE_AUTHORITY,
+    CONF_TOPIC_PREFIX,
+    PlatformFramework,
+)
+
+from ..types import SetCoreConfigCallable
+
+
+def test_transport_ws_rejected_on_non_esp32(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """Test that ws/wss is rejected on non-ESP32 platforms."""
+    set_core_config(PlatformFramework.ESP8266_ARDUINO)
+    with pytest.raises(cv.Invalid, match="only supported on ESP32"):
+        _validate_transport(MQTT_TRANSPORT_WS)
+
+
+def test_transport_wss_rejected_on_esp32_arduino(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """Test that ws/wss is rejected under the Arduino framework (needs esp-idf)."""
+    set_core_config(PlatformFramework.ESP32_ARDUINO)
+    with pytest.raises(cv.Invalid, match="esp-idf"):
+        _validate_transport(MQTT_TRANSPORT_WSS)
+
+
+def test_transport_wss_accepted_on_esp32_idf(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """Test that wss validates on ESP32 + esp-idf."""
+    set_core_config(PlatformFramework.ESP32_IDF)
+    assert _validate_transport(MQTT_TRANSPORT_WSS) == MQTT_TRANSPORT_WSS
+
+
+def test_transport_tcp_accepted_off_esp32(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """Test that the default tcp transport stays valid on non-ESP32 targets."""
+    set_core_config(PlatformFramework.ESP8266_ARDUINO)
+    assert _validate_transport(MQTT_TRANSPORT_TCP) == MQTT_TRANSPORT_TCP
+
+
+def test_ws_path_rejected_without_websocket_transport() -> None:
+    """Test that ws_path is rejected when transport is not ws/wss."""
+    with pytest.raises(cv.Invalid, match="only valid when"):
+        validate_config(
+            {
+                CONF_TRANSPORT: MQTT_TRANSPORT_TCP,
+                CONF_WS_PATH: "/mqtt",
+                CONF_TOPIC_PREFIX: "test",
+            }
+        )
+
+
+def test_plaintext_ws_with_ca_rejected() -> None:
+    """Test that pairing a CA with unencrypted ws is rejected."""
+    with pytest.raises(cv.Invalid, match="unencrypted"):
+        validate_config(
+            {
+                CONF_TRANSPORT: MQTT_TRANSPORT_WS,
+                CONF_CERTIFICATE_AUTHORITY: "-----BEGIN CERTIFICATE-----",
+                CONF_TOPIC_PREFIX: "test",
+            }
+        )

--- a/tests/components/mqtt/test-ws.esp32-idf.yaml
+++ b/tests/components/mqtt/test-ws.esp32-idf.yaml
@@ -1,0 +1,16 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+mqtt:
+  broker: "broker.example.com"
+  port: 9001
+  username: debug
+  password: debug
+  transport: ws
+  ws_path: /mqtt
+  topic_prefix: mqttws-test
+
+sensor:
+  - platform: uptime
+    name: Uptime

--- a/tests/components/mqtt/test-wss.esp32-idf.yaml
+++ b/tests/components/mqtt/test-wss.esp32-idf.yaml
@@ -1,0 +1,17 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+mqtt:
+  broker: "broker.example.com"
+  port: 8443
+  username: debug
+  password: debug
+  transport: wss
+  ws_path: /mqtt
+  # No certificate_authority: exercises the IDF CA bundle fallback path
+  topic_prefix: mqttws-test
+
+sensor:
+  - platform: uptime
+    name: Uptime


### PR DESCRIPTION
# What does this implement/fix?

Adds WebSocket (`ws`) and Secure WebSocket (`wss`) transport to the **MQTT** component on **ESP32 + ESP-IDF**, backed by the `esp-mqtt` library ESPHome already uses on that target (`MQTT_TRANSPORT_OVER_WS` / `MQTT_TRANSPORT_OVER_WSS`).

WebSocket is the only practical way for an ESPHome device to reach an MQTT broker that:

- sits behind a reverse proxy / ingress that only speaks HTTP(S),
- is exposed through a Cloudflare Tunnel / Argo (HTTP-only fronting), or
- lives on a CGNAT network with no inbound port forwarding.

New options on the `mqtt:` block:

- `transport:` — one of `tcp` (default), `ws`, `wss`
- `ws_path:` — WebSocket path on the broker (default `/mqtt`)

### Secure transport actually verifies the server

When `transport: wss` is used **without** `certificate_authority:`, the backend attaches the ESP-IDF certificate bundle via `esp_crt_bundle_attach`, and codegen enables `CONFIG_MBEDTLS_CERTIFICATE_BUNDLE` for that case. The broker certificate is verified against the bundled public roots — the same approach `http_request` uses — instead of connecting unverified. Hostname checking stays on (`skip_cert_common_name_check` keeps its configured value, default `false`). Supplying `certificate_authority:` still pins that CA as before.

### Design

- `transport` is a typed `enum class MQTTTransport { TCP, WS, WSS }` (`mqtt_backend.h`), set from Python via a `cg` enum — no string comparisons and no duplicated `std::string` members (the values live only in the backend; `MQTTClientComponent` setters are pass-throughs).
- Validation restricts `ws`/`wss` to the **esp-idf framework** (not just the ESP32 chip), so ESP32-Arduino configs fail at validation with a clear message instead of compiling into a runtime no-op. It also rejects a CA / client certificate paired with plaintext `ws` (a likely `wss` typo).
- `tcp` is unchanged and remains the default: existing YAML still auto-upgrades to SSL when a CA is set, with the same TLS task-stack-size behavior.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/feature-requests#3635
- supersedes #12112

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6534

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266 — gated off in the schema; backend untouched
- [ ] RP2040/RP2350
- [ ] BK72xx — gated off in the schema; backend untouched
- [ ] RTL87xx — gated off in the schema; backend untouched
- [ ] LN882x
- [ ] nRF52840

**Compile tests:** `tests/components/mqtt/test-ws.esp32-idf.yaml` and `test-wss.esp32-idf.yaml` (the latter has no `certificate_authority:`, exercising the bundle path) are built in CI.

**On real hardware (ESP32-WROOM-32, ESP-IDF):** with `transport: wss`, `port: 443`, `ws_path: /mqtt` and **no `certificate_authority:`**, against a broker fronted by a Cloudflare Tunnel, the device completes the TLS/WSS handshake with no certificate errors, reaches `MQTT_EVENT_CONNECTED`, and publishes its retained birth message. A CA-less `wss` handshake cannot succeed unless a CA source is attached, so the successful connection demonstrates the IDF certificate bundle is verifying the server.

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf

mqtt:
  broker: mqttws.example.com
  port: 443
  transport: wss      # one of: tcp (default), ws, wss
  ws_path: /mqtt      # default "/mqtt"; only used for ws/wss
  username: !secret mqtt_user
  password: !secret mqtt_pass
  # No certificate_authority: -> the IDF certificate bundle verifies the broker.
```

Plain `ws://` (e.g. a Mosquitto `listener 9001 / protocol websockets` config) works with `transport: ws` and the matching `port:`.

## What's in the diff

5 files in `esphome/components/mqtt/` + 2 esp32-idf compile fixtures:

| File | Change |
| --- | --- |
| `__init__.py` | `transport` / `ws_path` options, framework-gated validator, `ws`+CA guard, codegen, and sdkconfig (`CONFIG_MBEDTLS_CERTIFICATE_BUNDLE` for CA-less `wss`; `CONFIG_MQTT_TRANSPORT_WEBSOCKET[_SECURE]`) |
| `mqtt_backend.h` | `enum class MQTTTransport { TCP, WS, WSS }` |
| `mqtt_backend_esp32.h` | `transport_` / `ws_path_` members + setters |
| `mqtt_backend_esp32.cpp` | transport selection, `esp_crt_bundle_attach` fallback for CA-less `wss`, TLS task-stack-size predicate |
| `mqtt_client.h` | pass-through `set_transport` / `set_ws_path` |
| `tests/components/mqtt/test-ws.esp32-idf.yaml` | CI fixture: `transport: ws` |
| `tests/components/mqtt/test-wss.esp32-idf.yaml` | CI fixture: CA-less `transport: wss` (bundle path) |

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).
- [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) — esphome/esphome-docs#6534.
