### PR TITLE
[es8388] Add initial option configuration for DAC output and ADC input mic

### DIFF
--- a/esphome/components/es8388/es8388.cpp
+++ b/esphome/components/es8388/es8388.cpp
@@ -113,22 +113,42 @@ void ES8388::setup() {
 
 #ifdef USE_SELECT
   if (this->dac_output_select_ != nullptr) {
-    auto dac_power = this->get_dac_power();
-    if (dac_power.has_value()) {
-      if (this->dac_output_select_->has_index(dac_power.value())) {
-        this->dac_output_select_->publish_state(dac_power.value());
+    if (this->dac_output_initial_index_.has_value()) {
+      size_t idx = this->dac_output_initial_index_.value();
+      if (this->dac_output_select_->has_index(idx)) {
+        ES8388_ERROR_FAILED(this->set_dac_output(static_cast<DacOutputLine>(idx)));
+        this->dac_output_select_->publish_state(idx);
       } else {
-        ESP_LOGW(TAG, "Unknown DAC output power value: %d", dac_power.value());
+        ESP_LOGW(TAG, "Invalid dac_output initial_option index: %zu", idx);
+      }
+    } else {
+      auto dac_power = this->get_dac_power();
+      if (dac_power.has_value()) {
+        if (this->dac_output_select_->has_index(dac_power.value())) {
+          this->dac_output_select_->publish_state(dac_power.value());
+        } else {
+          ESP_LOGW(TAG, "Unknown DAC output power value: %d", dac_power.value());
+        }
       }
     }
   }
   if (this->adc_input_mic_select_ != nullptr) {
-    auto mic_input = this->get_mic_input();
-    if (mic_input.has_value()) {
-      if (this->adc_input_mic_select_->has_index(mic_input.value())) {
-        this->adc_input_mic_select_->publish_state(mic_input.value());
+    if (this->adc_input_mic_initial_index_.has_value()) {
+      size_t idx = this->adc_input_mic_initial_index_.value();
+      if (this->adc_input_mic_select_->has_index(idx)) {
+        ES8388_ERROR_FAILED(this->set_adc_input_mic(static_cast<AdcInputMicLine>(idx)));
+        this->adc_input_mic_select_->publish_state(idx);
       } else {
-        ESP_LOGW(TAG, "Unknown ADC input mic value: %d", mic_input.value());
+        ESP_LOGW(TAG, "Invalid adc_input_mic initial_option index: %zu", idx);
+      }
+    } else {
+      auto mic_input = this->get_mic_input();
+      if (mic_input.has_value()) {
+        if (this->adc_input_mic_select_->has_index(mic_input.value())) {
+          this->adc_input_mic_select_->publish_state(mic_input.value());
+        } else {
+          ESP_LOGW(TAG, "Unknown ADC input mic value: %d", mic_input.value());
+        }
       }
     }
   }

--- a/esphome/components/es8388/es8388.h
+++ b/esphome/components/es8388/es8388.h
@@ -68,11 +68,20 @@ class ES8388 final : public audio_dac::AudioDac, public Component, public i2c::I
   bool set_dac_output(DacOutputLine line);
   bool set_adc_input_mic(AdcInputMicLine line);
 
+  /// If set from YAML `initial_option`, setup() applies this index instead of reading the codec.
+  void set_dac_output_initial_index(size_t index) { this->dac_output_initial_index_ = index; }
+  void set_adc_input_mic_initial_index(size_t index) { this->adc_input_mic_initial_index_ = index; }
+
  protected:
   /// @brief Mutes or unmutes the DAC audio out
   /// @param mute_state True to mute, false to unmute
   /// @return True if successful and false otherwise
   bool set_mute_state_(bool mute_state);
+
+  bool is_muted_{false};
+
+  optional<size_t> dac_output_initial_index_{};
+  optional<size_t> adc_input_mic_initial_index_{};
 };
 
 }  // namespace esphome::es8388

--- a/esphome/components/es8388/es8388.h
+++ b/esphome/components/es8388/es8388.h
@@ -78,8 +78,6 @@ class ES8388 final : public audio_dac::AudioDac, public Component, public i2c::I
   /// @return True if successful and false otherwise
   bool set_mute_state_(bool mute_state);
 
-  bool is_muted_{false};
-
   optional<size_t> dac_output_initial_index_{};
   optional<size_t> adc_input_mic_initial_index_{};
 };

--- a/esphome/components/es8388/select/__init__.py
+++ b/esphome/components/es8388/select/__init__.py
@@ -54,8 +54,8 @@ async def to_code(config):
         )
         await cg.register_parented(s, parent)
         cg.add(parent.set_dac_output_select(s))
-        if CONF_INITIAL_OPTION in dac_output_config:
-            idx = DAC_OUTPUT_OPTIONS.index(dac_output_config[CONF_INITIAL_OPTION])
+        if (initial := dac_output_config.get(CONF_INITIAL_OPTION)) is not None:
+            idx = DAC_OUTPUT_OPTIONS.index(initial)
             cg.add(parent.set_dac_output_initial_index(idx))
 
     if adc_input_mic_config := config.get(CONF_ADC_INPUT_MIC):
@@ -65,6 +65,6 @@ async def to_code(config):
         )
         await cg.register_parented(s, parent)
         cg.add(parent.set_adc_input_mic_select(s))
