### PR TITLE
[mipi_dsi] Add DMA2D-backed async flush support

### DIFF
--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -72,6 +72,7 @@ ColorBitness = display.display_ns.enum("ColorBitness")
 CONF_LANE_BIT_RATE = "lane_bit_rate"
 CONF_LANES = "lanes"
 CONF_USE_DMA2D = "use_dma2d"
+CONF_ASYNC_LVGL_FLUSH = "async_lvgl_flush"
 
 DriverChip("CUSTOM")
 
@@ -144,6 +145,7 @@ def model_schema(config):
                 cv.bps, cv.Range(min=100e6, max=3200e6)
             ),
             model.option(CONF_USE_DMA2D, True): cv.boolean,
+            model.option(CONF_ASYNC_LVGL_FLUSH, False): cv.boolean,
             iseqconf: cv.ensure_list(map_sequence),
             model.option(CONF_BYTE_ORDER, BYTE_ORDER_LITTLE): cv.one_of(
                 BYTE_ORDER_LITTLE, BYTE_ORDER_BIG, lower=True
@@ -224,6 +226,7 @@ async def to_code(config):
     cg.add(var.set_lanes(int(config[CONF_LANES])))
     cg.add(var.set_lane_bit_rate(config[CONF_LANE_BIT_RATE] / 1.0e6))
     cg.add(var.set_use_dma2d(config[CONF_USE_DMA2D]))
+    cg.add(var.set_async_lvgl_flush(config[CONF_ASYNC_LVGL_FLUSH]))
     if reset_pin := config.get(CONF_RESET_PIN):
         reset = await cg.gpio_pin_expression(reset_pin)
         cg.add(var.set_reset_pin(reset))

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import pkgutil
+from pathlib import Path
 
 from esphome import pins
 import esphome.codegen as cg
@@ -206,6 +207,10 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 
 async def to_code(config):
     cg.add_define("USE_MIPI_DSI")
+    if config[CONF_ASYNC_LVGL_FLUSH]:
+        patch_script = Path(__file__).with_name("patch_espidf_dsi_dma2d.py")
+        cg.add_platformio_option("extra_scripts", [f"pre:{patch_script.as_posix()}"])
+
     model = MODELS[config[CONF_MODEL].upper()]
     color_depth = COLOR_DEPTHS[get_color_depth(config)]
     pixel_mode = int(config[CONF_PIXEL_MODE].removesuffix("bit"))

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -145,7 +145,7 @@ def model_schema(config):
             model.option(CONF_LANE_BIT_RATE, None): cv.All(
                 cv.bps, cv.Range(min=100e6, max=3200e6)
             ),
-            model.option(CONF_USE_DMA2D, True): cv.boolean,
+            model.option(CONF_USE_DMA2D, False): cv.boolean,
             model.option(CONF_ASYNC_LVGL_FLUSH, False): cv.boolean,
             iseqconf: cv.ensure_list(map_sequence),
             model.option(CONF_BYTE_ORDER, BYTE_ORDER_LITTLE): cv.one_of(

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -1,7 +1,7 @@
 import importlib
 import logging
-import pkgutil
 from pathlib import Path
+import pkgutil
 
 from esphome import pins
 import esphome.codegen as cg

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -201,6 +201,7 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):
+    cg.add_define("USE_MIPI_DSI")
     model = MODELS[config[CONF_MODEL].upper()]
     color_depth = COLOR_DEPTHS[get_color_depth(config)]
     pixel_mode = int(config[CONF_PIXEL_MODE].removesuffix("bit"))

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -71,6 +71,7 @@ ColorBitness = display.display_ns.enum("ColorBitness")
 
 CONF_LANE_BIT_RATE = "lane_bit_rate"
 CONF_LANES = "lanes"
+CONF_USE_DMA2D = "use_dma2d"
 
 DriverChip("CUSTOM")
 
@@ -142,6 +143,7 @@ def model_schema(config):
             model.option(CONF_LANE_BIT_RATE, None): cv.All(
                 cv.bps, cv.Range(min=100e6, max=3200e6)
             ),
+            model.option(CONF_USE_DMA2D, True): cv.boolean,
             iseqconf: cv.ensure_list(map_sequence),
             model.option(CONF_BYTE_ORDER, BYTE_ORDER_LITTLE): cv.one_of(
                 BYTE_ORDER_LITTLE, BYTE_ORDER_BIG, lower=True
@@ -221,6 +223,7 @@ async def to_code(config):
     cg.add(var.set_pclk_frequency(config[CONF_PCLK_FREQUENCY] / 1.0e6))
     cg.add(var.set_lanes(int(config[CONF_LANES])))
     cg.add(var.set_lane_bit_rate(config[CONF_LANE_BIT_RATE] / 1.0e6))
+    cg.add(var.set_use_dma2d(config[CONF_USE_DMA2D]))
     if reset_pin := config.get(CONF_RESET_PIN):
         reset = await cg.gpio_pin_expression(reset_pin)
         cg.add(var.set_reset_pin(reset))

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -15,7 +15,7 @@ namespace esphome::mipi_dsi {
 static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
 static constexpr size_t DMA2D_SAFE_ALIGN_BYTES = 4;
 
-static bool is_aligned_(uintptr_t value, size_t alignment) { return (value & (alignment - 1U)) == 0; }
+static bool is_aligned(uintptr_t value, size_t alignment) { return (value & (alignment - 1U)) == 0; }
 
 static bool IRAM_ATTR notify_color_trans_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata,
                                                void *user_ctx) {
@@ -242,7 +242,7 @@ void MipiDsi::start_async_flush_task_() {
   constexpr BaseType_t flush_core = 0;
 #endif
   TaskHandle_t task_handle = nullptr;
-  const BaseType_t ok = xTaskCreatePinnedToCore(&MipiDsi::async_flush_task_trampoline_, "mipi_flush_ready", 4096, this,
+  const BaseType_t ok = xTaskCreatePinnedToCore(&MipiDsi::async_flush_task_trampoline, "mipi_flush_ready", 4096, this,
                                                 6, &task_handle, flush_core);
   if (ok != pdPASS) {
     ESP_LOGW(TAG, "Async LVGL flush task allocation failed");
@@ -253,7 +253,7 @@ void MipiDsi::start_async_flush_task_() {
   ESP_LOGCONFIG(TAG, "Async LVGL flush ready task enabled on core %d", (int) flush_core);
 }
 
-void MipiDsi::async_flush_task_trampoline_(void *arg) { static_cast<MipiDsi *>(arg)->async_flush_task_(); }
+void MipiDsi::async_flush_task_trampoline(void *arg) { static_cast<MipiDsi *>(arg)->async_flush_task_(); }
 
 void MipiDsi::async_flush_task_() {
   while (true) {
@@ -371,9 +371,9 @@ bool MipiDsi::draw_pixels_at_async(int x_start, int y_start, int w, int h, const
   const size_t row_bytes = static_cast<size_t>(w) * this->get_bytes_per_pixel_();
   const uintptr_t ptr_addr = reinterpret_cast<uintptr_t>(ptr);
   const bool src_internal = esp_ptr_internal(ptr);
-  const bool unsafe_addr = !is_aligned_(ptr_addr, DMA2D_SAFE_ALIGN_BYTES);
-  const bool unsafe_row = !is_aligned_(row_bytes, DMA2D_SAFE_ALIGN_BYTES);
-  const bool unsafe_size = !is_aligned_(payload_size, DMA2D_SAFE_ALIGN_BYTES);
+  const bool unsafe_addr = !is_aligned(ptr_addr, DMA2D_SAFE_ALIGN_BYTES);
+  const bool unsafe_row = !is_aligned(row_bytes, DMA2D_SAFE_ALIGN_BYTES);
+  const bool unsafe_size = !is_aligned(payload_size, DMA2D_SAFE_ALIGN_BYTES);
   const bool can_zero_copy = src_internal && !unsafe_addr && !unsafe_row && !unsafe_size;
   const uint8_t *flush_ptr = ptr;
   bool staged = false;

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -98,7 +98,7 @@ void MipiDsi::setup() {
                                                },
                                            .flags = {
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
-                                               .use_dma2d = true,
+                                               .use_dma2d = this->use_dma2d_,
 #endif
                                            }};
   // clang-format on
@@ -119,12 +119,15 @@ void MipiDsi::setup() {
     ESP_LOGW(TAG, "DPI framebuffer unavailable: %s", esp_err_to_name(err));
   }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-  err = esp_lcd_dpi_panel_enable_dma2d(this->handle_);
-  if (err != ESP_OK) {
-    this->smark_failed(LOG_STR("esp_lcd_dpi_panel_enable_dma2d failed"), err);
-    return;
+  if (this->use_dma2d_) {
+    err = esp_lcd_dpi_panel_enable_dma2d(this->handle_);
+    if (err != ESP_OK) {
+      this->smark_failed(LOG_STR("esp_lcd_dpi_panel_enable_dma2d failed"), err);
+      return;
+    }
   }
 #endif
+  ESP_LOGCONFIG(TAG, "DPI DMA2D draw hook: %s", YESNO(this->use_dma2d_));
   if (this->reset_pin_ != nullptr) {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(true);
@@ -436,11 +439,12 @@ void MipiDsi::dump_config() {
                 "\n  Buffer Color Depth: %d bit"
                 "\n  Display Pixel Mode: %d bit"
                 "\n  Invert Colors: %s"
+                "\n  DMA2D: %s"
                 "\n  Pixel Clock: %.1fMHz",
                 this->model_, this->width_, this->height_, this->rotation_, this->lanes_, this->lane_bit_rate_,
                 this->hsync_pulse_width_, this->hsync_back_porch_, this->hsync_front_porch_, this->vsync_pulse_width_,
                 this->vsync_back_porch_, this->vsync_front_porch_, (3 - this->color_depth_) * 8, this->pixel_mode_,
-                YESNO(this->invert_colors_), this->pclk_frequency_);
+                YESNO(this->invert_colors_), YESNO(this->use_dma2d_), this->pclk_frequency_);
   LOG_PIN("  Reset Pin ", this->reset_pin_);
 }
 }  // namespace esphome::mipi_dsi

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -1,19 +1,33 @@
 #ifdef USE_ESP32_VARIANT_ESP32P4
+#include <algorithm>
+#include <cstring>
 #include <utility>
 #include "mipi_dsi.h"
 #include "esphome/core/helpers.h"
+#include "esp_cache.h"
+#include "esp_heap_caps.h"
+#include "esp_memory_utils.h"
+#include "esp_timer.h"
 
 namespace esphome::mipi_dsi {
 
 // Maximum bytes to log for init commands (truncated if larger)
 static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
+static constexpr size_t DMA2D_SAFE_ALIGN_BYTES = 4;
+
+static bool is_aligned_(uintptr_t value, size_t alignment) { return (value & (alignment - 1U)) == 0; }
 
 static bool IRAM_ATTR notify_color_trans_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata,
                                                void *user_ctx) {
   auto *ctx = static_cast<MipiDsiCallbackContext *>(user_ctx);
   BaseType_t need_yield = pdFALSE;
-  if (ctx != nullptr && ctx->color_trans_done != nullptr)
+  if (ctx != nullptr && ctx->async_flush_pending != nullptr && *ctx->async_flush_pending &&
+      ctx->async_flush_done != nullptr) {
+    *ctx->async_flush_pending = false;
+    xSemaphoreGiveFromISR(ctx->async_flush_done, &need_yield);
+  } else if (ctx != nullptr && ctx->color_trans_done != nullptr) {
     xSemaphoreGiveFromISR(ctx->color_trans_done, &need_yield);
+  }
   return (need_yield == pdTRUE);
 }
 
@@ -188,8 +202,18 @@ void MipiDsi::setup() {
   }
   this->io_lock_ = xSemaphoreCreateBinary();
   this->refresh_lock_ = xSemaphoreCreateBinary();
+  if (this->async_lvgl_flush_) {
+    this->async_flush_done_ = xSemaphoreCreateBinary();
+    if (this->async_flush_done_ == nullptr) {
+      ESP_LOGW(TAG, "Async LVGL flush requested but semaphore allocation failed");
+      this->async_lvgl_flush_ = false;
+    }
+  }
   this->callback_context_.color_trans_done = this->io_lock_;
   this->callback_context_.refresh_done = this->refresh_lock_;
+  this->callback_context_.async_flush_done = this->async_flush_done_;
+  this->callback_context_.async_flush_pending = &this->async_flush_pending_;
+  this->start_async_flush_task_();
   esp_lcd_dpi_panel_event_callbacks_t cbs = {
       .on_color_trans_done = notify_color_trans_ready,
       .on_refresh_done = notify_refresh_done,
@@ -202,6 +226,82 @@ void MipiDsi::setup() {
   }
 
   ESP_LOGCONFIG(TAG, "MIPI DSI setup complete");
+}
+
+void MipiDsi::start_async_flush_task_() {
+  if (!this->async_lvgl_flush_)
+    return;
+  if (!this->use_dma2d_) {
+    ESP_LOGW(TAG, "Async LVGL flush requested but DMA2D is disabled");
+    this->async_lvgl_flush_ = false;
+    return;
+  }
+#if CONFIG_FREERTOS_UNICORE
+  constexpr BaseType_t flush_core = tskNO_AFFINITY;
+#else
+  constexpr BaseType_t flush_core = 0;
+#endif
+  TaskHandle_t task_handle = nullptr;
+  const BaseType_t ok = xTaskCreatePinnedToCore(&MipiDsi::async_flush_task_trampoline_, "mipi_flush_ready", 4096, this,
+                                                6, &task_handle, flush_core);
+  if (ok != pdPASS) {
+    ESP_LOGW(TAG, "Async LVGL flush task allocation failed");
+    this->async_lvgl_flush_ = false;
+    return;
+  }
+  this->async_flush_task_handle_ = task_handle;
+  ESP_LOGCONFIG(TAG, "Async LVGL flush ready task enabled on core %d", (int) flush_core);
+}
+
+void MipiDsi::async_flush_task_trampoline_(void *arg) {
+  static_cast<MipiDsi *>(arg)->async_flush_task_();
+}
+
+void MipiDsi::async_flush_task_() {
+  while (true) {
+    if (xSemaphoreTake(this->async_flush_done_, portMAX_DELAY) != pdTRUE)
+      continue;
+    if (this->async_transfer_start_us_ != 0) {
+      const uint32_t done_us = (uint32_t) (esp_timer_get_time() - this->async_transfer_start_us_);
+      this->async_perf_done_us_ += done_us;
+      this->async_perf_done_flushes_++;
+      if (done_us > this->async_perf_done_max_us_)
+        this->async_perf_done_max_us_ = done_us;
+      this->async_transfer_start_us_ = 0;
+    }
+    auto *callback = this->async_ready_callback_;
+    void *arg = this->async_ready_arg_;
+    this->async_ready_callback_ = nullptr;
+    this->async_ready_arg_ = nullptr;
+    if (callback != nullptr)
+      callback(arg);
+  }
+}
+
+bool MipiDsi::ensure_async_staging_buffer_(size_t size) {
+  if (size == 0)
+    return false;
+  if (this->async_staging_buffer_ != nullptr && this->async_staging_buffer_size_ >= size)
+    return true;
+
+  if (this->async_staging_buffer_ != nullptr) {
+    heap_caps_free(this->async_staging_buffer_);
+    this->async_staging_buffer_ = nullptr;
+    this->async_staging_buffer_size_ = 0;
+  }
+
+  const size_t aligned_size = (size + 127U) & ~size_t{127U};
+  auto *buffer = static_cast<uint8_t *>(
+      heap_caps_aligned_alloc(128, aligned_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA | MALLOC_CAP_8BIT));
+  if (buffer == nullptr) {
+    ESP_LOGW(TAG, "Async LVGL flush staging buffer allocation failed (%zu bytes)", aligned_size);
+    return false;
+  }
+
+  this->async_staging_buffer_ = buffer;
+  this->async_staging_buffer_size_ = aligned_size;
+  ESP_LOGI(TAG, "Async LVGL flush staging buffer: %p %zu bytes in PSRAM", buffer, aligned_size);
+  return true;
 }
 
 bool MipiDsi::wait_for_refresh_done(uint32_t timeout_ms) {
@@ -253,8 +353,162 @@ void MipiDsi::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
   this->write_to_display_(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
 }
 
+bool MipiDsi::draw_pixels_at_async(int x_start, int y_start, int w, int h, const uint8_t *ptr,
+                                    display::ColorOrder order, display::ColorBitness bitness, bool big_endian,
+                                    int x_offset, int y_offset, int x_pad, AsyncFlushReadyCallback ready_callback,
+                                    void *ready_arg) {
+  if (!this->async_lvgl_flush_ || this->async_flush_done_ == nullptr || this->async_flush_task_handle_ == nullptr ||
+      ready_callback == nullptr)
+    return false;
+  if (w <= 0 || h <= 0 || ptr == nullptr)
+    return false;
+  if (!this->use_dma2d_ || bitness != this->color_depth_)
+    return false;
+  if (x_offset != 0 || y_offset != 0 || x_pad != 0)
+    return false;
+  if (this->async_flush_pending_)
+    return false;
+
+  const size_t payload_size = static_cast<size_t>(w) * static_cast<size_t>(h) * this->get_bytes_per_pixel_();
+  const size_t row_bytes = static_cast<size_t>(w) * this->get_bytes_per_pixel_();
+  const uintptr_t ptr_addr = reinterpret_cast<uintptr_t>(ptr);
+  const bool src_internal = esp_ptr_internal(ptr);
+  const bool unsafe_addr = !is_aligned_(ptr_addr, DMA2D_SAFE_ALIGN_BYTES);
+  const bool unsafe_row = !is_aligned_(row_bytes, DMA2D_SAFE_ALIGN_BYTES);
+  const bool unsafe_size = !is_aligned_(payload_size, DMA2D_SAFE_ALIGN_BYTES);
+  const bool can_zero_copy = src_internal && !unsafe_addr && !unsafe_row && !unsafe_size;
+  const uint8_t *flush_ptr = ptr;
+  bool staged = false;
+  uint32_t sync_us = 0;
+  uint32_t copy_us = 0;
+  if (can_zero_copy) {
+    const uint64_t sync_start_us = esp_timer_get_time();
+    esp_err_t sync_err = esp_cache_msync(const_cast<uint8_t *>(ptr), payload_size,
+                                         ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    sync_us = (uint32_t) (esp_timer_get_time() - sync_start_us);
+    if (sync_err != ESP_OK) {
+      ESP_LOGW(TAG, "async zero-copy cache sync failed: %s ptr=%p size=%zu w=%d h=%d row=%zu",
+               esp_err_to_name(sync_err), ptr, payload_size, w, h, row_bytes);
+      return false;
+    }
+  } else if (!esp_ptr_external_ram(ptr)) {
+    if (!this->ensure_async_staging_buffer_(payload_size))
+      return false;
+    const uint64_t copy_start_us = esp_timer_get_time();
+    memcpy(this->async_staging_buffer_, ptr, payload_size);
+    __sync_synchronize();
+    copy_us = (uint32_t) (esp_timer_get_time() - copy_start_us);
+    flush_ptr = this->async_staging_buffer_;
+    staged = true;
+  }
+
+  this->async_ready_callback_ = ready_callback;
+  this->async_ready_arg_ = ready_arg;
+  this->async_flush_pending_ = true;
+  this->async_transfer_start_us_ = esp_timer_get_time();
+  esp_err_t err = esp_lcd_panel_draw_bitmap(this->handle_, x_start, y_start, x_start + w, y_start + h, flush_ptr);
+  const uint32_t submit_us = (uint32_t) (esp_timer_get_time() - this->async_transfer_start_us_);
+  if (err != ESP_OK) {
+    this->async_flush_pending_ = false;
+    this->async_transfer_start_us_ = 0;
+    this->async_ready_callback_ = nullptr;
+    this->async_ready_arg_ = nullptr;
+    ESP_LOGW(TAG, "async lcd_panel_draw_bitmap failed: %s", esp_err_to_name(err));
+    return false;
+  }
+  this->async_perf_flushes_++;
+  if (can_zero_copy)
+    this->async_perf_zero_copy_flushes_++;
+  this->async_perf_sync_us_ += sync_us;
+  if (sync_us > this->async_perf_sync_max_us_)
+    this->async_perf_sync_max_us_ = sync_us;
+  this->async_perf_submit_us_ += submit_us;
+  if (submit_us > this->async_perf_submit_max_us_)
+    this->async_perf_submit_max_us_ = submit_us;
+  if (staged) {
+    this->async_perf_staged_flushes_++;
+    if (unsafe_addr)
+      this->async_perf_unsafe_addr_flushes_++;
+    if (unsafe_row)
+      this->async_perf_unsafe_row_flushes_++;
+    if (unsafe_size)
+      this->async_perf_unsafe_size_flushes_++;
+    this->async_perf_staged_bytes_ += payload_size;
+    this->async_perf_copy_us_ += copy_us;
+    if (copy_us > this->async_perf_copy_max_us_)
+      this->async_perf_copy_max_us_ = copy_us;
+  }
+  return true;
+}
+
+void MipiDsi::consume_async_flush_perf(AsyncFlushPerfStats *stats) {
+  if (stats == nullptr)
+    return;
+  stats->flushes = this->async_perf_flushes_;
+  stats->zero_copy_flushes = this->async_perf_zero_copy_flushes_;
+  stats->staged_flushes = this->async_perf_staged_flushes_;
+  stats->done_flushes = this->async_perf_done_flushes_;
+  stats->unsafe_addr_flushes = this->async_perf_unsafe_addr_flushes_;
+  stats->unsafe_row_flushes = this->async_perf_unsafe_row_flushes_;
+  stats->unsafe_size_flushes = this->async_perf_unsafe_size_flushes_;
+  stats->staged_bytes = this->async_perf_staged_bytes_;
+  stats->sync_us = this->async_perf_sync_us_;
+  stats->copy_us = this->async_perf_copy_us_;
+  stats->submit_us = this->async_perf_submit_us_;
+  stats->done_us = this->async_perf_done_us_;
+  stats->sync_max_us = this->async_perf_sync_max_us_;
+  stats->copy_max_us = this->async_perf_copy_max_us_;
+  stats->submit_max_us = this->async_perf_submit_max_us_;
+  stats->done_max_us = this->async_perf_done_max_us_;
+
+  this->async_perf_flushes_ = 0;
+  this->async_perf_zero_copy_flushes_ = 0;
+  this->async_perf_staged_flushes_ = 0;
+  this->async_perf_done_flushes_ = 0;
+  this->async_perf_unsafe_addr_flushes_ = 0;
+  this->async_perf_unsafe_row_flushes_ = 0;
+  this->async_perf_unsafe_size_flushes_ = 0;
+  this->async_perf_staged_bytes_ = 0;
+  this->async_perf_sync_us_ = 0;
+  this->async_perf_copy_us_ = 0;
+  this->async_perf_submit_us_ = 0;
+  this->async_perf_done_us_ = 0;
+  this->async_perf_sync_max_us_ = 0;
+  this->async_perf_copy_max_us_ = 0;
+  this->async_perf_submit_max_us_ = 0;
+  this->async_perf_done_max_us_ = 0;
+}
+
+bool MipiDsi::present_frame_buffer(uint8_t *frame_buffer, int y_start, int y_end) {
+  if (frame_buffer == nullptr || (frame_buffer != this->frame_buffers_[0] && frame_buffer != this->frame_buffers_[1]))
+    return false;
+  if (y_end < y_start)
+    return false;
+  if (this->async_lvgl_flush_) {
+    const TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(50);
+    while (this->async_flush_pending_) {
+      if ((int32_t) (xTaskGetTickCount() - deadline) >= 0) {
+        ESP_LOGW(TAG, "present_frame_buffer timed out waiting for async LVGL flush");
+        return false;
+      }
+      vTaskDelay(pdMS_TO_TICKS(1));
+    }
+  }
+  y_start = std::max(0, y_start);
+  y_end = std::min<int>(this->height_ - 1, y_end);
+  if (y_end < y_start)
+    return false;
+  esp_err_t err = esp_lcd_panel_draw_bitmap(this->handle_, 0, y_start, this->width_, y_end + 1, frame_buffer);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "present_frame_buffer failed: %s", esp_err_to_name(err));
+    return false;
+  }
+  xSemaphoreTake(this->io_lock_, portMAX_DELAY);
+  return true;
+}
+
 void MipiDsi::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                                int x_pad) {
+                                 int x_pad) {
   esp_err_t err = ESP_OK;
   auto bytes_per_pixel = this->get_bytes_per_pixel_();
   auto stride = (x_offset + w + x_pad) * bytes_per_pixel;

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -253,9 +253,7 @@ void MipiDsi::start_async_flush_task_() {
   ESP_LOGCONFIG(TAG, "Async LVGL flush ready task enabled on core %d", (int) flush_core);
 }
 
-void MipiDsi::async_flush_task_trampoline_(void *arg) {
-  static_cast<MipiDsi *>(arg)->async_flush_task_();
-}
+void MipiDsi::async_flush_task_trampoline_(void *arg) { static_cast<MipiDsi *>(arg)->async_flush_task_(); }
 
 void MipiDsi::async_flush_task_() {
   while (true) {
@@ -354,9 +352,9 @@ void MipiDsi::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
 }
 
 bool MipiDsi::draw_pixels_at_async(int x_start, int y_start, int w, int h, const uint8_t *ptr,
-                                    display::ColorOrder order, display::ColorBitness bitness, bool big_endian,
-                                    int x_offset, int y_offset, int x_pad, AsyncFlushReadyCallback ready_callback,
-                                    void *ready_arg) {
+                                   display::ColorOrder order, display::ColorBitness bitness, bool big_endian,
+                                   int x_offset, int y_offset, int x_pad, AsyncFlushReadyCallback ready_callback,
+                                   void *ready_arg) {
   if (!this->async_lvgl_flush_ || this->async_flush_done_ == nullptr || this->async_flush_task_handle_ == nullptr ||
       ready_callback == nullptr)
     return false;
@@ -508,7 +506,7 @@ bool MipiDsi::present_frame_buffer(uint8_t *frame_buffer, int y_start, int y_end
 }
 
 void MipiDsi::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
-                                 int x_pad) {
+                                int x_pad) {
   esp_err_t err = ESP_OK;
   auto bytes_per_pixel = this->get_bytes_per_pixel_();
   auto stride = (x_offset + w + x_pad) * bytes_per_pixel;

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -8,10 +8,21 @@ namespace esphome::mipi_dsi {
 // Maximum bytes to log for init commands (truncated if larger)
 static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
 
-static bool notify_refresh_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata, void *user_ctx) {
-  SemaphoreHandle_t sem = static_cast<SemaphoreHandle_t>(user_ctx);
+static bool IRAM_ATTR notify_color_trans_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata,
+                                               void *user_ctx) {
+  auto *ctx = static_cast<MipiDsiCallbackContext *>(user_ctx);
   BaseType_t need_yield = pdFALSE;
-  xSemaphoreGiveFromISR(sem, &need_yield);
+  if (ctx != nullptr && ctx->color_trans_done != nullptr)
+    xSemaphoreGiveFromISR(ctx->color_trans_done, &need_yield);
+  return (need_yield == pdTRUE);
+}
+
+static bool IRAM_ATTR notify_refresh_done(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata,
+                                          void *user_ctx) {
+  auto *ctx = static_cast<MipiDsiCallbackContext *>(user_ctx);
+  BaseType_t need_yield = pdFALSE;
+  if (ctx != nullptr && ctx->refresh_done != nullptr)
+    xSemaphoreGiveFromISR(ctx->refresh_done, &need_yield);
   return (need_yield == pdTRUE);
 }
 
@@ -173,17 +184,29 @@ void MipiDsi::setup() {
     }
   }
   this->io_lock_ = xSemaphoreCreateBinary();
+  this->refresh_lock_ = xSemaphoreCreateBinary();
+  this->callback_context_.color_trans_done = this->io_lock_;
+  this->callback_context_.refresh_done = this->refresh_lock_;
   esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = notify_refresh_ready,
+      .on_color_trans_done = notify_color_trans_ready,
+      .on_refresh_done = notify_refresh_done,
   };
 
-  err = (esp_lcd_dpi_panel_register_event_callbacks(this->handle_, &cbs, this->io_lock_));
+  err = (esp_lcd_dpi_panel_register_event_callbacks(this->handle_, &cbs, &this->callback_context_));
   if (err != ESP_OK) {
     this->smark_failed(LOG_STR("Failed to register callbacks"), err);
     return;
   }
 
   ESP_LOGCONFIG(TAG, "MIPI DSI setup complete");
+}
+
+bool MipiDsi::wait_for_refresh_done(uint32_t timeout_ms) {
+  if (this->refresh_lock_ == nullptr)
+    return false;
+  while (xSemaphoreTake(this->refresh_lock_, 0) == pdTRUE) {
+  }
+  return xSemaphoreTake(this->refresh_lock_, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
 }
 
 void MipiDsi::update() {

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -73,7 +73,7 @@ void MipiDsi::setup() {
                                            .dpi_clock_freq_mhz = this->pclk_frequency_,
                                            .pixel_format = pixel_format,
 #endif
-                                           .num_fbs = 1,  // number of frame buffers to allocate
+                                           .num_fbs = 2,  // number of frame buffers to allocate
                                            .video_timing =
                                                {
                                                    .h_size = this->width_,
@@ -95,6 +95,17 @@ void MipiDsi::setup() {
   if (err != ESP_OK) {
     this->smark_failed(LOG_STR("esp_lcd_new_panel_dpi failed"), err);
     return;
+  }
+  void *fb0 = nullptr;
+  void *fb1 = nullptr;
+  err = esp_lcd_dpi_panel_get_frame_buffer(this->handle_, 2, &fb0, &fb1);
+  if (err == ESP_OK && fb0 != nullptr && fb1 != nullptr) {
+    this->frame_buffers_[0] = static_cast<uint8_t *>(fb0);
+    this->frame_buffers_[1] = static_cast<uint8_t *>(fb1);
+    ESP_LOGI(TAG, "DPI framebuffers exposed at %p / %p (%zu bytes each)", this->frame_buffers_[0],
+             this->frame_buffers_[1], this->get_frame_buffer_size());
+  } else {
+    ESP_LOGW(TAG, "DPI framebuffer unavailable: %s", esp_err_to_name(err));
   }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   err = esp_lcd_dpi_panel_enable_dma2d(this->handle_);
@@ -219,7 +230,7 @@ void MipiDsi::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
 void MipiDsi::write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
                                 int x_pad) {
   esp_err_t err = ESP_OK;
-  auto bytes_per_pixel = 3 - this->color_depth_;
+  auto bytes_per_pixel = this->get_bytes_per_pixel_();
   auto stride = (x_offset + w + x_pad) * bytes_per_pixel;
   ptr += y_offset * stride + x_offset * bytes_per_pixel;  // skip to the first pixel
   // x_ and y_offset are offsets into the source buffer, unrelated to our own offsets into the display.

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -59,6 +59,10 @@ class MipiDsi : public display::Display {
   void set_model(const char *model) { this->model_ = model; }
   void set_lane_bit_rate(float lane_bit_rate) { this->lane_bit_rate_ = lane_bit_rate; }
   void set_lanes(uint8_t lanes) { this->lanes_ = lanes; }
+  uint8_t *get_frame_buffer() const { return this->frame_buffers_[0]; }
+  uint8_t *get_frame_buffer(size_t index) const { return index < 2 ? this->frame_buffers_[index] : nullptr; }
+  size_t get_frame_buffer_size() const { return this->width_ * this->height_ * this->get_bytes_per_pixel_(); }
+  size_t get_bytes_per_pixel() const { return this->get_bytes_per_pixel_(); }
 
   void smark_failed(const LogString *message, esp_err_t err);
 
@@ -80,6 +84,7 @@ class MipiDsi : public display::Display {
   void write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
                          int x_pad);
   bool check_buffer_();
+  size_t get_bytes_per_pixel_() const { return this->color_depth_ == display::COLOR_BITNESS_888 ? 3 : 2; }
   GPIOPin *reset_pin_{nullptr};
   std::vector<GPIOPin *> enable_pins_{};
   size_t width_{};
@@ -105,6 +110,7 @@ class MipiDsi : public display::Display {
   esp_lcd_dsi_bus_handle_t bus_handle_{};
   esp_lcd_panel_io_handle_t io_handle_{};
   SemaphoreHandle_t io_lock_{};
+  uint8_t *frame_buffers_[2]{nullptr, nullptr};
   uint8_t *buffer_{nullptr};
   uint16_t x_low_{1};
   uint16_t y_low_{1};

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -123,7 +123,7 @@ class MipiDsi : public display::Display {
   void write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
                          int x_pad);
   void start_async_flush_task_();
-  static void async_flush_task_trampoline_(void *arg);
+  static void async_flush_task_trampoline(void *arg);
   void async_flush_task_();
   bool ensure_async_staging_buffer_(size_t size);
   bool check_buffer_();

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -15,6 +15,9 @@
 #include "esp_lcd_panel_io.h"
 
 #include "esp_lcd_mipi_dsi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
 
 namespace esphome::mipi_dsi {
 
@@ -38,6 +41,29 @@ const uint8_t MADCTL_YFLIP = 0x01;  // Mirror the display vertically
 struct MipiDsiCallbackContext {
   SemaphoreHandle_t color_trans_done{};
   SemaphoreHandle_t refresh_done{};
+  SemaphoreHandle_t async_flush_done{};
+  volatile bool *async_flush_pending{};
+};
+
+using AsyncFlushReadyCallback = void (*)(void *);
+
+struct AsyncFlushPerfStats {
+  uint32_t flushes{};
+  uint32_t zero_copy_flushes{};
+  uint32_t staged_flushes{};
+  uint32_t done_flushes{};
+  uint32_t unsafe_addr_flushes{};
+  uint32_t unsafe_row_flushes{};
+  uint32_t unsafe_size_flushes{};
+  uint64_t staged_bytes{};
+  uint64_t sync_us{};
+  uint64_t copy_us{};
+  uint64_t submit_us{};
+  uint64_t done_us{};
+  uint32_t sync_max_us{};
+  uint32_t copy_max_us{};
+  uint32_t submit_max_us{};
+  uint32_t done_max_us{};
 };
 
 class MipiDsi : public display::Display {
@@ -65,6 +91,7 @@ class MipiDsi : public display::Display {
   void set_lane_bit_rate(float lane_bit_rate) { this->lane_bit_rate_ = lane_bit_rate; }
   void set_lanes(uint8_t lanes) { this->lanes_ = lanes; }
   void set_use_dma2d(bool use_dma2d) { this->use_dma2d_ = use_dma2d; }
+  void set_async_lvgl_flush(bool async_lvgl_flush) { this->async_lvgl_flush_ = async_lvgl_flush; }
   uint8_t *get_frame_buffer() const { return this->frame_buffers_[0]; }
   uint8_t *get_frame_buffer(size_t index) const { return index < 2 ? this->frame_buffers_[index] : nullptr; }
   size_t get_frame_buffer_size() const { return this->width_ * this->height_ * this->get_bytes_per_pixel_(); }
@@ -79,6 +106,11 @@ class MipiDsi : public display::Display {
 
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
+  bool draw_pixels_at_async(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
+                            display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad,
+                            AsyncFlushReadyCallback ready_callback, void *ready_arg);
+  bool present_frame_buffer(uint8_t *frame_buffer, int y_start, int y_end);
+  void consume_async_flush_perf(AsyncFlushPerfStats *stats);
 
   void draw_pixel_at(int x, int y, Color color) override;
   void fill(Color color) override;
@@ -90,6 +122,10 @@ class MipiDsi : public display::Display {
  protected:
   void write_to_display_(int x_start, int y_start, int w, int h, const uint8_t *ptr, int x_offset, int y_offset,
                          int x_pad);
+  void start_async_flush_task_();
+  static void async_flush_task_trampoline_(void *arg);
+  void async_flush_task_();
+  bool ensure_async_staging_buffer_(size_t size);
   bool check_buffer_();
   size_t get_bytes_per_pixel_() const { return this->color_depth_ == display::COLOR_BITNESS_888 ? 3 : 2; }
   GPIOPin *reset_pin_{nullptr};
@@ -108,6 +144,7 @@ class MipiDsi : public display::Display {
   float lane_bit_rate_{1500};  // in Mbps
   uint8_t lanes_{2};           // 1, 2, 3 or 4 lanes
   bool use_dma2d_{true};
+  bool async_lvgl_flush_{false};
 
   bool invert_colors_{};
   display::ColorOrder color_mode_{display::COLOR_ORDER_BGR};
@@ -119,7 +156,31 @@ class MipiDsi : public display::Display {
   esp_lcd_panel_io_handle_t io_handle_{};
   SemaphoreHandle_t io_lock_{};
   SemaphoreHandle_t refresh_lock_{};
+  SemaphoreHandle_t async_flush_done_{};
+  TaskHandle_t async_flush_task_handle_{};
   MipiDsiCallbackContext callback_context_{};
+  AsyncFlushReadyCallback async_ready_callback_{};
+  void *async_ready_arg_{};
+  volatile bool async_flush_pending_{false};
+  uint64_t async_transfer_start_us_{0};
+  uint8_t *async_staging_buffer_{nullptr};
+  size_t async_staging_buffer_size_{0};
+  uint32_t async_perf_flushes_{0};
+  uint32_t async_perf_zero_copy_flushes_{0};
+  uint32_t async_perf_staged_flushes_{0};
+  uint32_t async_perf_done_flushes_{0};
+  uint32_t async_perf_unsafe_addr_flushes_{0};
+  uint32_t async_perf_unsafe_row_flushes_{0};
+  uint32_t async_perf_unsafe_size_flushes_{0};
+  uint64_t async_perf_staged_bytes_{0};
+  uint64_t async_perf_sync_us_{0};
+  uint64_t async_perf_copy_us_{0};
+  uint64_t async_perf_submit_us_{0};
+  uint64_t async_perf_done_us_{0};
+  uint32_t async_perf_sync_max_us_{0};
+  uint32_t async_perf_copy_max_us_{0};
+  uint32_t async_perf_submit_max_us_{0};
+  uint32_t async_perf_done_max_us_{0};
   uint8_t *frame_buffers_[2]{nullptr, nullptr};
   uint8_t *buffer_{nullptr};
   uint16_t x_low_{1};

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -35,6 +35,11 @@ const uint8_t MADCTL_MV = 0x20;     // row/column swap
 const uint8_t MADCTL_XFLIP = 0x02;  // Mirror the display horizontally
 const uint8_t MADCTL_YFLIP = 0x01;  // Mirror the display vertically
 
+struct MipiDsiCallbackContext {
+  SemaphoreHandle_t color_trans_done{};
+  SemaphoreHandle_t refresh_done{};
+};
+
 class MipiDsi : public display::Display {
  public:
   MipiDsi(size_t width, size_t height, display::ColorBitness color_depth, uint8_t pixel_mode)
@@ -63,6 +68,7 @@ class MipiDsi : public display::Display {
   uint8_t *get_frame_buffer(size_t index) const { return index < 2 ? this->frame_buffers_[index] : nullptr; }
   size_t get_frame_buffer_size() const { return this->width_ * this->height_ * this->get_bytes_per_pixel_(); }
   size_t get_bytes_per_pixel() const { return this->get_bytes_per_pixel_(); }
+  bool wait_for_refresh_done(uint32_t timeout_ms = 50);
 
   void smark_failed(const LogString *message, esp_err_t err);
 
@@ -110,6 +116,8 @@ class MipiDsi : public display::Display {
   esp_lcd_dsi_bus_handle_t bus_handle_{};
   esp_lcd_panel_io_handle_t io_handle_{};
   SemaphoreHandle_t io_lock_{};
+  SemaphoreHandle_t refresh_lock_{};
+  MipiDsiCallbackContext callback_context_{};
   uint8_t *frame_buffers_[2]{nullptr, nullptr};
   uint8_t *buffer_{nullptr};
   uint16_t x_low_{1};

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -143,7 +143,7 @@ class MipiDsi : public display::Display {
   float pclk_frequency_ = 16;  // in MHz
   float lane_bit_rate_{1500};  // in Mbps
   uint8_t lanes_{2};           // 1, 2, 3 or 4 lanes
-  bool use_dma2d_{true};
+  bool use_dma2d_{false};
   bool async_lvgl_flush_{false};
 
   bool invert_colors_{};

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -64,6 +64,7 @@ class MipiDsi : public display::Display {
   void set_model(const char *model) { this->model_ = model; }
   void set_lane_bit_rate(float lane_bit_rate) { this->lane_bit_rate_ = lane_bit_rate; }
   void set_lanes(uint8_t lanes) { this->lanes_ = lanes; }
+  void set_use_dma2d(bool use_dma2d) { this->use_dma2d_ = use_dma2d; }
   uint8_t *get_frame_buffer() const { return this->frame_buffers_[0]; }
   uint8_t *get_frame_buffer(size_t index) const { return index < 2 ? this->frame_buffers_[index] : nullptr; }
   size_t get_frame_buffer_size() const { return this->width_ * this->height_ * this->get_bytes_per_pixel_(); }
@@ -106,6 +107,7 @@ class MipiDsi : public display::Display {
   float pclk_frequency_ = 16;  // in MHz
   float lane_bit_rate_{1500};  // in Mbps
   uint8_t lanes_{2};           // 1, 2, 3 or 4 lanes
+  bool use_dma2d_{true};
 
   bool invert_colors_{};
   display::ColorOrder color_mode_{display::COLOR_ORDER_BGR};

--- a/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
+++ b/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
@@ -9,9 +9,12 @@
 
 # ruff: noqa: F821
 # pylint: disable=undefined-variable
+from contextlib import suppress
 from pathlib import Path
 
-Import("env")  # type: ignore[name-defined]
+env = None
+with suppress(NameError):
+    Import("env")  # noqa: F821  # type: ignore[name-defined]
 
 
 def main() -> None:
@@ -95,4 +98,5 @@ static bool dpi_panel_skip_draw_buffer_msync(const void *draw_buffer)
     print("MIPI DSI patch: applied ESP-IDF DMA2D internal-buffer cache sync guard")
 
 
-main()
+if env is not None:
+    main()

--- a/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
+++ b/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
@@ -7,6 +7,8 @@
 #
 # Remove this once the framework package contains the same guard upstream.
 
+# ruff: noqa: F821
+# pylint: disable=undefined-variable
 from pathlib import Path
 
 Import("env")  # type: ignore[name-defined]

--- a/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
+++ b/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
@@ -17,12 +17,20 @@ def main() -> None:
     if not framework_dir:
         raise RuntimeError("framework-espidf package directory not found")
 
-    target = Path(framework_dir) / "components" / "esp_lcd" / "dsi" / "esp_lcd_panel_dpi.c"
+    target = (
+        Path(framework_dir) / "components" / "esp_lcd" / "dsi" / "esp_lcd_panel_dpi.c"
+    )
     text = target.read_text(encoding="utf-8")
 
-    for include in ('#include "esp_memory_utils.h"', '#include "hal/cache_ll.h"', '#include "soc/soc_caps.h"'):
+    for include in (
+        '#include "esp_memory_utils.h"',
+        '#include "hal/cache_ll.h"',
+        '#include "soc/soc_caps.h"',
+    ):
         if include not in text:
-            text = text.replace('#include "esp_cache.h"\n', f'#include "esp_cache.h"\n{include}\n')
+            text = text.replace(
+                '#include "esp_cache.h"\n', f'#include "esp_cache.h"\n{include}\n'
+            )
 
     helper = """
 static bool dpi_panel_skip_draw_buffer_msync(const void *draw_buffer)
@@ -45,7 +53,9 @@ static bool dpi_panel_skip_draw_buffer_msync(const void *draw_buffer)
             "int x_end, int y_end, const void *color_data);\n"
         )
         if anchor not in text:
-            raise RuntimeError("ESP-IDF DSI draw_bitmap declaration not found; patch needs review")
+            raise RuntimeError(
+                "ESP-IDF DSI draw_bitmap declaration not found; patch needs review"
+            )
         text = text.replace(anchor, f"{anchor}{helper}", 1)
 
     old = (
@@ -66,14 +76,18 @@ static bool dpi_panel_skip_draw_buffer_msync(const void *draw_buffer)
     )
 
     if new in text:
-        print("MIPI DSI patch: ESP-IDF DMA2D internal-buffer cache sync guard already present")
+        print(
+            "MIPI DSI patch: ESP-IDF DMA2D internal-buffer cache sync guard already present"
+        )
         return
     if old_guard in text:
         text = text.replace(old_guard, new)
     elif old in text:
         text = text.replace(old, new)
     else:
-        raise RuntimeError("ESP-IDF DSI DMA2D cache sync line not found; patch needs review")
+        raise RuntimeError(
+            "ESP-IDF DSI DMA2D cache sync line not found; patch needs review"
+        )
 
     target.write_text(text, encoding="utf-8")
     print("MIPI DSI patch: applied ESP-IDF DMA2D internal-buffer cache sync guard")

--- a/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
+++ b/esphome/components/mipi_dsi/patch_espidf_dsi_dma2d.py
@@ -1,0 +1,82 @@
+# ESP-IDF 5.5.x workaround for ESP32-P4 MIPI DSI + DMA2D.
+#
+# The DPI panel driver's async framebuffer copy path calls esp_cache_msync()
+# for every LVGL draw buffer. The optimized MIPI DSI component performs the
+# required cache writeback before handing an internal draw buffer to ESP-IDF, so
+# this patch skips ESP-IDF's duplicate sync for internal memory buffers.
+#
+# Remove this once the framework package contains the same guard upstream.
+
+from pathlib import Path
+
+Import("env")  # type: ignore[name-defined]
+
+
+def main() -> None:
+    framework_dir = env.PioPlatform().get_package_dir("framework-espidf")
+    if not framework_dir:
+        raise RuntimeError("framework-espidf package directory not found")
+
+    target = Path(framework_dir) / "components" / "esp_lcd" / "dsi" / "esp_lcd_panel_dpi.c"
+    text = target.read_text(encoding="utf-8")
+
+    for include in ('#include "esp_memory_utils.h"', '#include "hal/cache_ll.h"', '#include "soc/soc_caps.h"'):
+        if include not in text:
+            text = text.replace('#include "esp_cache.h"\n', f'#include "esp_cache.h"\n{include}\n')
+
+    helper = """
+static bool dpi_panel_skip_draw_buffer_msync(const void *draw_buffer)
+{
+    if (esp_ptr_internal(draw_buffer)) {
+        return true;
+    }
+#if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE && defined(CACHE_LL_L2MEM_CACHE_ADDR)
+    const void *cache_addr = (const void *)CACHE_LL_L2MEM_CACHE_ADDR(draw_buffer);
+    if (esp_ptr_internal(cache_addr)) {
+        return true;
+    }
+#endif
+    return false;
+}
+"""
+    if "dpi_panel_skip_draw_buffer_msync" not in text:
+        anchor = (
+            "static esp_err_t dpi_panel_draw_bitmap(esp_lcd_panel_t *panel, int x_start, int y_start, "
+            "int x_end, int y_end, const void *color_data);\n"
+        )
+        if anchor not in text:
+            raise RuntimeError("ESP-IDF DSI draw_bitmap declaration not found; patch needs review")
+        text = text.replace(anchor, f"{anchor}{helper}", 1)
+
+    old = (
+        "        esp_cache_msync(draw_buffer, color_data_size, "
+        "ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);"
+    )
+    old_guard = (
+        "        if (!esp_ptr_internal(draw_buffer)) {\n"
+        "            esp_cache_msync(draw_buffer, color_data_size, "
+        "ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);\n"
+        "        }"
+    )
+    new = (
+        "        if (!dpi_panel_skip_draw_buffer_msync(draw_buffer)) {\n"
+        "            esp_cache_msync(draw_buffer, color_data_size, "
+        "ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);\n"
+        "        }"
+    )
+
+    if new in text:
+        print("MIPI DSI patch: ESP-IDF DMA2D internal-buffer cache sync guard already present")
+        return
+    if old_guard in text:
+        text = text.replace(old_guard, new)
+    elif old in text:
+        text = text.replace(old, new)
+    else:
+        raise RuntimeError("ESP-IDF DSI DMA2D cache sync line not found; patch needs review")
+
+    target.write_text(text, encoding="utf-8")
+    print("MIPI DSI patch: applied ESP-IDF DMA2D internal-buffer cache sync guard")
+
+
+main()


### PR DESCRIPTION
# What does this implement/fix?

This adds ESP32-P4 MIPI DSI support needed by LVGL direct-mode and DMA2D-backed rendering paths.

The PR exposes the DPI frame buffers owned by the ESP-IDF MIPI DSI driver, adds a refresh-completion wait helper, and introduces an optional asynchronous LVGL flush path that can use DMA2D to submit aligned internal-memory draw buffers without blocking LVGL until the transfer callback fires. It also adds performance counters for the async flush path so downstream display integrations can measure zero-copy vs staged transfers, cache sync time, copy time, submit time, and completion latency.

The changes are intended to make high-resolution ESP32-P4 MIPI DSI displays usable with LVGL workloads that need direct rendering, explicit present/wait synchronization, and lower flush overhead. The default behavior stays conservative: both the DMA2D path and the new async LVGL flush path are opt-in.

Implemented by Tomasz Witke (@kyvaith).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) - [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) - [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/6747

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested with an ESP32-P4 MIPI DSI 800x800 display project using ESP-IDF through ESPHome. The branch was rebased onto current `esphome/esphome:dev` and validated against the current `mipi_dsi` component updates, including the upstream `MipiDsi` class rename and display metadata changes.

## Example entry for `config.yaml`:

```yaml
display:
  - platform: mipi_dsi
    model: CUSTOM
    dimensions:
      width: 800
      height: 800
    color_depth: 24
    pixel_mode: 24bit
    pclk_frequency: 48MHz
    lane_bit_rate: 1200Mbps
    lanes: 2
    use_dma2d: true
    async_lvgl_flush: true
    reset_pin: GPIOXX
    enable_pin: GPIOXX
    init_sequence:
      # panel-specific initialization sequence
      - [0x11]
      - delay 120ms
      - [0x29]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Local validation performed:

- `git diff --check upstream/dev..HEAD`
- `python -m py_compile esphome/components/mipi_dsi/display.py`
- ESPHome config validation with a local checkout of current upstream `dev`

Full downstream firmware compilation currently requires the downstream LVGL integration to be updated from the old `mipi_dsi::MIPI_DSI` class name to the upstream `mipi_dsi::MipiDsi` class name. The `mipi_dsi` component itself is rebased and validated against the current upstream naming.
