### PR TITLE
[sx126x] Add support for Channel Activity Detection and PA_CTX pin control for Heltec v4.3

### DIFF
--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -41,6 +41,8 @@ CONF_SPREADING_FACTOR = "spreading_factor"
 CONF_SYNC_VALUE = "sync_value"
 CONF_TCXO_VOLTAGE = "tcxo_voltage"
 CONF_TCXO_DELAY = "tcxo_delay"
+CONF_PA_CTX_PIN = "pa_ctx_pin"
+CONF_CAD_TIMEOUT = "cad_timeout"
 
 sx126x_ns = cg.esphome_ns.namespace("sx126x")
 SX126x = sx126x_ns.class_("SX126x", cg.Component, spi.SPIDevice)
@@ -134,6 +136,9 @@ RunImageCalAction = sx126x_ns.class_(
 )
 SendPacketAction = sx126x_ns.class_(
     "SendPacketAction", automation.Action, cg.Parented.template(SX126x)
+)
+AsyncSendPacketAction = sx126x_ns.class_(
+    "AsyncSendPacketAction", automation.Action, cg.Parented.template(SX126x)
 )
 SetModeTxAction = sx126x_ns.class_(
     "SetModeTxAction", automation.Action, cg.Parented.template(SX126x)
@@ -232,6 +237,11 @@ CONFIG_SCHEMA = (
                 cv.positive_time_period_microseconds,
                 cv.Range(max=TimePeriod(microseconds=262144000)),
             ),
+            cv.Optional(CONF_PA_CTX_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_CAD_TIMEOUT, default="0s"): cv.All(
+                cv.templatable(cv.positive_time_period_milliseconds),
+                cv.Range(max=TimePeriod(milliseconds=262144000))
+            )
         },
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -285,6 +295,11 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_rf_switch(config[CONF_RF_SWITCH]))
     cg.add(var.set_tcxo_voltage(config[CONF_TCXO_VOLTAGE]))
     cg.add(var.set_tcxo_delay(config[CONF_TCXO_DELAY]))
+
+    if CONF_PA_CTX_PIN in config:
+        pa_ctx_pin = await cg.gpio_pin_expression(config[CONF_PA_CTX_PIN])
+        cg.add(var.set_pa_ctx_pin(pa_ctx_pin))
+    cg.add(var.set_cad_timeout(int(config[CONF_CAD_TIMEOUT].total_milliseconds)))
 
 
 NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
@@ -364,6 +379,19 @@ SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
     key=CONF_DATA,
 )
 
+ASYNC_SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.GenerateID(): cv.use_id(SX126x),
+        cv.Required(CONF_DATA): cv.templatable(validate_raw_data),
+        cv.Optional(CONF_CAD_TIMEOUT): cv.All(
+            cv.templatable(cv.positive_time_period_milliseconds),
+            cv.Range(max=TimePeriod(milliseconds=262144000))
+        )
+    },
+    key=CONF_DATA,
+)
+
+
 
 @automation.register_action(
     "sx126x.send_packet",
@@ -390,4 +418,43 @@ async def send_packet_action_to_code(
         arr_id = ID(f"{action_id}_data", is_declaration=True, type=cg.uint8)
         arr = cg.static_const_array(arr_id, cg.ArrayInitializer(*data))
         cg.add(var.set_data_static(arr, len(data)))
+    return var
+
+
+@automation.register_action(
+    "sx126x.async_send_packet",
+    AsyncSendPacketAction,
+    ASYNC_SEND_PACKET_ACTION_SCHEMA,
+    synchronous=False,
+)
+async def async_send_packet_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    data = config[CONF_DATA]
+    if isinstance(data, bytes):
+        data = list(data)
+    if cg.is_template(data):
+        templ = await cg.templatable(data, args, cg.std_vector.template(cg.uint8))
+        cg.add(var.set_data_template(templ))
+    else:
+        # Generate static array in flash to avoid RAM copy
+        arr_id = ID(f"{action_id}_data", is_declaration=True, type=cg.uint8)
+        arr = cg.static_const_array(arr_id, cg.ArrayInitializer(*data))
+        cg.add(var.set_data_static(arr, len(data)))
+
+    if CONF_CAD_TIMEOUT in config:
+        cad_val = config[CONF_CAD_TIMEOUT]
+        if cg.is_template(cad_val):
+            cad_templ = await cg.templatable(cad_val, args, cg.optional.template(cg.uint32))
+            cg.add(var.set_cad_timeout(cad_templ))
+        else:
+            cad_ms = int(cad_val.total_milliseconds)
+            cad_templ = await cg.templatable(cad_ms, args, cg.optional.template(cg.uint32))
+            cg.add(var.set_cad_timeout(cad_templ))
+
     return var

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -240,8 +240,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_PA_CTX_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_CAD_TIMEOUT, default="0s"): cv.All(
                 cv.templatable(cv.positive_time_period_milliseconds),
-                cv.Range(max=TimePeriod(milliseconds=262144000))
-            )
+                cv.Range(max=TimePeriod(milliseconds=262144000)),
+            ),
         },
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -385,12 +385,11 @@ ASYNC_SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
         cv.Required(CONF_DATA): cv.templatable(validate_raw_data),
         cv.Optional(CONF_CAD_TIMEOUT): cv.All(
             cv.templatable(cv.positive_time_period_milliseconds),
-            cv.Range(max=TimePeriod(milliseconds=262144000))
-        )
+            cv.Range(max=TimePeriod(milliseconds=262144000)),
+        ),
     },
     key=CONF_DATA,
 )
