### PR TITLE
[lvgl] Support smaller buffer size fractions

### DIFF
--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -367,10 +367,16 @@ async def to_code(configs):
             frac = 1
         elif frac >= 0.375:
             frac = 2
-        elif frac > 0.19:
+        elif frac >= 0.19:
             frac = 4
-        elif frac != 0:
+        elif frac >= 0.095:
             frac = 8
+        elif frac >= 0.0475:
+            frac = 16
+        elif frac >= 0.023:
+            frac = 32
+        elif frac != 0:
+            frac = 64
         displays = [
             await cg.get_variable(display) for display in config[df.CONF_DISPLAYS]
         ]


### PR DESCRIPTION
# What does this implement/fix?

This expands LVGL draw-buffer fraction selection so `buffer_size` values below the existing 12% bucket can be represented as smaller internal fractions. This allows memory-constrained or performance-tuned ESP32 display configurations to request smaller partial draw buffers instead of being rounded up to 1/8 screen size.

The existing larger buckets remain unchanged, and the default behavior remains unchanged when `buffer_size` is not configured.

Implemented by Tomasz Witke (@kyvaith).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) - [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) - [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/6748

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Validated as part of downstream ESP32-P4 LVGL display work. This standalone branch was also checked locally against current `esphome/esphome:dev`.

## Example entry for `config.yaml`:

```yaml
lvgl:
  displays:
    - my_display
  buffer_size: 5%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Local validation performed:

- `git diff --check upstream/dev...lvgl/buffer-size-granularity`
- `python -m py_compile` for changed Python files
