### PR TITLE
[climate] add ordered fan modes interface

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1102,7 +1102,7 @@ message ListEntitiesClimateResponse {
   // Deprecated in API version 1.5
   bool legacy_supports_away = 11 [deprecated=true];
   bool supports_action = 12; // Deprecated: use feature_flags
-  repeated ClimateFanMode supported_fan_modes = 13 [(container_pointer_no_template) = "climate::ClimateFanModeMask"];
+  repeated ClimateFanMode supported_fan_modes = 13 [(container_pointer_no_template) = "climate::ClimateFanModeList"];
   repeated ClimateSwingMode supported_swing_modes = 14 [(container_pointer_no_template) = "climate::ClimateSwingModeMask"];
   repeated string supported_custom_fan_modes = 15 [(container_pointer_no_template) = "std::vector<const char *>"];
   repeated ClimatePreset supported_presets = 16 [(container_pointer_no_template) = "climate::ClimatePresetMask"];

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -776,7 +776,7 @@ uint16_t APIConnection::try_send_climate_info(EntityBase *entity, APIConnection 
   msg.visual_current_temperature_step = traits.get_visual_current_temperature_step();
   msg.visual_min_humidity = traits.get_visual_min_humidity();
   msg.visual_max_humidity = traits.get_visual_max_humidity();
-  msg.supported_fan_modes = &traits.get_supported_fan_modes();
+  msg.supported_fan_modes = &traits.get_supported_fan_modes_ordered();
   msg.supported_custom_fan_modes = &traits.get_supported_custom_fan_modes();
   msg.supported_presets = &traits.get_supported_presets();
   msg.supported_custom_presets = &traits.get_supported_custom_presets();

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1390,7 +1390,7 @@ class ListEntitiesClimateResponse final : public InfoResponseProtoMessage {
   float visual_max_temperature{0.0f};
   float visual_target_temperature_step{0.0f};
   bool supports_action{false};
-  const climate::ClimateFanModeMask *supported_fan_modes{};
+  const climate::ClimateFanModeList *supported_fan_modes{};
   const climate::ClimateSwingModeMask *supported_swing_modes{};
   const std::vector<const char *> *supported_custom_fan_modes{};
   const climate::ClimatePresetMask *supported_presets{};

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -768,10 +768,12 @@ void Climate::dump_traits_(const char *tag) {
     for (ClimateMode m : traits.get_supported_modes())
       ESP_LOGCONFIG(tag, "  - %s", LOG_STR_ARG(climate_mode_to_string(m)));
   }
-  if (!traits.get_supported_fan_modes().empty()) {
+  if (!traits.get_supported_fan_modes_ordered().empty()) {
     ESP_LOGCONFIG(tag, "  Supported fan modes:");
-    for (ClimateFanMode m : traits.get_supported_fan_modes())
-      ESP_LOGCONFIG(tag, "  - %s", LOG_STR_ARG(climate_fan_mode_to_string(m)));
+    for (ClimateFanMode m : traits.get_supported_fan_modes_ordered()) {
+      if (traits.supports_fan_mode(m))
+        ESP_LOGCONFIG(tag, "  - %s", LOG_STR_ARG(climate_fan_mode_to_string(m)));
+    }
   }
   if (!traits.get_supported_custom_fan_modes().empty()) {
     ESP_LOGCONFIG(tag, "  Supported custom fan modes:");

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -114,9 +114,7 @@ class ClimateTraits {
   // Remove before 2026.11.0
   ESPDEPRECATED("Call set_supported_fan_modes_ordered() on the Climate entity instead. Removed in 2026.11.0",
                 "2026.5.0")
-  void set_supported_fan_modes(const ClimateFanModeList &modes) {
-    this->set_supported_fan_modes_ordered(modes);
-  }
+  void set_supported_fan_modes(const ClimateFanModeList &modes) { this->set_supported_fan_modes_ordered(modes); }
   void add_supported_fan_mode(ClimateFanMode mode) {
     if (this->supports_fan_mode(mode))
       return;

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -14,6 +14,7 @@ namespace esphome::climate {
 // Bitmask size is automatically calculated from the last enum value
 using ClimateModeMask = FiniteSetMask<ClimateMode, DefaultBitPolicy<ClimateMode, CLIMATE_MODE_AUTO + 1>>;
 using ClimateFanModeMask = FiniteSetMask<ClimateFanMode, DefaultBitPolicy<ClimateFanMode, CLIMATE_FAN_QUIET + 1>>;
+using ClimateFanModeList = StaticVector<ClimateFanMode, CLIMATE_FAN_QUIET + 1>;
 using ClimateSwingModeMask =
     FiniteSetMask<ClimateSwingMode, DefaultBitPolicy<ClimateSwingMode, CLIMATE_SWING_HORIZONTAL + 1>>;
 using ClimatePresetMask = FiniteSetMask<ClimatePreset, DefaultBitPolicy<ClimatePreset, CLIMATE_PRESET_ACTIVITY + 1>>;
@@ -86,11 +87,45 @@ class ClimateTraits {
   bool supports_mode(ClimateMode mode) const { return this->supported_modes_.count(mode); }
   const ClimateModeMask &get_supported_modes() const { return this->supported_modes_; }
 
-  void set_supported_fan_modes(ClimateFanModeMask modes) { this->supported_fan_modes_ = modes; }
-  void add_supported_fan_mode(ClimateFanMode mode) { this->supported_fan_modes_.insert(mode); }
+  void set_supported_fan_modes(ClimateFanModeMask modes) {
+    this->supported_fan_modes_ = modes;
+    this->supported_fan_modes_ordered_.clear();
+    for (ClimateFanMode mode : modes)
+      this->supported_fan_modes_ordered_.push_back(mode);
+  }
+  void set_supported_fan_modes_ordered(std::initializer_list<ClimateFanMode> modes) {
+    this->supported_fan_modes_.clear();
+    this->supported_fan_modes_ordered_.clear();
+    for (ClimateFanMode mode : modes)
+      this->add_supported_fan_mode(mode);
+  }
+  void set_supported_fan_modes_ordered(const ClimateFanModeList &modes) {
+    this->supported_fan_modes_.clear();
+    this->supported_fan_modes_ordered_.clear();
+    for (ClimateFanMode mode : modes)
+      this->add_supported_fan_mode(mode);
+  }
+  // Remove before 2026.11.0
+  ESPDEPRECATED("Call set_supported_fan_modes_ordered() on the Climate entity instead. Removed in 2026.11.0",
+                "2026.5.0")
+  void set_supported_fan_modes(std::initializer_list<ClimateFanMode> modes) {
+    this->set_supported_fan_modes_ordered(modes);
+  }
+  // Remove before 2026.11.0
+  ESPDEPRECATED("Call set_supported_fan_modes_ordered() on the Climate entity instead. Removed in 2026.11.0",
+                "2026.5.0")
+  void set_supported_fan_modes(const ClimateFanModeList &modes) {
+    this->set_supported_fan_modes_ordered(modes);
+  }
+  void add_supported_fan_mode(ClimateFanMode mode) {
+    if (this->supports_fan_mode(mode))
+      return;
+    this->supported_fan_modes_.insert(mode);
+    this->supported_fan_modes_ordered_.push_back(mode);
+  }
   bool supports_fan_mode(ClimateFanMode fan_mode) const { return this->supported_fan_modes_.count(fan_mode); }
   bool get_supports_fan_modes() const {
-    if (!this->supported_fan_modes_.empty()) {
+    if (!this->supported_fan_modes_.empty() || !this->supported_fan_modes_ordered_.empty()) {
       return true;
     }
     // Same precedence as get_supported_custom_fan_modes() getter
@@ -100,6 +135,7 @@ class ClimateTraits {
     return !this->compat_custom_fan_modes_.empty();  // Compat: remove in 2026.11.0
   }
   const ClimateFanModeMask &get_supported_fan_modes() const { return this->supported_fan_modes_; }
+  const ClimateFanModeList &get_supported_fan_modes_ordered() const { return this->supported_fan_modes_ordered_; }
 
   // Remove before 2026.11.0
   ESPDEPRECATED("Call set_supported_custom_fan_modes() on the Climate entity instead. Removed in 2026.11.0", "2026.5.0")
@@ -215,9 +251,16 @@ class ClimateTraits {
   }
   void set_fan_mode_support_(climate::ClimateFanMode mode, bool supported) {
     if (supported) {
-      this->supported_fan_modes_.insert(mode);
+      this->add_supported_fan_mode(mode);
     } else {
       this->supported_fan_modes_.erase(mode);
+      ClimateFanModeList supported_fan_modes_ordered;
+      for (ClimateFanMode existing_mode : this->supported_fan_modes_ordered_) {
+        if (existing_mode != mode) {
+          supported_fan_modes_ordered.push_back(existing_mode);
+        }
+      }
+      this->supported_fan_modes_ordered_ = supported_fan_modes_ordered;
     }
   }
   void set_swing_mode_support_(climate::ClimateSwingMode mode, bool supported) {
@@ -272,6 +315,7 @@ class ClimateTraits {
 
   climate::ClimateModeMask supported_modes_{climate::CLIMATE_MODE_OFF};
   climate::ClimateFanModeMask supported_fan_modes_;
+  climate::ClimateFanModeList supported_fan_modes_ordered_;
   climate::ClimateSwingModeMask supported_swing_modes_;
   climate::ClimatePresetMask supported_presets_;
 

--- a/esphome/components/demo/demo_climate.h
+++ b/esphome/components/demo/demo_climate.h
@@ -105,7 +105,7 @@ class DemoClimate : public climate::Climate, public Component {
             climate::CLIMATE_MODE_FAN_ONLY,
         });
         traits.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
-        traits.set_supported_fan_modes({
+        traits.set_supported_fan_modes_ordered({
             climate::CLIMATE_FAN_ON,
             climate::CLIMATE_FAN_OFF,
             climate::CLIMATE_FAN_AUTO,

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -163,26 +163,10 @@ void MQTTClimateComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCo
     root[MQTT_FAN_MODE_STATE_TOPIC] = this->get_fan_mode_state_topic();
     // fan_modes
     JsonArray fan_modes = root[ESPHOME_F("fan_modes")].to<JsonArray>();
-    if (traits.supports_fan_mode(CLIMATE_FAN_ON))
-      fan_modes.add(ESPHOME_F("on"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_OFF))
-      fan_modes.add(ESPHOME_F("off"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_AUTO))
-      fan_modes.add(ESPHOME_F("auto"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_LOW))
-      fan_modes.add(ESPHOME_F("low"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_MEDIUM))
-      fan_modes.add(ESPHOME_F("medium"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_HIGH))
-      fan_modes.add(ESPHOME_F("high"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_MIDDLE))
-      fan_modes.add(ESPHOME_F("middle"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_FOCUS))
-      fan_modes.add(ESPHOME_F("focus"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_DIFFUSE))
-      fan_modes.add(ESPHOME_F("diffuse"));
-    if (traits.supports_fan_mode(CLIMATE_FAN_QUIET))
-      fan_modes.add(ESPHOME_F("quiet"));
+    for (ClimateFanMode fan_mode : traits.get_supported_fan_modes_ordered()) {
+      if (traits.supports_fan_mode(fan_mode))
+        fan_modes.add(climate_fan_mode_to_mqtt_str(fan_mode));
+    }
     for (const auto &fan_mode : traits.get_supported_custom_fan_modes())
       fan_modes.add(fan_mode);
   }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1564,8 +1564,10 @@ json::SerializationBuffer<> WebServer::climate_json_(climate::Climate *obj, Json
       opt.add(PSTR_LOCAL(climate::climate_mode_to_string(m)));
     if (traits.get_supports_fan_modes()) {
       JsonArray opt = root[ESPHOME_F("fan_modes")].to<JsonArray>();
-      for (climate::ClimateFanMode m : traits.get_supported_fan_modes())
-        opt.add(PSTR_LOCAL(climate::climate_fan_mode_to_string(m)));
+      for (climate::ClimateFanMode m : traits.get_supported_fan_modes_ordered()) {
+        if (traits.supports_fan_mode(m))
+          opt.add(PSTR_LOCAL(climate::climate_fan_mode_to_string(m)));
+      }
     }
 
     if (!traits.get_supported_custom_fan_modes().empty()) {

--- a/tests/benchmarks/components/climate/bench_climate.cpp
+++ b/tests/benchmarks/components/climate/bench_climate.cpp
@@ -32,7 +32,7 @@ static void setup_hvac_climate(BenchClimate &climate) {
       climate::CLIMATE_MODE_HEAT,
       climate::CLIMATE_MODE_FAN_ONLY,
   });
-  climate.traits_.set_supported_fan_modes({
+  climate.traits_.set_supported_fan_modes_ordered({
       climate::CLIMATE_FAN_AUTO,
       climate::CLIMATE_FAN_LOW,
       climate::CLIMATE_FAN_MEDIUM,

--- a/tests/integration/fixtures/climate_fan_mode_order.yaml
+++ b/tests/integration/fixtures/climate_fan_mode_order.yaml
@@ -11,6 +11,6 @@ external_components:
   - source: EXTERNAL_COMPONENT_PATH
 
 climate:
-  - platform: ordered_climate
+  - platform: ordered_climate_component
     id: ordered_climate
     name: Ordered Climate

--- a/tests/integration/fixtures/climate_fan_mode_order.yaml
+++ b/tests/integration/fixtures/climate_fan_mode_order.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: climate-fan-mode-order-test
+
+host:
+
+api:
+
+logger:
+
+external_components:
+  - source: EXTERNAL_COMPONENT_PATH
+
+climate:
+  - platform: ordered_climate
+    id: ordered_climate
+    name: Ordered Climate

--- a/tests/integration/fixtures/external_components/ordered_climate_component/__init__.py
+++ b/tests/integration/fixtures/external_components/ordered_climate_component/__init__.py
@@ -1,0 +1,1 @@
+"""Ordered climate component used by integration tests."""

--- a/tests/integration/fixtures/external_components/ordered_climate_component/climate/__init__.py
+++ b/tests/integration/fixtures/external_components/ordered_climate_component/climate/__init__.py
@@ -6,7 +6,9 @@ import esphome.config_validation as cv
 from esphome.types import ConfigType
 
 ordered_climate_ns = cg.esphome_ns.namespace("ordered_climate_test")
-OrderedClimate = ordered_climate_ns.class_("OrderedClimate", climate.Climate, cg.Component)
+OrderedClimate = ordered_climate_ns.class_(
+    "OrderedClimate", climate.Climate, cg.Component
+)
 
 CONFIG_SCHEMA = climate.climate_schema(OrderedClimate).extend(cv.COMPONENT_SCHEMA)
 

--- a/tests/integration/fixtures/external_components/ordered_climate_component/climate/__init__.py
+++ b/tests/integration/fixtures/external_components/ordered_climate_component/climate/__init__.py
@@ -1,0 +1,16 @@
+"""Climate platform that exposes fan modes in a custom order."""
+
+import esphome.codegen as cg
+from esphome.components import climate
+import esphome.config_validation as cv
+from esphome.types import ConfigType
+
+ordered_climate_ns = cg.esphome_ns.namespace("ordered_climate_test")
+OrderedClimate = ordered_climate_ns.class_("OrderedClimate", climate.Climate, cg.Component)
+
+CONFIG_SCHEMA = climate.climate_schema(OrderedClimate).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = await climate.new_climate(config)
+    await cg.register_component(var, config)

--- a/tests/integration/fixtures/external_components/ordered_climate_component/climate/ordered_climate.h
+++ b/tests/integration/fixtures/external_components/ordered_climate_component/climate/ordered_climate.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "esphome/components/climate/climate.h"
+#include "esphome/core/component.h"
+
+namespace esphome::ordered_climate_test {
+
+class OrderedClimate : public climate::Climate, public Component {
+ public:
+  void setup() override {
+    this->mode = climate::CLIMATE_MODE_OFF;
+    this->target_temperature = 21.0f;
+    this->publish_state();
+  }
+
+ protected:
+  void control(const climate::ClimateCall &call) override {
+    if (call.get_mode().has_value()) {
+      this->mode = *call.get_mode();
+    }
+    if (call.get_target_temperature().has_value()) {
+      this->target_temperature = *call.get_target_temperature();
+    }
+    if (call.get_fan_mode().has_value()) {
+      this->set_fan_mode_(*call.get_fan_mode());
+    }
+    if (call.has_custom_fan_mode()) {
+      this->set_custom_fan_mode_(call.get_custom_fan_mode());
+    }
+    this->publish_state();
+  }
+
+  climate::ClimateTraits traits() override {
+    climate::ClimateTraits traits{};
+    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+    traits.add_supported_fan_mode(climate::CLIMATE_FAN_HIGH);
+    traits.add_supported_fan_mode(climate::CLIMATE_FAN_AUTO);
+    traits.add_supported_fan_mode(climate::CLIMATE_FAN_LOW);
+    return traits;
+  }
+};
+
+}  // namespace esphome::ordered_climate_test

--- a/tests/integration/test_climate_fan_mode_order.py
+++ b/tests/integration/test_climate_fan_mode_order.py
@@ -1,0 +1,42 @@
+"""Integration test for ordered climate fan-mode serialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aioesphomeapi import ClimateFanMode, ClimateInfo
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_climate_fan_mode_order(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that supported fan modes preserve the order defined by the component."""
+    external_components_path = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        entities, _ = await client.list_entities_services()
+        climate_infos = [e for e in entities if isinstance(e, ClimateInfo)]
+        assert len(climate_infos) == 1, (
+            f"Expected 1 climate entity, got {len(climate_infos)}"
+        )
+
+        ordered_climate = climate_infos[0]
+        assert ordered_climate.supported_fan_modes == [
+            ClimateFanMode.CLIMATE_FAN_HIGH,
+            ClimateFanMode.CLIMATE_FAN_AUTO,
+            ClimateFanMode.CLIMATE_FAN_LOW,
+        ], (
+            "Expected supported fan modes to preserve component-defined order, "
+            f"got {ordered_climate.supported_fan_modes}"
+        )

--- a/tests/integration/test_climate_fan_mode_order.py
+++ b/tests/integration/test_climate_fan_mode_order.py
@@ -33,9 +33,9 @@ async def test_climate_fan_mode_order(
 
         ordered_climate = climate_infos[0]
         assert ordered_climate.supported_fan_modes == [
-            ClimateFanMode.CLIMATE_FAN_HIGH,
-            ClimateFanMode.CLIMATE_FAN_AUTO,
-            ClimateFanMode.CLIMATE_FAN_LOW,
+            ClimateFanMode.HIGH,
+            ClimateFanMode.AUTO,
+            ClimateFanMode.LOW,
         ], (
             "Expected supported fan modes to preserve component-defined order, "
             f"got {ordered_climate.supported_fan_modes}"


### PR DESCRIPTION
# What does this implement/fix?

Add ability to define the order of standard fan modes through interface set_supported_fan_modes_ordered. Can e.g. be used by custom component to control the presented order of fan modes in Home Assistant and enable correct mapping of fan speed percentage in [Home Assistant Matter Hub](https://github.com/RiDDiX/home-assistant-matter-hub).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#5860

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