-
 
 
 @automation.register_action(
@@ -450,11 +449,15 @@ async def async_send_packet_action_to_code(
     if CONF_CAD_TIMEOUT in config:
         cad_val = config[CONF_CAD_TIMEOUT]
         if cg.is_template(cad_val):
-            cad_templ = await cg.templatable(cad_val, args, cg.optional.template(cg.uint32))
+            cad_templ = await cg.templatable(
+                cad_val, args, cg.optional.template(cg.uint32)
+            )
             cg.add(var.set_cad_timeout(cad_templ))
         else:
             cad_ms = int(cad_val.total_milliseconds)
-            cad_templ = await cg.templatable(cad_ms, args, cg.optional.template(cg.uint32))
+            cad_templ = await cg.templatable(
+                cad_ms, args, cg.optional.template(cg.uint32)
+            )
             cg.add(var.set_cad_timeout(cad_templ))
 
     return var

--- a/esphome/components/sx126x/automation.h
+++ b/esphome/components/sx126x/automation.h
@@ -43,6 +43,42 @@ template<typename... Ts> class SendPacketAction : public Action<Ts...>, public P
   } data_;
 };
 
+template<typename... Ts> class AsyncSendPacketAction : public Action<Ts...>, public Parented<SX126x> {
+ public:
+  void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
+    this->data_.func = func;
+    this->len_ = -1;  // Sentinel value indicates template mode
+  }
+
+  void set_data_static(const uint8_t *data, size_t len) {
+    this->data_.data = data;
+    this->len_ = len;  // Length >= 0 indicates static mode
+  }
+
+  TEMPLATABLE_VALUE(optional<uint32_t>, cad_timeout)
+
+  void play(const Ts &...x) override {
+    std::vector<uint8_t> data;
+    if (this->len_ >= 0) {
+      // Static mode: copy from flash to vector
+      data.assign(this->data_.data, this->data_.data + this->len_);
+    } else {
+      // Template mode: call function
+      data = this->data_.func(x...);
+    }
+    optional<uint32_t> cad_timeout = this->cad_timeout_.value(x...);
+    
+    this->parent_->async_transmit_packet(data, cad_timeout);
+  }
+
+ protected:
+  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
+  union Data {
+    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
+    const uint8_t *data;                  // Pointer to static data in flash
+  } data_;
+};
+
 template<typename... Ts> class SetModeTxAction : public Action<Ts...>, public Parented<SX126x> {
  public:
   void play(const Ts &...x) override { this->parent_->set_mode_tx(); }

--- a/esphome/components/sx126x/automation.h
+++ b/esphome/components/sx126x/automation.h
@@ -67,7 +67,7 @@ template<typename... Ts> class AsyncSendPacketAction : public Action<Ts...>, pub
       data = this->data_.func(x...);
     }
     optional<uint32_t> cad_timeout = this->cad_timeout_.value(x...);
