### PR TITLE
[time_based] external sensing

### DIFF
--- a/esphome/components/time_based/cover/time_based_cover.cpp
+++ b/esphome/components/time_based/cover/time_based_cover.cpp
@@ -60,6 +60,10 @@ CoverTraits TimeBasedCover::get_traits() {
   return traits;
 }
 void TimeBasedCover::control(const CoverCall &call) {
+  if (this->is_external_override_) {
+    ESP_LOGW(TAG, "External manual control active. Ignoring Home Assistant command.");
+    return;
+  }
   if (call.get_stop()) {
     this->start_direction_(COVER_OPERATION_IDLE);
     this->publish_state();
@@ -180,6 +184,40 @@ void TimeBasedCover::recompute_position_() {
   this->position = clamp(this->position, 0.0f, 1.0f);
 
   this->last_recompute_time_ = now;
+}
+
+void TimeBasedCover::update_external_state(bool up_active, bool down_active) {
+  this->is_external_override_ = (up_active || down_active);
+
+  cover::CoverOperation desired_op = COVER_OPERATION_IDLE;
+  if (up_active && !down_active) {
+    desired_op = COVER_OPERATION_OPENING;
+  } else if (!up_active && down_active) {
+    desired_op = COVER_OPERATION_CLOSING;
+  }
+
+  if (this->current_operation == desired_op) return;
+
+  this->recompute_position_();
+
+  if (this->prev_command_trigger_ != nullptr) {
+    this->stop_prev_trigger_();
+    this->stop_trigger_.trigger();
+  }
+
+  this->current_operation = desired_op;
+
+  if (desired_op != COVER_OPERATION_IDLE) {
+    this->last_operation_ = desired_op;
+    this->target_position_ = (desired_op == COVER_OPERATION_OPENING) ? COVER_OPEN : COVER_CLOSED;
+  }
+
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
+  this->last_recompute_time_ = now;
+  this->last_publish_time_ = now;
+
+  this->publish_state();
 }
 
 }  // namespace esphome::time_based

--- a/esphome/components/time_based/cover/time_based_cover.cpp
+++ b/esphome/components/time_based/cover/time_based_cover.cpp
@@ -196,7 +196,8 @@ void TimeBasedCover::update_external_state(bool up_active, bool down_active) {
     desired_op = COVER_OPERATION_CLOSING;
   }
 
-  if (this->current_operation == desired_op) return;
+  if (this->current_operation == desired_op)
+    return;
 
   this->recompute_position_();
 

--- a/esphome/components/time_based/cover/time_based_cover.h
+++ b/esphome/components/time_based/cover/time_based_cover.h
@@ -22,8 +22,10 @@ class TimeBasedCover : public cover::Cover, public Component {
   void set_manual_control(bool value) { this->manual_control_ = value; }
   void set_assumed_state(bool value) { this->assumed_state_ = value; }
   cover::CoverOperation get_last_operation() const { return this->last_operation_; }
+  void update_external_state(bool up_active, bool down_active);
 
  protected:
+  bool is_external_override_{false};
   void control(const cover::CoverCall &call) override;
   void stop_prev_trigger_();
   bool is_at_target_() const;

--- a/tests/components/time_based/common.yaml
+++ b/tests/components/time_based/common.yaml
@@ -10,3 +10,13 @@ cover:
     close_action:
       - logger.log: close_action
     close_duration: 4.5min
+
+button:
+  - platform: template
+    name: Time Based Cover Lambda
+    on_press:
+      - lambda: |-
+          id(time_based_cover).update_external_state(true, false);
+          id(time_based_cover).update_external_state(false, true);
+          id(time_based_cover).update_external_state(true, true);
+          id(time_based_cover).update_external_state(false, false);


### PR DESCRIPTION
# What does this implement/fix?

Can now track external input, rather than just the output time from the cover itself.

<!-- Quick description and explanation of changes -->

User can use a new lambda function to track external input to the time_based cover, enabling both home assistant control and manual control tracking.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6680

## Test Environment

- [X] ESP32
- [X] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
script:
  - id: process_desk_buttons
    mode: restart
    then:
      - lambda: |-
          bool human_up = id(desk_button_up).state && !id(button_up).state;
          bool human_down = id(desk_button_down).state && !id(button_down).state;

          if (id(button_up).state && !human_down) return;
          if (id(button_down).state && !human_up) return;

          id(desk_cover).update_external_state(human_up, human_down);

      - if:
          condition:
            and:
              - binary_sensor.is_on: desk_button_up
              - binary_sensor.is_on: desk_button_down
          then:
            - switch.turn_off: button_up
            - switch.turn_off: button_down

binary_sensor:
  - platform: gpio
    id: desk_button_up
    pin:
      number: 18
      mode: INPUT_OUTPUT_OPEN_DRAIN
      allow_other_uses: true
      inverted: true
    filters:
      - delayed_on: 50ms
      - delayed_off: 50ms
    on_state:
      then:
        - script.execute: process_desk_buttons

  - platform: gpio
    id: desk_button_down
    pin:
      number: 16
      mode: INPUT_OUTPUT_OPEN_DRAIN
      allow_other_uses: true
      inverted: true
    filters:
      - delayed_on: 50ms
      - delayed_off: 50ms
    on_state:
      then:
        - script.execute: process_desk_buttons

cover:
  - platform: time_based
    name: "Desk"
    id: desk_cover

    open_duration: 17s
    close_duration: 16s

    open_action:
      - switch.turn_on: button_up
    close_action:
      - switch.turn_on: button_down
    stop_action:
      - switch.turn_off: button_up
      - switch.turn_off: button_down

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
