### PR TITLE
[modbus_controller] validate response payload size before dispatching to sensors

### DIFF
--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -117,9 +117,8 @@ template<typename T> T get_data(const std::vector<uint8_t> &data, size_t buffer_
   // responses before they reach here, but this prevents undefined behavior
   // if that check is bypassed.
   if (buffer_offset + sizeof(T) > data.size()) {
-    ESP_LOGW("modbus_helpers",
-             "get_data: offset %zu + size %zu exceeds data length %zu - returning 0",
-             buffer_offset, sizeof(T), data.size());
+    ESP_LOGW("modbus_helpers", "get_data: offset %zu + size %zu exceeds data length %zu - returning 0", buffer_offset,
+             sizeof(T), data.size());
     return T(0);
   }
 

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -117,8 +117,6 @@ template<typename T> T get_data(const std::vector<uint8_t> &data, size_t buffer_
   // responses before they reach here, but this prevents undefined behavior
   // if that check is bypassed.
   if (buffer_offset + sizeof(T) > data.size()) {
-    ESP_LOGW("modbus_helpers", "get_data: offset %zu + size %zu exceeds data length %zu - returning 0", buffer_offset,
-             sizeof(T), data.size());
     return T(0);
   }
 

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -113,6 +113,16 @@ inline uint64_t qword_from_hex_str(const std::string &value, uint8_t pos) {
  * @return value of type T extracted from buffer
  */
 template<typename T> T get_data(const std::vector<uint8_t> &data, size_t buffer_offset) {
+  // Defensive bounds check the controller layer should reject mismatched
+  // responses before they reach here, but this prevents undefined behavior
+  // if that check is bypassed.
+  if (buffer_offset + sizeof(T) > data.size()) {
+    ESP_LOGW("modbus_helpers",
+             "get_data: offset %zu + size %zu exceeds data length %zu - returning 0",
+             buffer_offset, sizeof(T), data.size());
+    return T(0);
+  }
+
   if (sizeof(T) == sizeof(uint8_t)) {
     return T(data[buffer_offset]);
   }

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -64,6 +64,35 @@ void ModbusController::on_modbus_data(const std::vector<uint8_t> &data) {
   }
   auto &current_command = this->command_queue_.front();
   if (current_command != nullptr) {
+    // Validate response payload size for read commands. Sensors index into the
+    // payload at pre-computed offsets - a size mismatch (e.g., from a bus collision
+    // where another master's response is captured) causes out-of-bounds reads.
+    size_t expected_bytes = 0;
+    bool requires_validation = true;
+
+    switch (current_command->function_code) {
+      case ModbusFunctionCode::READ_COILS:
+      case ModbusFunctionCode::READ_DISCRETE_INPUTS:
+        expected_bytes = (current_command->register_count + 7) / 8;
+        break;
+      case ModbusFunctionCode::READ_HOLDING_REGISTERS:
+      case ModbusFunctionCode::READ_INPUT_REGISTERS:
+        expected_bytes = current_command->register_count * 2;
+        break;
+      default:
+        // CUSTOM and Write function codes do not require payload size validation
+        requires_validation = false;
+        break;
+    }
+
+    if (requires_validation && data.size() != expected_bytes) {
+      ESP_LOGW(TAG,
+               "Response size mismatch for device=%d address=0x%04X: got %zu bytes, expected %zu. "
+               "Possible bus collision - discarding response and retrying.",
+               this->address_, current_command->register_address, data.size(), expected_bytes);
+      return;  // Don't dequeue the command  -  it will be retried on the next cycle
+    }
+
     if (this->module_offline_) {
       ESP_LOGW(TAG, "Modbus device=%d back online", this->address_);
 


### PR DESCRIPTION
# Validate Modbus response payload size before dispatching to sensors

## What does this do?

Adds response payload size validation for read commands (FC01-FC04) in `ModbusController::on_modbus_data()`, and a defensive bounds check in `modbus::helpers::get_data<T>()`.

## Problem

ESPHome accepts any Modbus response that passes CRC and slave address checks, without verifying that the payload size matches the pending request's expected byte count (`register_count * 2` for FC03/FC04, `ceil(register_count / 8)` for FC01/FC02). Sensors then index into the payload at pre-computed offsets using `std::vector::operator[]` with no bounds checking.

On multi-master RS-485 buses (common with solar inverters where a manufacturer's WiFi dongle shares the bus), the dongle's response to a different request can arrive while ESPHome is waiting for its own. Since both use the same slave address and FC03, and the response frame contains no register address information, ESPHome accepts it. Result:

- Sensors at offsets within the shorter response read **wrong register data** (silent corruption)
- Sensors at offsets beyond the response read **past the vector end** (undefined behavior)

## Fix

**Controller layer** (`modbus_controller.cpp`): A `switch` on the pending command's function code computes the expected payload size. If `data.size()` doesn't match, the response is discarded without dequeuing — the retry mechanism re-sends the request on the next cycle. Write responses and CUSTOM function codes skip validation.

**Helper layer** (`modbus_helpers.h`): `get_data<T>()` now checks `buffer_offset + sizeof(T) > data.size()` before indexing. Returns `T(0)` with a warning log if exceeded. This is a safety net — the controller check should prevent this path from being reached.

## Evidence

Observed on a hybrid inverter with manufacturer WiFi dongle performing periodic bulk reads (every 5 minutes) on the same RS-485 bus as an ESP32 running ESPHome. Symptoms: batch of sensors intermittently publishes zeros mixed with values in the millions (wrong data mapped onto wrong offsets). 7 events captured over 19 hours — consistent with the dongle's response being shorter than expected.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)