-    
+
     this->parent_->async_transmit_packet(data, cad_timeout);
   }
 

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -114,6 +114,9 @@ void SX126x::setup() {
     static_cast<InternalGPIOPin *>(this->dio1_pin_)
         ->attach_interrupt(&SX126x::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
   }
+  if ( this->pa_ctx_pin_ ){
+    this->pa_ctx_pin_->setup();
+  }
 
   // start spi
   this->spi_setup();
@@ -312,6 +315,28 @@ SX126xError SX126x::transmit_packet(const std::vector<uint8_t> &packet) {
     return SX126xError::INVALID_PARAMS;
   }
 
+  // don't use this -- this would be a blocking loop for CAD -- using async_transmit_packet is a better choice
+  // as the retry loop is at least asynchronous.  if scan_channel_clear() is returning false due to being in the 
+  // middle of receiving a packet, it could be tens-of-millieconds (or more) before the packet is fully received,
+  // so blocking isn't playing very nice with the esphome scheduler
+  //
+  // use async if you want cad... so we don't hold the cpu
+  // optional: CAD before transmit
+  // if ( this->cad_enable_ && !skip_cad ){
+  //   for ( int attempt = 0; attempt < 10; ++attempt ){
+  //     if (this->scan_channel_clear()) {
+  //       break;
+  //     }
+  //     if (attempt < 9){
+  //       // random backoff 20-50ms
+  //       uint32_t backoff = 50; // temporarily 20 ms static
+  //       delay(backoff); // this is a blocking wait... we would have to change quite a bit to queue a packet to make this async
+  //     } else {
+  //       ESP_LOGW(TAG, "Channel busy after 5 CAD attempts, transmitting anyway...");
+  //     }
+  //   }
+  // }
+
   SX126xError ret = SX126xError::NONE;
   this->set_mode_standby(STDBY_XOSC);
   if (this->payload_length_ == 0) {
@@ -343,6 +368,91 @@ SX126xError SX126x::transmit_packet(const std::vector<uint8_t> &packet) {
     this->set_mode_sleep();
   }
   return ret;
+}
+
+// validates and enqueues a packet to transmit, assigning the packet cad timeout
+// and kicking off the async transmit process after a 1ms delay (immediately) subject
+// to device scheduling
+SX126xError SX126x::async_transmit_packet(const std::vector<uint8_t> &packet, optional<uint32_t> cad_timeout) {
+  if (this->payload_length_ > 0 && this->payload_length_ != packet.size()) {
+    ESP_LOGE(TAG, "Packet size does not match config");
+    return SX126xError::INVALID_PARAMS;
+  }
+  if (packet.empty() || packet.size() > this->get_max_packet_size()) {
+    ESP_LOGE(TAG, "Packet size out of range");
+    return SX126xError::INVALID_PARAMS;
+  }
+
+  // wrap the packet and the cad_timeout value, preferring the local value over the global config
+  uint32_t cadto = cad_timeout.value_or(this->cad_timeout_);
+  AsyncPacket ap = AsyncPacket(packet, cadto);
+
+  ESP_LOGD(TAG, "async_transmit_packet: packet queued size=%d, cad_timeout=%lu", packet.size(), ap.cad_timeout);
+  this->async_tx_queue_.push(ap);  
+
+  // schedule the next send loop only 1ms out
+  this->set_timeout("maybe_transmit_queued_packet", 1, [this](){ this->maybe_transmit_queued_packet(); });
+
+  return SX126xError::NONE;
+}
+
+// transmit a packet if there is one to send
+// will first invoke channel activity detection if configured, maintain and check per-packet timeout values
+// and then transmit the packet if the air is clear or the cad_timeout has been exceeded
+void SX126x::maybe_transmit_queued_packet() {
+  if ( this->async_tx_queue_.empty() ){
+    return;
+  }
+  ESP_LOGD(TAG, "TX packet - queue_size=%d", this->async_tx_queue_.size());
+
+  AsyncPacket &ap = this->async_tx_queue_.front(); // peek at the front item in the queue to send it
+  
+  // if there is a cad_timeout assigned and the start_time is still 0, then assign the current time
+  // to the async packet, to 'start the clock' on cad_timeout for this packet
+  if ( ap.cad_timeout && ap.start_time == 0 ){
+    ap.start_time = millis();
+  }
+
+  bool cad = true;
+  if ( ap.cad_timeout == 0 ){
+    // cad_timeout is disabled, skip this (leave cad = true, process it right away)
+  } else if ( millis() - ap.start_time >= ap.cad_timeout ){
+    // the timeout has been exceeded, leave cad = true to transmit it anyway.  
+    ESP_LOGW(TAG, "CAD timeout, transmitting anyway.");
+  } else {
+    // perform channel activity detection and record result
+    uint32_t start = millis();
+    cad = this->scan_channel_clear();
+    ESP_LOGD(TAG, "TX CAD duration=%lu ms, result=%s", millis()-start, cad ? "clear" : "busy");
+  }
+
+
+  if ( cad ) {   // cad == true means that the channel is clear
+    
+    ESP_LOGV(TAG, "transmitting queued packet size=%d", ap.packet.size());
+
+    SX126xError result = this->transmit_packet(ap.packet);
+
+    if ( result == SX126xError::NONE ){ // we already validated the size before enqueue, so only a tx timeout can fail here - which may be hardware error
+      ESP_LOGD(TAG, "TX packet size=%d", ap.packet.size());
+    } else {
+      ESP_LOGW(TAG, "TX ERROR TRANSMITTING PACKET, PACKET DROPPED size=%s", ap.packet.size());
+    }
+
+    // the only error types are essentially fatal for the packet, so pop it from the queue no matter what so we don't get stuck on a poison packet
+    this->async_tx_queue_.pop(); 
+
+    // if there are still items in the queue, try to send the next 100ms later.
+    if ( !this->async_tx_queue_.empty() ){
+      ESP_LOGD(TAG, "TX more packets in queue, setting timeout to send the next in 100ms");
+      this->set_timeout("maybe_transmit_queued_packet", 100, [this](){ this->maybe_transmit_queued_packet(); });
+    }
+
+  } else { // cad == false -- the channel is busy
+    ESP_LOGD(TAG, "CAD channel not clear , deferring tx for 20ms");
+    this->set_timeout("maybe_transmit_queued_packet", 20, [this](){ this->maybe_transmit_queued_packet(); });
+  } 
+
 }
 
 void SX126x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr) {
@@ -413,8 +523,16 @@ void SX126x::run_image_cal() {
 void SX126x::set_mode_rx() {
   uint8_t buf[8];
 
+  if ( this->pa_ctx_pin_ ){
+    if ( this->pa_ctx_pin_->digital_read() ){
+      ESP_LOGV(TAG, "setting pa_ctx_pin %d LOW for RX", static_cast<InternalGPIOPin *>(this->pa_ctx_pin_)->get_pin());
+      this->pa_ctx_pin_->digital_write(false);
+      delay(1); // let pa switch stabilize
+    }
+  }
+
   // configure irq params
-  uint16_t irq = IRQ_RX_DONE | IRQ_RX_TX_TIMEOUT | IRQ_CRC_ERROR;
+  uint16_t irq = IRQ_RX_DONE | IRQ_RX_TX_TIMEOUT | IRQ_CRC_ERROR | IRQ_PREAMBLE_DETECTED;
   buf[0] = (irq >> 8) & 0xFF;
   buf[1] = (irq >> 0) & 0xFF;
   buf[2] = (irq >> 8) & 0xFF;
@@ -423,7 +541,7 @@ void SX126x::set_mode_rx() {
   buf[5] = (IRQ_RADIO_NONE >> 0) & 0xFF;
   buf[6] = (IRQ_RADIO_NONE >> 8) & 0xFF;
   buf[7] = (IRQ_RADIO_NONE >> 0) & 0xFF;
-  this->write_opcode_(RADIO_SET_DIOIRQPARAMS, buf, 8);
+  this->write_opcode_(RADIO_SET_DIOIRQPARAMS, buf, 8); 
 
   // set timeout to 0
   buf[0] = 0x00;
@@ -438,6 +556,14 @@ void SX126x::set_mode_rx() {
 
 void SX126x::set_mode_tx() {
   uint8_t buf[8];
+
+  if ( this->pa_ctx_pin_ ){
+    if ( !this->pa_ctx_pin_->digital_read() ){
+      ESP_LOGV(TAG, "setting pa_ctx_pin %d HIGH for TX", static_cast<InternalGPIOPin *>(this->pa_ctx_pin_)->get_pin());
+      this->pa_ctx_pin_->digital_write(true);
+      delay(2); // let pa stabilize
+    }
+  }
 
   // configure irq params
   uint16_t irq = IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT;
@@ -463,12 +589,23 @@ void SX126x::set_mode_sleep(bool cold) {
   uint8_t buf[1];
   buf[0] = cold ? 0x00 : 0x04;
   this->write_opcode_(RADIO_SET_SLEEP, buf, 1);
+
+  if ( this->pa_ctx_pin_ ){
+    ESP_LOGV(TAG, "setting pa_ctx_pin %d LOW for SLEEP", static_cast<InternalGPIOPin *>(this->pa_ctx_pin_)->get_pin());
+    this->pa_ctx_pin_->digital_write(false); 
+    // no delay, we're going to sleep anyway
+  }
 }
 
 void SX126x::set_mode_standby(SX126xStandbyMode mode) {
   uint8_t buf[1];
   buf[0] = mode;
   this->write_opcode_(RADIO_SET_STANDBY, buf, 1);
+
+  if ( this->pa_ctx_pin_ ){
+    this->pa_ctx_pin_->digital_write(false);
+    // no delay, we're going to standby anyway
+  }
 }
 
 void SX126x::wait_busy_() {
@@ -490,6 +627,9 @@ void SX126x::dump_config() {
   LOG_PIN("  BUSY Pin: ", this->busy_pin_);
   LOG_PIN("  RST Pin: ", this->rst_pin_);
   LOG_PIN("  DIO1 Pin: ", this->dio1_pin_);
+  if ( this->pa_ctx_pin_ ){
+    LOG_PIN("  PA_CTX Pin: ", this->pa_ctx_pin_);
+  }
   ESP_LOGCONFIG(TAG,
                 "  HW Version: %15s\n"
                 "  Frequency: %" PRIu32 " Hz\n"
@@ -545,5 +685,92 @@ void SX126x::dump_config() {
     ESP_LOGE(TAG, "Configuring SX126x failed");
   }
 }
+
+// invoke the sx126x channel air detection mode to determine if the channel is free to transmit
+// this is an efficient, hardware-enabled 'listen-before-talk' implementation.
+// before invoking the hardware CAD mode, we first check to see if we're in the middle of receiving a 
+// LORA packet -- based on the radio registers indicating that a preamble packet has been received,
+// but the packet is not yet 'done'.  
+bool SX126x::scan_channel_clear() {
+
+  ESP_LOGV(TAG, "CAD detection started");
+  
+  // check IRQ register directly to determine if radio is mid-packet
+  {
+    uint8_t irq_raw[2] = {0, 0};
+    this->read_opcode_(RADIO_GET_IRQSTATUS, irq_raw, 2);
+    uint16_t flags = ((uint16_t)irq_raw[0] << 8) | irq_raw[1];
+    if ((flags & IRQ_PREAMBLE_DETECTED) && !(flags & IRQ_RX_DONE)) {
+      ESP_LOGD(TAG, "CAD skipped: preamble in register (0x%04X)", flags);
+      return false; // report busy - caller should retry
+    }
+  }
+
+  // 1. standby
+  this->set_mode_standby(STDBY_XOSC);
+
+  // 2. Configure IRQ for CAD
+  uint16_t irq_mask = IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED;
+  
+  uint8_t irq_buf[8] = {
+    (uint8_t)((irq_mask >> 8) & 0xFF),   // global IRQ mask high — flags still set in register
+    (uint8_t)(irq_mask & 0xFF),          // global IRQ mask low
+    0x00, 0x00,                          // DIO1: assert nothing
+    0x00, 0x00,                          // DIO2: assert nothing — won't disturb RF switch
+    0x00, 0x00                           // DIO3: assert nothing
+  };
+  this->write_opcode_(RADIO_SET_DIOIRQPARAMS, irq_buf, 8);
+
+  // 3. Clear stale IRQs
+  uint8_t clr[2] = {0xFF, 0xFF};
+  this->write_opcode_(RADIO_CLR_IRQSTATUS, clr, 2);
+
+  // 4. Set CAD parameters - AN1200.48 recommended values
+  static const uint8_t CAD_DET_PEAK[6] = {22, 22, 24, 25, 26, 30}; // SF7..SF12
+  uint8_t sf = this->spreading_factor_;
+  uint8_t det_peak = (sf >= 7 && sf <= 12) ? CAD_DET_PEAK[sf-7] : 22;
+
+  uint8_t cad_params[7] = {
+    0x01, // cadSymbolNum: 2 symbols (CAD_ON_2_SYMB)
+    det_peak,
+    10,   // cadDetMin
+    0x00, // cadExitMode, STDBY_RC after CAD done
+    0x00, 0x00, 0x00  // cadTimeout: 0
+  };
+  this->write_opcode_(RADIO_SET_CADPARAMS, cad_params, 7);
+
+  // 5. Start CAD
+  this->write_opcode_(RADIO_SET_CAD, nullptr, 0);
+
+  // 6. Poll IRQ register (not DIO1) to avoid loop() race
+  uint16_t irq_flags = 0;
+  uint32_t start = millis();
+  while(!(irq_flags & (IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED))) {
+    ESP_LOGV(TAG, "CAD detect loop");
+    if(millis() - start > 100) { // 100ms timeout
+      ESP_LOGW(TAG, "CAD timeout, returning busy");
+      this->set_mode_rx();
+      return false; // cad detected busy airtime
+    }
+    delayMicroseconds(200);
+    uint8_t raw[2] = {0, 0};
+    this->read_opcode_(RADIO_GET_IRQSTATUS, raw, 2);
+    irq_flags = ((uint16_t)raw[0] << 8) | raw[1];
+  }
+
+  // 7. Clear CAD IRQ flags
+  uint8_t clr2[2] = {(uint8_t)((irq_flags >> 8) & 0xFF), (uint8_t)(irq_flags & 0xFF)};
+  this->write_opcode_(RADIO_CLR_IRQSTATUS, clr2, 2);
+
+  // 8. Restore RX
+  this->set_mode_rx(); // also resets radio_state_ to RX_LISTENING
+
+  // 9. Result
+  bool clear = !(irq_flags & IRQ_CAD_ACTIVITY_DETECTED);
+  ESP_LOGV(TAG, "CAD result: %s (IRQ=0x%04X, SF%u)", clear ? "clear" : "busy", irq_flags, sf);
+  
+  return clear; // ? CadResult::CLEAR : CadResult::BUSY;
+}
+
 
 }  // namespace esphome::sx126x

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -114,7 +114,7 @@ void SX126x::setup() {
     static_cast<InternalGPIOPin *>(this->dio1_pin_)
         ->attach_interrupt(&SX126x::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
   }
-  if ( this->pa_ctx_pin_ ){
+  if (this->pa_ctx_pin_) {
     this->pa_ctx_pin_->setup();
   }
 
@@ -316,7 +316,7 @@ SX126xError SX126x::transmit_packet(const std::vector<uint8_t> &packet) {
   }
 
   // don't use this -- this would be a blocking loop for CAD -- using async_transmit_packet is a better choice
-  // as the retry loop is at least asynchronous.  if scan_channel_clear() is returning false due to being in the 
+  // as the retry loop is at least asynchronous.  if scan_channel_clear() is returning false due to being in the
   // middle of receiving a packet, it could be tens-of-millieconds (or more) before the packet is fully received,
   // so blocking isn't playing very nice with the esphome scheduler
   //
@@ -330,7 +330,8 @@ SX126xError SX126x::transmit_packet(const std::vector<uint8_t> &packet) {
   //     if (attempt < 9){
   //       // random backoff 20-50ms
   //       uint32_t backoff = 50; // temporarily 20 ms static
-  //       delay(backoff); // this is a blocking wait... we would have to change quite a bit to queue a packet to make this async
+  //       delay(backoff); // this is a blocking wait... we would have to change quite a bit to queue a packet to make
+  //       this async
   //     } else {
   //       ESP_LOGW(TAG, "Channel busy after 5 CAD attempts, transmitting anyway...");
   //     }
@@ -388,10 +389,10 @@ SX126xError SX126x::async_transmit_packet(const std::vector<uint8_t> &packet, op
   AsyncPacket ap = AsyncPacket(packet, cadto);
 
   ESP_LOGD(TAG, "async_transmit_packet: packet queued size=%d, cad_timeout=%lu", packet.size(), ap.cad_timeout);
-  this->async_tx_queue_.push(ap);  
+  this->async_tx_queue_.push(ap);
 
   // schedule the next send loop only 1ms out
-  this->set_timeout("maybe_transmit_queued_packet", 1, [this](){ this->maybe_transmit_queued_packet(); });
+  this->set_timeout("maybe_transmit_queued_packet", 1, [this]() { this->maybe_transmit_queued_packet(); });
 
   return SX126xError::NONE;
 }
@@ -400,59 +401,59 @@ SX126xError SX126x::async_transmit_packet(const std::vector<uint8_t> &packet, op
 // will first invoke channel activity detection if configured, maintain and check per-packet timeout values
 // and then transmit the packet if the air is clear or the cad_timeout has been exceeded
 void SX126x::maybe_transmit_queued_packet() {
-  if ( this->async_tx_queue_.empty() ){
+  if (this->async_tx_queue_.empty()) {
     return;
   }
   ESP_LOGD(TAG, "TX packet - queue_size=%d", this->async_tx_queue_.size());
 
-  AsyncPacket &ap = this->async_tx_queue_.front(); // peek at the front item in the queue to send it
-  
+  AsyncPacket &ap = this->async_tx_queue_.front();  // peek at the front item in the queue to send it
+
   // if there is a cad_timeout assigned and the start_time is still 0, then assign the current time
   // to the async packet, to 'start the clock' on cad_timeout for this packet
-  if ( ap.cad_timeout && ap.start_time == 0 ){
+  if (ap.cad_timeout && ap.start_time == 0) {
     ap.start_time = millis();
   }
 
   bool cad = true;
-  if ( ap.cad_timeout == 0 ){
+  if (ap.cad_timeout == 0) {
     // cad_timeout is disabled, skip this (leave cad = true, process it right away)
-  } else if ( millis() - ap.start_time >= ap.cad_timeout ){
-    // the timeout has been exceeded, leave cad = true to transmit it anyway.  
+  } else if (millis() - ap.start_time >= ap.cad_timeout) {
+    // the timeout has been exceeded, leave cad = true to transmit it anyway.
     ESP_LOGW(TAG, "CAD timeout, transmitting anyway.");
   } else {
     // perform channel activity detection and record result
     uint32_t start = millis();
     cad = this->scan_channel_clear();
-    ESP_LOGD(TAG, "TX CAD duration=%lu ms, result=%s", millis()-start, cad ? "clear" : "busy");
+    ESP_LOGD(TAG, "TX CAD duration=%lu ms, result=%s", millis() - start, cad ? "clear" : "busy");
   }
 
+  if (cad) {  // cad == true means that the channel is clear
 
-  if ( cad ) {   // cad == true means that the channel is clear
-    
     ESP_LOGV(TAG, "transmitting queued packet size=%d", ap.packet.size());
 
     SX126xError result = this->transmit_packet(ap.packet);
 
-    if ( result == SX126xError::NONE ){ // we already validated the size before enqueue, so only a tx timeout can fail here - which may be hardware error
+    if (result == SX126xError::NONE) {  // we already validated the size before enqueue, so only a tx timeout can fail
+                                        // here - which may be hardware error
       ESP_LOGD(TAG, "TX packet size=%d", ap.packet.size());
     } else {
       ESP_LOGW(TAG, "TX ERROR TRANSMITTING PACKET, PACKET DROPPED size=%s", ap.packet.size());
     }
 
-    // the only error types are essentially fatal for the packet, so pop it from the queue no matter what so we don't get stuck on a poison packet
-    this->async_tx_queue_.pop(); 
+    // the only error types are essentially fatal for the packet, so pop it from the queue no matter what so we don't
+    // get stuck on a poison packet
+    this->async_tx_queue_.pop();
 
     // if there are still items in the queue, try to send the next 100ms later.
-    if ( !this->async_tx_queue_.empty() ){
+    if (!this->async_tx_queue_.empty()) {
       ESP_LOGD(TAG, "TX more packets in queue, setting timeout to send the next in 100ms");
-      this->set_timeout("maybe_transmit_queued_packet", 100, [this](){ this->maybe_transmit_queued_packet(); });
+      this->set_timeout("maybe_transmit_queued_packet", 100, [this]() { this->maybe_transmit_queued_packet(); });
     }
 
-  } else { // cad == false -- the channel is busy
+  } else {  // cad == false -- the channel is busy
     ESP_LOGD(TAG, "CAD channel not clear , deferring tx for 20ms");
-    this->set_timeout("maybe_transmit_queued_packet", 20, [this](){ this->maybe_transmit_queued_packet(); });
-  } 
-
+    this->set_timeout("maybe_transmit_queued_packet", 20, [this]() { this->maybe_transmit_queued_packet(); });
+  }
 }
 
 void SX126x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr) {
@@ -523,11 +524,11 @@ void SX126x::run_image_cal() {
 void SX126x::set_mode_rx() {
   uint8_t buf[8];
 
-  if ( this->pa_ctx_pin_ ){
-    if ( this->pa_ctx_pin_->digital_read() ){
+  if (this->pa_ctx_pin_) {
+    if (this->pa_ctx_pin_->digital_read()) {
       ESP_LOGV(TAG, "setting pa_ctx_pin %d LOW for RX", static_cast<InternalGPIOPin *>(this->pa_ctx_pin_)->get_pin());
       this->pa_ctx_pin_->digital_write(false);
-      delay(1); // let pa switch stabilize
+      delay(1);  // let pa switch stabilize
     }
   }
 
@@ -541,7 +542,7 @@ void SX126x::set_mode_rx() {
   buf[5] = (IRQ_RADIO_NONE >> 0) & 0xFF;
   buf[6] = (IRQ_RADIO_NONE >> 8) & 0xFF;
   buf[7] = (IRQ_RADIO_NONE >> 0) & 0xFF;
-  this->write_opcode_(RADIO_SET_DIOIRQPARAMS, buf, 8); 
+  this->write_opcode_(RADIO_SET_DIOIRQPARAMS, buf, 8);
 
   // set timeout to 0
   buf[0] = 0x00;
@@ -557,11 +558,11 @@ void SX126x::set_mode_rx() {
 void SX126x::set_mode_tx() {
   uint8_t buf[8];
 
-  if ( this->pa_ctx_pin_ ){
-    if ( !this->pa_ctx_pin_->digital_read() ){
+  if (this->pa_ctx_pin_) {
+    if (!this->pa_ctx_pin_->digital_read()) {
       ESP_LOGV(TAG, "setting pa_ctx_pin %d HIGH for TX", static_cast<InternalGPIOPin *>(this->pa_ctx_pin_)->get_pin());
       this->pa_ctx_pin_->digital_write(true);
-      delay(2); // let pa stabilize
+      delay(2);  // let pa stabilize
     }
   }
 
@@ -590,9 +591,9 @@ void SX126x::set_mode_sleep(bool cold) {
   buf[0] = cold ? 0x00 : 0x04;
   this->write_opcode_(RADIO_SET_SLEEP, buf, 1);
 
-  if ( this->pa_ctx_pin_ ){
+  if (this->pa_ctx_pin_) {
     ESP_LOGV(TAG, "setting pa_ctx_pin %d LOW for SLEEP", static_cast<InternalGPIOPin *>(this->pa_ctx_pin_)->get_pin());
-    this->pa_ctx_pin_->digital_write(false); 
+    this->pa_ctx_pin_->digital_write(false);
     // no delay, we're going to sleep anyway
   }
 }
@@ -602,7 +603,7 @@ void SX126x::set_mode_standby(SX126xStandbyMode mode) {
   buf[0] = mode;
   this->write_opcode_(RADIO_SET_STANDBY, buf, 1);
 
-  if ( this->pa_ctx_pin_ ){
+  if (this->pa_ctx_pin_) {
     this->pa_ctx_pin_->digital_write(false);
     // no delay, we're going to standby anyway
   }
@@ -627,7 +628,7 @@ void SX126x::dump_config() {
   LOG_PIN("  BUSY Pin: ", this->busy_pin_);
   LOG_PIN("  RST Pin: ", this->rst_pin_);
   LOG_PIN("  DIO1 Pin: ", this->dio1_pin_);
-  if ( this->pa_ctx_pin_ ){
+  if (this->pa_ctx_pin_) {
     LOG_PIN("  PA_CTX Pin: ", this->pa_ctx_pin_);
   }
   ESP_LOGCONFIG(TAG,
@@ -688,21 +689,20 @@ void SX126x::dump_config() {
 
 // invoke the sx126x channel air detection mode to determine if the channel is free to transmit
 // this is an efficient, hardware-enabled 'listen-before-talk' implementation.
-// before invoking the hardware CAD mode, we first check to see if we're in the middle of receiving a 
+// before invoking the hardware CAD mode, we first check to see if we're in the middle of receiving a
 // LORA packet -- based on the radio registers indicating that a preamble packet has been received,
-// but the packet is not yet 'done'.  
+// but the packet is not yet 'done'.
 bool SX126x::scan_channel_clear() {
-
   ESP_LOGV(TAG, "CAD detection started");
-  
+
   // check IRQ register directly to determine if radio is mid-packet
   {
     uint8_t irq_raw[2] = {0, 0};
     this->read_opcode_(RADIO_GET_IRQSTATUS, irq_raw, 2);
-    uint16_t flags = ((uint16_t)irq_raw[0] << 8) | irq_raw[1];
+    uint16_t flags = ((uint16_t) irq_raw[0] << 8) | irq_raw[1];
     if ((flags & IRQ_PREAMBLE_DETECTED) && !(flags & IRQ_RX_DONE)) {
       ESP_LOGD(TAG, "CAD skipped: preamble in register (0x%04X)", flags);
-      return false; // report busy - caller should retry
+      return false;  // report busy - caller should retry
     }
   }
 
@@ -711,13 +711,16 @@ bool SX126x::scan_channel_clear() {
 
   // 2. Configure IRQ for CAD
   uint16_t irq_mask = IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED;
-  
+
   uint8_t irq_buf[8] = {
-    (uint8_t)((irq_mask >> 8) & 0xFF),   // global IRQ mask high — flags still set in register
-    (uint8_t)(irq_mask & 0xFF),          // global IRQ mask low
-    0x00, 0x00,                          // DIO1: assert nothing
-    0x00, 0x00,                          // DIO2: assert nothing — won't disturb RF switch
-    0x00, 0x00                           // DIO3: assert nothing
+      (uint8_t) ((irq_mask >> 8) & 0xFF),  // global IRQ mask high — flags still set in register
+      (uint8_t) (irq_mask & 0xFF),         // global IRQ mask low
+      0x00,
+      0x00,  // DIO1: assert nothing
+      0x00,
+      0x00,  // DIO2: assert nothing — won't disturb RF switch
+      0x00,
+      0x00  // DIO3: assert nothing
   };
   this->write_opcode_(RADIO_SET_DIOIRQPARAMS, irq_buf, 8);
 
@@ -726,16 +729,16 @@ bool SX126x::scan_channel_clear() {
   this->write_opcode_(RADIO_CLR_IRQSTATUS, clr, 2);
 
   // 4. Set CAD parameters - AN1200.48 recommended values
-  static const uint8_t CAD_DET_PEAK[6] = {22, 22, 24, 25, 26, 30}; // SF7..SF12
+  static const uint8_t CAD_DET_PEAK[6] = {22, 22, 24, 25, 26, 30};  // SF7..SF12
   uint8_t sf = this->spreading_factor_;
-  uint8_t det_peak = (sf >= 7 && sf <= 12) ? CAD_DET_PEAK[sf-7] : 22;
+  uint8_t det_peak = (sf >= 7 && sf <= 12) ? CAD_DET_PEAK[sf - 7] : 22;
 
   uint8_t cad_params[7] = {
-    0x01, // cadSymbolNum: 2 symbols (CAD_ON_2_SYMB)
-    det_peak,
-    10,   // cadDetMin
-    0x00, // cadExitMode, STDBY_RC after CAD done
-    0x00, 0x00, 0x00  // cadTimeout: 0
+      0x01,  // cadSymbolNum: 2 symbols (CAD_ON_2_SYMB)
+      det_peak,
+      10,                   // cadDetMin
+      0x00,                 // cadExitMode, STDBY_RC after CAD done
+      0x00,     0x00, 0x00  // cadTimeout: 0
   };
   this->write_opcode_(RADIO_SET_CADPARAMS, cad_params, 7);
 
@@ -745,32 +748,31 @@ bool SX126x::scan_channel_clear() {
   // 6. Poll IRQ register (not DIO1) to avoid loop() race
   uint16_t irq_flags = 0;
   uint32_t start = millis();
-  while(!(irq_flags & (IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED))) {
+  while (!(irq_flags & (IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED))) {
     ESP_LOGV(TAG, "CAD detect loop");
-    if(millis() - start > 100) { // 100ms timeout
+    if (millis() - start > 100) {  // 100ms timeout
       ESP_LOGW(TAG, "CAD timeout, returning busy");
       this->set_mode_rx();
-      return false; // cad detected busy airtime
+      return false;  // cad detected busy airtime
     }
     delayMicroseconds(200);
     uint8_t raw[2] = {0, 0};
     this->read_opcode_(RADIO_GET_IRQSTATUS, raw, 2);
-    irq_flags = ((uint16_t)raw[0] << 8) | raw[1];
+    irq_flags = ((uint16_t) raw[0] << 8) | raw[1];
   }
 
   // 7. Clear CAD IRQ flags
-  uint8_t clr2[2] = {(uint8_t)((irq_flags >> 8) & 0xFF), (uint8_t)(irq_flags & 0xFF)};
+  uint8_t clr2[2] = {(uint8_t) ((irq_flags >> 8) & 0xFF), (uint8_t) (irq_flags & 0xFF)};
   this->write_opcode_(RADIO_CLR_IRQSTATUS, clr2, 2);
 
   // 8. Restore RX
-  this->set_mode_rx(); // also resets radio_state_ to RX_LISTENING
+  this->set_mode_rx();  // also resets radio_state_ to RX_LISTENING
 
   // 9. Result
   bool clear = !(irq_flags & IRQ_CAD_ACTIVITY_DETECTED);
   ESP_LOGV(TAG, "CAD result: %s (IRQ=0x%04X, SF%u)", clear ? "clear" : "busy", irq_flags, sf);
-  
-  return clear; // ? CadResult::CLEAR : CadResult::BUSY;
-}
 
+  return clear;  // ? CadResult::CLEAR : CadResult::BUSY;
+}
 
 }  // namespace esphome::sx126x

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -388,11 +388,11 @@ SX126xError SX126x::async_transmit_packet(const std::vector<uint8_t> &packet, op
   uint32_t cadto = cad_timeout.value_or(this->cad_timeout_);
   AsyncPacket ap = AsyncPacket(packet, cadto);
 
-  ESP_LOGD(TAG, "async_transmit_packet: packet queued size=%d, cad_timeout=%lu", packet.size(), ap.cad_timeout);
+  ESP_LOGD(TAG, "async_transmit_packet: packet queued size=%zu, cad_timeout=%u", packet.size(), ap.cad_timeout);
   this->async_tx_queue_.push(ap);
 
   // schedule the next send loop only 1ms out
-  this->set_timeout("maybe_transmit_queued_packet", 1, [this]() { this->maybe_transmit_queued_packet(); });
+  this->set_timeout("maybe_transmit_queued_packet", 1, [this]() { this->maybe_transmit_queued_packet_(); });
 
   return SX126xError::NONE;
 }
@@ -400,7 +400,7 @@ SX126xError SX126x::async_transmit_packet(const std::vector<uint8_t> &packet, op
 // transmit a packet if there is one to send
 // will first invoke channel activity detection if configured, maintain and check per-packet timeout values
 // and then transmit the packet if the air is clear or the cad_timeout has been exceeded
-void SX126x::maybe_transmit_queued_packet() {
+void SX126x::maybe_transmit_queued_packet_() {
   if (this->async_tx_queue_.empty()) {
     return;
   }
@@ -424,7 +424,7 @@ void SX126x::maybe_transmit_queued_packet() {
     // perform channel activity detection and record result
     uint32_t start = millis();
     cad = this->scan_channel_clear();
-    ESP_LOGD(TAG, "TX CAD duration=%lu ms, result=%s", millis() - start, cad ? "clear" : "busy");
+    ESP_LOGD(TAG, "TX CAD duration=%u ms, result=%s", millis() - start, cad ? "clear" : "busy");
   }
 
   if (cad) {  // cad == true means that the channel is clear
@@ -437,7 +437,7 @@ void SX126x::maybe_transmit_queued_packet() {
                                         // here - which may be hardware error
       ESP_LOGD(TAG, "TX packet size=%d", ap.packet.size());
     } else {
-      ESP_LOGW(TAG, "TX ERROR TRANSMITTING PACKET, PACKET DROPPED size=%s", ap.packet.size());
+      ESP_LOGW(TAG, "TX ERROR TRANSMITTING PACKET, PACKET DROPPED size=%zu", ap.packet.size());
     }
 
     // the only error types are essentially fatal for the packet, so pop it from the queue no matter what so we don't
@@ -447,12 +447,12 @@ void SX126x::maybe_transmit_queued_packet() {
     // if there are still items in the queue, try to send the next 100ms later.
     if (!this->async_tx_queue_.empty()) {
       ESP_LOGD(TAG, "TX more packets in queue, setting timeout to send the next in 100ms");
-      this->set_timeout("maybe_transmit_queued_packet", 100, [this]() { this->maybe_transmit_queued_packet(); });
+      this->set_timeout("maybe_transmit_queued_packet", 100, [this]() { this->maybe_transmit_queued_packet_(); });
     }
 
   } else {  // cad == false -- the channel is busy
     ESP_LOGD(TAG, "CAD channel not clear , deferring tx for 20ms");
-    this->set_timeout("maybe_transmit_queued_packet", 20, [this]() { this->maybe_transmit_queued_packet(); });
+    this->set_timeout("maybe_transmit_queued_packet", 20, [this]() { this->maybe_transmit_queued_packet_(); });
   }
 }
 

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -9,7 +9,6 @@
 #include <vector>
 #include <queue>
 
-
 namespace esphome::sx126x {
 
 enum SX126xBw : uint8_t {
@@ -110,7 +109,8 @@ class SX126x : public Component,
   void set_pa_ctx_pin(GPIOPin *pa_ctx_pin) { this->pa_ctx_pin_ = pa_ctx_pin; }
   void set_cad_timeout(uint32_t cad_timeout) { this->cad_timeout_ = cad_timeout; }
   bool scan_channel_clear();
-  SX126xError async_transmit_packet(const std::vector<uint8_t> &packet, optional<uint32_t> cad_timeout = optional<uint32_t>(0));
+  SX126xError async_transmit_packet(const std::vector<uint8_t> &packet,
+                                    optional<uint32_t> cad_timeout = optional<uint32_t>(0));
 
  protected:
   static void IRAM_ATTR gpio_intr(SX126x *arg);

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -7,6 +7,8 @@
 #include "sx126x_reg.h"
 #include <utility>
 #include <vector>
+#include <queue>
+
 
 namespace esphome::sx126x {
 
@@ -47,6 +49,13 @@ enum SX126xBw : uint8_t {
 };
 
 enum class SX126xError { NONE = 0, TIMEOUT, INVALID_PARAMS };
+
+struct AsyncPacket {
+  std::vector<uint8_t> packet;
+  uint32_t cad_timeout;
+  uint32_t start_time = 0;
+  AsyncPacket(const std::vector<uint8_t> &p, uint32_t cad) : packet(p), cad_timeout(cad) {}
+};
 
 class SX126xListener {
  public:
@@ -98,6 +107,10 @@ class SX126x : public Component,
   SX126xError transmit_packet(const std::vector<uint8_t> &packet);
   void register_listener(SX126xListener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() { return &this->packet_trigger_; }
+  void set_pa_ctx_pin(GPIOPin *pa_ctx_pin) { this->pa_ctx_pin_ = pa_ctx_pin; }
+  void set_cad_timeout(uint32_t cad_timeout) { this->cad_timeout_ = cad_timeout; }
+  bool scan_channel_clear();
+  SX126xError async_transmit_packet(const std::vector<uint8_t> &packet, optional<uint32_t> cad_timeout = optional<uint32_t>(0));
 
  protected:
   static void IRAM_ATTR gpio_intr(SX126x *arg);
@@ -112,6 +125,7 @@ class SX126x : public Component,
   void read_register_(uint16_t reg, uint8_t *data, uint8_t size);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   void wait_busy_();
+  void maybe_transmit_queued_packet();
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX126xListener *> listeners_;
   std::vector<uint8_t> packet_;
@@ -119,6 +133,7 @@ class SX126x : public Component,
   GPIOPin *busy_pin_{nullptr};
   GPIOPin *dio1_pin_{nullptr};
   GPIOPin *rst_pin_{nullptr};
+  GPIOPin *pa_ctx_pin_{nullptr};
   std::string hw_version_;
   char version_[16];
   SX126xBw bandwidth_{SX126X_BW_125000};
@@ -143,6 +158,8 @@ class SX126x : public Component,
   int8_t pa_power_{0};
   bool rx_start_{false};
   bool rf_switch_{false};
+  uint32_t cad_timeout_{0};
+  std::queue<AsyncPacket> async_tx_queue_;
 };
 
 }  // namespace esphome::sx126x

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -125,7 +125,7 @@ class SX126x : public Component,
   void read_register_(uint16_t reg, uint8_t *data, uint8_t size);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   void wait_busy_();
-  void maybe_transmit_queued_packet();
+  void maybe_transmit_queued_packet_();
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX126xListener *> listeners_;
   std::vector<uint8_t> packet_;


### PR DESCRIPTION
# What does this implement/fix?

2 enhancements to the sx126x component:

- Add channel activity detection support and asynchronous packet transmission function

- Add support for the PA_CTX pin control required for Heltec v4.3 devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

TODO
- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sx126x:
  # ...
  pa_ctx_pin: GPIO5  # The Heltec v4.3 has an externally controlled PA_CTX switch that needs to be HIGH for TX, LOW for RX
  cad_timeout: 10s   # enable channel activity detection, waiting up to 10s to detect clear air before transmitting anyway
 # ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
