### PR TITLE
[voice_assistant] Wait for media player to finish announcing before before reopening mic

### DIFF
--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -159,6 +159,7 @@ class MediaPlayer : public EntityBase {
   }
 
   virtual bool is_muted() const { return false; }
+  bool is_announcing() const { return this->state == MEDIA_PLAYER_STATE_ANNOUNCING; }
 
   virtual MediaPlayerTraits get_traits() = 0;
 

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -479,6 +479,14 @@ void VoiceAssistant::loop() {
         this->tts_stream_end_trigger_.trigger();
       }
 #endif
+#ifdef USE_MEDIA_PLAYER
+      if (this->speaker_ == nullptr && this->media_player_ != nullptr) {
+        if (this->media_player_->is_announcing()) {
+          break;
+        }
+        ESP_LOGD(TAG, "Media player has finished announcing");
+      }
+#endif
       if (this->continue_conversation_) {
         this->set_state_(State::START_MICROPHONE, State::START_PIPELINE);
       } else {


### PR DESCRIPTION
# What does this implement/fix?

In continuous conversation mode with an external media player (e.g. with OpenAI TTS), the `RESPONSE_FINISHED` state was transitioning to `START_MICROPHONE` immediately after the TTS data stream finished — without waiting for the media player to finish **playing** the buffered audio.

Fast TTS providers like OpenAI TTS deliver the complete audio file significantly faster than real-time playback. The HTTP download may complete in ~2 seconds while the actual audio is 4+ seconds long. As a result, the voice assistant state machine was opening the microphone while the device was still speaking, causing the microphone to pick up the TTS output and re-trigger STT — breaking continuous conversation mode.

**Root cause:** In `RESPONSE_FINISHED`, the existing speaker checks (`has_buffered_data()`, `is_running()`) correctly gate the speaker path. But the `media_player_` path had no equivalent check — the state machine transitioned to `START_MICROPHONE` immediately after the TTS stream was received.

**Fix:** Add a `is_announcing()` helper method to `MediaPlayer` and use it in `RESPONSE_FINISHED` to hold the state until the media player is no longer announcing before allowing the conversation to continue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/home-assistant-voice-pe/issues/563

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
voice_assistant:
  media_player: my_media_player
  noise_suppression_level: 2
  auto_gain: 31dBFS
  volume_multiplier: 4.0
  on_tts_end:
    - media_player.play_media: !lambda return x;
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).


---
_Generated by [Claude Code](https://claude.ai/code/session_019HtKRXtVufmoM6kCFw4Yri)_