### PR TITLE
[tuya] Add wifi_reset option and on_wifi_reset/on_wifi_select triggers

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -9,8 +9,11 @@ DEPENDENCIES = ["uart"]
 CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS = "ignore_mcu_update_on_datapoints"
 
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
+CONF_ON_WIFI_RESET = "on_wifi_reset"
+CONF_ON_WIFI_SELECT = "on_wifi_select"
 CONF_DATAPOINT_TYPE = "datapoint_type"
 CONF_STATUS_PIN = "status_pin"
+CONF_WIFI_RESET = "wifi_reset"
 
 tuya_ns = cg.esphome_ns.namespace("tuya")
 TuyaDatapointType = tuya_ns.enum("TuyaDatapointType", is_class=True)
@@ -90,6 +93,9 @@ CONFIG_SCHEMA = (
                 cv.uint8_t
             ),
             cv.Optional(CONF_STATUS_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_WIFI_RESET, default=False): cv.boolean,
+            cv.Optional(CONF_ON_WIFI_RESET): automation.validate_automation({}),
+            cv.Optional(CONF_ON_WIFI_SELECT): automation.validate_automation({}),
             cv.Optional(CONF_ON_DATAPOINT_UPDATE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -122,6 +128,8 @@ async def to_code(config):
     if CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS in config:
         for dp in config[CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS]:
             cg.add(var.add_ignore_mcu_update_on_datapoints(dp))
+    if config[CONF_WIFI_RESET]:
+        cg.add(var.set_wifi_reset_enabled(True))
     for conf in config.get(CONF_ON_DATAPOINT_UPDATE, []):
         trigger = cg.new_Pvariable(
             conf[CONF_TRIGGER_ID], var, conf[CONF_SENSOR_DATAPOINT]
@@ -129,3 +137,17 @@ async def to_code(config):
         await automation.build_automation(
             trigger, [(DATAPOINT_TYPES[conf[CONF_DATAPOINT_TYPE]], "x")], conf
         )
+
+    _CALLBACK_AUTOMATIONS = (
+        automation.CallbackAutomation(
+            CONF_ON_WIFI_RESET,
+            "add_on_wifi_reset_callback",
+            [],
+        ),
+        automation.CallbackAutomation(
+            CONF_ON_WIFI_SELECT,
+            "add_on_wifi_select_callback",
+            [],
+        ),
+    )
+    await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -302,8 +302,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
         this->send_command_(st);
         st.payload[0] = 0x04;
         this->send_command_(st);
-        ESP_LOGI(TAG, "WIFI_SELECT received (%s), replied with WIFI_STATE confirming connection established",
-                 mode_str);
+        ESP_LOGI(TAG, "WIFI_SELECT received (%s), replied with WIFI_STATE confirming connection established", mode_str);
       }
       break;
     }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -1,5 +1,8 @@
 #include "tuya.h"
+#ifdef USE_NETWORK
 #include "esphome/components/network/util.h"
+#endif
+#include "esphome/core/application.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -231,35 +234,77 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
         this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
       }
       break;
