### PR TITLE
[cover] Expose toggle support in native API

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -384,6 +384,7 @@ message ListEntitiesCoverResponse {
   EntityCategory entity_category = 11;
   bool supports_stop = 12;
   uint32 device_id = 13 [(field_ifdef) = "USE_DEVICES"];
+  bool supports_toggle = 14;
 }
 
 // Deprecated in API version 1.1
@@ -445,6 +446,7 @@ message CoverCommandRequest {
   float tilt = 7;
   bool stop = 8;
   uint32 device_id = 9 [(field_ifdef) = "USE_DEVICES"];
+  bool toggle = 10;
 }
 
 // ==================== FAN ====================

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -498,6 +498,7 @@ uint16_t APIConnection::try_send_cover_info(EntityBase *entity, APIConnection *c
   msg.supports_position = traits.get_supports_position();
   msg.supports_tilt = traits.get_supports_tilt();
   msg.supports_stop = traits.get_supports_stop();
+  msg.supports_toggle = traits.get_supports_toggle();
   return fill_and_encode_entity_info_with_device_class(cover, msg, msg.device_class, conn, remaining_size);
 }
 void APIConnection::on_cover_command_request(const CoverCommandRequest &msg) {
@@ -508,6 +509,8 @@ void APIConnection::on_cover_command_request(const CoverCommandRequest &msg) {
     call.set_tilt(msg.tilt);
   if (msg.stop)
     call.set_command_stop();
+  if (msg.toggle)
+    call.set_command_toggle();
   call.perform();
 }
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -290,6 +290,7 @@ uint8_t *ListEntitiesCoverResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE
 #ifdef USE_DEVICES
   ProtoEncode::encode_uint32(pos PROTO_ENCODE_DEBUG_ARG, 13, this->device_id);
 #endif
+  ProtoEncode::encode_bool(pos PROTO_ENCODE_DEBUG_ARG, 14, this->supports_toggle);
   return pos;
 }
 uint32_t ListEntitiesCoverResponse::calculate_size() const {
@@ -310,6 +311,7 @@ uint32_t ListEntitiesCoverResponse::calculate_size() const {
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
+  size += ProtoSize::calc_bool(1, this->supports_toggle);
   return size;
 }
 uint8_t *CoverStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
@@ -350,6 +352,9 @@ bool CoverCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t 
       this->device_id = value;
       break;
 #endif
+    case 10:
+      this->toggle = value != 0;
+      break;
     default:
       return false;
   }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -642,7 +642,7 @@ class BinarySensorStateResponse final : public StateResponseProtoMessage {
 class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 13;
-  static constexpr uint8_t ESTIMATED_SIZE = 57;
+  static constexpr uint8_t ESTIMATED_SIZE = 59;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_cover_response"); }
 #endif
@@ -651,6 +651,7 @@ class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
   bool supports_tilt{false};
   StringRef device_class{};
   bool supports_stop{false};
+  bool supports_toggle{false};
   uint8_t *encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const;
   uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -680,7 +681,7 @@ class CoverStateResponse final : public StateResponseProtoMessage {
 class CoverCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 30;
-  static constexpr uint8_t ESTIMATED_SIZE = 25;
+  static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("cover_command_request"); }
 #endif
@@ -689,6 +690,7 @@ class CoverCommandRequest final : public CommandProtoMessage {
   bool has_tilt{false};
   float tilt{0.0f};
   bool stop{false};
+  bool toggle{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1026,6 +1026,7 @@ const char *ListEntitiesCoverResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, ESPHOME_PSTR("device_id"), this->device_id);
 #endif
+  dump_field(out, ESPHOME_PSTR("supports_toggle"), this->supports_toggle);
   return out.c_str();
 }
 const char *CoverStateResponse::dump_to(DumpBuffer &out) const {
@@ -1050,6 +1051,7 @@ const char *CoverCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, ESPHOME_PSTR("device_id"), this->device_id);
 #endif
+  dump_field(out, ESPHOME_PSTR("toggle"), this->toggle);
   return out.c_str();
 }
 #endif

--- a/tests/components/cover/common.yaml
+++ b/tests/components/cover/common.yaml
@@ -1,0 +1,30 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+api:
+
+cover:
+  - platform: template
+    name: "Template Cover"
+    id: template_cover
+    optimistic: true
+    toggle_action:
+      - logger.log: "Cover toggle triggered"
+    open_action:
+      - logger.log: "Cover open triggered"
+    close_action:
+      - logger.log: "Cover close triggered"
+    stop_action:
+      - logger.log: "Cover stop triggered"
+    on_opened:
+      - logger.log: "Cover opened"
+    on_closed:
+      - logger.log: "Cover closed"
+
+esphome:
+  on_boot:
+    - cover.open: template_cover
+    - cover.close: template_cover
+    - cover.stop: template_cover
+    - cover.toggle: template_cover

--- a/tests/components/cover/test.esp32-idf.yaml
+++ b/tests/components/cover/test.esp32-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/cover/test.esp8266-ard.yaml
+++ b/tests/components/cover/test.esp8266-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/cover/test.rp2040-ard.yaml
+++ b/tests/components/cover/test.rp2040-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

The native API (protobuf) for covers was missing toggle support despite it being fully implemented at the C++ level.

This means API clients such as Home Assistant via `aioesphomeapi` had no way to:

1. Know whether a cover supports toggle
2. Send a toggle command to a cover

This PR "fixes" it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This PR is a revival of https://github.com/esphome/esphome/pull/8049.

- refs https://github.com/home-assistant/core/issues/135099

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
cover:
  - platform: template
    name: "My Garage Door"
    optimistic: true
    toggle_action:
      - switch.toggle: garage_relay
    open_action:
      - switch.turn_on: garage_relay
    close_action:
      - switch.turn_on: garage_relay
    stop_action:
      - switch.turn_off: garage_relay
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
