### PR TITLE
[lvgl] Disable runtime asserts in generated config

### DIFF
--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -309,6 +309,11 @@ async def to_code(configs):
     cg.add_define("USE_LVGL")
     # suppress default enabling of extra widgets
     # cg.add_define("LV_KCONFIG_PRESENT")
+    df.add_define("LV_USE_ASSERT_NULL", "0")
+    df.add_define("LV_USE_ASSERT_MALLOC", "0")
+    df.add_define("LV_USE_ASSERT_STYLE", "0")
+    df.add_define("LV_USE_ASSERT_MEM_INTEGRITY", "0")
+    df.add_define("LV_USE_ASSERT_OBJ", "0")
     # Always enable - lots of things use it.
     df.add_define("LV_DRAW_SW_COMPLEX", "1")
 


### PR DESCRIPTION
# What does this implement/fix?

This explicitly disables LVGL runtime assert checks in the generated ESPHome LVGL configuration.

ESPHome already validates LVGL YAML at compile time and these runtime assert paths add overhead on constrained display targets. Keeping the generated config explicit also avoids depending on LVGL defaults that may vary between releases.

Implemented by Tomasz Witke (@kyvaith).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) - [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) - [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A - no user-facing configuration is added by this branch.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Validated as part of downstream ESP32-P4 LVGL display work. This standalone branch was also checked locally against current `esphome/esphome:dev`.

## Example entry for `config.yaml`:

```yaml
# No YAML changes; this updates generated LVGL runtime assert settings.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Local validation performed:

- `git diff --check upstream/dev...lvgl/disable-runtime-asserts`
- `python -m py_compile` for changed Python files