-        if CONF_INITIAL_OPTION in adc_input_mic_config:
-            idx = ADC_INPUT_MIC_OPTIONS.index(adc_input_mic_config[CONF_INITIAL_OPTION])
+        if (initial := adc_input_mic_config.get(CONF_INITIAL_OPTION)) is not None:
+            idx = ADC_INPUT_MIC_OPTIONS.index(initial)
             cg.add(parent.set_adc_input_mic_initial_index(idx))

--- a/esphome/components/es8388/select/__init__.py
+++ b/esphome/components/es8388/select/__init__.py
@@ -1,31 +1,48 @@
 import esphome.codegen as cg
 from esphome.components import select
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_CONFIG, ICON_CHIP  # noqa: F401
+from esphome.const import (
+    CONF_INITIAL_OPTION,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_CHIP,  # noqa: F401
+)
 
 from ..audio_dac import CONF_ES8388_ID, ES8388, es8388_ns
 
 CONF_DAC_OUTPUT = "dac_output"
 CONF_ADC_INPUT_MIC = "adc_input_mic"
 
+DAC_OUTPUT_OPTIONS = ("LINE1", "LINE2", "BOTH")
+ADC_INPUT_MIC_OPTIONS = ("LINE1", "LINE2", "DIFFERENCE")
+
 DacOutputSelect = es8388_ns.class_("DacOutputSelect", select.Select)
 ADCInputMicSelect = es8388_ns.class_("ADCInputMicSelect", select.Select)
 
-CONFIG_SCHEMA = cv.All(
-    {
-        cv.GenerateID(CONF_ES8388_ID): cv.use_id(ES8388),
-        cv.Optional(CONF_DAC_OUTPUT): select.select_schema(
-            DacOutputSelect,
-            entity_category=ENTITY_CATEGORY_CONFIG,
-            icon=ICON_CHIP,
-        ),
-        cv.Optional(CONF_ADC_INPUT_MIC): select.select_schema(
-            ADCInputMicSelect,
-            entity_category=ENTITY_CATEGORY_CONFIG,
-            icon=ICON_CHIP,
-        ),
-    }
-)
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ES8388_ID): cv.use_id(ES8388),
+    cv.Optional(CONF_DAC_OUTPUT): select.select_schema(
+        DacOutputSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_CHIP,
+    ).extend(
+        {
+            cv.Optional(CONF_INITIAL_OPTION): cv.one_of(
+                *DAC_OUTPUT_OPTIONS, upper=True
+            ),
+        }
+    ),
+    cv.Optional(CONF_ADC_INPUT_MIC): select.select_schema(
+        ADCInputMicSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_CHIP,
+    ).extend(
+        {
+            cv.Optional(CONF_INITIAL_OPTION): cv.one_of(
+                *ADC_INPUT_MIC_OPTIONS, upper=True
+            ),
+        }
+    ),
+}
 
 
 async def to_code(config):
@@ -33,15 +50,21 @@ async def to_code(config):
     if dac_output_config := config.get(CONF_DAC_OUTPUT):
         s = await select.new_select(
             dac_output_config,
-            options=["LINE1", "LINE2", "BOTH"],
+            options=list(DAC_OUTPUT_OPTIONS),
         )
         await cg.register_parented(s, parent)
         cg.add(parent.set_dac_output_select(s))
+        if CONF_INITIAL_OPTION in dac_output_config:
+            idx = DAC_OUTPUT_OPTIONS.index(dac_output_config[CONF_INITIAL_OPTION])
+            cg.add(parent.set_dac_output_initial_index(idx))
 
     if adc_input_mic_config := config.get(CONF_ADC_INPUT_MIC):
         s = await select.new_select(
             adc_input_mic_config,
-            options=["LINE1", "LINE2", "DIFFERENCE"],
+            options=list(ADC_INPUT_MIC_OPTIONS),
         )
         await cg.register_parented(s, parent)
         cg.add(parent.set_adc_input_mic_select(s))
+        if CONF_INITIAL_OPTION in adc_input_mic_config:
+            idx = ADC_INPUT_MIC_OPTIONS.index(adc_input_mic_config[CONF_INITIAL_OPTION])
+            cg.add(parent.set_adc_input_mic_initial_index(idx))

--- a/tests/components/es8388/common.yaml
+++ b/tests/components/es8388/common.yaml
@@ -17,5 +17,9 @@ select:
     es8388_id: es8388_parent
     dac_output:
       name: "DAC Output"
+      id: es8388_test_dac_output_select
+      initial_option: BOTH
     adc_input_mic:
       name: "ADC Input MIC"
+      id: es8388_test_adc_input_mic_select
+      initial_option: LINE2


### PR DESCRIPTION


- Introduced `initial_option` for both DAC output and ADC input mic in the configuration schema.
- Updated setup logic to utilize the initial index if provided, improving initialization handling.
- Enhanced logging for invalid indices.
- Updated tests to include initial option settings for DAC output and ADC input mic.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome#15986

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6598

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
select:
  - platform: es8388
    es8388_id: es8388_dac
    dac_output:
      name: "DAC Output"
      id: dac_output_select
      initial_option: BOTH
    adc_input_mic:
      name: "ADC Input MIC"
      id: adc_input_select
      initial_option: LINE2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
