### PR TITLE
[socket] DNM: diagnostic logging for #15953 OTA hang on ESP8266

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -52,6 +52,12 @@ static const char *const TAG = "socket.lwip";
 #define LWIP_LOG(msg, ...)
 #endif
 
+// DNM diagnostic: trace lwip TCP receive callback invocations and accept-queue
+// activity at WARN level so they show up at default log verbosity. Used to
+// diagnose esphome/esphome#15953 (ESP8266 OTA hang where firmware data appears
+// on the wire but never reaches the application). Remove before merge.
+#define LWIP_DIAG(msg, ...) ESP_LOGW(TAG, "lwip-diag %p: " msg, this, ##__VA_ARGS__)
+
 // Clear arg, recv, and err callbacks, then abort a connected PCB.
 // Only valid for full tcp_pcb (not tcp_pcb_listen).
 // Must be called before destroying the object that tcp_arg points to —
@@ -432,6 +438,15 @@ err_t LWIPRawImpl::recv_fn(struct pbuf *pb, err_t err) {
   // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
   // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
   LWIP_LOG("recv(pb=%p err=%d)", pb, err);
+  // DNM diagnostic for #15953: prove whether lwip is actually delivering
+  // OTA firmware bursts up to the application layer. err!=0/pb==nullptr
+  // are connection-close signals and not part of the symptom we're chasing.
+  if (pb != nullptr && err == 0) {
+    LWIP_DIAG("recv tot_len=%u rx_buf=%p rx_off=%u closed=%d", pb->tot_len, this->rx_buf_, this->rx_buf_offset_,
+              this->rx_closed_ ? 1 : 0);
+  } else {
+    LWIP_DIAG("recv close pb=%p err=%d", pb, err);
+  }
   if (err != 0) {
     // "An error code if there has been an error receiving Only return ERR_ABRT if you have
     // called tcp_abort from within the callback function!"
@@ -736,6 +751,12 @@ err_t LWIPRawListenImpl::s_queued_recv_fn(void *arg, struct tcp_pcb *pcb, struct
   // causing the API handshake to silently fail (client sends Hello, server never sees it).
   (void) pcb;
   auto *entry = reinterpret_cast<QueuedPcb *>(arg);
+  // DNM diagnostic for #15953.
+  if (pb != nullptr && err == ERR_OK) {
+    ESP_LOGW(TAG, "lwip-diag queued-recv entry=%p tot_len=%u rx_buf=%p", entry, pb->tot_len, entry->rx_buf);
+  } else {
+    ESP_LOGW(TAG, "lwip-diag queued-recv close entry=%p pb=%p err=%d", entry, pb, err);
+  }
   if (pb == nullptr || err != ERR_OK) {
     // Remote closed or error
     if (pb != nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

**Do not merge — diagnostic only.**

Adds WARN-level traces in `LWIPRawImpl::recv_fn` and `LWIPRawListenImpl::s_queued_recv_fn` so we can confirm whether lwIP is actually delivering received TCP data up to the application on a failing OTA, and bisect what's going wrong on ESP8266.

## Why

The packet capture in #15953 (provided by the reporter) shows that on a failing OTA:

- Handshake on port 8266 completes normally (magic / features / MD5 are read and acknowledged by the device).
- After the device sends the MD5-OK byte, the client immediately bursts 4 back-to-back TCP segments totalling 5798 bytes — exactly the device's announced receive window.
- The device's TCP stack then sends a *bare* `ack=43 win=5798` 24 ms later: the firmware bytes are not acknowledged.
- The client retransmits seq 43→1503 with exponential backoff (~0.2s, 0.6s, 1.2s, 2.4s, 4.8s, 9.6s, 19.2s, 38.4s). None get ACK'd.
- After 90s the application's wall-clock timer fires (`No data received for 90000 ms`), the device sends 1 error byte + FIN, and the OTA aborts.
- During this same 90 s window, the API connection on port 6053 keeps working — small HA pings (23 bytes) are ACK'd promptly. Web OTA on port 80 also works for the same user (different stack: ESPAsyncTCP).

So: lwIP itself is alive, the network path is fine for small frames, but on the OTA PCB nothing past the handshake is making it to the application. The candidate fix from #16045 (already merged in 2026.5.0-dev) does not change the symptom on the reporter's hardware.

The two questions these traces are meant to answer:
1. Does `LWIPRawImpl::recv_fn` actually fire for the firmware burst? (i.e., is lwIP delivering it to us, or is it being dropped below the recv callback?)
2. If a packet arrives between `accept_fn_` and the application's `accept()`, does `s_queued_recv_fn` see it?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other (DNM diagnostic / debugging build)

**Related issue or feature (if applicable):**

- diagnostic for https://github.com/esphome/esphome/issues/15953

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — internal diagnostic, not for merge.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config; build a firmware off this branch and reproduce the
# OTA failure with the default logger level. Successful and failing runs both
# produce 'lwip-diag' lines on every TCP recv callback the lwip raw socket
# impl sees on accepted connections.
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).