### PR TITLE
[epaper_spi] Add Waveshare 7.3" G (BWYR epd7in3g)

### DIFF
--- a/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
@@ -42,7 +42,7 @@ void EPaperEpd7In3G::power_on() {}
 bool HOT EPaperEpd7In3G::transfer_data() {
   if (this->xfer_phase_ == 0) {
     ESP_LOGV(TAG, "Power on");
-    this->command(this->CMD_BOOSTER_SOFTSTART);
+    this->command(CMD_BOOSTER_SOFTSTART);
     this->xfer_phase_ = 1;
     return false;
   }
@@ -60,7 +60,7 @@ bool HOT EPaperEpd7In3G::transfer_data() {
   const size_t buffer_length = this->buffer_length_;
   if (this->current_data_index_ == 0) {
     ESP_LOGV(TAG, "Sending data to the display");
-    this->command(this->CMD_TRANSFER);
+    this->command(CMD_TRANSFER);
   }
 
   size_t buf_idx = 0;
@@ -93,17 +93,17 @@ bool HOT EPaperEpd7In3G::transfer_data() {
 void EPaperEpd7In3G::refresh_screen(bool partial) {
   ESP_LOGV(TAG, "Refresh");
   (void) partial;
-  this->cmd_data(this->CMD_REFRESH, {this->DATA_REFRESH});
+  this->cmd_data(CMD_REFRESH, {DATA_REFRESH});
 }
 
 void EPaperEpd7In3G::power_off() {
   ESP_LOGV(TAG, "Power off");
-  this->cmd_data(this->CMD_POWEROFF, {this->DATA_POWEROFF});
+  this->cmd_data(CMD_POWEROFF, {DATA_POWEROFF});
 }
 
 void EPaperEpd7In3G::deep_sleep() {
   ESP_LOGV(TAG, "Deep sleep");
-  this->cmd_data(this->CMD_DEEPSLEEP, {this->DATA_DEEPSLEEP_KEY});
+  this->cmd_data(CMD_DEEPSLEEP, {DATA_DEEPSLEEP_KEY});
 }
 
 }  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
@@ -51,7 +51,6 @@ bool HOT EPaperEpd7In3G::transfer_data() {
       App.feed_wdt();
       return false;
     }
-    delay(200);  // NOLINT
     this->xfer_phase_ = 2;
     return false;
   }

--- a/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
@@ -12,8 +12,7 @@ void EPaperEpd7In3G::fill(Color color) {
     EPaperBase::fill(color);
     return;
   }
-  const uint8_t p =
-      color_to_bwyr(color, UINT8_C(0), UINT8_C(1), UINT8_C(2), UINT8_C(3));
+  const uint8_t p = color_to_bwyr(color, UINT8_C(0), UINT8_C(1), UINT8_C(2), UINT8_C(3));
   const unsigned pu = static_cast<unsigned>(p);
   const uint8_t packed = static_cast<uint8_t>(pu << 6 | pu << 4 | pu << 2 | pu);
   this->buffer_.fill(packed);
@@ -28,14 +27,13 @@ void EPaperEpd7In3G::clear() { this->fill(COLOR_ON); }
 void HOT EPaperEpd7In3G::draw_pixel_at(int x, int y, Color color) {
   if (!this->rotate_coordinates_(x, y))
     return;
-  const uint8_t p =
-      color_to_bwyr(color, UINT8_C(0), UINT8_C(1), UINT8_C(2), UINT8_C(3));
+  const uint8_t p = color_to_bwyr(color, UINT8_C(0), UINT8_C(1), UINT8_C(2), UINT8_C(3));
   const uint16_t row_bytes = this->width_ / 4;
   const uint32_t idx = static_cast<uint32_t>(y) * row_bytes + static_cast<uint32_t>(x >> 2);
   const uint8_t shift = static_cast<uint8_t>((3 - (x & 3)) * 2);
   const auto orig = this->buffer_[idx];
-  this->buffer_[idx] = static_cast<uint8_t>(
-      (orig & static_cast<uint8_t>(~(0x03U << shift))) | static_cast<uint8_t>(static_cast<unsigned>(p) << shift));
+  this->buffer_[idx] = static_cast<uint8_t>((orig & static_cast<uint8_t>(~(0x03U << shift))) |
+                                            static_cast<uint8_t>(static_cast<unsigned>(p) << shift));
 }
 
 // State machine calls power_on after transfer; epd7in3g expects booster soft-start before RAM write.
@@ -74,8 +72,7 @@ bool HOT EPaperEpd7In3G::transfer_data() {
       this->start_data_();
       this->write_array(bytes_to_send, buf_idx);
       this->disable();
-      ESP_LOGV(TAG, "Wrote %u bytes at %ums", static_cast<unsigned>(buf_idx),
-               static_cast<unsigned>(millis()));
+      ESP_LOGV(TAG, "Wrote %u bytes at %ums", static_cast<unsigned>(buf_idx), static_cast<unsigned>(millis()));
       buf_idx = 0;
 
       if (millis() - start_time > MAX_TRANSFER_TIME) {

--- a/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_epd7in3g.cpp
@@ -1,0 +1,112 @@
+#include "epaper_spi_epd7in3g.h"
+
+#include "colorconv.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+namespace esphome::epaper_spi {
+static const char *const TAG = "epaper_spi.epd7in3g";
+
+void EPaperEpd7In3G::fill(Color color) {
+  if (this->get_clipping().is_set()) {
+    EPaperBase::fill(color);
+    return;
+  }
+  const uint8_t p =
+      color_to_bwyr(color, UINT8_C(0), UINT8_C(1), UINT8_C(2), UINT8_C(3));
+  const unsigned pu = static_cast<unsigned>(p);
+  const uint8_t packed = static_cast<uint8_t>(pu << 6 | pu << 4 | pu << 2 | pu);
+  this->buffer_.fill(packed);
+  this->x_high_ = this->width_;
+  this->y_high_ = this->height_;
+  this->x_low_ = 0;
+  this->y_low_ = 0;
+}
+
+void EPaperEpd7In3G::clear() { this->fill(COLOR_ON); }
+
+void HOT EPaperEpd7In3G::draw_pixel_at(int x, int y, Color color) {
+  if (!this->rotate_coordinates_(x, y))
+    return;
+  const uint8_t p =
+      color_to_bwyr(color, UINT8_C(0), UINT8_C(1), UINT8_C(2), UINT8_C(3));
+  const uint16_t row_bytes = this->width_ / 4;
+  const uint32_t idx = static_cast<uint32_t>(y) * row_bytes + static_cast<uint32_t>(x >> 2);
+  const uint8_t shift = static_cast<uint8_t>((3 - (x & 3)) * 2);
+  const auto orig = this->buffer_[idx];
+  this->buffer_[idx] = static_cast<uint8_t>(
+      (orig & static_cast<uint8_t>(~(0x03U << shift))) | static_cast<uint8_t>(static_cast<unsigned>(p) << shift));
+}
+
+// State machine calls power_on after transfer; epd7in3g expects booster soft-start before RAM write.
+void EPaperEpd7In3G::power_on() {}
+
+bool HOT EPaperEpd7In3G::transfer_data() {
+  if (this->xfer_phase_ == 0) {
+    ESP_LOGV(TAG, "Power on");
+    this->command(this->CMD_BOOSTER_SOFTSTART);
+    this->xfer_phase_ = 1;
+    return false;
+  }
+  if (this->xfer_phase_ == 1) {
+    if (!this->is_idle_()) {
+      App.feed_wdt();
+      return false;
+    }
+    delay(200);  // NOLINT
+    this->xfer_phase_ = 2;
+    return false;
+  }
+
+  const uint32_t start_time = App.get_loop_component_start_time();
+  const size_t buffer_length = this->buffer_length_;
+  if (this->current_data_index_ == 0) {
+    ESP_LOGV(TAG, "Sending data to the display");
+    this->command(this->CMD_TRANSFER);
+  }
+
+  size_t buf_idx = 0;
+  uint8_t bytes_to_send[MAX_TRANSFER_SIZE];
+  while (this->current_data_index_ != buffer_length) {
+    bytes_to_send[buf_idx++] = this->buffer_[this->current_data_index_++];
+
+    if (buf_idx == sizeof bytes_to_send) {
+      this->start_data_();
+      this->write_array(bytes_to_send, buf_idx);
+      this->disable();
+      ESP_LOGV(TAG, "Wrote %u bytes at %ums", static_cast<unsigned>(buf_idx),
+               static_cast<unsigned>(millis()));
+      buf_idx = 0;
+
+      if (millis() - start_time > MAX_TRANSFER_TIME) {
+        return false;
+      }
+    }
+  }
+  if (buf_idx != 0) {
+    this->start_data_();
+    this->write_array(bytes_to_send, buf_idx);
+    this->disable();
+  }
+  this->current_data_index_ = 0;
+  this->xfer_phase_ = 0;
+  return true;
+}
+
+void EPaperEpd7In3G::refresh_screen(bool partial) {
+  ESP_LOGV(TAG, "Refresh");
+  (void) partial;
+  this->cmd_data(this->CMD_REFRESH, {this->DATA_REFRESH});
+}
+
+void EPaperEpd7In3G::power_off() {
+  ESP_LOGV(TAG, "Power off");
+  this->cmd_data(this->CMD_POWEROFF, {this->DATA_POWEROFF});
+}
+
+void EPaperEpd7In3G::deep_sleep() {
+  ESP_LOGV(TAG, "Deep sleep");
+  this->cmd_data(this->CMD_DEEPSLEEP, {this->DATA_DEEPSLEEP_KEY});
+}
+
+}  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/epaper_spi_epd7in3g.h
+++ b/esphome/components/epaper_spi/epaper_spi_epd7in3g.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "epaper_spi.h"
+
+namespace esphome::epaper_spi {
+
+/// Waveshare 7.3 inch e-Paper HAT (G): BWYR, vendor epd7in3g protocol; framebuffer 2 bpp, four pixels per byte.
+class EPaperEpd7In3G final : public EPaperBase {
+ public:
+  EPaperEpd7In3G(const char *name, uint16_t width, uint16_t height, const uint8_t *init_sequence,
+                 size_t init_sequence_length)
+      : EPaperBase(name, width, height, init_sequence, init_sequence_length, DISPLAY_TYPE_COLOR) {
+    this->buffer_length_ = static_cast<size_t>((width / 4) * height);
+  }
+
+  void fill(Color color) override;
+  void clear() override;
+
+ protected:
+  void draw_pixel_at(int x, int y, Color color) override;
+  bool transfer_data() override;
+  void power_on() override;
+  void refresh_screen(bool partial) override;
+  void power_off() override;
+  void deep_sleep() override;
+
+ private:
+  /** @name IC command / payload bytes (@c epd7in3g reference) @{ */
+  static constexpr uint8_t CMD_BOOSTER_SOFTSTART = 0x04;
+  static constexpr uint8_t CMD_POWEROFF = 0x02;
+  static constexpr uint8_t CMD_DEEPSLEEP = 0x07;
+  static constexpr uint8_t CMD_TRANSFER = 0x10;
+  static constexpr uint8_t CMD_REFRESH = 0x12;
+  static constexpr uint8_t DATA_POWEROFF = 0x00;
+  static constexpr uint8_t DATA_DEEPSLEEP_KEY = 0xA5;
+  static constexpr uint8_t DATA_REFRESH = 0x01;
+  /** @} */
+
+  uint8_t xfer_phase_{0};
+};
+
+}  // namespace esphome::epaper_spi

--- a/esphome/components/epaper_spi/models/waveshare_7p3in_g.py
+++ b/esphome/components/epaper_spi/models/waveshare_7p3in_g.py
@@ -1,0 +1,44 @@
+from . import EpaperModel
+
+
+class Waveshare7p3inG(EpaperModel):
+    """Waveshare 7.3 inch HAT (G): black / white / red / yellow.
+
+    800x480 framebuffer - epd7in3g wiring, 2 bpp, 4 pixels per byte."""
+
+    def __init__(self, name, class_name="EPaperEpd7In3G", **defaults):
+        super().__init__(name, class_name, **defaults)
+
+    def get_init_sequence(self, config: dict):
+        width, height = self.get_dimensions(config)
+        return (
+            (30, 0xFF),  # post-reset settle
+            (0xAA, 0x49, 0x55, 0x20, 0x08, 0x09, 0x18),
+            (0x01, 0x3F),
+            (0x00, 0x4F, 0x69),
+            (0x05, 0x40, 0x1F, 0x1F, 0x2C),
+            (0x08, 0x6F, 0x1F, 0x1F, 0x22),
+            (0x06, 0x6F, 0x1F, 0x14, 0x14),
+            (0x03, 0x00, 0x54, 0x00, 0x44),
+            (0x60, 0x02, 0x00),
+            (0x30, 0x08),
+            (0x50, 0x3F),
+            (
+                0x61,
+                width // 256,
+                width % 256,
+                height // 256,
+                height % 256,
+            ),
+            (0xE3, 0x2F),
+            (0x84, 0x01),
+        )
+
+
+waveshare_7p3in_g = Waveshare7p3inG(
+    "Waveshare-7.3in-G",
+    width=800,
+    height=480,
+    minimum_update_interval="30s",
+    data_rate="20MHz",
+)

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -59,6 +59,23 @@ display:
 
   - platform: epaper_spi
     spi_id: spi_bus
+    model: waveshare-7.3in-G
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+      inverted: true
+
+  - platform: epaper_spi
+    spi_id: spi_bus
     model: waveshare-7.5in-H
     cs_pin:
       allow_other_uses: true


### PR DESCRIPTION
# What does this implement/fix?

Adds epaper_spi support for Waveshare 7.3in-G, a 4 colour BWYR 800x480 display.

This uses the same 2bpp BWYR pixel format as the Waveshare 7.5in-H, but with a fairly different init sequence. I've used the [Waveshare epd7in3g example vendor code](https://github.com/waveshareteam/e-Paper/blob/master/Arduino/epd7in3g/epd7in3g.h) as a reference for this. Busy pin is also inverted like the 7.5in-H. I'm not sure about driver naming for this - very open to feedback on that.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6581

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
external_components:
  - source: github://vemek/esphome@vemek/waveshare-7.3in-g
    components: [epaper_spi]

spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23

display:
  - platform: epaper_spi
    model: waveshare-7.3in-G
    cs_pin: GPIO05
    dc_pin: GPIO03
    reset_pin: GPIO16
    busy_pin:
      number: GPIO4
      inverted: true
    update_interval: 1min
    lambda: |-
      const int w = it.get_width();
      const int h = it.get_height();
      const int band = w / 4;
      it.filled_rectangle(0, 0, band, h, Color::BLACK);
      it.filled_rectangle(band, 0, band * 2, h, Color::WHITE);
      it.filled_rectangle(band * 2, 0, band * 3, h, Color(255, 255, 0));
      it.filled_rectangle(band * 3, 0, w, h, Color(255, 0, 0));
      it.rectangle(0, 0, w, h, Color::BLACK);
      it.print(24, h / 2 - 24, id(title_font), Color::BLACK, "Waveshare 7.3in G");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