-    case TuyaCommandType::WIFI_SELECT:
     case TuyaCommandType::WIFI_RESET: {
-      const bool is_select = (len >= 1);
-      // Send WIFI_SELECT ACK
+      // Send ACK immediately via send_raw_command_ to bypass the command queue.
+      // Using send_command_() would queue the ACK, but process_command_queue_() won't
+      // flush it when expected_response_ is set (e.g. waiting for DP response during init).
       TuyaCommand ack;
-      ack.cmd = is_select ? TuyaCommandType::WIFI_SELECT : TuyaCommandType::WIFI_RESET;
+      ack.cmd = TuyaCommandType::WIFI_RESET;
       ack.payload.clear();
-      this->send_command_(ack);
-      // Establish pairing mode for correct first WIFI_STATE byte, EZ (0x00) default
-      uint8_t first = 0x00;
-      const char *mode_str = "EZ";
-      if (is_select && buffer[0] == 0x01) {
-        first = 0x01;
-        mode_str = "AP";
+      this->send_raw_command_(ack);
+      this->flush();
+
+      this->wifi_reset_callback_.call();
+
+      if (this->wifi_reset_enabled_) {
+        ESP_LOGI(TAG, "WIFI_RESET received, clearing WiFi credentials and rebooting");
+#ifdef USE_WIFI
+        wifi::global_wifi_component->save_wifi_sta("", "");
+#endif
+        App.safe_reboot();
+      } else {
+        // Legacy behavior: fake WIFI_STATE progression for MCU compatibility
+        TuyaCommand st;
+        st.cmd = TuyaCommandType::WIFI_STATE;
+        st.payload.resize(1);
+        st.payload[0] = 0x00;
+        this->send_command_(st);
+        st.payload[0] = 0x02;
+        this->send_command_(st);
+        st.payload[0] = 0x03;
+        this->send_command_(st);
+        st.payload[0] = 0x04;
+        this->send_command_(st);
+        ESP_LOGI(TAG, "WIFI_RESET received (EZ), replied with WIFI_STATE confirming connection established");
       }
-      // Send WIFI_STATE response, MCU exits pairing mode
-      TuyaCommand st;
-      st.cmd = TuyaCommandType::WIFI_STATE;
-      st.payload.resize(1);
-      st.payload[0] = first;
-      this->send_command_(st);
-      st.payload[0] = 0x02;
-      this->send_command_(st);
-      st.payload[0] = 0x03;
-      this->send_command_(st);
-      st.payload[0] = 0x04;
-      this->send_command_(st);
-      ESP_LOGI(TAG, "%s received (%s), replied with WIFI_STATE confirming connection established",
-               is_select ? "WIFI_SELECT" : "WIFI_RESET", mode_str);
+      break;
+    }
+    case TuyaCommandType::WIFI_SELECT: {
+      TuyaCommand ack;
+      ack.cmd = TuyaCommandType::WIFI_SELECT;
+      ack.payload.clear();
+      this->send_raw_command_(ack);
+      this->flush();
+
+      this->wifi_select_callback_.call();
+
+      if (this->wifi_reset_enabled_) {
+        ESP_LOGI(TAG, "WIFI_SELECT received, clearing WiFi credentials and rebooting");
+#ifdef USE_WIFI
+        wifi::global_wifi_component->save_wifi_sta("", "");
+#endif
+        App.safe_reboot();
+      } else {
+        uint8_t first = 0x00;
+        const char *mode_str = "EZ";
+        if (len >= 1 && buffer[0] == 0x01) {
+          first = 0x01;
+          mode_str = "AP";
+        }
+        TuyaCommand st;
+        st.cmd = TuyaCommandType::WIFI_STATE;
+        st.payload.resize(1);
+        st.payload[0] = first;
+        this->send_command_(st);
+        st.payload[0] = 0x02;
+        this->send_command_(st);
+        st.payload[0] = 0x03;
+        this->send_command_(st);
+        st.payload[0] = 0x04;
+        this->send_command_(st);
+        ESP_LOGI(TAG, "WIFI_SELECT received (%s), replied with WIFI_STATE confirming connection established",
+                 mode_str);
+      }
       break;
     }
     case TuyaCommandType::DATAPOINT_DELIVER:
@@ -538,13 +583,18 @@ void Tuya::send_empty_command_(TuyaCommandType command) {
 }
 
 void Tuya::set_status_pin_() {
+#ifdef USE_NETWORK
   bool is_network_ready = network::is_connected() && remote_is_connected();
+#else
+  bool is_network_ready = false;
+#endif
   this->status_pin_->digital_write(is_network_ready);
 }
 
 uint8_t Tuya::get_wifi_status_code_() {
   uint8_t status = 0x02;
 
+#ifdef USE_NETWORK
   if (network::is_connected()) {
     status = 0x03;
 
@@ -559,6 +609,7 @@ uint8_t Tuya::get_wifi_status_code_() {
     }
 #endif
   };
+#endif
 
   return status;
 }

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -114,6 +114,13 @@ class Tuya : public Component, public uart::UARTDevice {
   template<typename F> void add_on_initialized_callback(F &&callback) {
     this->initialized_callback_.add(std::forward<F>(callback));
   }
+  void set_wifi_reset_enabled(bool enabled) { this->wifi_reset_enabled_ = enabled; }
+  template<typename F> void add_on_wifi_reset_callback(F &&callback) {
+    this->wifi_reset_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_wifi_select_callback(F &&callback) {
+    this->wifi_select_callback_.add(std::forward<F>(callback));
+  }
 
  protected:
   void handle_char_(uint8_t c);
@@ -158,6 +165,9 @@ class Tuya : public Component, public uart::UARTDevice {
   std::vector<TuyaCommand> command_queue_;
   optional<TuyaCommandType> expected_response_{};
   uint8_t wifi_status_ = -1;
+  bool wifi_reset_enabled_{false};
+  CallbackManager<void()> wifi_reset_callback_;
+  CallbackManager<void()> wifi_select_callback_;
   CallbackManager<void()> initialized_callback_{};
 };
 

--- a/tests/components/tuya/common.yaml
+++ b/tests/components/tuya/common.yaml
@@ -6,6 +6,11 @@ tuya:
   status_pin:
     number: ${status_pin}
     inverted: true
+  wifi_reset: true
+  on_wifi_reset:
+    - logger.log: "WiFi reset triggered (EZ mode)"
+  on_wifi_select:
+    - logger.log: "WiFi select triggered (AP mode)"
   on_datapoint_update:
     - sensor_datapoint: 6
       datapoint_type: raw


### PR DESCRIPTION


# What does this implement/fix?

Add opt-in `wifi_reset` boolean config (default: false) that clears WiFi credentials and reboots when the MCU sends `WIFI_RESET` (0x04) or `WIFI_SELECT` (0x05). Add separate `on_wifi_reset` and `on_wifi_select` automation triggers for reacting to EZ and AP pairing mode requests independently.

Use `send_raw_command_()` with `flush()` for the `WIFI_RESET`/`WIFI_SELECT` ACK instead of `send_command_()`. The command queue only drains when `expected_response_` is unset, but during init the queue is often blocked waiting for a DP response. Since these handlers call `safe_reboot()` immediately after, the queued ACK would never be transmitted. Bypassing the queue ensures the ACK reaches the MCU before reboot.

Guard `network/util.h` and `network::is_connected()` calls with `#ifdef USE_NETWORK` so the component compiles without the network component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Clear WiFi credentials and reboot when MCU sends reset command (opt-in replacement for the legacy fake WIFI_STATE behavior):

```yaml
tuya:
  wifi_reset: true
```

Custom logic only - reboot without clearing credentials:
```yaml
tuya:
  on_wifi_reset:
    - lambda: App.safe_reboot();
  on_wifi_select:
    - lambda: App.safe_reboot();
```

```yaml
tuya:
  wifi_reset: true
  on_wifi_reset:
    - logger.log: "Entering EZ pairing mode"
    - switch.turn_off: relay
  on_wifi_select:
    - logger.log: "Entering AP pairing mode"
    - switch.turn_off: relay
```

Combined - clear credentials + custom automation before reboot:
```yaml
tuya:
  wifi_reset: true
  on_wifi_reset:
    - logger.log: "Entering EZ pairing mode"
    - switch.turn_off: relay
  on_wifi_select:
    - logger.log: "Entering AP pairing mode"
    - switch.turn_off: relay
```

React to reset without rebooting (e.g., notify home assistant):
```yaml
tuya:
  on_wifi_reset:
    - homeassistant.event:
        event: esphome.tuya_wifi_reset
        data:
          mode: EZ
  on_wifi_select:
    - homeassistant.event:
        event: esphome.tuya_wifi_reset
        data:
          mode: AP
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
