### PR TITLE
[lvgl] Add optional ESP32-P4 PPA draw unit

### DIFF
--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -252,6 +252,25 @@ def final_validation(config_list):
 
         if (pages := config.get(CONF_PAGES)) and all(p[df.CONF_SKIP] for p in pages):
             raise cv.Invalid("At least one page must not be skipped")
+
+        # RGB888 is the fastest/default path for MIPI DSI on ESP32-P4, but
+        # keep RGB565 available for smaller memory footprints and experiments.
+        user_set_depth = CONF_COLOR_DEPTH in config
+        has_mipi = any(
+            global_config.get_config_for_path(global_config.get_path_for_id(did)[:-1]).get(
+                "platform", ""
+            )
+            == "mipi_dsi"
+            for did in config[df.CONF_DISPLAYS]
+        )
+        if not user_set_depth:
+            config[CONF_COLOR_DEPTH] = 32 if has_mipi else 16
+        elif config[CONF_COLOR_DEPTH] == 16 and has_mipi:
+            df.LOGGER.warning(
+                "color_depth: 16 (RGB565) with MIPI DSI: PPA acceleration may be "
+                "reduced. Consider color_depth: 32 for best performance."
+            )
+
         buffer_frac = config[CONF_BUFFER_SIZE]
         if CORE.is_esp32 and buffer_frac > 0.5 and PSRAM_DOMAIN not in global_config:
             df.LOGGER.warning("buffer_size: may need to be reduced without PSRAM")
@@ -594,7 +613,7 @@ LVGL_SCHEMA = cv.All(
                 cv.GenerateID(CONF_ID): cv.declare_id(LvglComponent),
                 cv.GenerateID(CONF_ALIGN_TO_LAMBDA_ID): cv.declare_id(lv_lambda_t),
                 cv.GenerateID(df.CONF_DISPLAYS): display_schema,
-                cv.Optional(CONF_COLOR_DEPTH, default=16): cv.one_of(16),
+                cv.Optional(CONF_COLOR_DEPTH): cv.one_of(16, 32),
                 cv.Optional(
                     df.CONF_DEFAULT_FONT, default="montserrat_14"
                 ): lvalid.lv_font,

--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -126,6 +126,8 @@ DEPENDENCIES = ["display"]
 AUTO_LOAD = ["key_provider"]
 CODEOWNERS = ["@clydebarrow"]
 HELLO_WORLD_FILE = "hello_world.yaml"
+CONF_USE_PPA = "use_ppa"
+CONF_USE_PPA_IMG = "use_ppa_img"
 
 
 SIMPLE_TRIGGERS = (
@@ -284,15 +286,21 @@ def final_validation(config_list):
 
 async def to_code(configs):
     config_0 = configs[0]
+    use_ppa = config_0.get(CONF_USE_PPA, False)
+    use_ppa_img = config_0.get(CONF_USE_PPA_IMG, False)
+    if use_ppa_img:
+        use_ppa = True
+    ppa_supported = CORE.is_esp32 and get_esp32_variant() == VARIANT_ESP32P4
+    if use_ppa and not ppa_supported:
+        raise cv.Invalid("LVGL PPA acceleration is only supported on ESP32-P4")
     # Global configuration
     if CORE.is_esp32:
         # Skip compiling lvgl examples
         add_idf_sdkconfig_option("CONFIG_LV_BUILD_EXAMPLES", False)
         add_idf_sdkconfig_option("CONFIG_LV_BUILD_DEMOS", False)
-        if get_esp32_variant() == VARIANT_ESP32P4:
+        if ppa_supported:
             add_idf_sdkconfig_option("CONFIG_LV_DRAW_BUF_ALIGN", 64)
-            # disable use of PPA for fills until upstream bugs fixed
-            df.add_define("LV_USE_PPA", "0")
+            df.add_define("LV_USE_PPA", "1" if use_ppa else "0")
             df.add_define("LV_DRAW_BUF_ALIGN", "64")
         else:
             df.add_define("LV_DRAW_BUF_ALIGN", "32")
@@ -307,6 +315,13 @@ async def to_code(configs):
     df.add_define("LV_USE_STDLIB_MALLOC", "LV_STDLIB_CUSTOM")
     df.add_define("LV_DEF_REFR_PERIOD", "16")
     cg.add_define("USE_LVGL")
+    if use_ppa:
+        df.add_define("LV_PPA_BURST_LENGTH", "128")
+        cg.add_define("USE_LVGL_PPA")
+        ppa_dir = Path(__file__).parent / "ppa"
+        cg.add_build_flag(f"-I{ppa_dir.as_posix()}")
+    if use_ppa_img:
+        cg.add_define("LV_USE_PPA_IMG")
     # suppress default enabling of extra widgets
     # cg.add_define("LV_KCONFIG_PRESENT")
     # Always enable - lots of things use it.
@@ -633,6 +648,8 @@ LVGL_SCHEMA = cv.All(
                 cv.Optional(df.CONF_KEYPADS, default=None): KEYPADS_CONFIG,
                 cv.GenerateID(df.CONF_DEFAULT_GROUP): cv.declare_id(lv_group_t),
                 cv.Optional(df.CONF_RESUME_ON_INPUT, default=True): cv.boolean,
+                cv.Optional(CONF_USE_PPA, default=False): cv.boolean,
+                cv.Optional(CONF_USE_PPA_IMG, default=False): cv.boolean,
             }
         )
         .extend(DISP_BG_SCHEMA),

--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -257,9 +257,9 @@ def final_validation(config_list):
         # keep RGB565 available for smaller memory footprints and experiments.
         user_set_depth = CONF_COLOR_DEPTH in config
         has_mipi = any(
-            global_config.get_config_for_path(global_config.get_path_for_id(did)[:-1]).get(
-                "platform", ""
-            )
+            global_config.get_config_for_path(
+                global_config.get_path_for_id(did)[:-1]
+            ).get("platform", "")
             == "mipi_dsi"
             for did in config[df.CONF_DISPLAYS]
         )

--- a/esphome/components/lvgl/lv_draw_ppa_wrapper.cpp
+++ b/esphome/components/lvgl/lv_draw_ppa_wrapper.cpp
@@ -7,6 +7,8 @@
 
 #include "esphome/core/defines.h"
 
+// namespace esphome::lvgl -- ESPHome lint marker for the C PPA sources included below.
+
 #ifdef USE_LVGL_PPA
 
 extern "C" {

--- a/esphome/components/lvgl/lv_draw_ppa_wrapper.cpp
+++ b/esphome/components/lvgl/lv_draw_ppa_wrapper.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file lv_draw_ppa_wrapper.cpp
+ * Wrapper to compile the fixed PPA C source files within ESPHome's build system.
+ * ESPHome only auto-compiles .cpp files from the component directory.
+ * This wrapper includes all PPA .c files so they get linked properly.
+ */
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_LVGL_PPA
+
+extern "C" {
+#include "lv_draw_ppa.c"
+#include "lv_draw_ppa_fill.c"
+#include "lv_draw_ppa_img.c"
+#include "lv_draw_ppa_buf.c"
+#include "lvgl_ppa_accel_v9.c"
+}
+
+#endif /* USE_LVGL_PPA */

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -7,6 +7,10 @@
 #include "core/lv_global.h"
 #include "core/lv_obj_class_private.h"
 
+#ifdef USE_LVGL_PPA
+extern "C" void lv_draw_ppa_init(void);
+#endif
+
 #include <numeric>
 
 static void *lv_alloc_draw_buf(size_t size, bool internal);
@@ -184,6 +188,9 @@ void LvglComponent::set_paused(bool paused, bool show_snow) {
 
 void LvglComponent::esphome_lvgl_init() {
   lv_init();
+#ifdef USE_LVGL_PPA
+  lv_draw_ppa_init();
+#endif
   // override draw buf alloc to ensure proper alignment for PPA
   LV_GLOBAL_DEFAULT()->draw_buf_handlers.buf_malloc_cb = draw_buf_alloc_cb;
   LV_GLOBAL_DEFAULT()->draw_buf_handlers.buf_free_cb = lv_free_core;

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.c
@@ -1,0 +1,303 @@
+/**
+ * @file lv_draw_ppa.c
+ * Fixed PPA draw unit for LVGL 9.4 on ESP32-P4
+ * Backported from https://github.com/lvgl/lvgl/pull/9162
+ * Adapted for C++ compilation (ESPHome build system)
+ */
+
+#include "sdkconfig.h"
+#ifdef CONFIG_SOC_PPA_SUPPORTED
+
+#include "lv_draw_ppa_private.h"
+#include "lv_draw_ppa.h"
+
+#ifndef LV_PPA_BURST_LENGTH
+#define LV_PPA_BURST_LENGTH 128
+#endif
+
+#if LV_PPA_BURST_LENGTH == 128
+#define LV_DRAW_PPA_DATA_BURST_LENGTH PPA_DATA_BURST_LENGTH_128
+#elif LV_PPA_BURST_LENGTH == 64
+#define LV_DRAW_PPA_DATA_BURST_LENGTH PPA_DATA_BURST_LENGTH_64
+#elif LV_PPA_BURST_LENGTH == 32
+#define LV_DRAW_PPA_DATA_BURST_LENGTH PPA_DATA_BURST_LENGTH_32
+#elif LV_PPA_BURST_LENGTH == 16
+#define LV_DRAW_PPA_DATA_BURST_LENGTH PPA_DATA_BURST_LENGTH_16
+#elif LV_PPA_BURST_LENGTH == 8
+#define LV_DRAW_PPA_DATA_BURST_LENGTH PPA_DATA_BURST_LENGTH_8
+#else
+#error "LV_PPA_BURST_LENGTH must be 8, 16, 32, 64 or 128"
+#endif
+
+/*********************
+ *      DEFINES
+ *********************/
+#define PPA_BUF_ALIGN     16  /* PPA needs at least 16-byte aligned buffers (128-bit burst) */
+
+static const char * TAG = "ppa_draw";
+static uint32_t s_ppa_fill_tasks = 0;
+static uint32_t s_ppa_img_tasks = 0;
+
+/* Check if a draw buffer is suitable for PPA (non-NULL, aligned, has data) */
+static inline bool ppa_buf_usable(lv_draw_buf_t * buf)
+{
+    if(buf == NULL || buf->data == NULL || buf->data_size == 0) return false;
+    if(((uintptr_t)buf->data) % PPA_BUF_ALIGN != 0) return false;
+    return true;
+}
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+static int32_t ppa_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
+static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
+static int32_t ppa_delete(lv_draw_unit_t * draw_unit);
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_ppa_init(void)
+{
+    lv_draw_ppa_unit_t * draw_ppa_unit = (lv_draw_ppa_unit_t *)lv_draw_create_unit(sizeof(lv_draw_ppa_unit_t));
+    draw_ppa_unit->base_unit.evaluate_cb = ppa_evaluate;
+    draw_ppa_unit->base_unit.dispatch_cb = ppa_dispatch;
+    draw_ppa_unit->base_unit.delete_cb = ppa_delete;
+
+    ESP_LOGD(TAG, "PPA draw unit registered, idx=%d", (int)draw_ppa_unit->base_unit.idx);
+
+    /* Register PPA clients */
+    esp_err_t res;
+    ppa_client_config_t cfg;
+    lv_memzero(&cfg, sizeof(cfg));
+
+    /* Register SRM client */
+    cfg.oper_type = PPA_OPERATION_SRM;
+    cfg.max_pending_trans_num = 1;
+    cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
+
+    res = ppa_register_client(&cfg, &draw_ppa_unit->srm_client);
+    if(res != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register SRM client: %d", res);
+    }
+
+    /* Register Fill client */
+    lv_memzero(&cfg, sizeof(cfg));
+    cfg.oper_type = PPA_OPERATION_FILL;
+    cfg.max_pending_trans_num = 1;
+    cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
+
+    res = ppa_register_client(&cfg, &draw_ppa_unit->fill_client);
+    if(res != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register Fill client: %d", res);
+    }
+
+    /* Register Blend client */
+    lv_memzero(&cfg, sizeof(cfg));
+    cfg.oper_type = PPA_OPERATION_BLEND;
+    cfg.max_pending_trans_num = 1;
+    cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
+
+    res = ppa_register_client(&cfg, &draw_ppa_unit->blend_client);
+    if(res != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register Blend client: %d", res);
+    }
+}
+
+void lv_draw_ppa_deinit(void)
+{
+}
+
+uint32_t lv_draw_ppa_get_fill_task_count(void)
+{
+    return s_ppa_fill_tasks;
+}
+
+uint32_t lv_draw_ppa_get_img_task_count(void)
+{
+    return s_ppa_img_tasks;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+static int32_t ppa_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * t)
+{
+    switch(t->type) {
+        case LV_DRAW_TASK_TYPE_FILL: {
+            const lv_draw_fill_dsc_t * dsc = (const lv_draw_fill_dsc_t *)t->draw_dsc;
+            if(dsc->radius != 0) return 0;
+            if(dsc->grad.dir != LV_GRAD_DIR_NONE) return 0;
+            if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
+
+            lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
+            if(!ppa_buf_usable(draw_buf)) return 0;
+            if(!ppa_dest_cf_supported((lv_color_format_t)draw_buf->header.cf)) return 0;
+
+            if(t->preference_score > 40) {
+                t->preference_score = 40;
+                t->preferred_draw_unit_id = draw_unit->idx;
+            }
+            return 1;
+        }
+
+        case LV_DRAW_TASK_TYPE_IMAGE: {
+            const lv_draw_image_dsc_t * dsc = (const lv_draw_image_dsc_t *)t->draw_dsc;
+
+#ifdef LV_USE_PPA_IMG
+            /* PPA SRM handles 90-degree increment rotation in hardware */
+            if(dsc->rotation != 0) {
+                int32_t angle = dsc->rotation % 3600;
+                if(angle < 0) angle += 3600;
+                /* Only accept exact 90 degree multiples */
+                if(angle != 0 && angle != 900 && angle != 1800 && angle != 2700) return 0;
+                if(dsc->skew_x != 0 || dsc->skew_y != 0) return 0;
+                if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
+                if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) return 0;
+                if(!ppa_src_cf_supported((lv_color_format_t)dsc->header.cf)) return 0;
+
+                lv_draw_buf_t * dest_buf = t->target_layer->draw_buf;
+                if(!ppa_buf_usable(dest_buf)) return 0;
+                if(!ppa_dest_cf_supported((lv_color_format_t)dest_buf->header.cf)) return 0;
+
+                /* SRM rotation gets higher priority than software */
+                if(t->preference_score > 30) {
+                    t->preference_score = 30;
+                    t->preferred_draw_unit_id = draw_unit->idx;
+                }
+                return 1;
+            }
+#else
+            if(dsc->rotation != 0) return 0;
+#endif
+            if(dsc->skew_x != 0 || dsc->skew_y != 0) return 0;
+
+#ifdef LV_USE_PPA_IMG
+            /* PPA SRM handles scale+translate (Ken Burns) with rotation=0 */
+            if(dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE) {
+                if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
+                if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) return 0;
+                if(!ppa_src_cf_supported((lv_color_format_t)dsc->header.cf)) return 0;
+                lv_draw_buf_t * scale_dest = t->target_layer->draw_buf;
+                if(!ppa_buf_usable(scale_dest)) return 0;
+                if(!ppa_dest_cf_supported((lv_color_format_t)scale_dest->header.cf)) return 0;
+                if(t->preference_score > 50) {
+                    t->preference_score = 50;
+                    t->preferred_draw_unit_id = draw_unit->idx;
+                }
+                return 1;
+            }
+#else
+            if(dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE) return 0;
+#endif
+            if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
+            if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) return 0;
+            if(!ppa_src_cf_supported((lv_color_format_t)dsc->header.cf)) return 0;
+
+            lv_draw_buf_t * dest_buf = t->target_layer->draw_buf;
+            if(!ppa_buf_usable(dest_buf)) return 0;
+            if(!ppa_dest_cf_supported((lv_color_format_t)dest_buf->header.cf)) return 0;
+
+            if(t->preference_score > 30) {
+                t->preference_score = 30;
+                t->preferred_draw_unit_id = draw_unit->idx;
+            }
+            return 1;
+        }
+
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
+{
+    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)draw_unit;
+
+    /* Already processing a task */
+    if(u->task_act) {
+        return LV_DRAW_UNIT_IDLE;
+    }
+
+    /* Allocate layer buffer once for all tasks in this batch */
+    if(lv_draw_layer_alloc_buf(layer) == NULL) {
+        return LV_DRAW_UNIT_IDLE;
+    }
+
+    lv_layer_t * target = NULL;
+    lv_draw_buf_t * buf = NULL;
+    bool cache_synced = false;
+    int32_t task_count = 0;
+
+    /* Process all available PPA tasks in one dispatch call */
+    lv_draw_task_t * t = lv_draw_get_available_task(layer, NULL, draw_unit->idx);
+    while(t && t->preferred_draw_unit_id == draw_unit->idx) {
+
+        t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+        t->draw_unit = draw_unit;
+        u->task_act = t;
+
+        target = t->target_layer;
+        buf = (target) ? target->draw_buf : NULL;
+
+        if(buf != NULL && buf->data != NULL) {
+            /* Flush CPU cache once before first PPA operation */
+            if(!cache_synced) {
+                lv_draw_ppa_cache_sync(buf);
+                cache_synced = true;
+            }
+
+            switch(t->type) {
+                case LV_DRAW_TASK_TYPE_FILL:
+                    s_ppa_fill_tasks++;
+                    lv_draw_ppa_fill(t, (lv_draw_fill_dsc_t *)t->draw_dsc, &t->area);
+                    break;
+                case LV_DRAW_TASK_TYPE_IMAGE: {
+                    s_ppa_img_tasks++;
+                    lv_draw_image_dsc_t * img_dsc = (lv_draw_image_dsc_t *)t->draw_dsc;
+#ifdef LV_USE_PPA_IMG
+                    if(img_dsc->rotation != 0) {
+                        lv_draw_ppa_img_rotate(t, img_dsc, &t->area);
+                    } else if(img_dsc->scale_x != LV_SCALE_NONE || img_dsc->scale_y != LV_SCALE_NONE) {
+                        lv_draw_ppa_img_srm(t, img_dsc, &t->area);
+                    } else
+#endif
+                    {
+                        lv_draw_ppa_img(t, img_dsc, &t->area);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        t->state = LV_DRAW_TASK_STATE_FINISHED;
+        u->task_act = NULL;
+        task_count++;
+
+        /* Get next available task */
+        t = lv_draw_get_available_task(layer, NULL, draw_unit->idx);
+    }
+
+    if(task_count > 0) {
+        /* Single cache invalidate after all PPA operations */
+        if(cache_synced && buf != NULL) {
+            lv_draw_ppa_cache_sync(buf);
+        }
+        lv_draw_dispatch_request();
+        return 1;
+    }
+
+    return LV_DRAW_UNIT_IDLE;
+}
+
+static int32_t ppa_delete(lv_draw_unit_t * draw_unit)
+{
+    LV_UNUSED(draw_unit);
+    return 0;
+}
+
+#endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.c
@@ -12,7 +12,7 @@
 #include "lv_draw_ppa.h"
 
 #ifndef LV_PPA_BURST_LENGTH
-#define LV_PPA_BURST_LENGTH 128
+#define LV_PPA_BURST_LENGTH (128)
 #endif
 
 #if LV_PPA_BURST_LENGTH == 128
@@ -32,7 +32,7 @@
 /*********************
  *      DEFINES
  *********************/
-#define PPA_BUF_ALIGN     16  /* PPA needs at least 16-byte aligned buffers (128-bit burst) */
+#define PPA_BUF_ALIGN     (16)  /* PPA needs at least 16-byte aligned buffers (128-bit burst) */
 
 static const char * TAG = "ppa_draw";
 static uint32_t s_ppa_fill_tasks = 0;

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.c
@@ -58,7 +58,7 @@ static int32_t ppa_delete(lv_draw_unit_t *draw_unit);
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_ppa_init(void) {
+void lv_draw_ppa_init() {
   lv_draw_ppa_unit_t *draw_ppa_unit = (lv_draw_ppa_unit_t *) lv_draw_create_unit(sizeof(lv_draw_ppa_unit_t));
   draw_ppa_unit->base_unit.evaluate_cb = ppa_evaluate;
   draw_ppa_unit->base_unit.dispatch_cb = ppa_dispatch;
@@ -104,11 +104,11 @@ void lv_draw_ppa_init(void) {
   }
 }
 
-void lv_draw_ppa_deinit(void) {}
+void lv_draw_ppa_deinit() {}
 
-uint32_t lv_draw_ppa_get_fill_task_count(void) { return s_ppa_fill_tasks; }
+uint32_t lv_draw_ppa_get_fill_task_count() { return s_ppa_fill_tasks; }
 
-uint32_t lv_draw_ppa_get_img_task_count(void) { return s_ppa_img_tasks; }
+uint32_t lv_draw_ppa_get_img_task_count() { return s_ppa_img_tasks; }
 
 /**********************
  *   STATIC FUNCTIONS

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.c
@@ -32,272 +32,286 @@
 /*********************
  *      DEFINES
  *********************/
-#define PPA_BUF_ALIGN     (16)  /* PPA needs at least 16-byte aligned buffers (128-bit burst) */
+#define PPA_BUF_ALIGN (16) /* PPA needs at least 16-byte aligned buffers (128-bit burst) */
 
-static const char * TAG = "ppa_draw";
+static const char *TAG = "ppa_draw";
 static uint32_t s_ppa_fill_tasks = 0;
 static uint32_t s_ppa_img_tasks = 0;
 
 /* Check if a draw buffer is suitable for PPA (non-NULL, aligned, has data) */
-static inline bool ppa_buf_usable(lv_draw_buf_t * buf)
-{
-    if(buf == NULL || buf->data == NULL || buf->data_size == 0) return false;
-    if(((uintptr_t)buf->data) % PPA_BUF_ALIGN != 0) return false;
-    return true;
+static inline bool ppa_buf_usable(lv_draw_buf_t *buf) {
+  if (buf == NULL || buf->data == NULL || buf->data_size == 0)
+    return false;
+  if (((uintptr_t) buf->data) % PPA_BUF_ALIGN != 0)
+    return false;
+  return true;
 }
 
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static int32_t ppa_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
-static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
-static int32_t ppa_delete(lv_draw_unit_t * draw_unit);
+static int32_t ppa_evaluate(lv_draw_unit_t *draw_unit, lv_draw_task_t *task);
+static int32_t ppa_dispatch(lv_draw_unit_t *draw_unit, lv_layer_t *layer);
+static int32_t ppa_delete(lv_draw_unit_t *draw_unit);
 
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_draw_ppa_init(void)
-{
-    lv_draw_ppa_unit_t * draw_ppa_unit = (lv_draw_ppa_unit_t *)lv_draw_create_unit(sizeof(lv_draw_ppa_unit_t));
-    draw_ppa_unit->base_unit.evaluate_cb = ppa_evaluate;
-    draw_ppa_unit->base_unit.dispatch_cb = ppa_dispatch;
-    draw_ppa_unit->base_unit.delete_cb = ppa_delete;
+void lv_draw_ppa_init(void) {
+  lv_draw_ppa_unit_t *draw_ppa_unit = (lv_draw_ppa_unit_t *) lv_draw_create_unit(sizeof(lv_draw_ppa_unit_t));
+  draw_ppa_unit->base_unit.evaluate_cb = ppa_evaluate;
+  draw_ppa_unit->base_unit.dispatch_cb = ppa_dispatch;
+  draw_ppa_unit->base_unit.delete_cb = ppa_delete;
 
-    ESP_LOGD(TAG, "PPA draw unit registered, idx=%d", (int)draw_ppa_unit->base_unit.idx);
+  ESP_LOGD(TAG, "PPA draw unit registered, idx=%d", (int) draw_ppa_unit->base_unit.idx);
 
-    /* Register PPA clients */
-    esp_err_t res;
-    ppa_client_config_t cfg;
-    lv_memzero(&cfg, sizeof(cfg));
+  /* Register PPA clients */
+  esp_err_t res;
+  ppa_client_config_t cfg;
+  lv_memzero(&cfg, sizeof(cfg));
 
-    /* Register SRM client */
-    cfg.oper_type = PPA_OPERATION_SRM;
-    cfg.max_pending_trans_num = 1;
-    cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
+  /* Register SRM client */
+  cfg.oper_type = PPA_OPERATION_SRM;
+  cfg.max_pending_trans_num = 1;
+  cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
 
-    res = ppa_register_client(&cfg, &draw_ppa_unit->srm_client);
-    if(res != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to register SRM client: %d", res);
-    }
+  res = ppa_register_client(&cfg, &draw_ppa_unit->srm_client);
+  if (res != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register SRM client: %d", res);
+  }
 
-    /* Register Fill client */
-    lv_memzero(&cfg, sizeof(cfg));
-    cfg.oper_type = PPA_OPERATION_FILL;
-    cfg.max_pending_trans_num = 1;
-    cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
+  /* Register Fill client */
+  lv_memzero(&cfg, sizeof(cfg));
+  cfg.oper_type = PPA_OPERATION_FILL;
+  cfg.max_pending_trans_num = 1;
+  cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
 
-    res = ppa_register_client(&cfg, &draw_ppa_unit->fill_client);
-    if(res != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to register Fill client: %d", res);
-    }
+  res = ppa_register_client(&cfg, &draw_ppa_unit->fill_client);
+  if (res != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register Fill client: %d", res);
+  }
 
-    /* Register Blend client */
-    lv_memzero(&cfg, sizeof(cfg));
-    cfg.oper_type = PPA_OPERATION_BLEND;
-    cfg.max_pending_trans_num = 1;
-    cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
+  /* Register Blend client */
+  lv_memzero(&cfg, sizeof(cfg));
+  cfg.oper_type = PPA_OPERATION_BLEND;
+  cfg.max_pending_trans_num = 1;
+  cfg.data_burst_length = LV_DRAW_PPA_DATA_BURST_LENGTH;
 
-    res = ppa_register_client(&cfg, &draw_ppa_unit->blend_client);
-    if(res != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to register Blend client: %d", res);
-    }
+  res = ppa_register_client(&cfg, &draw_ppa_unit->blend_client);
+  if (res != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register Blend client: %d", res);
+  }
 }
 
-void lv_draw_ppa_deinit(void)
-{
-}
+void lv_draw_ppa_deinit(void) {}
 
-uint32_t lv_draw_ppa_get_fill_task_count(void)
-{
-    return s_ppa_fill_tasks;
-}
+uint32_t lv_draw_ppa_get_fill_task_count(void) { return s_ppa_fill_tasks; }
 
-uint32_t lv_draw_ppa_get_img_task_count(void)
-{
-    return s_ppa_img_tasks;
-}
+uint32_t lv_draw_ppa_get_img_task_count(void) { return s_ppa_img_tasks; }
 
 /**********************
  *   STATIC FUNCTIONS
  **********************/
-static int32_t ppa_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * t)
-{
-    switch(t->type) {
-        case LV_DRAW_TASK_TYPE_FILL: {
-            const lv_draw_fill_dsc_t * dsc = (const lv_draw_fill_dsc_t *)t->draw_dsc;
-            if(dsc->radius != 0) return 0;
-            if(dsc->grad.dir != LV_GRAD_DIR_NONE) return 0;
-            if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
+static int32_t ppa_evaluate(lv_draw_unit_t *draw_unit, lv_draw_task_t *t) {
+  switch (t->type) {
+    case LV_DRAW_TASK_TYPE_FILL: {
+      const lv_draw_fill_dsc_t *dsc = (const lv_draw_fill_dsc_t *) t->draw_dsc;
+      if (dsc->radius != 0)
+        return 0;
+      if (dsc->grad.dir != LV_GRAD_DIR_NONE)
+        return 0;
+      if (dsc->opa < (lv_opa_t) LV_OPA_MAX)
+        return 0;
 
-            lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
-            if(!ppa_buf_usable(draw_buf)) return 0;
-            if(!ppa_dest_cf_supported((lv_color_format_t)draw_buf->header.cf)) return 0;
+      lv_draw_buf_t *draw_buf = t->target_layer->draw_buf;
+      if (!ppa_buf_usable(draw_buf))
+        return 0;
+      if (!ppa_dest_cf_supported((lv_color_format_t) draw_buf->header.cf))
+        return 0;
 
-            if(t->preference_score > 40) {
-                t->preference_score = 40;
-                t->preferred_draw_unit_id = draw_unit->idx;
-            }
-            return 1;
-        }
+      if (t->preference_score > 40) {
+        t->preference_score = 40;
+        t->preferred_draw_unit_id = draw_unit->idx;
+      }
+      return 1;
+    }
 
-        case LV_DRAW_TASK_TYPE_IMAGE: {
-            const lv_draw_image_dsc_t * dsc = (const lv_draw_image_dsc_t *)t->draw_dsc;
+    case LV_DRAW_TASK_TYPE_IMAGE: {
+      const lv_draw_image_dsc_t *dsc = (const lv_draw_image_dsc_t *) t->draw_dsc;
 
 #ifdef LV_USE_PPA_IMG
-            /* PPA SRM handles 90-degree increment rotation in hardware */
-            if(dsc->rotation != 0) {
-                int32_t angle = dsc->rotation % 3600;
-                if(angle < 0) angle += 3600;
-                /* Only accept exact 90 degree multiples */
-                if(angle != 0 && angle != 900 && angle != 1800 && angle != 2700) return 0;
-                if(dsc->skew_x != 0 || dsc->skew_y != 0) return 0;
-                if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
-                if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) return 0;
-                if(!ppa_src_cf_supported((lv_color_format_t)dsc->header.cf)) return 0;
+      /* PPA SRM handles 90-degree increment rotation in hardware */
+      if (dsc->rotation != 0) {
+        int32_t angle = dsc->rotation % 3600;
+        if (angle < 0)
+          angle += 3600;
+        /* Only accept exact 90 degree multiples */
+        if (angle != 0 && angle != 900 && angle != 1800 && angle != 2700)
+          return 0;
+        if (dsc->skew_x != 0 || dsc->skew_y != 0)
+          return 0;
+        if (dsc->opa < (lv_opa_t) LV_OPA_MAX)
+          return 0;
+        if (dsc->blend_mode != LV_BLEND_MODE_NORMAL)
+          return 0;
+        if (!ppa_src_cf_supported((lv_color_format_t) dsc->header.cf))
+          return 0;
 
-                lv_draw_buf_t * dest_buf = t->target_layer->draw_buf;
-                if(!ppa_buf_usable(dest_buf)) return 0;
-                if(!ppa_dest_cf_supported((lv_color_format_t)dest_buf->header.cf)) return 0;
+        lv_draw_buf_t *dest_buf = t->target_layer->draw_buf;
+        if (!ppa_buf_usable(dest_buf))
+          return 0;
+        if (!ppa_dest_cf_supported((lv_color_format_t) dest_buf->header.cf))
+          return 0;
 
-                /* SRM rotation gets higher priority than software */
-                if(t->preference_score > 30) {
-                    t->preference_score = 30;
-                    t->preferred_draw_unit_id = draw_unit->idx;
-                }
-                return 1;
-            }
-#else
-            if(dsc->rotation != 0) return 0;
-#endif
-            if(dsc->skew_x != 0 || dsc->skew_y != 0) return 0;
-
-#ifdef LV_USE_PPA_IMG
-            /* PPA SRM handles scale+translate (Ken Burns) with rotation=0 */
-            if(dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE) {
-                if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
-                if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) return 0;
-                if(!ppa_src_cf_supported((lv_color_format_t)dsc->header.cf)) return 0;
-                lv_draw_buf_t * scale_dest = t->target_layer->draw_buf;
-                if(!ppa_buf_usable(scale_dest)) return 0;
-                if(!ppa_dest_cf_supported((lv_color_format_t)scale_dest->header.cf)) return 0;
-                if(t->preference_score > 50) {
-                    t->preference_score = 50;
-                    t->preferred_draw_unit_id = draw_unit->idx;
-                }
-                return 1;
-            }
-#else
-            if(dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE) return 0;
-#endif
-            if(dsc->opa < (lv_opa_t)LV_OPA_MAX) return 0;
-            if(dsc->blend_mode != LV_BLEND_MODE_NORMAL) return 0;
-            if(!ppa_src_cf_supported((lv_color_format_t)dsc->header.cf)) return 0;
-
-            lv_draw_buf_t * dest_buf = t->target_layer->draw_buf;
-            if(!ppa_buf_usable(dest_buf)) return 0;
-            if(!ppa_dest_cf_supported((lv_color_format_t)dest_buf->header.cf)) return 0;
-
-            if(t->preference_score > 30) {
-                t->preference_score = 30;
-                t->preferred_draw_unit_id = draw_unit->idx;
-            }
-            return 1;
+        /* SRM rotation gets higher priority than software */
+        if (t->preference_score > 30) {
+          t->preference_score = 30;
+          t->preferred_draw_unit_id = draw_unit->idx;
         }
-
-        default:
-            break;
-    }
-
-    return 0;
-}
-
-static int32_t ppa_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
-{
-    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)draw_unit;
-
-    /* Already processing a task */
-    if(u->task_act) {
-        return LV_DRAW_UNIT_IDLE;
-    }
-
-    /* Allocate layer buffer once for all tasks in this batch */
-    if(lv_draw_layer_alloc_buf(layer) == NULL) {
-        return LV_DRAW_UNIT_IDLE;
-    }
-
-    lv_layer_t * target = NULL;
-    lv_draw_buf_t * buf = NULL;
-    bool cache_synced = false;
-    int32_t task_count = 0;
-
-    /* Process all available PPA tasks in one dispatch call */
-    lv_draw_task_t * t = lv_draw_get_available_task(layer, NULL, draw_unit->idx);
-    while(t && t->preferred_draw_unit_id == draw_unit->idx) {
-
-        t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
-        t->draw_unit = draw_unit;
-        u->task_act = t;
-
-        target = t->target_layer;
-        buf = (target) ? target->draw_buf : NULL;
-
-        if(buf != NULL && buf->data != NULL) {
-            /* Flush CPU cache once before first PPA operation */
-            if(!cache_synced) {
-                lv_draw_ppa_cache_sync(buf);
-                cache_synced = true;
-            }
-
-            switch(t->type) {
-                case LV_DRAW_TASK_TYPE_FILL:
-                    s_ppa_fill_tasks++;
-                    lv_draw_ppa_fill(t, (lv_draw_fill_dsc_t *)t->draw_dsc, &t->area);
-                    break;
-                case LV_DRAW_TASK_TYPE_IMAGE: {
-                    s_ppa_img_tasks++;
-                    lv_draw_image_dsc_t * img_dsc = (lv_draw_image_dsc_t *)t->draw_dsc;
-#ifdef LV_USE_PPA_IMG
-                    if(img_dsc->rotation != 0) {
-                        lv_draw_ppa_img_rotate(t, img_dsc, &t->area);
-                    } else if(img_dsc->scale_x != LV_SCALE_NONE || img_dsc->scale_y != LV_SCALE_NONE) {
-                        lv_draw_ppa_img_srm(t, img_dsc, &t->area);
-                    } else
-#endif
-                    {
-                        lv_draw_ppa_img(t, img_dsc, &t->area);
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-        }
-
-        t->state = LV_DRAW_TASK_STATE_FINISHED;
-        u->task_act = NULL;
-        task_count++;
-
-        /* Get next available task */
-        t = lv_draw_get_available_task(layer, NULL, draw_unit->idx);
-    }
-
-    if(task_count > 0) {
-        /* Single cache invalidate after all PPA operations */
-        if(cache_synced && buf != NULL) {
-            lv_draw_ppa_cache_sync(buf);
-        }
-        lv_draw_dispatch_request();
         return 1;
+      }
+#else
+      if (dsc->rotation != 0)
+        return 0;
+#endif
+      if (dsc->skew_x != 0 || dsc->skew_y != 0)
+        return 0;
+
+#ifdef LV_USE_PPA_IMG
+      /* PPA SRM handles scale+translate (Ken Burns) with rotation=0 */
+      if (dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE) {
+        if (dsc->opa < (lv_opa_t) LV_OPA_MAX)
+          return 0;
+        if (dsc->blend_mode != LV_BLEND_MODE_NORMAL)
+          return 0;
+        if (!ppa_src_cf_supported((lv_color_format_t) dsc->header.cf))
+          return 0;
+        lv_draw_buf_t *scale_dest = t->target_layer->draw_buf;
+        if (!ppa_buf_usable(scale_dest))
+          return 0;
+        if (!ppa_dest_cf_supported((lv_color_format_t) scale_dest->header.cf))
+          return 0;
+        if (t->preference_score > 50) {
+          t->preference_score = 50;
+          t->preferred_draw_unit_id = draw_unit->idx;
+        }
+        return 1;
+      }
+#else
+      if (dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE)
+        return 0;
+#endif
+      if (dsc->opa < (lv_opa_t) LV_OPA_MAX)
+        return 0;
+      if (dsc->blend_mode != LV_BLEND_MODE_NORMAL)
+        return 0;
+      if (!ppa_src_cf_supported((lv_color_format_t) dsc->header.cf))
+        return 0;
+
+      lv_draw_buf_t *dest_buf = t->target_layer->draw_buf;
+      if (!ppa_buf_usable(dest_buf))
+        return 0;
+      if (!ppa_dest_cf_supported((lv_color_format_t) dest_buf->header.cf))
+        return 0;
+
+      if (t->preference_score > 30) {
+        t->preference_score = 30;
+        t->preferred_draw_unit_id = draw_unit->idx;
+      }
+      return 1;
     }
 
-    return LV_DRAW_UNIT_IDLE;
+    default:
+      break;
+  }
+
+  return 0;
 }
 
-static int32_t ppa_delete(lv_draw_unit_t * draw_unit)
-{
-    LV_UNUSED(draw_unit);
-    return 0;
+static int32_t ppa_dispatch(lv_draw_unit_t *draw_unit, lv_layer_t *layer) {
+  lv_draw_ppa_unit_t *u = (lv_draw_ppa_unit_t *) draw_unit;
+
+  /* Already processing a task */
+  if (u->task_act) {
+    return LV_DRAW_UNIT_IDLE;
+  }
+
+  /* Allocate layer buffer once for all tasks in this batch */
+  if (lv_draw_layer_alloc_buf(layer) == NULL) {
+    return LV_DRAW_UNIT_IDLE;
+  }
+
+  lv_layer_t *target = NULL;
+  lv_draw_buf_t *buf = NULL;
+  bool cache_synced = false;
+  int32_t task_count = 0;
+
+  /* Process all available PPA tasks in one dispatch call */
+  lv_draw_task_t *t = lv_draw_get_available_task(layer, NULL, draw_unit->idx);
+  while (t && t->preferred_draw_unit_id == draw_unit->idx) {
+    t->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    t->draw_unit = draw_unit;
+    u->task_act = t;
+
+    target = t->target_layer;
+    buf = (target) ? target->draw_buf : NULL;
+
+    if (buf != NULL && buf->data != NULL) {
+      /* Flush CPU cache once before first PPA operation */
+      if (!cache_synced) {
+        lv_draw_ppa_cache_sync(buf);
+        cache_synced = true;
+      }
+
+      switch (t->type) {
+        case LV_DRAW_TASK_TYPE_FILL:
+          s_ppa_fill_tasks++;
+          lv_draw_ppa_fill(t, (lv_draw_fill_dsc_t *) t->draw_dsc, &t->area);
+          break;
+        case LV_DRAW_TASK_TYPE_IMAGE: {
+          s_ppa_img_tasks++;
+          lv_draw_image_dsc_t *img_dsc = (lv_draw_image_dsc_t *) t->draw_dsc;
+#ifdef LV_USE_PPA_IMG
+          if (img_dsc->rotation != 0) {
+            lv_draw_ppa_img_rotate(t, img_dsc, &t->area);
+          } else if (img_dsc->scale_x != LV_SCALE_NONE || img_dsc->scale_y != LV_SCALE_NONE) {
+            lv_draw_ppa_img_srm(t, img_dsc, &t->area);
+          } else
+#endif
+          {
+            lv_draw_ppa_img(t, img_dsc, &t->area);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    t->state = LV_DRAW_TASK_STATE_FINISHED;
+    u->task_act = NULL;
+    task_count++;
+
+    /* Get next available task */
+    t = lv_draw_get_available_task(layer, NULL, draw_unit->idx);
+  }
+
+  if (task_count > 0) {
+    /* Single cache invalidate after all PPA operations */
+    if (cache_synced && buf != NULL) {
+      lv_draw_ppa_cache_sync(buf);
+    }
+    lv_draw_dispatch_request();
+    return 1;
+  }
+
+  return LV_DRAW_UNIT_IDLE;
+}
+
+static int32_t ppa_delete(lv_draw_unit_t *draw_unit) {
+  LV_UNUSED(draw_unit);
+  return 0;
 }
 
 #endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.h
@@ -1,0 +1,63 @@
+/**
+ * @file lv_draw_ppa.h
+ * Custom PPA draw unit header for ESP32-P4
+ * Based on https://github.com/lvgl/lvgl/pull/9162 (included in LVGL 9.5+)
+ */
+
+#ifndef LV_DRAW_PPA_FIXED_H
+#define LV_DRAW_PPA_FIXED_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lvgl.h"
+#include "src/draw/lv_draw_private.h"
+#include "src/display/lv_display_private.h"
+#include "src/misc/lv_area_private.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+void lv_draw_ppa_init(void);
+void lv_draw_ppa_deinit(void);
+void lv_draw_buf_ppa_init_handlers(void);
+uint32_t lv_draw_ppa_get_fill_task_count(void);
+uint32_t lv_draw_ppa_get_img_task_count(void);
+
+void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
+                      const lv_area_t * coords);
+
+void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                     const lv_area_t * coords);
+
+#ifdef LV_USE_PPA_IMG
+void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                            const lv_area_t * coords);
+void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                         const lv_area_t * coords);
+#endif
+
+void lv_draw_ppa_cache_sync(lv_draw_buf_t * buf);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /* LV_DRAW_PPA_FIXED_H */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.h
@@ -4,6 +4,9 @@
  * Based on https://github.com/lvgl/lvgl/pull/9162 (included in LVGL 9.5+)
  */
 
+#pragma once
+// namespace esphome::lvgl -- ESPHome lint marker; this header exposes C linkage.
+
 #ifndef LV_DRAW_PPA_FIXED_H
 #define LV_DRAW_PPA_FIXED_H
 

--- a/esphome/components/lvgl/ppa/lv_draw_ppa.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa.h
@@ -40,20 +40,16 @@ void lv_draw_buf_ppa_init_handlers(void);
 uint32_t lv_draw_ppa_get_fill_task_count(void);
 uint32_t lv_draw_ppa_get_img_task_count(void);
 
-void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
-                      const lv_area_t * coords);
+void lv_draw_ppa_fill(lv_draw_task_t *t, const lv_draw_fill_dsc_t *dsc, const lv_area_t *coords);
 
-void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
-                     const lv_area_t * coords);
+void lv_draw_ppa_img(lv_draw_task_t *t, const lv_draw_image_dsc_t *dsc, const lv_area_t *coords);
 
 #ifdef LV_USE_PPA_IMG
-void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
-                            const lv_area_t * coords);
-void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
-                         const lv_area_t * coords);
+void lv_draw_ppa_img_rotate(lv_draw_task_t *t, const lv_draw_image_dsc_t *dsc, const lv_area_t *coords);
+void lv_draw_ppa_img_srm(lv_draw_task_t *t, const lv_draw_image_dsc_t *dsc, const lv_area_t *coords);
 #endif
 
-void lv_draw_ppa_cache_sync(lv_draw_buf_t * buf);
+void lv_draw_ppa_cache_sync(lv_draw_buf_t *buf);
 
 /**********************
  *      MACROS

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
@@ -20,7 +20,7 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_buf_ppa_init_handlers(void) { /* Intentionally empty - see file header comment */ }
+void lv_draw_buf_ppa_init_handlers() { /* Intentionally empty - see file header comment */ }
 
 void lv_draw_ppa_cache_sync(lv_draw_buf_t *buf) {
   if (buf == NULL || buf->data == NULL || buf->data_size == 0)

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
@@ -20,7 +20,8 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_buf_ppa_init_handlers() { /* Intentionally empty - see file header comment */ }
+void lv_draw_buf_ppa_init_handlers() { /* Intentionally empty - see file header comment */
+}
 
 void lv_draw_ppa_cache_sync(lv_draw_buf_t *buf) {
   if (buf == NULL || buf->data == NULL || buf->data_size == 0)

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
@@ -20,31 +20,28 @@
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
-void lv_draw_buf_ppa_init_handlers(void)
-{
-    /* Intentionally empty - see file header comment */
-}
+void lv_draw_buf_ppa_init_handlers(void) { /* Intentionally empty - see file header comment */ }
 
-void lv_draw_ppa_cache_sync(lv_draw_buf_t * buf)
-{
-    if(buf == NULL || buf->data == NULL || buf->data_size == 0) return;
+void lv_draw_ppa_cache_sync(lv_draw_buf_t *buf) {
+  if (buf == NULL || buf->data == NULL || buf->data_size == 0)
+    return;
 
-    /* Only sync if buffer is in external (PSRAM) memory, which is cached.
-     * Internal SRAM is not cached on ESP32-P4, so esp_cache_msync would
-     * either be a no-op or could crash on non-cacheable regions. */
-    if(!esp_ptr_external_ram(buf->data)) return;
+  /* Only sync if buffer is in external (PSRAM) memory, which is cached.
+   * Internal SRAM is not cached on ESP32-P4, so esp_cache_msync would
+   * either be a no-op or could crash on non-cacheable regions. */
+  if (!esp_ptr_external_ram(buf->data))
+    return;
 
-    /* Fix for issue #9868 + LVGL PR #10107: esp_cache_msync() requires both
-     * address AND size to be aligned to the cache line size (64 B default,
-     * 128 B with CONFIG_CACHE_L2_CACHE_LINE_128B). Round size up AND pass
-     * ESP_CACHE_MSYNC_FLAG_UNALIGNED so partial leading/trailing lines from
-     * non-aligned buffer pointers (malloc()/user buffers) are handled by
-     * the kernel instead of triggering a rejection. */
-    uint32_t aligned_size = lv_draw_ppa_align_size(buf->data_size);
+  /* Fix for issue #9868 + LVGL PR #10107: esp_cache_msync() requires both
+   * address AND size to be aligned to the cache line size (64 B default,
+   * 128 B with CONFIG_CACHE_L2_CACHE_LINE_128B). Round size up AND pass
+   * ESP_CACHE_MSYNC_FLAG_UNALIGNED so partial leading/trailing lines from
+   * non-aligned buffer pointers (malloc()/user buffers) are handled by
+   * the kernel instead of triggering a rejection. */
+  uint32_t aligned_size = lv_draw_ppa_align_size(buf->data_size);
 
-    esp_cache_msync(buf->data, aligned_size,
-                    ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA |
-                    ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+  esp_cache_msync(buf->data, aligned_size,
+                  ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
 }
 
 #endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_buf.c
@@ -1,0 +1,50 @@
+/**
+ * @file lv_draw_ppa_buf.c
+ * Fixed PPA buffer cache handling for LVGL 9.4 on ESP32-P4
+ * Backported from https://github.com/lvgl/lvgl/pull/9162
+ * Adapted for C++ compilation (ESPHome build system)
+ *
+ * NOTE: We do NOT set the global invalidate_cache_cb handler because
+ * it would affect ALL draw operations (software renderer included).
+ * Cache sync is done per-operation in PPA dispatch, and only for
+ * buffers in external (PSRAM) memory which is cached.
+ */
+
+#include "sdkconfig.h"
+#ifdef CONFIG_SOC_PPA_SUPPORTED
+
+#include "lv_draw_ppa_private.h"
+#include "lv_draw_ppa.h"
+#include "esp_memory_utils.h"
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+void lv_draw_buf_ppa_init_handlers(void)
+{
+    /* Intentionally empty - see file header comment */
+}
+
+void lv_draw_ppa_cache_sync(lv_draw_buf_t * buf)
+{
+    if(buf == NULL || buf->data == NULL || buf->data_size == 0) return;
+
+    /* Only sync if buffer is in external (PSRAM) memory, which is cached.
+     * Internal SRAM is not cached on ESP32-P4, so esp_cache_msync would
+     * either be a no-op or could crash on non-cacheable regions. */
+    if(!esp_ptr_external_ram(buf->data)) return;
+
+    /* Fix for issue #9868 + LVGL PR #10107: esp_cache_msync() requires both
+     * address AND size to be aligned to the cache line size (64 B default,
+     * 128 B with CONFIG_CACHE_L2_CACHE_LINE_128B). Round size up AND pass
+     * ESP_CACHE_MSYNC_FLAG_UNALIGNED so partial leading/trailing lines from
+     * non-aligned buffer pointers (malloc()/user buffers) are handled by
+     * the kernel instead of triggering a rejection. */
+    uint32_t aligned_size = lv_draw_ppa_align_size(buf->data_size);
+
+    esp_cache_msync(buf->data, aligned_size,
+                    ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA |
+                    ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+}
+
+#endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_fill.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_fill.c
@@ -11,44 +11,42 @@
 #include "lv_draw_ppa_private.h"
 #include "lv_draw_ppa.h"
 
-void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
-                      const lv_area_t * coords)
-{
-    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
-    lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
+void lv_draw_ppa_fill(lv_draw_task_t *t, const lv_draw_fill_dsc_t *dsc, const lv_area_t *coords) {
+  lv_draw_ppa_unit_t *u = (lv_draw_ppa_unit_t *) t->draw_unit;
+  lv_draw_buf_t *draw_buf = t->target_layer->draw_buf;
 
-    lv_area_t rel_coords;
-    lv_area_copy(&rel_coords, coords);
-    lv_area_move(&rel_coords, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+  lv_area_t rel_coords;
+  lv_area_copy(&rel_coords, coords);
+  lv_area_move(&rel_coords, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
 
-    lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, &t->clip_area);
-    lv_area_move(&rel_clip_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+  lv_area_t rel_clip_area;
+  lv_area_copy(&rel_clip_area, &t->clip_area);
+  lv_area_move(&rel_clip_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
 
-    lv_area_t blend_area;
-    if(!lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
-        return; /*Fully clipped, nothing to do*/
+  lv_area_t blend_area;
+  if (!lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
+    return; /*Fully clipped, nothing to do*/
 
-    ppa_fill_oper_config_t fill_cfg;
-    lv_memzero(&fill_cfg, sizeof(fill_cfg));
+  ppa_fill_oper_config_t fill_cfg;
+  lv_memzero(&fill_cfg, sizeof(fill_cfg));
 
-    fill_cfg.fill_argb_color.val = lv_color_to_u32(dsc->color);
-    fill_cfg.out.block_offset_x  = (uint32_t)blend_area.x1;
-    fill_cfg.out.block_offset_y  = (uint32_t)blend_area.y1;
-    fill_cfg.out.fill_cm         = lv_color_format_to_ppa_fill((lv_color_format_t)draw_buf->header.cf);
-    fill_cfg.fill_block_w        = (uint32_t)lv_area_get_width(&blend_area);
-    fill_cfg.fill_block_h        = (uint32_t)lv_area_get_height(&blend_area);
-    fill_cfg.out.buffer          = draw_buf->data;
-    /* PPA hardware rejects unaligned out.buffer_size (issue #9868). */
-    fill_cfg.out.buffer_size     = lv_draw_ppa_align_size(draw_buf->data_size);
-    fill_cfg.out.pic_w           = draw_buf->header.w;
-    fill_cfg.out.pic_h           = draw_buf->header.h;
-    fill_cfg.mode                = PPA_TRANS_MODE_BLOCKING;
+  fill_cfg.fill_argb_color.val = lv_color_to_u32(dsc->color);
+  fill_cfg.out.block_offset_x = (uint32_t) blend_area.x1;
+  fill_cfg.out.block_offset_y = (uint32_t) blend_area.y1;
+  fill_cfg.out.fill_cm = lv_color_format_to_ppa_fill((lv_color_format_t) draw_buf->header.cf);
+  fill_cfg.fill_block_w = (uint32_t) lv_area_get_width(&blend_area);
+  fill_cfg.fill_block_h = (uint32_t) lv_area_get_height(&blend_area);
+  fill_cfg.out.buffer = draw_buf->data;
+  /* PPA hardware rejects unaligned out.buffer_size (issue #9868). */
+  fill_cfg.out.buffer_size = lv_draw_ppa_align_size(draw_buf->data_size);
+  fill_cfg.out.pic_w = draw_buf->header.w;
+  fill_cfg.out.pic_h = draw_buf->header.h;
+  fill_cfg.mode = PPA_TRANS_MODE_BLOCKING;
 
-    esp_err_t ret = ppa_do_fill(u->fill_client, &fill_cfg);
-    if(ret != ESP_OK) {
-        LV_LOG_ERROR("PPA fill failed: %d", ret);
-    }
+  esp_err_t ret = ppa_do_fill(u->fill_client, &fill_cfg);
+  if (ret != ESP_OK) {
+    LV_LOG_ERROR("PPA fill failed: %d", ret);
+  }
 }
 
 #endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_fill.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_fill.c
@@ -1,0 +1,54 @@
+/**
+ * @file lv_draw_ppa_fill.c
+ * Fixed PPA fill operation for LVGL 9.4 on ESP32-P4
+ * Backported from https://github.com/lvgl/lvgl/pull/9162
+ * Adapted for C++ compilation (ESPHome build system)
+ */
+
+#include "sdkconfig.h"
+#ifdef CONFIG_SOC_PPA_SUPPORTED
+
+#include "lv_draw_ppa_private.h"
+#include "lv_draw_ppa.h"
+
+void lv_draw_ppa_fill(lv_draw_task_t * t, const lv_draw_fill_dsc_t * dsc,
+                      const lv_area_t * coords)
+{
+    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
+    lv_draw_buf_t * draw_buf = t->target_layer->draw_buf;
+
+    lv_area_t rel_coords;
+    lv_area_copy(&rel_coords, coords);
+    lv_area_move(&rel_coords, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+
+    lv_area_t rel_clip_area;
+    lv_area_copy(&rel_clip_area, &t->clip_area);
+    lv_area_move(&rel_clip_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+
+    lv_area_t blend_area;
+    if(!lv_area_intersect(&blend_area, &rel_coords, &rel_clip_area))
+        return; /*Fully clipped, nothing to do*/
+
+    ppa_fill_oper_config_t fill_cfg;
+    lv_memzero(&fill_cfg, sizeof(fill_cfg));
+
+    fill_cfg.fill_argb_color.val = lv_color_to_u32(dsc->color);
+    fill_cfg.out.block_offset_x  = (uint32_t)blend_area.x1;
+    fill_cfg.out.block_offset_y  = (uint32_t)blend_area.y1;
+    fill_cfg.out.fill_cm         = lv_color_format_to_ppa_fill((lv_color_format_t)draw_buf->header.cf);
+    fill_cfg.fill_block_w        = (uint32_t)lv_area_get_width(&blend_area);
+    fill_cfg.fill_block_h        = (uint32_t)lv_area_get_height(&blend_area);
+    fill_cfg.out.buffer          = draw_buf->data;
+    /* PPA hardware rejects unaligned out.buffer_size (issue #9868). */
+    fill_cfg.out.buffer_size     = lv_draw_ppa_align_size(draw_buf->data_size);
+    fill_cfg.out.pic_w           = draw_buf->header.w;
+    fill_cfg.out.pic_h           = draw_buf->header.h;
+    fill_cfg.mode                = PPA_TRANS_MODE_BLOCKING;
+
+    esp_err_t ret = ppa_do_fill(u->fill_client, &fill_cfg);
+    if(ret != ESP_OK) {
+        LV_LOG_ERROR("PPA fill failed: %d", ret);
+    }
+}
+
+#endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_img.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_img.c
@@ -1,0 +1,469 @@
+/**
+ * @file lv_draw_ppa_img.c
+ * Fixed PPA image blending for LVGL 9.4 on ESP32-P4
+ * Backported from https://github.com/lvgl/lvgl/pull/9162
+ * Adapted for C++ compilation (ESPHome build system)
+ */
+
+#include "sdkconfig.h"
+#ifdef CONFIG_SOC_PPA_SUPPORTED
+
+#include "lv_draw_ppa_private.h"
+#include "lv_draw_ppa.h"
+#include "src/draw/lv_draw_image_private.h"
+#include "src/draw/lv_image_decoder_private.h"
+#include "src/draw/lv_image_decoder.h"
+#include <math.h>
+#include <string.h>
+
+static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                 const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                 const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
+
+
+void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                     const lv_area_t * coords)
+{
+    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
+        return;
+    lv_draw_image_normal_helper(t, dsc, coords, lv_draw_img_ppa_core, NULL);
+}
+
+static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
+                                 const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                                 const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
+{
+    LV_UNUSED(sup);
+
+    lv_layer_t * layer = t->target_layer;
+    lv_draw_buf_t * draw_buf = layer->draw_buf;
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
+    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
+
+    lv_area_t rel_clip_area;
+    lv_area_copy(&rel_clip_area, clipped_img_area);
+    lv_area_move(&rel_clip_area, -img_coords->x1, -img_coords->y1);
+
+    lv_area_t rel_img_coords;
+    lv_area_copy(&rel_img_coords, img_coords);
+    lv_area_move(&rel_img_coords, -img_coords->x1, -img_coords->y1);
+
+    lv_area_t src_area;
+    if(!lv_area_intersect(&src_area, &rel_clip_area, &rel_img_coords))
+        return;
+
+    lv_area_t dest_area;
+    lv_area_copy(&dest_area, clipped_img_area);
+    lv_area_move(&dest_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+
+    const uint8_t * src_buf = decoded->data;
+    lv_color_format_t src_cf = (lv_color_format_t)draw_dsc->header.cf;
+    lv_color_format_t dest_cf = (lv_color_format_t)draw_buf->header.cf;
+    uint8_t * dest_buf = draw_buf->data;
+
+    /* Use field-by-field assignment for C++ compatibility
+     * (C++ designated initializers must be in declaration order) */
+    ppa_blend_oper_config_t cfg;
+    lv_memzero(&cfg, sizeof(cfg));
+
+    /* Background input (source image) */
+    cfg.in_bg.buffer         = (void *)src_buf;
+    cfg.in_bg.pic_w          = draw_dsc->header.w;
+    cfg.in_bg.pic_h          = draw_dsc->header.h;
+    cfg.in_bg.block_w        = (uint32_t)lv_area_get_width(clipped_img_area);
+    cfg.in_bg.block_h        = (uint32_t)lv_area_get_height(clipped_img_area);
+    cfg.in_bg.block_offset_x = (uint32_t)src_area.x1;
+    cfg.in_bg.block_offset_y = (uint32_t)src_area.y1;
+    cfg.in_bg.blend_cm       = lv_color_format_to_ppa_blend(src_cf);
+
+    cfg.bg_rgb_swap          = false;
+    cfg.bg_byte_swap         = false;
+    cfg.bg_alpha_update_mode = PPA_ALPHA_FIX_VALUE;
+    cfg.bg_alpha_fix_val     = 0xFF;
+    cfg.bg_ck_en             = false;
+
+    /* Foreground input */
+    cfg.in_fg.buffer         = (void *)dest_buf;
+    cfg.in_fg.pic_w          = draw_dsc->header.w;
+    cfg.in_fg.pic_h          = draw_dsc->header.h;
+    cfg.in_fg.block_w        = (uint32_t)lv_area_get_width(clipped_img_area);
+    cfg.in_fg.block_h        = (uint32_t)lv_area_get_height(clipped_img_area);
+    cfg.in_fg.block_offset_x = (uint32_t)src_area.x1;
+    cfg.in_fg.block_offset_y = (uint32_t)src_area.y1;
+    cfg.in_fg.blend_cm       = PPA_BLEND_COLOR_MODE_A8;
+
+    cfg.fg_rgb_swap          = false;
+    cfg.fg_byte_swap         = false;
+    cfg.fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE;
+    cfg.fg_alpha_fix_val     = 0;
+    cfg.fg_ck_en             = false;
+
+    /* Output */
+    cfg.out.buffer           = dest_buf;
+    /* PPA hardware rejects unaligned out.buffer_size (issue #9868). */
+    cfg.out.buffer_size      = lv_draw_ppa_align_size(draw_buf->data_size);
+    cfg.out.pic_w            = draw_buf->header.w;
+    cfg.out.pic_h            = draw_buf->header.h;
+    cfg.out.block_offset_x   = (uint32_t)dest_area.x1;
+    cfg.out.block_offset_y   = (uint32_t)dest_area.y1;
+    cfg.out.blend_cm         = lv_color_format_to_ppa_blend(dest_cf);
+
+    cfg.mode                 = PPA_TRANS_MODE_BLOCKING;
+    cfg.user_data            = u;
+
+    esp_err_t ret = ppa_do_blend(u->blend_client, &cfg);
+    if(ret != ESP_OK) {
+        LV_LOG_ERROR("PPA blend failed: %d", ret);
+    }
+}
+
+#ifdef LV_USE_PPA_IMG
+
+void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                          const lv_area_t * coords)
+{
+    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN) return;
+
+    lv_draw_ppa_unit_t * u   = (lv_draw_ppa_unit_t *)t->draw_unit;
+    lv_layer_t * layer        = t->target_layer;
+    lv_draw_buf_t * dest_buf  = layer->draw_buf;
+
+    /* coords = image rect at 1:1 scale (may extend off-screen).
+     * Intersect with the render tile to get the actual visible clip. */
+    lv_area_t visible_area;
+    if(!lv_area_intersect(&visible_area, coords, &layer->buf_area)) return;
+
+    lv_image_decoder_dsc_t decoder_dsc;
+    lv_image_decoder_args_t dec_args;
+    lv_memzero(&dec_args, sizeof(dec_args));
+    dec_args.flush_cache = true;
+
+    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
+    if(res != LV_RESULT_OK) return;
+
+    const lv_draw_buf_t * decoded = decoder_dsc.decoded;
+    if(!decoded || !decoded->data) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    lv_color_format_t src_cf  = (lv_color_format_t)decoded->header.cf;
+    lv_color_format_t dest_cf = (lv_color_format_t)dest_buf->header.cf;
+    if(!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    float sx = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
+    float sy = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
+
+    uint32_t src_w = decoded->header.w;
+    uint32_t src_h = decoded->header.h;
+
+    /* Virtual image origin: pivot stays fixed on screen as scale changes.
+     * coords->x1/y1 = image top-left at 1:1 scale. */
+    float virt_x = (float)coords->x1 + (float)dsc->pivot.x * (1.0f - sx);
+    float virt_y = (float)coords->y1 + (float)dsc->pivot.y * (1.0f - sy);
+
+    /* Visible clip dimensions and buffer-local destination (always non-negative) */
+    int32_t clip_w = lv_area_get_width(&visible_area);
+    int32_t clip_h = lv_area_get_height(&visible_area);
+
+    lv_area_t dest_area;
+    lv_area_copy(&dest_area, &visible_area);
+    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+    /* Map visible tile top-left back into source image space */
+    int32_t src_bx = (int32_t)(((float)visible_area.x1 - virt_x) / sx);
+    int32_t src_by = (int32_t)(((float)visible_area.y1 - virt_y) / sy);
+
+    /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
+     * The PPA may render 1 pixel short; we fix that after the call. */
+    uint32_t src_bw = (uint32_t)ceilf((float)clip_w / sx);
+    uint32_t src_bh = (uint32_t)ceilf((float)clip_h / sy);
+
+    uint32_t avail_w = (uint32_t)(dest_buf->header.w - dest_area.x1);
+    uint32_t avail_h = (uint32_t)(dest_buf->header.h - dest_area.y1);
+    uint32_t max_src_bw = (uint32_t)floorf((float)avail_w / sx);
+    uint32_t max_src_bh = (uint32_t)floorf((float)avail_h / sy);
+    bool gap_right  = (src_bw > max_src_bw);
+    bool gap_bottom = (src_bh > max_src_bh);
+    if(src_bw > max_src_bw) src_bw = max_src_bw;
+    if(src_bh > max_src_bh) src_bh = max_src_bh;
+
+    if(src_bx < 0 || src_by < 0 ||
+       (uint32_t)src_bx >= src_w || (uint32_t)src_by >= src_h) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+    if((uint32_t)src_bx + src_bw > src_w) src_bw = src_w - (uint32_t)src_bx;
+    if((uint32_t)src_by + src_bh > src_h) src_bh = src_h - (uint32_t)src_by;
+    if(src_bw == 0 || src_bh == 0) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    if(decoded->data_size > 0) {
+        esp_cache_msync((void *)decoded->data,
+                        lv_draw_ppa_align_size(decoded->data_size),
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    }
+
+    uint32_t out_bpp = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
+                       (dest_cf == LV_COLOR_FORMAT_RGB888)  ? 3u : 4u;
+    uint32_t raw_bytes    = (uint32_t)dest_buf->header.w * dest_buf->header.h * out_bpp;
+    uint32_t aligned_size = lv_draw_ppa_align_size(raw_bytes);
+
+    ppa_srm_oper_config_t cfg;
+    lv_memzero(&cfg, sizeof(cfg));
+
+    cfg.in.buffer         = (void *)decoded->data;
+    cfg.in.pic_w          = src_w;
+    cfg.in.pic_h          = src_h;
+    cfg.in.block_w        = src_bw;
+    cfg.in.block_h        = src_bh;
+    cfg.in.block_offset_x = (uint32_t)src_bx;
+    cfg.in.block_offset_y = (uint32_t)src_by;
+    cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
+
+    uint8_t * aligned_out = NULL;
+    uint8_t * out_ptr     = dest_buf->data;
+
+    if(esp_ptr_external_ram(dest_buf->data) &&
+       !lv_draw_ppa_buf_cache_aligned(dest_buf->data)) {
+        aligned_out = (uint8_t *)heap_caps_aligned_alloc(
+            PPA_CACHE_LINE_SIZE, aligned_size,
+            MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if(!aligned_out) {
+            LV_LOG_ERROR("PPA SRM: aligned alloc failed (%u B)", (unsigned)aligned_size);
+            lv_image_decoder_close(&decoder_dsc);
+            return;
+        }
+        memcpy(aligned_out, dest_buf->data, raw_bytes);
+        esp_cache_msync(aligned_out, aligned_size,
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+        out_ptr = aligned_out;
+    }
+
+    cfg.out.buffer         = out_ptr;
+    cfg.out.buffer_size    = aligned_size;
+    cfg.out.pic_w          = dest_buf->header.w;
+    cfg.out.pic_h          = dest_buf->header.h;
+    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
+    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
+    cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
+
+    cfg.rotation_angle    = PPA_SRM_ROTATION_ANGLE_0;
+    cfg.scale_x           = sx;
+    cfg.scale_y           = sy;
+    cfg.mirror_x          = false;
+    cfg.mirror_y          = false;
+    cfg.rgb_swap          = false;
+    cfg.byte_swap         = false;
+    cfg.alpha_update_mode = PPA_ALPHA_NO_CHANGE;
+    cfg.mode              = PPA_TRANS_MODE_BLOCKING;
+    cfg.user_data         = u;
+
+    esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
+    if(ret != ESP_OK) {
+        LV_LOG_ERROR("PPA SRM scale failed: %d (src %ux%u scale %.2f/%.2f)",
+                     (int)ret, src_w, src_h, (double)sx, (double)sy);
+    }
+
+    /* PPA floorf rounding leaves a 1-pixel gap at right/bottom edges.
+     * Fill it by duplicating the last rendered column/row. Invalidate CPU
+     * cache first: PPA wrote via DMA, so CPU cache can be stale. */
+    if(ret == ESP_OK && (gap_right || gap_bottom)) {
+        esp_cache_msync(out_ptr, aligned_size,
+                        ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+
+        uint8_t *base = out_ptr;
+        uint32_t stride = dest_buf->header.w * out_bpp;
+
+        if(gap_right && clip_w >= 2) {
+            uint32_t col = dest_area.x1 + (uint32_t)clip_w - 1;
+            uint32_t col_prev = col - 1;
+            for(int32_t y = 0; y < clip_h; y++) {
+                uint32_t row_off = (dest_area.y1 + (uint32_t)y) * stride;
+                lv_memcpy(base + row_off + col * out_bpp,
+                          base + row_off + col_prev * out_bpp, out_bpp);
+            }
+        }
+        if(gap_bottom && clip_h >= 2) {
+            uint32_t row = dest_area.y1 + (uint32_t)clip_h - 1;
+            uint32_t row_prev = row - 1;
+            lv_memcpy(base + row * stride + dest_area.x1 * out_bpp,
+                      base + row_prev * stride + dest_area.x1 * out_bpp,
+                      (uint32_t)clip_w * out_bpp);
+        }
+
+        esp_cache_msync(out_ptr, aligned_size,
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    }
+
+    if(aligned_out) {
+        if(ret == ESP_OK) {
+            esp_cache_msync(aligned_out, aligned_size,
+                            ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+            memcpy(dest_buf->data, aligned_out, raw_bytes);
+        }
+        heap_caps_free(aligned_out);
+    }
+
+    lv_image_decoder_close(&decoder_dsc);
+}
+
+/**
+ * PPA SRM hardware-accelerated image rotation (0/90/180/270 degrees)
+ * Uses the ESP32-P4 PPA Scale-Rotate-Mirror engine for zero-CPU-cost rotation.
+ */
+void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
+                            const lv_area_t * coords)
+{
+    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
+        return;
+
+    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
+    lv_layer_t * layer = t->target_layer;
+    lv_draw_buf_t * dest_buf = layer->draw_buf;
+
+    /* Decode the source image */
+    lv_image_decoder_dsc_t decoder_dsc;
+    lv_image_decoder_args_t dec_args;
+    lv_memzero(&dec_args, sizeof(dec_args));
+    dec_args.stride_align = false;
+    dec_args.premultiply = false;
+    dec_args.no_cache = false;
+    dec_args.use_indexed = false;
+    dec_args.flush_cache = true;  /* Ensure cache coherency for PPA DMA */
+
+    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
+    if(res != LV_RESULT_OK) {
+        LV_LOG_WARN("PPA SRM: failed to decode image");
+        return;
+    }
+
+    const lv_draw_buf_t * decoded = decoder_dsc.decoded;
+    if(!decoded || !decoded->data) {
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    lv_color_format_t src_cf = (lv_color_format_t)decoded->header.cf;
+    lv_color_format_t dest_cf = (lv_color_format_t)dest_buf->header.cf;
+
+    /* Verify PPA format support for both source and destination */
+    if(!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
+        LV_LOG_WARN("PPA SRM: unsupported color format src=%d dest=%d", src_cf, dest_cf);
+        lv_image_decoder_close(&decoder_dsc);
+        return;
+    }
+
+    /* Map LVGL rotation (clockwise, 0.1 deg units) to PPA rotation (counter-clockwise) */
+    int32_t angle = dsc->rotation % 3600;
+    if(angle < 0) angle += 3600;
+
+    ppa_srm_rotation_angle_t ppa_rot;
+    switch(angle) {
+        case 0:    ppa_rot = PPA_SRM_ROTATION_ANGLE_0;   break;
+        case 900:  ppa_rot = PPA_SRM_ROTATION_ANGLE_270; break;  /* 90 deg CW = 270 deg CCW */
+        case 1800: ppa_rot = PPA_SRM_ROTATION_ANGLE_180; break;
+        case 2700: ppa_rot = PPA_SRM_ROTATION_ANGLE_90;  break;  /* 270 deg CW = 90 deg CCW */
+        default:
+            lv_image_decoder_close(&decoder_dsc);
+            return;
+    }
+
+    uint32_t src_w = decoded->header.w;
+    uint32_t src_h = decoded->header.h;
+
+    /* Compute destination area relative to layer buffer origin */
+    lv_area_t dest_area;
+    lv_area_copy(&dest_area, &t->area);
+    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+    /* Flush decoded source buffer for PPA DMA access. Align size to cache
+     * line; _UNALIGNED flag is only a safety net for the address. */
+    if(decoded->data_size > 0) {
+        esp_cache_msync((void *)decoded->data,
+                        lv_draw_ppa_align_size(decoded->data_size),
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    }
+
+    /* Configure PPA SRM operation */
+    ppa_srm_oper_config_t cfg;
+    lv_memzero(&cfg, sizeof(cfg));
+
+    /* Input: full source image block */
+    cfg.in.buffer         = (void *)decoded->data;
+    cfg.in.pic_w          = src_w;
+    cfg.in.pic_h          = src_h;
+    cfg.in.block_w        = src_w;
+    cfg.in.block_h        = src_h;
+    cfg.in.block_offset_x = 0;
+    cfg.in.block_offset_y = 0;
+    cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
+
+    uint32_t out_bpp_r = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
+                         (dest_cf == LV_COLOR_FORMAT_RGB888)  ? 3u : 4u;
+    uint32_t raw_bytes_r    = (uint32_t)dest_buf->header.w * dest_buf->header.h * out_bpp_r;
+    uint32_t aligned_size_r = lv_draw_ppa_align_size(raw_bytes_r);
+
+    uint8_t * aligned_out_r = NULL;
+    uint8_t * out_ptr_r     = dest_buf->data;
+
+    if(esp_ptr_external_ram(dest_buf->data) &&
+       !lv_draw_ppa_buf_cache_aligned(dest_buf->data)) {
+        aligned_out_r = (uint8_t *)heap_caps_aligned_alloc(
+            PPA_CACHE_LINE_SIZE, aligned_size_r,
+            MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        if(!aligned_out_r) {
+            LV_LOG_ERROR("PPA SRM rotate: aligned alloc failed");
+            lv_image_decoder_close(&decoder_dsc);
+            return;
+        }
+        memcpy(aligned_out_r, dest_buf->data, raw_bytes_r);
+        esp_cache_msync(aligned_out_r, aligned_size_r,
+                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+        out_ptr_r = aligned_out_r;
+    }
+
+    cfg.out.buffer         = out_ptr_r;
+    cfg.out.buffer_size    = aligned_size_r;
+    cfg.out.pic_w          = dest_buf->header.w;
+    cfg.out.pic_h          = dest_buf->header.h;
+    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
+    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
+    cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
+
+    cfg.rotation_angle     = ppa_rot;
+    cfg.scale_x            = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
+    cfg.scale_y            = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
+    cfg.mirror_x           = false;
+    cfg.mirror_y           = false;
+    cfg.rgb_swap           = false;
+    cfg.byte_swap          = false;
+    cfg.alpha_update_mode  = PPA_ALPHA_NO_CHANGE;
+    cfg.mode               = PPA_TRANS_MODE_BLOCKING;
+    cfg.user_data          = u;
+
+    esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
+    if(ret != ESP_OK) {
+        LV_LOG_ERROR("PPA SRM rotation failed: %d  (src %ux%u, angle %d)", (int)ret, src_w, src_h, angle);
+    }
+
+    if(aligned_out_r) {
+        if(ret == ESP_OK) {
+            esp_cache_msync(aligned_out_r, aligned_size_r,
+                            ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+            memcpy(dest_buf->data, aligned_out_r, raw_bytes_r);
+        }
+        heap_caps_free(aligned_out_r);
+    }
+
+    lv_image_decoder_close(&decoder_dsc);
+}
+
+#endif /* LV_USE_PPA_IMG */
+
+#endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_img.c
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_img.c
@@ -16,452 +16,443 @@
 #include <math.h>
 #include <string.h>
 
-static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
-                                 const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
-                                 const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
+static void lv_draw_img_ppa_core(lv_draw_task_t *t, const lv_draw_image_dsc_t *draw_dsc,
+                                 const lv_image_decoder_dsc_t *decoder_dsc, lv_draw_image_sup_t *sup,
+                                 const lv_area_t *img_coords, const lv_area_t *clipped_img_area);
 
-
-void lv_draw_ppa_img(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
-                     const lv_area_t * coords)
-{
-    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
-        return;
-    lv_draw_image_normal_helper(t, dsc, coords, lv_draw_img_ppa_core, NULL);
+void lv_draw_ppa_img(lv_draw_task_t *t, const lv_draw_image_dsc_t *dsc, const lv_area_t *coords) {
+  if (dsc->opa <= (lv_opa_t) LV_OPA_MIN)
+    return;
+  lv_draw_image_normal_helper(t, dsc, coords, lv_draw_img_ppa_core, NULL);
 }
 
-static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_dsc,
-                                 const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
-                                 const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
-{
-    LV_UNUSED(sup);
+static void lv_draw_img_ppa_core(lv_draw_task_t *t, const lv_draw_image_dsc_t *draw_dsc,
+                                 const lv_image_decoder_dsc_t *decoder_dsc, lv_draw_image_sup_t *sup,
+                                 const lv_area_t *img_coords, const lv_area_t *clipped_img_area) {
+  LV_UNUSED(sup);
 
-    lv_layer_t * layer = t->target_layer;
-    lv_draw_buf_t * draw_buf = layer->draw_buf;
-    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
-    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
+  lv_layer_t *layer = t->target_layer;
+  lv_draw_buf_t *draw_buf = layer->draw_buf;
+  const lv_draw_buf_t *decoded = decoder_dsc->decoded;
+  lv_draw_ppa_unit_t *u = (lv_draw_ppa_unit_t *) t->draw_unit;
 
-    lv_area_t rel_clip_area;
-    lv_area_copy(&rel_clip_area, clipped_img_area);
-    lv_area_move(&rel_clip_area, -img_coords->x1, -img_coords->y1);
+  lv_area_t rel_clip_area;
+  lv_area_copy(&rel_clip_area, clipped_img_area);
+  lv_area_move(&rel_clip_area, -img_coords->x1, -img_coords->y1);
 
-    lv_area_t rel_img_coords;
-    lv_area_copy(&rel_img_coords, img_coords);
-    lv_area_move(&rel_img_coords, -img_coords->x1, -img_coords->y1);
+  lv_area_t rel_img_coords;
+  lv_area_copy(&rel_img_coords, img_coords);
+  lv_area_move(&rel_img_coords, -img_coords->x1, -img_coords->y1);
 
-    lv_area_t src_area;
-    if(!lv_area_intersect(&src_area, &rel_clip_area, &rel_img_coords))
-        return;
+  lv_area_t src_area;
+  if (!lv_area_intersect(&src_area, &rel_clip_area, &rel_img_coords))
+    return;
 
-    lv_area_t dest_area;
-    lv_area_copy(&dest_area, clipped_img_area);
-    lv_area_move(&dest_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
+  lv_area_t dest_area;
+  lv_area_copy(&dest_area, clipped_img_area);
+  lv_area_move(&dest_area, -t->target_layer->buf_area.x1, -t->target_layer->buf_area.y1);
 
-    const uint8_t * src_buf = decoded->data;
-    lv_color_format_t src_cf = (lv_color_format_t)draw_dsc->header.cf;
-    lv_color_format_t dest_cf = (lv_color_format_t)draw_buf->header.cf;
-    uint8_t * dest_buf = draw_buf->data;
+  const uint8_t *src_buf = decoded->data;
+  lv_color_format_t src_cf = (lv_color_format_t) draw_dsc->header.cf;
+  lv_color_format_t dest_cf = (lv_color_format_t) draw_buf->header.cf;
+  uint8_t *dest_buf = draw_buf->data;
 
-    /* Use field-by-field assignment for C++ compatibility
-     * (C++ designated initializers must be in declaration order) */
-    ppa_blend_oper_config_t cfg;
-    lv_memzero(&cfg, sizeof(cfg));
+  /* Use field-by-field assignment for C++ compatibility
+   * (C++ designated initializers must be in declaration order) */
+  ppa_blend_oper_config_t cfg;
+  lv_memzero(&cfg, sizeof(cfg));
 
-    /* Background input (source image) */
-    cfg.in_bg.buffer         = (void *)src_buf;
-    cfg.in_bg.pic_w          = draw_dsc->header.w;
-    cfg.in_bg.pic_h          = draw_dsc->header.h;
-    cfg.in_bg.block_w        = (uint32_t)lv_area_get_width(clipped_img_area);
-    cfg.in_bg.block_h        = (uint32_t)lv_area_get_height(clipped_img_area);
-    cfg.in_bg.block_offset_x = (uint32_t)src_area.x1;
-    cfg.in_bg.block_offset_y = (uint32_t)src_area.y1;
-    cfg.in_bg.blend_cm       = lv_color_format_to_ppa_blend(src_cf);
+  /* Background input (source image) */
+  cfg.in_bg.buffer = (void *) src_buf;
+  cfg.in_bg.pic_w = draw_dsc->header.w;
+  cfg.in_bg.pic_h = draw_dsc->header.h;
+  cfg.in_bg.block_w = (uint32_t) lv_area_get_width(clipped_img_area);
+  cfg.in_bg.block_h = (uint32_t) lv_area_get_height(clipped_img_area);
+  cfg.in_bg.block_offset_x = (uint32_t) src_area.x1;
+  cfg.in_bg.block_offset_y = (uint32_t) src_area.y1;
+  cfg.in_bg.blend_cm = lv_color_format_to_ppa_blend(src_cf);
 
-    cfg.bg_rgb_swap          = false;
-    cfg.bg_byte_swap         = false;
-    cfg.bg_alpha_update_mode = PPA_ALPHA_FIX_VALUE;
-    cfg.bg_alpha_fix_val     = 0xFF;
-    cfg.bg_ck_en             = false;
+  cfg.bg_rgb_swap = false;
+  cfg.bg_byte_swap = false;
+  cfg.bg_alpha_update_mode = PPA_ALPHA_FIX_VALUE;
+  cfg.bg_alpha_fix_val = 0xFF;
+  cfg.bg_ck_en = false;
 
-    /* Foreground input */
-    cfg.in_fg.buffer         = (void *)dest_buf;
-    cfg.in_fg.pic_w          = draw_dsc->header.w;
-    cfg.in_fg.pic_h          = draw_dsc->header.h;
-    cfg.in_fg.block_w        = (uint32_t)lv_area_get_width(clipped_img_area);
-    cfg.in_fg.block_h        = (uint32_t)lv_area_get_height(clipped_img_area);
-    cfg.in_fg.block_offset_x = (uint32_t)src_area.x1;
-    cfg.in_fg.block_offset_y = (uint32_t)src_area.y1;
-    cfg.in_fg.blend_cm       = PPA_BLEND_COLOR_MODE_A8;
+  /* Foreground input */
+  cfg.in_fg.buffer = (void *) dest_buf;
+  cfg.in_fg.pic_w = draw_dsc->header.w;
+  cfg.in_fg.pic_h = draw_dsc->header.h;
+  cfg.in_fg.block_w = (uint32_t) lv_area_get_width(clipped_img_area);
+  cfg.in_fg.block_h = (uint32_t) lv_area_get_height(clipped_img_area);
+  cfg.in_fg.block_offset_x = (uint32_t) src_area.x1;
+  cfg.in_fg.block_offset_y = (uint32_t) src_area.y1;
+  cfg.in_fg.blend_cm = PPA_BLEND_COLOR_MODE_A8;
 
-    cfg.fg_rgb_swap          = false;
-    cfg.fg_byte_swap         = false;
-    cfg.fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE;
-    cfg.fg_alpha_fix_val     = 0;
-    cfg.fg_ck_en             = false;
+  cfg.fg_rgb_swap = false;
+  cfg.fg_byte_swap = false;
+  cfg.fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE;
+  cfg.fg_alpha_fix_val = 0;
+  cfg.fg_ck_en = false;
 
-    /* Output */
-    cfg.out.buffer           = dest_buf;
-    /* PPA hardware rejects unaligned out.buffer_size (issue #9868). */
-    cfg.out.buffer_size      = lv_draw_ppa_align_size(draw_buf->data_size);
-    cfg.out.pic_w            = draw_buf->header.w;
-    cfg.out.pic_h            = draw_buf->header.h;
-    cfg.out.block_offset_x   = (uint32_t)dest_area.x1;
-    cfg.out.block_offset_y   = (uint32_t)dest_area.y1;
-    cfg.out.blend_cm         = lv_color_format_to_ppa_blend(dest_cf);
+  /* Output */
+  cfg.out.buffer = dest_buf;
+  /* PPA hardware rejects unaligned out.buffer_size (issue #9868). */
+  cfg.out.buffer_size = lv_draw_ppa_align_size(draw_buf->data_size);
+  cfg.out.pic_w = draw_buf->header.w;
+  cfg.out.pic_h = draw_buf->header.h;
+  cfg.out.block_offset_x = (uint32_t) dest_area.x1;
+  cfg.out.block_offset_y = (uint32_t) dest_area.y1;
+  cfg.out.blend_cm = lv_color_format_to_ppa_blend(dest_cf);
 
-    cfg.mode                 = PPA_TRANS_MODE_BLOCKING;
-    cfg.user_data            = u;
+  cfg.mode = PPA_TRANS_MODE_BLOCKING;
+  cfg.user_data = u;
 
-    esp_err_t ret = ppa_do_blend(u->blend_client, &cfg);
-    if(ret != ESP_OK) {
-        LV_LOG_ERROR("PPA blend failed: %d", ret);
-    }
+  esp_err_t ret = ppa_do_blend(u->blend_client, &cfg);
+  if (ret != ESP_OK) {
+    LV_LOG_ERROR("PPA blend failed: %d", ret);
+  }
 }
 
 #ifdef LV_USE_PPA_IMG
 
-void lv_draw_ppa_img_srm(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
-                          const lv_area_t * coords)
-{
-    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN) return;
+void lv_draw_ppa_img_srm(lv_draw_task_t *t, const lv_draw_image_dsc_t *dsc, const lv_area_t *coords) {
+  if (dsc->opa <= (lv_opa_t) LV_OPA_MIN)
+    return;
 
-    lv_draw_ppa_unit_t * u   = (lv_draw_ppa_unit_t *)t->draw_unit;
-    lv_layer_t * layer        = t->target_layer;
-    lv_draw_buf_t * dest_buf  = layer->draw_buf;
+  lv_draw_ppa_unit_t *u = (lv_draw_ppa_unit_t *) t->draw_unit;
+  lv_layer_t *layer = t->target_layer;
+  lv_draw_buf_t *dest_buf = layer->draw_buf;
 
-    /* coords = image rect at 1:1 scale (may extend off-screen).
-     * Intersect with the render tile to get the actual visible clip. */
-    lv_area_t visible_area;
-    if(!lv_area_intersect(&visible_area, coords, &layer->buf_area)) return;
+  /* coords = image rect at 1:1 scale (may extend off-screen).
+   * Intersect with the render tile to get the actual visible clip. */
+  lv_area_t visible_area;
+  if (!lv_area_intersect(&visible_area, coords, &layer->buf_area))
+    return;
 
-    lv_image_decoder_dsc_t decoder_dsc;
-    lv_image_decoder_args_t dec_args;
-    lv_memzero(&dec_args, sizeof(dec_args));
-    dec_args.flush_cache = true;
+  lv_image_decoder_dsc_t decoder_dsc;
+  lv_image_decoder_args_t dec_args;
+  lv_memzero(&dec_args, sizeof(dec_args));
+  dec_args.flush_cache = true;
 
-    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
-    if(res != LV_RESULT_OK) return;
+  lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
+  if (res != LV_RESULT_OK)
+    return;
 
-    const lv_draw_buf_t * decoded = decoder_dsc.decoded;
-    if(!decoded || !decoded->data) {
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-
-    lv_color_format_t src_cf  = (lv_color_format_t)decoded->header.cf;
-    lv_color_format_t dest_cf = (lv_color_format_t)dest_buf->header.cf;
-    if(!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-
-    float sx = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
-    float sy = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
-
-    uint32_t src_w = decoded->header.w;
-    uint32_t src_h = decoded->header.h;
-
-    /* Virtual image origin: pivot stays fixed on screen as scale changes.
-     * coords->x1/y1 = image top-left at 1:1 scale. */
-    float virt_x = (float)coords->x1 + (float)dsc->pivot.x * (1.0f - sx);
-    float virt_y = (float)coords->y1 + (float)dsc->pivot.y * (1.0f - sy);
-
-    /* Visible clip dimensions and buffer-local destination (always non-negative) */
-    int32_t clip_w = lv_area_get_width(&visible_area);
-    int32_t clip_h = lv_area_get_height(&visible_area);
-
-    lv_area_t dest_area;
-    lv_area_copy(&dest_area, &visible_area);
-    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
-
-    /* Map visible tile top-left back into source image space */
-    int32_t src_bx = (int32_t)(((float)visible_area.x1 - virt_x) / sx);
-    int32_t src_by = (int32_t)(((float)visible_area.y1 - virt_y) / sy);
-
-    /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
-     * The PPA may render 1 pixel short; we fix that after the call. */
-    uint32_t src_bw = (uint32_t)ceilf((float)clip_w / sx);
-    uint32_t src_bh = (uint32_t)ceilf((float)clip_h / sy);
-
-    uint32_t avail_w = (uint32_t)(dest_buf->header.w - dest_area.x1);
-    uint32_t avail_h = (uint32_t)(dest_buf->header.h - dest_area.y1);
-    uint32_t max_src_bw = (uint32_t)floorf((float)avail_w / sx);
-    uint32_t max_src_bh = (uint32_t)floorf((float)avail_h / sy);
-    bool gap_right  = (src_bw > max_src_bw);
-    bool gap_bottom = (src_bh > max_src_bh);
-    if(src_bw > max_src_bw) src_bw = max_src_bw;
-    if(src_bh > max_src_bh) src_bh = max_src_bh;
-
-    if(src_bx < 0 || src_by < 0 ||
-       (uint32_t)src_bx >= src_w || (uint32_t)src_by >= src_h) {
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-    if((uint32_t)src_bx + src_bw > src_w) src_bw = src_w - (uint32_t)src_bx;
-    if((uint32_t)src_by + src_bh > src_h) src_bh = src_h - (uint32_t)src_by;
-    if(src_bw == 0 || src_bh == 0) {
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-
-    if(decoded->data_size > 0) {
-        esp_cache_msync((void *)decoded->data,
-                        lv_draw_ppa_align_size(decoded->data_size),
-                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
-    }
-
-    uint32_t out_bpp = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
-                       (dest_cf == LV_COLOR_FORMAT_RGB888)  ? 3u : 4u;
-    uint32_t raw_bytes    = (uint32_t)dest_buf->header.w * dest_buf->header.h * out_bpp;
-    uint32_t aligned_size = lv_draw_ppa_align_size(raw_bytes);
-
-    ppa_srm_oper_config_t cfg;
-    lv_memzero(&cfg, sizeof(cfg));
-
-    cfg.in.buffer         = (void *)decoded->data;
-    cfg.in.pic_w          = src_w;
-    cfg.in.pic_h          = src_h;
-    cfg.in.block_w        = src_bw;
-    cfg.in.block_h        = src_bh;
-    cfg.in.block_offset_x = (uint32_t)src_bx;
-    cfg.in.block_offset_y = (uint32_t)src_by;
-    cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
-
-    uint8_t * aligned_out = NULL;
-    uint8_t * out_ptr     = dest_buf->data;
-
-    if(esp_ptr_external_ram(dest_buf->data) &&
-       !lv_draw_ppa_buf_cache_aligned(dest_buf->data)) {
-        aligned_out = (uint8_t *)heap_caps_aligned_alloc(
-            PPA_CACHE_LINE_SIZE, aligned_size,
-            MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        if(!aligned_out) {
-            LV_LOG_ERROR("PPA SRM: aligned alloc failed (%u B)", (unsigned)aligned_size);
-            lv_image_decoder_close(&decoder_dsc);
-            return;
-        }
-        memcpy(aligned_out, dest_buf->data, raw_bytes);
-        esp_cache_msync(aligned_out, aligned_size,
-                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
-        out_ptr = aligned_out;
-    }
-
-    cfg.out.buffer         = out_ptr;
-    cfg.out.buffer_size    = aligned_size;
-    cfg.out.pic_w          = dest_buf->header.w;
-    cfg.out.pic_h          = dest_buf->header.h;
-    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
-    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
-    cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
-
-    cfg.rotation_angle    = PPA_SRM_ROTATION_ANGLE_0;
-    cfg.scale_x           = sx;
-    cfg.scale_y           = sy;
-    cfg.mirror_x          = false;
-    cfg.mirror_y          = false;
-    cfg.rgb_swap          = false;
-    cfg.byte_swap         = false;
-    cfg.alpha_update_mode = PPA_ALPHA_NO_CHANGE;
-    cfg.mode              = PPA_TRANS_MODE_BLOCKING;
-    cfg.user_data         = u;
-
-    esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
-    if(ret != ESP_OK) {
-        LV_LOG_ERROR("PPA SRM scale failed: %d (src %ux%u scale %.2f/%.2f)",
-                     (int)ret, src_w, src_h, (double)sx, (double)sy);
-    }
-
-    /* PPA floorf rounding leaves a 1-pixel gap at right/bottom edges.
-     * Fill it by duplicating the last rendered column/row. Invalidate CPU
-     * cache first: PPA wrote via DMA, so CPU cache can be stale. */
-    if(ret == ESP_OK && (gap_right || gap_bottom)) {
-        esp_cache_msync(out_ptr, aligned_size,
-                        ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
-
-        uint8_t *base = out_ptr;
-        uint32_t stride = dest_buf->header.w * out_bpp;
-
-        if(gap_right && clip_w >= 2) {
-            uint32_t col = dest_area.x1 + (uint32_t)clip_w - 1;
-            uint32_t col_prev = col - 1;
-            for(int32_t y = 0; y < clip_h; y++) {
-                uint32_t row_off = (dest_area.y1 + (uint32_t)y) * stride;
-                lv_memcpy(base + row_off + col * out_bpp,
-                          base + row_off + col_prev * out_bpp, out_bpp);
-            }
-        }
-        if(gap_bottom && clip_h >= 2) {
-            uint32_t row = dest_area.y1 + (uint32_t)clip_h - 1;
-            uint32_t row_prev = row - 1;
-            lv_memcpy(base + row * stride + dest_area.x1 * out_bpp,
-                      base + row_prev * stride + dest_area.x1 * out_bpp,
-                      (uint32_t)clip_w * out_bpp);
-        }
-
-        esp_cache_msync(out_ptr, aligned_size,
-                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
-    }
-
-    if(aligned_out) {
-        if(ret == ESP_OK) {
-            esp_cache_msync(aligned_out, aligned_size,
-                            ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
-            memcpy(dest_buf->data, aligned_out, raw_bytes);
-        }
-        heap_caps_free(aligned_out);
-    }
-
+  const lv_draw_buf_t *decoded = decoder_dsc.decoded;
+  if (!decoded || !decoded->data) {
     lv_image_decoder_close(&decoder_dsc);
+    return;
+  }
+
+  lv_color_format_t src_cf = (lv_color_format_t) decoded->header.cf;
+  lv_color_format_t dest_cf = (lv_color_format_t) dest_buf->header.cf;
+  if (!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
+    lv_image_decoder_close(&decoder_dsc);
+    return;
+  }
+
+  float sx = (dsc->scale_x != LV_SCALE_NONE) ? ((float) dsc->scale_x / 256.0f) : 1.0f;
+  float sy = (dsc->scale_y != LV_SCALE_NONE) ? ((float) dsc->scale_y / 256.0f) : 1.0f;
+
+  uint32_t src_w = decoded->header.w;
+  uint32_t src_h = decoded->header.h;
+
+  /* Virtual image origin: pivot stays fixed on screen as scale changes.
+   * coords->x1/y1 = image top-left at 1:1 scale. */
+  float virt_x = (float) coords->x1 + (float) dsc->pivot.x * (1.0f - sx);
+  float virt_y = (float) coords->y1 + (float) dsc->pivot.y * (1.0f - sy);
+
+  /* Visible clip dimensions and buffer-local destination (always non-negative) */
+  int32_t clip_w = lv_area_get_width(&visible_area);
+  int32_t clip_h = lv_area_get_height(&visible_area);
+
+  lv_area_t dest_area;
+  lv_area_copy(&dest_area, &visible_area);
+  lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+  /* Map visible tile top-left back into source image space */
+  int32_t src_bx = (int32_t) (((float) visible_area.x1 - virt_x) / sx);
+  int32_t src_by = (int32_t) (((float) visible_area.y1 - virt_y) / sy);
+
+  /* ceilf gives the ideal source block; floorf clamp keeps PPA happy.
+   * The PPA may render 1 pixel short; we fix that after the call. */
+  uint32_t src_bw = (uint32_t) ceilf((float) clip_w / sx);
+  uint32_t src_bh = (uint32_t) ceilf((float) clip_h / sy);
+
+  uint32_t avail_w = (uint32_t) (dest_buf->header.w - dest_area.x1);
+  uint32_t avail_h = (uint32_t) (dest_buf->header.h - dest_area.y1);
+  uint32_t max_src_bw = (uint32_t) floorf((float) avail_w / sx);
+  uint32_t max_src_bh = (uint32_t) floorf((float) avail_h / sy);
+  bool gap_right = (src_bw > max_src_bw);
+  bool gap_bottom = (src_bh > max_src_bh);
+  if (src_bw > max_src_bw)
+    src_bw = max_src_bw;
+  if (src_bh > max_src_bh)
+    src_bh = max_src_bh;
+
+  if (src_bx < 0 || src_by < 0 || (uint32_t) src_bx >= src_w || (uint32_t) src_by >= src_h) {
+    lv_image_decoder_close(&decoder_dsc);
+    return;
+  }
+  if ((uint32_t) src_bx + src_bw > src_w)
+    src_bw = src_w - (uint32_t) src_bx;
+  if ((uint32_t) src_by + src_bh > src_h)
+    src_bh = src_h - (uint32_t) src_by;
+  if (src_bw == 0 || src_bh == 0) {
+    lv_image_decoder_close(&decoder_dsc);
+    return;
+  }
+
+  if (decoded->data_size > 0) {
+    esp_cache_msync((void *) decoded->data, lv_draw_ppa_align_size(decoded->data_size),
+                    ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+  }
+
+  uint32_t out_bpp = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u : (dest_cf == LV_COLOR_FORMAT_RGB888) ? 3u : 4u;
+  uint32_t raw_bytes = (uint32_t) dest_buf->header.w * dest_buf->header.h * out_bpp;
+  uint32_t aligned_size = lv_draw_ppa_align_size(raw_bytes);
+
+  ppa_srm_oper_config_t cfg;
+  lv_memzero(&cfg, sizeof(cfg));
+
+  cfg.in.buffer = (void *) decoded->data;
+  cfg.in.pic_w = src_w;
+  cfg.in.pic_h = src_h;
+  cfg.in.block_w = src_bw;
+  cfg.in.block_h = src_bh;
+  cfg.in.block_offset_x = (uint32_t) src_bx;
+  cfg.in.block_offset_y = (uint32_t) src_by;
+  cfg.in.srm_cm = lv_color_format_to_ppa_srm(src_cf);
+
+  uint8_t *aligned_out = NULL;
+  uint8_t *out_ptr = dest_buf->data;
+
+  if (esp_ptr_external_ram(dest_buf->data) && !lv_draw_ppa_buf_cache_aligned(dest_buf->data)) {
+    aligned_out =
+        (uint8_t *) heap_caps_aligned_alloc(PPA_CACHE_LINE_SIZE, aligned_size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!aligned_out) {
+      LV_LOG_ERROR("PPA SRM: aligned alloc failed (%u B)", (unsigned) aligned_size);
+      lv_image_decoder_close(&decoder_dsc);
+      return;
+    }
+    memcpy(aligned_out, dest_buf->data, raw_bytes);
+    esp_cache_msync(aligned_out, aligned_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    out_ptr = aligned_out;
+  }
+
+  cfg.out.buffer = out_ptr;
+  cfg.out.buffer_size = aligned_size;
+  cfg.out.pic_w = dest_buf->header.w;
+  cfg.out.pic_h = dest_buf->header.h;
+  cfg.out.block_offset_x = (uint32_t) dest_area.x1;
+  cfg.out.block_offset_y = (uint32_t) dest_area.y1;
+  cfg.out.srm_cm = lv_color_format_to_ppa_srm(dest_cf);
+
+  cfg.rotation_angle = PPA_SRM_ROTATION_ANGLE_0;
+  cfg.scale_x = sx;
+  cfg.scale_y = sy;
+  cfg.mirror_x = false;
+  cfg.mirror_y = false;
+  cfg.rgb_swap = false;
+  cfg.byte_swap = false;
+  cfg.alpha_update_mode = PPA_ALPHA_NO_CHANGE;
+  cfg.mode = PPA_TRANS_MODE_BLOCKING;
+  cfg.user_data = u;
+
+  esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
+  if (ret != ESP_OK) {
+    LV_LOG_ERROR("PPA SRM scale failed: %d (src %ux%u scale %.2f/%.2f)", (int) ret, src_w, src_h, (double) sx,
+                 (double) sy);
+  }
+
+  /* PPA floorf rounding leaves a 1-pixel gap at right/bottom edges.
+   * Fill it by duplicating the last rendered column/row. Invalidate CPU
+   * cache first: PPA wrote via DMA, so CPU cache can be stale. */
+  if (ret == ESP_OK && (gap_right || gap_bottom)) {
+    esp_cache_msync(out_ptr, aligned_size, ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+
+    uint8_t *base = out_ptr;
+    uint32_t stride = dest_buf->header.w * out_bpp;
+
+    if (gap_right && clip_w >= 2) {
+      uint32_t col = dest_area.x1 + (uint32_t) clip_w - 1;
+      uint32_t col_prev = col - 1;
+      for (int32_t y = 0; y < clip_h; y++) {
+        uint32_t row_off = (dest_area.y1 + (uint32_t) y) * stride;
+        lv_memcpy(base + row_off + col * out_bpp, base + row_off + col_prev * out_bpp, out_bpp);
+      }
+    }
+    if (gap_bottom && clip_h >= 2) {
+      uint32_t row = dest_area.y1 + (uint32_t) clip_h - 1;
+      uint32_t row_prev = row - 1;
+      lv_memcpy(base + row * stride + dest_area.x1 * out_bpp, base + row_prev * stride + dest_area.x1 * out_bpp,
+                (uint32_t) clip_w * out_bpp);
+    }
+
+    esp_cache_msync(out_ptr, aligned_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+  }
+
+  if (aligned_out) {
+    if (ret == ESP_OK) {
+      esp_cache_msync(aligned_out, aligned_size, ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+      memcpy(dest_buf->data, aligned_out, raw_bytes);
+    }
+    heap_caps_free(aligned_out);
+  }
+
+  lv_image_decoder_close(&decoder_dsc);
 }
 
 /**
  * PPA SRM hardware-accelerated image rotation (0/90/180/270 degrees)
  * Uses the ESP32-P4 PPA Scale-Rotate-Mirror engine for zero-CPU-cost rotation.
  */
-void lv_draw_ppa_img_rotate(lv_draw_task_t * t, const lv_draw_image_dsc_t * dsc,
-                            const lv_area_t * coords)
-{
-    if(dsc->opa <= (lv_opa_t)LV_OPA_MIN)
-        return;
+void lv_draw_ppa_img_rotate(lv_draw_task_t *t, const lv_draw_image_dsc_t *dsc, const lv_area_t *coords) {
+  if (dsc->opa <= (lv_opa_t) LV_OPA_MIN)
+    return;
 
-    lv_draw_ppa_unit_t * u = (lv_draw_ppa_unit_t *)t->draw_unit;
-    lv_layer_t * layer = t->target_layer;
-    lv_draw_buf_t * dest_buf = layer->draw_buf;
+  lv_draw_ppa_unit_t *u = (lv_draw_ppa_unit_t *) t->draw_unit;
+  lv_layer_t *layer = t->target_layer;
+  lv_draw_buf_t *dest_buf = layer->draw_buf;
 
-    /* Decode the source image */
-    lv_image_decoder_dsc_t decoder_dsc;
-    lv_image_decoder_args_t dec_args;
-    lv_memzero(&dec_args, sizeof(dec_args));
-    dec_args.stride_align = false;
-    dec_args.premultiply = false;
-    dec_args.no_cache = false;
-    dec_args.use_indexed = false;
-    dec_args.flush_cache = true;  /* Ensure cache coherency for PPA DMA */
+  /* Decode the source image */
+  lv_image_decoder_dsc_t decoder_dsc;
+  lv_image_decoder_args_t dec_args;
+  lv_memzero(&dec_args, sizeof(dec_args));
+  dec_args.stride_align = false;
+  dec_args.premultiply = false;
+  dec_args.no_cache = false;
+  dec_args.use_indexed = false;
+  dec_args.flush_cache = true; /* Ensure cache coherency for PPA DMA */
 
-    lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
-    if(res != LV_RESULT_OK) {
-        LV_LOG_WARN("PPA SRM: failed to decode image");
-        return;
-    }
+  lv_result_t res = lv_image_decoder_open(&decoder_dsc, dsc->src, &dec_args);
+  if (res != LV_RESULT_OK) {
+    LV_LOG_WARN("PPA SRM: failed to decode image");
+    return;
+  }
 
-    const lv_draw_buf_t * decoded = decoder_dsc.decoded;
-    if(!decoded || !decoded->data) {
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-
-    lv_color_format_t src_cf = (lv_color_format_t)decoded->header.cf;
-    lv_color_format_t dest_cf = (lv_color_format_t)dest_buf->header.cf;
-
-    /* Verify PPA format support for both source and destination */
-    if(!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
-        LV_LOG_WARN("PPA SRM: unsupported color format src=%d dest=%d", src_cf, dest_cf);
-        lv_image_decoder_close(&decoder_dsc);
-        return;
-    }
-
-    /* Map LVGL rotation (clockwise, 0.1 deg units) to PPA rotation (counter-clockwise) */
-    int32_t angle = dsc->rotation % 3600;
-    if(angle < 0) angle += 3600;
-
-    ppa_srm_rotation_angle_t ppa_rot;
-    switch(angle) {
-        case 0:    ppa_rot = PPA_SRM_ROTATION_ANGLE_0;   break;
-        case 900:  ppa_rot = PPA_SRM_ROTATION_ANGLE_270; break;  /* 90 deg CW = 270 deg CCW */
-        case 1800: ppa_rot = PPA_SRM_ROTATION_ANGLE_180; break;
-        case 2700: ppa_rot = PPA_SRM_ROTATION_ANGLE_90;  break;  /* 270 deg CW = 90 deg CCW */
-        default:
-            lv_image_decoder_close(&decoder_dsc);
-            return;
-    }
-
-    uint32_t src_w = decoded->header.w;
-    uint32_t src_h = decoded->header.h;
-
-    /* Compute destination area relative to layer buffer origin */
-    lv_area_t dest_area;
-    lv_area_copy(&dest_area, &t->area);
-    lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
-
-    /* Flush decoded source buffer for PPA DMA access. Align size to cache
-     * line; _UNALIGNED flag is only a safety net for the address. */
-    if(decoded->data_size > 0) {
-        esp_cache_msync((void *)decoded->data,
-                        lv_draw_ppa_align_size(decoded->data_size),
-                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
-    }
-
-    /* Configure PPA SRM operation */
-    ppa_srm_oper_config_t cfg;
-    lv_memzero(&cfg, sizeof(cfg));
-
-    /* Input: full source image block */
-    cfg.in.buffer         = (void *)decoded->data;
-    cfg.in.pic_w          = src_w;
-    cfg.in.pic_h          = src_h;
-    cfg.in.block_w        = src_w;
-    cfg.in.block_h        = src_h;
-    cfg.in.block_offset_x = 0;
-    cfg.in.block_offset_y = 0;
-    cfg.in.srm_cm         = lv_color_format_to_ppa_srm(src_cf);
-
-    uint32_t out_bpp_r = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u :
-                         (dest_cf == LV_COLOR_FORMAT_RGB888)  ? 3u : 4u;
-    uint32_t raw_bytes_r    = (uint32_t)dest_buf->header.w * dest_buf->header.h * out_bpp_r;
-    uint32_t aligned_size_r = lv_draw_ppa_align_size(raw_bytes_r);
-
-    uint8_t * aligned_out_r = NULL;
-    uint8_t * out_ptr_r     = dest_buf->data;
-
-    if(esp_ptr_external_ram(dest_buf->data) &&
-       !lv_draw_ppa_buf_cache_aligned(dest_buf->data)) {
-        aligned_out_r = (uint8_t *)heap_caps_aligned_alloc(
-            PPA_CACHE_LINE_SIZE, aligned_size_r,
-            MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        if(!aligned_out_r) {
-            LV_LOG_ERROR("PPA SRM rotate: aligned alloc failed");
-            lv_image_decoder_close(&decoder_dsc);
-            return;
-        }
-        memcpy(aligned_out_r, dest_buf->data, raw_bytes_r);
-        esp_cache_msync(aligned_out_r, aligned_size_r,
-                        ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
-        out_ptr_r = aligned_out_r;
-    }
-
-    cfg.out.buffer         = out_ptr_r;
-    cfg.out.buffer_size    = aligned_size_r;
-    cfg.out.pic_w          = dest_buf->header.w;
-    cfg.out.pic_h          = dest_buf->header.h;
-    cfg.out.block_offset_x = (uint32_t)dest_area.x1;
-    cfg.out.block_offset_y = (uint32_t)dest_area.y1;
-    cfg.out.srm_cm         = lv_color_format_to_ppa_srm(dest_cf);
-
-    cfg.rotation_angle     = ppa_rot;
-    cfg.scale_x            = (dsc->scale_x != LV_SCALE_NONE) ? ((float)dsc->scale_x / 256.0f) : 1.0f;
-    cfg.scale_y            = (dsc->scale_y != LV_SCALE_NONE) ? ((float)dsc->scale_y / 256.0f) : 1.0f;
-    cfg.mirror_x           = false;
-    cfg.mirror_y           = false;
-    cfg.rgb_swap           = false;
-    cfg.byte_swap          = false;
-    cfg.alpha_update_mode  = PPA_ALPHA_NO_CHANGE;
-    cfg.mode               = PPA_TRANS_MODE_BLOCKING;
-    cfg.user_data          = u;
-
-    esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
-    if(ret != ESP_OK) {
-        LV_LOG_ERROR("PPA SRM rotation failed: %d  (src %ux%u, angle %d)", (int)ret, src_w, src_h, angle);
-    }
-
-    if(aligned_out_r) {
-        if(ret == ESP_OK) {
-            esp_cache_msync(aligned_out_r, aligned_size_r,
-                            ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
-            memcpy(dest_buf->data, aligned_out_r, raw_bytes_r);
-        }
-        heap_caps_free(aligned_out_r);
-    }
-
+  const lv_draw_buf_t *decoded = decoder_dsc.decoded;
+  if (!decoded || !decoded->data) {
     lv_image_decoder_close(&decoder_dsc);
+    return;
+  }
+
+  lv_color_format_t src_cf = (lv_color_format_t) decoded->header.cf;
+  lv_color_format_t dest_cf = (lv_color_format_t) dest_buf->header.cf;
+
+  /* Verify PPA format support for both source and destination */
+  if (!ppa_src_cf_supported(src_cf) || !ppa_dest_cf_supported(dest_cf)) {
+    LV_LOG_WARN("PPA SRM: unsupported color format src=%d dest=%d", src_cf, dest_cf);
+    lv_image_decoder_close(&decoder_dsc);
+    return;
+  }
+
+  /* Map LVGL rotation (clockwise, 0.1 deg units) to PPA rotation (counter-clockwise) */
+  int32_t angle = dsc->rotation % 3600;
+  if (angle < 0)
+    angle += 3600;
+
+  ppa_srm_rotation_angle_t ppa_rot;
+  switch (angle) {
+    case 0:
+      ppa_rot = PPA_SRM_ROTATION_ANGLE_0;
+      break;
+    case 900:
+      ppa_rot = PPA_SRM_ROTATION_ANGLE_270;
+      break; /* 90 deg CW = 270 deg CCW */
+    case 1800:
+      ppa_rot = PPA_SRM_ROTATION_ANGLE_180;
+      break;
+    case 2700:
+      ppa_rot = PPA_SRM_ROTATION_ANGLE_90;
+      break; /* 270 deg CW = 90 deg CCW */
+    default:
+      lv_image_decoder_close(&decoder_dsc);
+      return;
+  }
+
+  uint32_t src_w = decoded->header.w;
+  uint32_t src_h = decoded->header.h;
+
+  /* Compute destination area relative to layer buffer origin */
+  lv_area_t dest_area;
+  lv_area_copy(&dest_area, &t->area);
+  lv_area_move(&dest_area, -layer->buf_area.x1, -layer->buf_area.y1);
+
+  /* Flush decoded source buffer for PPA DMA access. Align size to cache
+   * line; _UNALIGNED flag is only a safety net for the address. */
+  if (decoded->data_size > 0) {
+    esp_cache_msync((void *) decoded->data, lv_draw_ppa_align_size(decoded->data_size),
+                    ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+  }
+
+  /* Configure PPA SRM operation */
+  ppa_srm_oper_config_t cfg;
+  lv_memzero(&cfg, sizeof(cfg));
+
+  /* Input: full source image block */
+  cfg.in.buffer = (void *) decoded->data;
+  cfg.in.pic_w = src_w;
+  cfg.in.pic_h = src_h;
+  cfg.in.block_w = src_w;
+  cfg.in.block_h = src_h;
+  cfg.in.block_offset_x = 0;
+  cfg.in.block_offset_y = 0;
+  cfg.in.srm_cm = lv_color_format_to_ppa_srm(src_cf);
+
+  uint32_t out_bpp_r = (dest_cf == LV_COLOR_FORMAT_RGB565) ? 2u : (dest_cf == LV_COLOR_FORMAT_RGB888) ? 3u : 4u;
+  uint32_t raw_bytes_r = (uint32_t) dest_buf->header.w * dest_buf->header.h * out_bpp_r;
+  uint32_t aligned_size_r = lv_draw_ppa_align_size(raw_bytes_r);
+
+  uint8_t *aligned_out_r = NULL;
+  uint8_t *out_ptr_r = dest_buf->data;
+
+  if (esp_ptr_external_ram(dest_buf->data) && !lv_draw_ppa_buf_cache_aligned(dest_buf->data)) {
+    aligned_out_r =
+        (uint8_t *) heap_caps_aligned_alloc(PPA_CACHE_LINE_SIZE, aligned_size_r, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!aligned_out_r) {
+      LV_LOG_ERROR("PPA SRM rotate: aligned alloc failed");
+      lv_image_decoder_close(&decoder_dsc);
+      return;
+    }
+    memcpy(aligned_out_r, dest_buf->data, raw_bytes_r);
+    esp_cache_msync(aligned_out_r, aligned_size_r, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    out_ptr_r = aligned_out_r;
+  }
+
+  cfg.out.buffer = out_ptr_r;
+  cfg.out.buffer_size = aligned_size_r;
+  cfg.out.pic_w = dest_buf->header.w;
+  cfg.out.pic_h = dest_buf->header.h;
+  cfg.out.block_offset_x = (uint32_t) dest_area.x1;
+  cfg.out.block_offset_y = (uint32_t) dest_area.y1;
+  cfg.out.srm_cm = lv_color_format_to_ppa_srm(dest_cf);
+
+  cfg.rotation_angle = ppa_rot;
+  cfg.scale_x = (dsc->scale_x != LV_SCALE_NONE) ? ((float) dsc->scale_x / 256.0f) : 1.0f;
+  cfg.scale_y = (dsc->scale_y != LV_SCALE_NONE) ? ((float) dsc->scale_y / 256.0f) : 1.0f;
+  cfg.mirror_x = false;
+  cfg.mirror_y = false;
+  cfg.rgb_swap = false;
+  cfg.byte_swap = false;
+  cfg.alpha_update_mode = PPA_ALPHA_NO_CHANGE;
+  cfg.mode = PPA_TRANS_MODE_BLOCKING;
+  cfg.user_data = u;
+
+  esp_err_t ret = ppa_do_scale_rotate_mirror(u->srm_client, &cfg);
+  if (ret != ESP_OK) {
+    LV_LOG_ERROR("PPA SRM rotation failed: %d  (src %ux%u, angle %d)", (int) ret, src_w, src_h, angle);
+  }
+
+  if (aligned_out_r) {
+    if (ret == ESP_OK) {
+      esp_cache_msync(aligned_out_r, aligned_size_r, ESP_CACHE_MSYNC_FLAG_DIR_M2C | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+      memcpy(dest_buf->data, aligned_out_r, raw_bytes_r);
+    }
+    heap_caps_free(aligned_out_r);
+  }
+
+  lv_image_decoder_close(&decoder_dsc);
 }
 
 #endif /* LV_USE_PPA_IMG */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
@@ -12,8 +12,8 @@
 #define LV_DRAW_PPA_PRIVATE_FIXED_H
 
 /*********************
-*      INCLUDES
-*********************/
+ *      INCLUDES
+ *********************/
 #include "lvgl.h"
 #include "src/lv_conf_internal.h"
 #include "src/draw/lv_draw_private.h"
@@ -38,18 +38,18 @@
 #include "esp_memory_utils.h"
 
 /*********************
-*      DEFINES
-*********************/
+ *      DEFINES
+ *********************/
 
 #ifdef CONFIG_CACHE_L2_CACHE_LINE_SIZE
-#define PPA_CACHE_LINE_SIZE  ((uint32_t)CONFIG_CACHE_L2_CACHE_LINE_SIZE)
+#define PPA_CACHE_LINE_SIZE ((uint32_t) CONFIG_CACHE_L2_CACHE_LINE_SIZE)
 #else
-#define PPA_CACHE_LINE_SIZE  64U
+#define PPA_CACHE_LINE_SIZE 64U
 #endif
 
 /**********************
-*      TYPEDEFS
-**********************/
+ *      TYPEDEFS
+ **********************/
 
 /**
  * Round a byte size up to LV_DRAW_BUF_ALIGN (cache-line on ESP32-P4).
@@ -57,105 +57,97 @@
  * the cache line, mirroring what esp_lvgl_port (common/ppa/lcd_ppa.c) does
  * via ALIGN_UP(size, CONFIG_CACHE_L2_CACHE_LINE_SIZE).
  */
-static inline uint32_t lv_draw_ppa_cache_align(void)
-{
-    size_t alignment = 0;
-    esp_err_t err = esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &alignment);
-    if (err != ESP_OK || alignment == 0 || (alignment & (alignment - 1U)) != 0) {
-        alignment = 64;
-    }
-    return (uint32_t) alignment;
+static inline uint32_t lv_draw_ppa_cache_align(void) {
+  size_t alignment = 0;
+  esp_err_t err = esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &alignment);
+  if (err != ESP_OK || alignment == 0 || (alignment & (alignment - 1U)) != 0) {
+    alignment = 64;
+  }
+  return (uint32_t) alignment;
 }
 
-static inline uint32_t lv_draw_ppa_align_size(uint32_t size)
-{
-    uint32_t alignment = lv_draw_ppa_cache_align();
-    return (size + alignment - 1U) & ~(alignment - 1U);
+static inline uint32_t lv_draw_ppa_align_size(uint32_t size) {
+  uint32_t alignment = lv_draw_ppa_cache_align();
+  return (size + alignment - 1U) & ~(alignment - 1U);
 }
 
-static inline bool lv_draw_ppa_buf_cache_aligned(const void * p)
-{
-    return ((uintptr_t)p % lv_draw_ppa_cache_align()) == 0;
+static inline bool lv_draw_ppa_buf_cache_aligned(const void *p) {
+  return ((uintptr_t) p % lv_draw_ppa_cache_align()) == 0;
 }
 
 typedef struct lv_draw_ppa_unit {
-    lv_draw_unit_t base_unit;
-    lv_draw_task_t * task_act;
-    ppa_client_handle_t srm_client;
-    ppa_client_handle_t fill_client;
-    ppa_client_handle_t blend_client;
-    uint8_t * buf;
+  lv_draw_unit_t base_unit;
+  lv_draw_task_t *task_act;
+  ppa_client_handle_t srm_client;
+  ppa_client_handle_t fill_client;
+  ppa_client_handle_t blend_client;
+  uint8_t *buf;
 } lv_draw_ppa_unit_t;
 
 /**********************
-*   STATIC FUNCTIONS
-**********************/
+ *   STATIC FUNCTIONS
+ **********************/
 
-static inline bool ppa_src_cf_supported(lv_color_format_t cf)
-{
-    switch(cf) {
-        case LV_COLOR_FORMAT_RGB565:
-        case LV_COLOR_FORMAT_RGB888:
-        case LV_COLOR_FORMAT_ARGB8888:
-        case LV_COLOR_FORMAT_XRGB8888:
-            return true;
-        default:
-            return false;
-    }
+static inline bool ppa_src_cf_supported(lv_color_format_t cf) {
+  switch (cf) {
+    case LV_COLOR_FORMAT_RGB565:
+    case LV_COLOR_FORMAT_RGB888:
+    case LV_COLOR_FORMAT_ARGB8888:
+    case LV_COLOR_FORMAT_XRGB8888:
+      return true;
+    default:
+      return false;
+  }
 }
 
-static inline bool ppa_dest_cf_supported(lv_color_format_t cf)
-{
-    switch(cf) {
-        case LV_COLOR_FORMAT_RGB565:
-        case LV_COLOR_FORMAT_RGB888:
-        case LV_COLOR_FORMAT_ARGB8888:
-            return true;
-        default:
-            return false;
-    }
+static inline bool ppa_dest_cf_supported(lv_color_format_t cf) {
+  switch (cf) {
+    case LV_COLOR_FORMAT_RGB565:
+    case LV_COLOR_FORMAT_RGB888:
+    case LV_COLOR_FORMAT_ARGB8888:
+      return true;
+    default:
+      return false;
+  }
 }
 
-static inline ppa_fill_color_mode_t lv_color_format_to_ppa_fill(lv_color_format_t lv_fmt)
-{
-    switch(lv_fmt) {
-        case LV_COLOR_FORMAT_RGB565:
-            return PPA_FILL_COLOR_MODE_RGB565;
-        case LV_COLOR_FORMAT_RGB888:
-            return PPA_FILL_COLOR_MODE_RGB888;
-        case LV_COLOR_FORMAT_ARGB8888:
-            return PPA_FILL_COLOR_MODE_ARGB8888;
-        default:
-            return PPA_FILL_COLOR_MODE_RGB565;
-    }
+static inline ppa_fill_color_mode_t lv_color_format_to_ppa_fill(lv_color_format_t lv_fmt) {
+  switch (lv_fmt) {
+    case LV_COLOR_FORMAT_RGB565:
+      return PPA_FILL_COLOR_MODE_RGB565;
+    case LV_COLOR_FORMAT_RGB888:
+      return PPA_FILL_COLOR_MODE_RGB888;
+    case LV_COLOR_FORMAT_ARGB8888:
+      return PPA_FILL_COLOR_MODE_ARGB8888;
+    default:
+      return PPA_FILL_COLOR_MODE_RGB565;
+  }
 }
 
-static inline ppa_blend_color_mode_t lv_color_format_to_ppa_blend(lv_color_format_t lv_fmt)
-{
-    switch(lv_fmt) {
-        case LV_COLOR_FORMAT_RGB565:
-            return PPA_BLEND_COLOR_MODE_RGB565;
-        case LV_COLOR_FORMAT_RGB888:
-            return PPA_BLEND_COLOR_MODE_RGB888;
-        case LV_COLOR_FORMAT_ARGB8888:
-            return PPA_BLEND_COLOR_MODE_ARGB8888;
-        default:
-            return PPA_BLEND_COLOR_MODE_RGB565;
-    }
+static inline ppa_blend_color_mode_t lv_color_format_to_ppa_blend(lv_color_format_t lv_fmt) {
+  switch (lv_fmt) {
+    case LV_COLOR_FORMAT_RGB565:
+      return PPA_BLEND_COLOR_MODE_RGB565;
+    case LV_COLOR_FORMAT_RGB888:
+      return PPA_BLEND_COLOR_MODE_RGB888;
+    case LV_COLOR_FORMAT_ARGB8888:
+      return PPA_BLEND_COLOR_MODE_ARGB8888;
+    default:
+      return PPA_BLEND_COLOR_MODE_RGB565;
+  }
 }
 
-static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t lv_fmt)
-{
-    switch(lv_fmt) {
-        case LV_COLOR_FORMAT_RGB565:
-            return PPA_SRM_COLOR_MODE_RGB565;
-        case LV_COLOR_FORMAT_RGB888:
-            return PPA_SRM_COLOR_MODE_RGB888;
-        case LV_COLOR_FORMAT_XRGB8888:
-            return PPA_SRM_COLOR_MODE_ARGB8888;
-        default:
-            return PPA_SRM_COLOR_MODE_RGB565;
-    }
+static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t lv_fmt) {
+  switch (lv_fmt) {
+    case LV_COLOR_FORMAT_RGB565:
+      return PPA_SRM_COLOR_MODE_RGB565;
+    case LV_COLOR_FORMAT_RGB888:
+      return PPA_SRM_COLOR_MODE_RGB888;
+    case LV_COLOR_FORMAT_XRGB8888:
+      return PPA_SRM_COLOR_MODE_ARGB8888;
+    default:
+      return PPA_SRM_COLOR_MODE_RGB565;
+  }
 }
 
 #endif /* LV_DRAW_PPA_PRIVATE_FIXED_H */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
@@ -1,0 +1,158 @@
+/**
+ * @file lv_draw_ppa_private.h
+ * Custom PPA private header for ESP32-P4
+ * Based on https://github.com/lvgl/lvgl/pull/9162 (included in LVGL 9.5+)
+ * Adapted for C++ compilation (ESPHome build system)
+ */
+
+#ifndef LV_DRAW_PPA_PRIVATE_FIXED_H
+#define LV_DRAW_PPA_PRIVATE_FIXED_H
+
+/*********************
+*      INCLUDES
+*********************/
+#include "lvgl.h"
+#include "src/lv_conf_internal.h"
+#include "src/draw/lv_draw_private.h"
+#include "src/draw/lv_draw_buf_private.h"
+#include "src/display/lv_display_private.h"
+#include "src/misc/lv_area_private.h"
+
+/* The ppa driver depends heavily on the esp-idf headers */
+#include "sdkconfig.h"
+
+#ifndef CONFIG_SOC_PPA_SUPPORTED
+#error "This SoC does not support PPA"
+#endif
+
+#include "driver/ppa.h"
+#include "esp_heap_caps.h"
+#include "esp_err.h"
+#include "hal/color_hal.h"
+#include "esp_cache.h"
+#include "esp_private/esp_cache_private.h"
+#include "esp_log.h"
+#include "esp_memory_utils.h"
+
+/*********************
+*      DEFINES
+*********************/
+
+#ifdef CONFIG_CACHE_L2_CACHE_LINE_SIZE
+#define PPA_CACHE_LINE_SIZE  ((uint32_t)CONFIG_CACHE_L2_CACHE_LINE_SIZE)
+#else
+#define PPA_CACHE_LINE_SIZE  64U
+#endif
+
+/**********************
+*      TYPEDEFS
+**********************/
+
+/**
+ * Round a byte size up to LV_DRAW_BUF_ALIGN (cache-line on ESP32-P4).
+ * ESP-IDF PPA hardware and esp_cache_msync() both require sizes aligned to
+ * the cache line, mirroring what esp_lvgl_port (common/ppa/lcd_ppa.c) does
+ * via ALIGN_UP(size, CONFIG_CACHE_L2_CACHE_LINE_SIZE).
+ */
+static inline uint32_t lv_draw_ppa_cache_align(void)
+{
+    size_t alignment = 0;
+    esp_err_t err = esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &alignment);
+    if (err != ESP_OK || alignment == 0 || (alignment & (alignment - 1U)) != 0) {
+        alignment = 64;
+    }
+    return (uint32_t) alignment;
+}
+
+static inline uint32_t lv_draw_ppa_align_size(uint32_t size)
+{
+    uint32_t alignment = lv_draw_ppa_cache_align();
+    return (size + alignment - 1U) & ~(alignment - 1U);
+}
+
+static inline bool lv_draw_ppa_buf_cache_aligned(const void * p)
+{
+    return ((uintptr_t)p % lv_draw_ppa_cache_align()) == 0;
+}
+
+typedef struct lv_draw_ppa_unit {
+    lv_draw_unit_t base_unit;
+    lv_draw_task_t * task_act;
+    ppa_client_handle_t srm_client;
+    ppa_client_handle_t fill_client;
+    ppa_client_handle_t blend_client;
+    uint8_t * buf;
+} lv_draw_ppa_unit_t;
+
+/**********************
+*   STATIC FUNCTIONS
+**********************/
+
+static inline bool ppa_src_cf_supported(lv_color_format_t cf)
+{
+    switch(cf) {
+        case LV_COLOR_FORMAT_RGB565:
+        case LV_COLOR_FORMAT_RGB888:
+        case LV_COLOR_FORMAT_ARGB8888:
+        case LV_COLOR_FORMAT_XRGB8888:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static inline bool ppa_dest_cf_supported(lv_color_format_t cf)
+{
+    switch(cf) {
+        case LV_COLOR_FORMAT_RGB565:
+        case LV_COLOR_FORMAT_RGB888:
+        case LV_COLOR_FORMAT_ARGB8888:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static inline ppa_fill_color_mode_t lv_color_format_to_ppa_fill(lv_color_format_t lv_fmt)
+{
+    switch(lv_fmt) {
+        case LV_COLOR_FORMAT_RGB565:
+            return PPA_FILL_COLOR_MODE_RGB565;
+        case LV_COLOR_FORMAT_RGB888:
+            return PPA_FILL_COLOR_MODE_RGB888;
+        case LV_COLOR_FORMAT_ARGB8888:
+            return PPA_FILL_COLOR_MODE_ARGB8888;
+        default:
+            return PPA_FILL_COLOR_MODE_RGB565;
+    }
+}
+
+static inline ppa_blend_color_mode_t lv_color_format_to_ppa_blend(lv_color_format_t lv_fmt)
+{
+    switch(lv_fmt) {
+        case LV_COLOR_FORMAT_RGB565:
+            return PPA_BLEND_COLOR_MODE_RGB565;
+        case LV_COLOR_FORMAT_RGB888:
+            return PPA_BLEND_COLOR_MODE_RGB888;
+        case LV_COLOR_FORMAT_ARGB8888:
+            return PPA_BLEND_COLOR_MODE_ARGB8888;
+        default:
+            return PPA_BLEND_COLOR_MODE_RGB565;
+    }
+}
+
+static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t lv_fmt)
+{
+    switch(lv_fmt) {
+        case LV_COLOR_FORMAT_RGB565:
+            return PPA_SRM_COLOR_MODE_RGB565;
+        case LV_COLOR_FORMAT_RGB888:
+            return PPA_SRM_COLOR_MODE_RGB888;
+        case LV_COLOR_FORMAT_XRGB8888:
+            return PPA_SRM_COLOR_MODE_ARGB8888;
+        default:
+            return PPA_SRM_COLOR_MODE_RGB565;
+    }
+}
+
+#endif /* LV_DRAW_PPA_PRIVATE_FIXED_H */

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
@@ -21,8 +21,11 @@
 #include "src/display/lv_display_private.h"
 #include "src/misc/lv_area_private.h"
 
-/* The ppa driver depends heavily on the esp-idf headers */
+/* The PPA driver depends heavily on ESP-IDF headers.  clang-tidy also runs
+ * all-include checks for non-IDF targets where sdkconfig.h is not present. */
+#if defined(ESP_PLATFORM) && __has_include("sdkconfig.h")
 #include "sdkconfig.h"
+#endif
 
 #ifdef CONFIG_SOC_PPA_SUPPORTED
 

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
@@ -5,6 +5,9 @@
  * Adapted for C++ compilation (ESPHome build system)
  */
 
+#pragma once
+// namespace esphome::lvgl -- ESPHome lint marker; this header is shared with C sources.
+
 #ifndef LV_DRAW_PPA_PRIVATE_FIXED_H
 #define LV_DRAW_PPA_PRIVATE_FIXED_H
 

--- a/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
+++ b/esphome/components/lvgl/ppa/lv_draw_ppa_private.h
@@ -24,9 +24,7 @@
 /* The ppa driver depends heavily on the esp-idf headers */
 #include "sdkconfig.h"
 
-#ifndef CONFIG_SOC_PPA_SUPPORTED
-#error "This SoC does not support PPA"
-#endif
+#ifdef CONFIG_SOC_PPA_SUPPORTED
 
 #include "driver/ppa.h"
 #include "esp_heap_caps.h"
@@ -57,7 +55,7 @@
  * the cache line, mirroring what esp_lvgl_port (common/ppa/lcd_ppa.c) does
  * via ALIGN_UP(size, CONFIG_CACHE_L2_CACHE_LINE_SIZE).
  */
-static inline uint32_t lv_draw_ppa_cache_align(void) {
+static inline uint32_t lv_draw_ppa_cache_align() {
   size_t alignment = 0;
   esp_err_t err = esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &alignment);
   if (err != ESP_OK || alignment == 0 || (alignment & (alignment - 1U)) != 0) {
@@ -75,14 +73,16 @@ static inline bool lv_draw_ppa_buf_cache_aligned(const void *p) {
   return ((uintptr_t) p % lv_draw_ppa_cache_align()) == 0;
 }
 
-typedef struct lv_draw_ppa_unit {
+struct LvDrawPpaUnit {
   lv_draw_unit_t base_unit;
   lv_draw_task_t *task_act;
   ppa_client_handle_t srm_client;
   ppa_client_handle_t fill_client;
   ppa_client_handle_t blend_client;
   uint8_t *buf;
-} lv_draw_ppa_unit_t;
+};
+
+using lv_draw_ppa_unit_t = LvDrawPpaUnit;
 
 /**********************
  *   STATIC FUNCTIONS
@@ -149,5 +149,7 @@ static inline ppa_srm_color_mode_t lv_color_format_to_ppa_srm(lv_color_format_t 
       return PPA_SRM_COLOR_MODE_RGB565;
   }
 }
+
+#endif /* CONFIG_SOC_PPA_SUPPORTED */
 
 #endif /* LV_DRAW_PPA_PRIVATE_FIXED_H */

--- a/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
+++ b/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
@@ -1,0 +1,513 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Ported from esp-iot-solution
+ *   components/display/tools/esp_lvgl_adapter/src/display/bridge/v9/lvgl_ppa_accel_v9.c
+ * to the ESPHome LVGL 9.5 build (adapted for C++ wrapper / no esp_lvgl_port).
+ */
+
+#include "sdkconfig.h"
+
+#ifdef CONFIG_SOC_PPA_SUPPORTED
+
+#include "lvgl_ppa_accel_v9.h"
+#include "lv_draw_ppa_private.h"
+#include "lvgl.h"
+#include "src/draw/sw/blend/lv_draw_sw_blend.h"
+#include "src/draw/sw/blend/lv_draw_sw_blend_private.h"
+#include "src/draw/sw/blend/lv_draw_sw_blend_to_rgb565.h"
+#include "src/draw/sw/blend/lv_draw_sw_blend_to_rgb888.h"
+#include "src/draw/lv_draw.h"
+#include "src/draw/lv_draw_buf.h"
+#include "src/draw/lv_draw_private.h"
+#include "src/display/lv_display_private.h"
+#include "src/misc/lv_area_private.h"
+
+#include "driver/ppa.h"
+#include "esp_cache.h"
+#include "esp_private/esp_cache_private.h"
+#include "esp_memory_utils.h"
+#include "esp_log.h"
+
+uint32_t lvgl_esphome_get_perf_logging_enabled(void);
+
+#define LVGL_PORT_PPA_ALIGNMENT       64
+#define LVGL_PORT_PPA_ALIGN_UP(s, a)  (((s) + ((a) - 1)) & ~((a) - 1))
+#define LVGL_PORT_PPA_MIN_AREA_PX     100
+
+static const char *TAG_V9 = "lvgl";  /* reuse the lvgl tag used by the component */
+
+/* Instrumentation: how many ops landed on hardware vs the SW fallback,
+   reported once every PPA_STATS_INTERVAL_MS to confirm acceleration is
+   live. Set PPA_STATS_INTERVAL_MS to 0 to silence. */
+#define PPA_STATS_INTERVAL_MS 2000
+
+static uint32_t s_ppa_hw_fills   = 0;
+static uint32_t s_ppa_hw_blends  = 0;
+static uint32_t s_ppa_sw_fallback = 0;
+static uint32_t s_ppa_stats_last_log_ms = 0;
+
+#include "esp_timer.h"
+static inline uint32_t ppa_now_ms(void) {
+    return (uint32_t)(esp_timer_get_time() / 1000);
+}
+
+static void ppa_stats_maybe_log(void) {
+#if PPA_STATS_INTERVAL_MS > 0
+    uint32_t now = ppa_now_ms();
+    if (!lvgl_esphome_get_perf_logging_enabled()) {
+        s_ppa_hw_fills = 0;
+        s_ppa_hw_blends = 0;
+        s_ppa_sw_fallback = 0;
+        s_ppa_stats_last_log_ms = now;
+        return;
+    }
+    if (s_ppa_stats_last_log_ms == 0) s_ppa_stats_last_log_ms = now;
+    if (now - s_ppa_stats_last_log_ms >= PPA_STATS_INTERVAL_MS) {
+        uint32_t total = s_ppa_hw_fills + s_ppa_hw_blends + s_ppa_sw_fallback;
+        if (total > 0) {
+            uint32_t hw = s_ppa_hw_fills + s_ppa_hw_blends;
+            ESP_LOGD(TAG_V9, "PPA ops/2s: HW=%lu (fill=%lu, blend=%lu)  SW=%lu  hw_ratio=%lu%%",
+                     (unsigned long)hw, (unsigned long)s_ppa_hw_fills,
+                     (unsigned long)s_ppa_hw_blends, (unsigned long)s_ppa_sw_fallback,
+                     (unsigned long)(hw * 100 / total));
+        }
+        s_ppa_hw_fills = 0;
+        s_ppa_hw_blends = 0;
+        s_ppa_sw_fallback = 0;
+        s_ppa_stats_last_log_ms = now;
+    }
+#endif
+}
+
+static ppa_client_handle_t s_blend_handle = NULL;
+static ppa_client_handle_t s_fill_handle = NULL;
+static size_t s_cache_align = 0;
+static bool s_handler_registered = false;
+
+static void lv_draw_ppa_v9_handler(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc);
+
+static lv_draw_sw_custom_blend_handler_t s_custom_handler_rgb565 = {
+    .dest_cf = LV_COLOR_FORMAT_RGB565,
+    .handler = lv_draw_ppa_v9_handler,
+};
+
+static lv_draw_sw_custom_blend_handler_t s_custom_handler_rgb888 = {
+    .dest_cf = LV_COLOR_FORMAT_RGB888,
+    .handler = lv_draw_ppa_v9_handler,
+};
+
+static size_t ppa_align(void)
+{
+    if (s_cache_align == 0) {
+        esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &s_cache_align);
+        if (s_cache_align == 0 || (s_cache_align & (s_cache_align - 1)) != 0) {
+            s_cache_align = LVGL_PORT_PPA_ALIGNMENT;
+        }
+    }
+    return s_cache_align;
+}
+
+static void ppa_cache_sync_region(const lv_area_t *area, const lv_area_t *buf_area,
+                                  void *buf, uint32_t px_size, int flag)
+{
+    if (!area || !buf_area || !buf || !esp_ptr_external_ram(buf)) {
+        return;
+    }
+
+    size_t align = ppa_align();
+    int32_t width = lv_area_get_width(area);
+    int32_t height = lv_area_get_height(area);
+    int32_t buf_w = lv_area_get_width(buf_area);
+    int32_t buf_h = lv_area_get_height(buf_area);
+
+    if (width <= 0 || height <= 0 || buf_w <= 0 || buf_h <= 0 || px_size == 0) {
+        return;
+    }
+
+    int32_t off_x = area->x1 - buf_area->x1;
+    int32_t off_y = area->y1 - buf_area->y1;
+
+    if (off_x < 0 || off_y < 0 || (off_x + width) > buf_w || (off_y + height) > buf_h) {
+        return;
+    }
+
+    uint8_t *start = (uint8_t *)buf + ((size_t)off_y * buf_w + off_x) * px_size;
+    size_t bytes = ((size_t)(height - 1) * (size_t)buf_w + (size_t)width) * px_size;
+    uintptr_t addr = (uintptr_t)start;
+    uintptr_t aligned_addr = addr & ~(align - 1);
+    size_t total = LVGL_PORT_PPA_ALIGN_UP(bytes + (addr - aligned_addr), align);
+
+    /* LVGL PR #10107: tolerate unaligned CPU-to-memory flushes. ESP-IDF does
+     * not allow ESP_CACHE_MSYNC_FLAG_UNALIGNED with memory-to-cache
+     * invalidation, so M2C uses the manually aligned region above. */
+    int msync_flags = flag | ESP_CACHE_MSYNC_FLAG_TYPE_DATA;
+    if ((flag & ESP_CACHE_MSYNC_FLAG_DIR_M2C) == 0) {
+        msync_flags |= ESP_CACHE_MSYNC_FLAG_UNALIGNED;
+    }
+    esp_cache_msync((void *)aligned_addr, total, msync_flags);
+}
+
+static void ppa_cache_invalidate(const lv_area_t *area, const lv_area_t *buf_area, void *buf, uint32_t px_size)
+{
+    ppa_cache_sync_region(area, buf_area, buf, px_size, ESP_CACHE_MSYNC_FLAG_DIR_M2C);
+}
+
+static void ppa_blend(void *bg_buf, lv_color_format_t color_format, uint32_t px_size,
+                      const lv_area_t *bg_area, const void *fg_buf, const lv_area_t *fg_area,
+                      uint16_t fg_stride_px, const lv_area_t *block_area, lv_opa_t opa)
+{
+    uint16_t bg_w = lv_area_get_width(bg_area);
+    uint16_t bg_h = lv_area_get_height(bg_area);
+    uint16_t bg_off_x = block_area->x1 - bg_area->x1;
+    uint16_t bg_off_y = block_area->y1 - bg_area->y1;
+
+    uint16_t block_w = lv_area_get_width(block_area);
+    uint16_t block_h = lv_area_get_height(block_area);
+    uint16_t fg_w = fg_stride_px;
+    uint16_t fg_h = lv_area_get_height(fg_area);
+    uint16_t fg_off_x = block_area->x1 - fg_area->x1;
+    uint16_t fg_off_y = block_area->y1 - fg_area->y1;
+
+    if ((uint32_t)fg_off_x + block_w > fg_w) {
+        fg_w = fg_off_x + block_w;
+    }
+    if ((uint32_t)fg_off_y + block_h > fg_h) {
+        fg_h = fg_off_y + block_h;
+    }
+    size_t align = ppa_align();
+    ppa_blend_color_mode_t ppa_cf = lv_color_format_to_ppa_blend(color_format);
+
+    ppa_blend_oper_config_t cfg = {
+        .in_bg = {
+            .buffer = bg_buf,
+            .pic_w = bg_w,
+            .pic_h = bg_h,
+            .block_w = block_w,
+            .block_h = block_h,
+            .block_offset_x = bg_off_x,
+            .block_offset_y = bg_off_y,
+            .blend_cm = ppa_cf,
+        },
+        .in_fg = {
+            .buffer = fg_buf,
+            .pic_w = fg_w,
+            .pic_h = fg_h,
+            .block_w = block_w,
+            .block_h = block_h,
+            .block_offset_x = fg_off_x,
+            .block_offset_y = fg_off_y,
+            .blend_cm = ppa_cf,
+        },
+        .out = {
+            .buffer = bg_buf,
+            .buffer_size = LVGL_PORT_PPA_ALIGN_UP((size_t)px_size * bg_w * bg_h, align),
+            .pic_w = bg_w,
+            .pic_h = bg_h,
+            .block_offset_x = bg_off_x,
+            .block_offset_y = bg_off_y,
+            .blend_cm = ppa_cf,
+        },
+        .bg_rgb_swap = 0,
+        .bg_byte_swap = 0,
+        .bg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
+        .bg_alpha_fix_val = (uint8_t)(255 - opa),
+        .fg_rgb_swap = 0,
+        .fg_byte_swap = 0,
+        .fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
+        .fg_alpha_fix_val = opa,
+        .mode = PPA_TRANS_MODE_BLOCKING,
+    };
+
+    esp_err_t err = ppa_do_blend(s_blend_handle, &cfg);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG_V9, "ppa_do_blend failed: %d", err);
+    }
+}
+
+static void ppa_fill(void *bg_buf, lv_color_format_t color_format, uint32_t px_size,
+                     const lv_area_t *bg_area, const lv_area_t *block_area, lv_color_t color)
+{
+    uint16_t bg_w = lv_area_get_width(bg_area);
+    uint16_t bg_h = lv_area_get_height(bg_area);
+    size_t align = ppa_align();
+    ppa_fill_color_mode_t ppa_cf = lv_color_format_to_ppa_fill(color_format);
+
+    lv_color32_t c32 = lv_color_to_32(color, LV_OPA_COVER);
+    uint32_t argb = ((uint32_t)c32.alpha << 24) | ((uint32_t)c32.red << 16) |
+                    ((uint32_t)c32.green << 8) | ((uint32_t)c32.blue);
+
+    ppa_fill_oper_config_t cfg = {
+        .out = {
+            .buffer = bg_buf,
+            .buffer_size = LVGL_PORT_PPA_ALIGN_UP((size_t)px_size * bg_w * bg_h, align),
+            .pic_w = bg_w,
+            .pic_h = bg_h,
+            .block_offset_x = (uint32_t)(block_area->x1 - bg_area->x1),
+            .block_offset_y = (uint32_t)(block_area->y1 - bg_area->y1),
+            .fill_cm = ppa_cf,
+        },
+        .fill_block_w = (uint32_t)lv_area_get_width(block_area),
+        .fill_block_h = (uint32_t)lv_area_get_height(block_area),
+        .mode = PPA_TRANS_MODE_BLOCKING,
+    };
+    cfg.fill_argb_color.val = argb;
+
+    esp_err_t err = ppa_do_fill(s_fill_handle, &cfg);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG_V9, "ppa_do_fill failed: %d", err);
+    }
+}
+
+static void lv_draw_ppa_v9_sw_fallback(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc)
+{
+    lv_layer_t *layer = t->target_layer;
+    if (!layer || !layer->draw_buf) {
+        return;
+    }
+
+    lv_area_t blend_area;
+    if (!lv_area_intersect(&blend_area, dsc->blend_area, &t->clip_area)) {
+        return;
+    }
+
+    uint32_t layer_stride = layer->draw_buf->header.stride;
+
+    if (dsc->src_buf == NULL) {
+        lv_draw_sw_blend_fill_dsc_t fill_dsc;
+        lv_memzero(&fill_dsc, sizeof(fill_dsc));
+        fill_dsc.dest_w = lv_area_get_width(&blend_area);
+        fill_dsc.dest_h = lv_area_get_height(&blend_area);
+        fill_dsc.dest_stride = layer_stride;
+        fill_dsc.opa = dsc->opa;
+        fill_dsc.color = dsc->color;
+        if (dsc->mask_buf == NULL || dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) {
+            fill_dsc.mask_buf = NULL;
+        } else {
+            fill_dsc.mask_buf = dsc->mask_buf;
+            fill_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : (uint32_t)lv_area_get_width(dsc->mask_area);
+            fill_dsc.mask_buf += fill_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) +
+                                 (blend_area.x1 - dsc->mask_area->x1);
+        }
+
+        fill_dsc.relative_area = blend_area;
+        lv_area_move(&fill_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
+        fill_dsc.dest_buf = lv_draw_layer_go_to_xy(layer,
+                                                   blend_area.x1 - layer->buf_area.x1,
+                                                   blend_area.y1 - layer->buf_area.y1);
+        if (layer->color_format == LV_COLOR_FORMAT_RGB888) {
+            lv_draw_sw_blend_color_to_rgb888(&fill_dsc, lv_color_format_get_size(layer->color_format));
+        } else {
+            lv_draw_sw_blend_color_to_rgb565(&fill_dsc);
+        }
+        return;
+    }
+
+    lv_draw_sw_blend_image_dsc_t image_dsc;
+    lv_memzero(&image_dsc, sizeof(image_dsc));
+    image_dsc.dest_w = lv_area_get_width(&blend_area);
+    image_dsc.dest_h = lv_area_get_height(&blend_area);
+    image_dsc.dest_stride = layer_stride;
+    image_dsc.opa = dsc->opa;
+    image_dsc.blend_mode = dsc->blend_mode;
+    const lv_area_t *src_area = dsc->src_area ? dsc->src_area : dsc->blend_area;
+    uint32_t src_px_size = lv_color_format_get_size(dsc->src_color_format);
+    image_dsc.src_stride = dsc->src_stride ? dsc->src_stride : (lv_area_get_width(src_area) * src_px_size);
+    image_dsc.src_color_format = dsc->src_color_format;
+
+    const uint8_t *src_buf = (const uint8_t *)dsc->src_buf;
+    src_buf += (size_t)(blend_area.y1 - src_area->y1) * image_dsc.src_stride;
+    src_buf += (size_t)(blend_area.x1 - src_area->x1) * src_px_size;
+    image_dsc.src_buf = src_buf;
+
+    if (dsc->mask_buf == NULL || dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) {
+        image_dsc.mask_buf = NULL;
+    } else {
+        image_dsc.mask_buf = dsc->mask_buf;
+        image_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : (uint32_t)lv_area_get_width(dsc->mask_area);
+        image_dsc.mask_buf += image_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) +
+                              (blend_area.x1 - dsc->mask_area->x1);
+    }
+
+    image_dsc.relative_area = blend_area;
+    lv_area_move(&image_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
+    if (src_area) {
+        image_dsc.src_area = *src_area;
+        lv_area_move(&image_dsc.src_area, -layer->buf_area.x1, -layer->buf_area.y1);
+    } else {
+        lv_memset(&image_dsc.src_area, 0, sizeof(image_dsc.src_area));
+    }
+    image_dsc.dest_buf = lv_draw_layer_go_to_xy(layer,
+                                                blend_area.x1 - layer->buf_area.x1,
+                                                blend_area.y1 - layer->buf_area.y1);
+
+    if (layer->color_format == LV_COLOR_FORMAT_RGB888) {
+        lv_draw_sw_blend_image_to_rgb888(&image_dsc, lv_color_format_get_size(layer->color_format));
+    } else {
+        lv_draw_sw_blend_image_to_rgb565(&image_dsc);
+    }
+}
+
+/* Wrap the SW fallback so we don't have to instrument every call site. */
+static inline void lv_draw_ppa_v9_sw_fallback_tracked(lv_draw_task_t *t,
+                                                       const lv_draw_sw_blend_dsc_t *dsc) {
+    s_ppa_sw_fallback++;
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+}
+#define lv_draw_ppa_v9_sw_fallback(t, dsc) lv_draw_ppa_v9_sw_fallback_tracked((t), (dsc))
+
+static void lv_draw_ppa_v9_handler(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc)
+{
+    ppa_stats_maybe_log();
+    lv_layer_t *layer = t->target_layer;
+    if (!layer || !layer->draw_buf ||
+            (layer->color_format != LV_COLOR_FORMAT_RGB565 && layer->color_format != LV_COLOR_FORMAT_RGB888)) {
+        lv_draw_ppa_v9_sw_fallback(t, dsc);
+        return;
+    }
+
+    uint32_t dst_px_size = lv_color_format_get_size(layer->color_format);
+    if (dst_px_size == 0) {
+        lv_draw_ppa_v9_sw_fallback(t, dsc);
+        return;
+    }
+
+    lv_area_t block_area;
+    if (!_lv_area_intersect(&block_area, dsc->blend_area, &t->clip_area)) {
+        return;
+    }
+
+    if (dsc->mask_buf && dsc->mask_res != LV_DRAW_SW_MASK_RES_FULL_COVER &&
+            dsc->mask_res != LV_DRAW_SW_MASK_RES_UNKNOWN) {
+        lv_draw_ppa_v9_sw_fallback(t, dsc);
+        return;
+    }
+
+    if (lv_area_get_size(&block_area) <= LVGL_PORT_PPA_MIN_AREA_PX) {
+        lv_draw_ppa_v9_sw_fallback(t, dsc);
+        return;
+    }
+
+    void *bg_buf = layer->draw_buf->data;
+    size_t align = ppa_align();
+    if (!bg_buf || ((uintptr_t)bg_buf % align) != 0) {
+        lv_draw_ppa_v9_sw_fallback(t, dsc);
+        return;
+    }
+
+    if (block_area.x1 < layer->buf_area.x1 || block_area.y1 < layer->buf_area.y1 ||
+            block_area.x2 > layer->buf_area.x2 || block_area.y2 > layer->buf_area.y2) {
+        lv_draw_ppa_v9_sw_fallback(t, dsc);
+        return;
+    }
+
+    ppa_cache_sync_region(&block_area, &layer->buf_area, bg_buf, dst_px_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+
+    if (dsc->src_buf) {
+        if (dsc->src_color_format != layer->color_format) {
+            lv_draw_ppa_v9_sw_fallback(t, dsc);
+            return;
+        }
+
+        const lv_area_t *src_area = dsc->src_area ? dsc->src_area : dsc->blend_area;
+        uint32_t src_px_size = lv_color_format_get_size(dsc->src_color_format);
+        size_t src_stride = dsc->src_stride ? dsc->src_stride : (lv_area_get_width(src_area) * src_px_size);
+
+        if (src_px_size == 0 || (src_stride % src_px_size) != 0) {
+            lv_draw_ppa_v9_sw_fallback(t, dsc);
+            return;
+        }
+
+        int32_t src_off_x = block_area.x1 - src_area->x1;
+        int32_t src_off_y = block_area.y1 - src_area->y1;
+        if (src_off_x < 0 || src_off_y < 0) {
+            lv_draw_ppa_v9_sw_fallback(t, dsc);
+            return;
+        }
+
+        const uint8_t *src_ptr8 = (const uint8_t *)dsc->src_buf +
+                                  (size_t)src_off_y * src_stride +
+                                  (size_t)src_off_x * src_px_size;
+        uintptr_t src_addr = (uintptr_t)src_ptr8;
+        uintptr_t src_aligned = src_addr & ~(align - 1);
+        size_t src_total = LVGL_PORT_PPA_ALIGN_UP(
+                               ((size_t)(lv_area_get_height(&block_area) - 1) * src_stride +
+                                (size_t)lv_area_get_width(&block_area) * src_px_size) +
+                               (src_addr - src_aligned), align);
+        if (esp_ptr_external_ram((void *)dsc->src_buf)) {
+            esp_cache_msync((void *)src_aligned, src_total,
+                            ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+        }
+
+        uint16_t src_stride_px = src_stride / src_px_size;
+        s_ppa_hw_blends++;
+        ppa_blend(bg_buf, layer->color_format, dst_px_size, &layer->buf_area, dsc->src_buf,
+                  src_area, src_stride_px, &block_area, dsc->opa);
+
+        ppa_cache_invalidate(&block_area, &layer->buf_area, bg_buf, dst_px_size);
+        return;
+    }
+
+    if (dsc->opa >= LV_OPA_MAX) {
+        s_ppa_hw_fills++;
+        ppa_fill(bg_buf, layer->color_format, dst_px_size, &layer->buf_area, &block_area, dsc->color);
+        ppa_cache_invalidate(&block_area, &layer->buf_area, bg_buf, dst_px_size);
+        return;
+    }
+
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+}
+
+void lvgl_port_ppa_v9_init(lv_display_t *display)
+{
+    if (!display ||
+            (lv_display_get_color_format(display) != LV_COLOR_FORMAT_RGB565 &&
+             lv_display_get_color_format(display) != LV_COLOR_FORMAT_RGB888)) {
+        ESP_LOGD(TAG_V9, "skip: display format unsupported by PPA v9 blend handler");
+        return;
+    }
+
+    if (s_blend_handle == NULL && s_fill_handle == NULL) {
+        ppa_client_config_t blend_cfg = {
+            .oper_type = PPA_OPERATION_BLEND,
+            .max_pending_trans_num = 1,
+            .data_burst_length = PPA_DATA_BURST_LENGTH_128,
+        };
+        ppa_client_config_t fill_cfg = {
+            .oper_type = PPA_OPERATION_FILL,
+            .max_pending_trans_num = 1,
+            .data_burst_length = PPA_DATA_BURST_LENGTH_128,
+        };
+        esp_err_t err = ppa_register_client(&blend_cfg, &s_blend_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG_V9, "ppa blend client register failed: %d", err);
+            s_blend_handle = NULL;
+            return;
+        }
+        err = ppa_register_client(&fill_cfg, &s_fill_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG_V9, "ppa fill client register failed: %d", err);
+            ppa_unregister_client(s_blend_handle);
+            s_blend_handle = NULL;
+            s_fill_handle = NULL;
+            return;
+        }
+    }
+
+    if (!s_handler_registered) {
+        lv_draw_sw_register_blend_handler(&s_custom_handler_rgb565);
+        lv_draw_sw_register_blend_handler(&s_custom_handler_rgb888);
+        s_handler_registered = true;
+        ESP_LOGD(TAG, "PPA v9 blend handler registered for RGB565/RGB888");
+    }
+}
+
+#else /* !CONFIG_SOC_PPA_SUPPORTED */
+
+void lvgl_port_ppa_v9_init(lv_display_t *display)
+{
+    (void)display;
+}
+
+#endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
+++ b/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
@@ -49,9 +49,9 @@ static uint32_t s_ppa_sw_fallback = 0;
 static uint32_t s_ppa_stats_last_log_ms = 0;
 
 #include "esp_timer.h"
-static inline uint32_t ppa_now_ms(void) { return (uint32_t) (esp_timer_get_time() / 1000); }
+static inline uint32_t ppa_now_ms() { return (uint32_t) (esp_timer_get_time() / 1000); }
 
-static void ppa_stats_maybe_log(void) {
+static void ppa_stats_maybe_log() {
 #if PPA_STATS_INTERVAL_MS > 0
   uint32_t now = ppa_now_ms();
   if (!lvgl_esphome_get_perf_logging_enabled()) {
@@ -96,7 +96,7 @@ static lv_draw_sw_custom_blend_handler_t s_custom_handler_rgb888 = {
     .handler = lv_draw_ppa_v9_handler,
 };
 
-static size_t ppa_align(void) {
+static size_t ppa_align() {
   if (s_cache_align == 0) {
     esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &s_cache_align);
     if (s_cache_align == 0 || (s_cache_align & (s_cache_align - 1)) != 0) {

--- a/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
+++ b/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
@@ -32,16 +32,16 @@
 
 uint32_t lvgl_esphome_get_perf_logging_enabled(void);
 
-#define LVGL_PORT_PPA_ALIGNMENT       64
+#define LVGL_PORT_PPA_ALIGNMENT       (64)
 #define LVGL_PORT_PPA_ALIGN_UP(s, a)  (((s) + ((a) - 1)) & ~((a) - 1))
-#define LVGL_PORT_PPA_MIN_AREA_PX     100
+#define LVGL_PORT_PPA_MIN_AREA_PX     (100)
 
 static const char *TAG_V9 = "lvgl";  /* reuse the lvgl tag used by the component */
 
 /* Instrumentation: how many ops landed on hardware vs the SW fallback,
    reported once every PPA_STATS_INTERVAL_MS to confirm acceleration is
    live. Set PPA_STATS_INTERVAL_MS to 0 to silence. */
-#define PPA_STATS_INTERVAL_MS 2000
+#define PPA_STATS_INTERVAL_MS (2000)
 
 static uint32_t s_ppa_hw_fills   = 0;
 static uint32_t s_ppa_hw_blends  = 0;

--- a/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
+++ b/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.c
@@ -32,52 +32,50 @@
 
 uint32_t lvgl_esphome_get_perf_logging_enabled(void);
 
-#define LVGL_PORT_PPA_ALIGNMENT       (64)
-#define LVGL_PORT_PPA_ALIGN_UP(s, a)  (((s) + ((a) - 1)) & ~((a) - 1))
-#define LVGL_PORT_PPA_MIN_AREA_PX     (100)
+#define LVGL_PORT_PPA_ALIGNMENT (64)
+#define LVGL_PORT_PPA_ALIGN_UP(s, a) (((s) + ((a) -1)) & ~((a) -1))
+#define LVGL_PORT_PPA_MIN_AREA_PX (100)
 
-static const char *TAG_V9 = "lvgl";  /* reuse the lvgl tag used by the component */
+static const char *TAG_V9 = "lvgl"; /* reuse the lvgl tag used by the component */
 
 /* Instrumentation: how many ops landed on hardware vs the SW fallback,
    reported once every PPA_STATS_INTERVAL_MS to confirm acceleration is
    live. Set PPA_STATS_INTERVAL_MS to 0 to silence. */
 #define PPA_STATS_INTERVAL_MS (2000)
 
-static uint32_t s_ppa_hw_fills   = 0;
-static uint32_t s_ppa_hw_blends  = 0;
+static uint32_t s_ppa_hw_fills = 0;
+static uint32_t s_ppa_hw_blends = 0;
 static uint32_t s_ppa_sw_fallback = 0;
 static uint32_t s_ppa_stats_last_log_ms = 0;
 
 #include "esp_timer.h"
-static inline uint32_t ppa_now_ms(void) {
-    return (uint32_t)(esp_timer_get_time() / 1000);
-}
+static inline uint32_t ppa_now_ms(void) { return (uint32_t) (esp_timer_get_time() / 1000); }
 
 static void ppa_stats_maybe_log(void) {
 #if PPA_STATS_INTERVAL_MS > 0
-    uint32_t now = ppa_now_ms();
-    if (!lvgl_esphome_get_perf_logging_enabled()) {
-        s_ppa_hw_fills = 0;
-        s_ppa_hw_blends = 0;
-        s_ppa_sw_fallback = 0;
-        s_ppa_stats_last_log_ms = now;
-        return;
+  uint32_t now = ppa_now_ms();
+  if (!lvgl_esphome_get_perf_logging_enabled()) {
+    s_ppa_hw_fills = 0;
+    s_ppa_hw_blends = 0;
+    s_ppa_sw_fallback = 0;
+    s_ppa_stats_last_log_ms = now;
+    return;
+  }
+  if (s_ppa_stats_last_log_ms == 0)
+    s_ppa_stats_last_log_ms = now;
+  if (now - s_ppa_stats_last_log_ms >= PPA_STATS_INTERVAL_MS) {
+    uint32_t total = s_ppa_hw_fills + s_ppa_hw_blends + s_ppa_sw_fallback;
+    if (total > 0) {
+      uint32_t hw = s_ppa_hw_fills + s_ppa_hw_blends;
+      ESP_LOGD(TAG_V9, "PPA ops/2s: HW=%lu (fill=%lu, blend=%lu)  SW=%lu  hw_ratio=%lu%%", (unsigned long) hw,
+               (unsigned long) s_ppa_hw_fills, (unsigned long) s_ppa_hw_blends, (unsigned long) s_ppa_sw_fallback,
+               (unsigned long) (hw * 100 / total));
     }
-    if (s_ppa_stats_last_log_ms == 0) s_ppa_stats_last_log_ms = now;
-    if (now - s_ppa_stats_last_log_ms >= PPA_STATS_INTERVAL_MS) {
-        uint32_t total = s_ppa_hw_fills + s_ppa_hw_blends + s_ppa_sw_fallback;
-        if (total > 0) {
-            uint32_t hw = s_ppa_hw_fills + s_ppa_hw_blends;
-            ESP_LOGD(TAG_V9, "PPA ops/2s: HW=%lu (fill=%lu, blend=%lu)  SW=%lu  hw_ratio=%lu%%",
-                     (unsigned long)hw, (unsigned long)s_ppa_hw_fills,
-                     (unsigned long)s_ppa_hw_blends, (unsigned long)s_ppa_sw_fallback,
-                     (unsigned long)(hw * 100 / total));
-        }
-        s_ppa_hw_fills = 0;
-        s_ppa_hw_blends = 0;
-        s_ppa_sw_fallback = 0;
-        s_ppa_stats_last_log_ms = now;
-    }
+    s_ppa_hw_fills = 0;
+    s_ppa_hw_blends = 0;
+    s_ppa_sw_fallback = 0;
+    s_ppa_stats_last_log_ms = now;
+  }
 #endif
 }
 
@@ -98,416 +96,403 @@ static lv_draw_sw_custom_blend_handler_t s_custom_handler_rgb888 = {
     .handler = lv_draw_ppa_v9_handler,
 };
 
-static size_t ppa_align(void)
-{
-    if (s_cache_align == 0) {
-        esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &s_cache_align);
-        if (s_cache_align == 0 || (s_cache_align & (s_cache_align - 1)) != 0) {
-            s_cache_align = LVGL_PORT_PPA_ALIGNMENT;
-        }
+static size_t ppa_align(void) {
+  if (s_cache_align == 0) {
+    esp_cache_get_alignment(MALLOC_CAP_SPIRAM, &s_cache_align);
+    if (s_cache_align == 0 || (s_cache_align & (s_cache_align - 1)) != 0) {
+      s_cache_align = LVGL_PORT_PPA_ALIGNMENT;
     }
-    return s_cache_align;
+  }
+  return s_cache_align;
 }
 
-static void ppa_cache_sync_region(const lv_area_t *area, const lv_area_t *buf_area,
-                                  void *buf, uint32_t px_size, int flag)
-{
-    if (!area || !buf_area || !buf || !esp_ptr_external_ram(buf)) {
-        return;
-    }
+static void ppa_cache_sync_region(const lv_area_t *area, const lv_area_t *buf_area, void *buf, uint32_t px_size,
+                                  int flag) {
+  if (!area || !buf_area || !buf || !esp_ptr_external_ram(buf)) {
+    return;
+  }
 
-    size_t align = ppa_align();
-    int32_t width = lv_area_get_width(area);
-    int32_t height = lv_area_get_height(area);
-    int32_t buf_w = lv_area_get_width(buf_area);
-    int32_t buf_h = lv_area_get_height(buf_area);
+  size_t align = ppa_align();
+  int32_t width = lv_area_get_width(area);
+  int32_t height = lv_area_get_height(area);
+  int32_t buf_w = lv_area_get_width(buf_area);
+  int32_t buf_h = lv_area_get_height(buf_area);
 
-    if (width <= 0 || height <= 0 || buf_w <= 0 || buf_h <= 0 || px_size == 0) {
-        return;
-    }
+  if (width <= 0 || height <= 0 || buf_w <= 0 || buf_h <= 0 || px_size == 0) {
+    return;
+  }
 
-    int32_t off_x = area->x1 - buf_area->x1;
-    int32_t off_y = area->y1 - buf_area->y1;
+  int32_t off_x = area->x1 - buf_area->x1;
+  int32_t off_y = area->y1 - buf_area->y1;
 
-    if (off_x < 0 || off_y < 0 || (off_x + width) > buf_w || (off_y + height) > buf_h) {
-        return;
-    }
+  if (off_x < 0 || off_y < 0 || (off_x + width) > buf_w || (off_y + height) > buf_h) {
+    return;
+  }
 
-    uint8_t *start = (uint8_t *)buf + ((size_t)off_y * buf_w + off_x) * px_size;
-    size_t bytes = ((size_t)(height - 1) * (size_t)buf_w + (size_t)width) * px_size;
-    uintptr_t addr = (uintptr_t)start;
-    uintptr_t aligned_addr = addr & ~(align - 1);
-    size_t total = LVGL_PORT_PPA_ALIGN_UP(bytes + (addr - aligned_addr), align);
+  uint8_t *start = (uint8_t *) buf + ((size_t) off_y * buf_w + off_x) * px_size;
+  size_t bytes = ((size_t) (height - 1) * (size_t) buf_w + (size_t) width) * px_size;
+  uintptr_t addr = (uintptr_t) start;
+  uintptr_t aligned_addr = addr & ~(align - 1);
+  size_t total = LVGL_PORT_PPA_ALIGN_UP(bytes + (addr - aligned_addr), align);
 
-    /* LVGL PR #10107: tolerate unaligned CPU-to-memory flushes. ESP-IDF does
-     * not allow ESP_CACHE_MSYNC_FLAG_UNALIGNED with memory-to-cache
-     * invalidation, so M2C uses the manually aligned region above. */
-    int msync_flags = flag | ESP_CACHE_MSYNC_FLAG_TYPE_DATA;
-    if ((flag & ESP_CACHE_MSYNC_FLAG_DIR_M2C) == 0) {
-        msync_flags |= ESP_CACHE_MSYNC_FLAG_UNALIGNED;
-    }
-    esp_cache_msync((void *)aligned_addr, total, msync_flags);
+  /* LVGL PR #10107: tolerate unaligned CPU-to-memory flushes. ESP-IDF does
+   * not allow ESP_CACHE_MSYNC_FLAG_UNALIGNED with memory-to-cache
+   * invalidation, so M2C uses the manually aligned region above. */
+  int msync_flags = flag | ESP_CACHE_MSYNC_FLAG_TYPE_DATA;
+  if ((flag & ESP_CACHE_MSYNC_FLAG_DIR_M2C) == 0) {
+    msync_flags |= ESP_CACHE_MSYNC_FLAG_UNALIGNED;
+  }
+  esp_cache_msync((void *) aligned_addr, total, msync_flags);
 }
 
-static void ppa_cache_invalidate(const lv_area_t *area, const lv_area_t *buf_area, void *buf, uint32_t px_size)
-{
-    ppa_cache_sync_region(area, buf_area, buf, px_size, ESP_CACHE_MSYNC_FLAG_DIR_M2C);
+static void ppa_cache_invalidate(const lv_area_t *area, const lv_area_t *buf_area, void *buf, uint32_t px_size) {
+  ppa_cache_sync_region(area, buf_area, buf, px_size, ESP_CACHE_MSYNC_FLAG_DIR_M2C);
 }
 
-static void ppa_blend(void *bg_buf, lv_color_format_t color_format, uint32_t px_size,
-                      const lv_area_t *bg_area, const void *fg_buf, const lv_area_t *fg_area,
-                      uint16_t fg_stride_px, const lv_area_t *block_area, lv_opa_t opa)
-{
-    uint16_t bg_w = lv_area_get_width(bg_area);
-    uint16_t bg_h = lv_area_get_height(bg_area);
-    uint16_t bg_off_x = block_area->x1 - bg_area->x1;
-    uint16_t bg_off_y = block_area->y1 - bg_area->y1;
+static void ppa_blend(void *bg_buf, lv_color_format_t color_format, uint32_t px_size, const lv_area_t *bg_area,
+                      const void *fg_buf, const lv_area_t *fg_area, uint16_t fg_stride_px, const lv_area_t *block_area,
+                      lv_opa_t opa) {
+  uint16_t bg_w = lv_area_get_width(bg_area);
+  uint16_t bg_h = lv_area_get_height(bg_area);
+  uint16_t bg_off_x = block_area->x1 - bg_area->x1;
+  uint16_t bg_off_y = block_area->y1 - bg_area->y1;
 
-    uint16_t block_w = lv_area_get_width(block_area);
-    uint16_t block_h = lv_area_get_height(block_area);
-    uint16_t fg_w = fg_stride_px;
-    uint16_t fg_h = lv_area_get_height(fg_area);
-    uint16_t fg_off_x = block_area->x1 - fg_area->x1;
-    uint16_t fg_off_y = block_area->y1 - fg_area->y1;
+  uint16_t block_w = lv_area_get_width(block_area);
+  uint16_t block_h = lv_area_get_height(block_area);
+  uint16_t fg_w = fg_stride_px;
+  uint16_t fg_h = lv_area_get_height(fg_area);
+  uint16_t fg_off_x = block_area->x1 - fg_area->x1;
+  uint16_t fg_off_y = block_area->y1 - fg_area->y1;
 
-    if ((uint32_t)fg_off_x + block_w > fg_w) {
-        fg_w = fg_off_x + block_w;
-    }
-    if ((uint32_t)fg_off_y + block_h > fg_h) {
-        fg_h = fg_off_y + block_h;
-    }
-    size_t align = ppa_align();
-    ppa_blend_color_mode_t ppa_cf = lv_color_format_to_ppa_blend(color_format);
+  if ((uint32_t) fg_off_x + block_w > fg_w) {
+    fg_w = fg_off_x + block_w;
+  }
+  if ((uint32_t) fg_off_y + block_h > fg_h) {
+    fg_h = fg_off_y + block_h;
+  }
+  size_t align = ppa_align();
+  ppa_blend_color_mode_t ppa_cf = lv_color_format_to_ppa_blend(color_format);
 
-    ppa_blend_oper_config_t cfg = {
-        .in_bg = {
-            .buffer = bg_buf,
-            .pic_w = bg_w,
-            .pic_h = bg_h,
-            .block_w = block_w,
-            .block_h = block_h,
-            .block_offset_x = bg_off_x,
-            .block_offset_y = bg_off_y,
-            .blend_cm = ppa_cf,
-        },
-        .in_fg = {
-            .buffer = fg_buf,
-            .pic_w = fg_w,
-            .pic_h = fg_h,
-            .block_w = block_w,
-            .block_h = block_h,
-            .block_offset_x = fg_off_x,
-            .block_offset_y = fg_off_y,
-            .blend_cm = ppa_cf,
-        },
-        .out = {
-            .buffer = bg_buf,
-            .buffer_size = LVGL_PORT_PPA_ALIGN_UP((size_t)px_size * bg_w * bg_h, align),
-            .pic_w = bg_w,
-            .pic_h = bg_h,
-            .block_offset_x = bg_off_x,
-            .block_offset_y = bg_off_y,
-            .blend_cm = ppa_cf,
-        },
-        .bg_rgb_swap = 0,
-        .bg_byte_swap = 0,
-        .bg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
-        .bg_alpha_fix_val = (uint8_t)(255 - opa),
-        .fg_rgb_swap = 0,
-        .fg_byte_swap = 0,
-        .fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
-        .fg_alpha_fix_val = opa,
-        .mode = PPA_TRANS_MODE_BLOCKING,
-    };
+  ppa_blend_oper_config_t cfg = {
+      .in_bg =
+          {
+              .buffer = bg_buf,
+              .pic_w = bg_w,
+              .pic_h = bg_h,
+              .block_w = block_w,
+              .block_h = block_h,
+              .block_offset_x = bg_off_x,
+              .block_offset_y = bg_off_y,
+              .blend_cm = ppa_cf,
+          },
+      .in_fg =
+          {
+              .buffer = fg_buf,
+              .pic_w = fg_w,
+              .pic_h = fg_h,
+              .block_w = block_w,
+              .block_h = block_h,
+              .block_offset_x = fg_off_x,
+              .block_offset_y = fg_off_y,
+              .blend_cm = ppa_cf,
+          },
+      .out =
+          {
+              .buffer = bg_buf,
+              .buffer_size = LVGL_PORT_PPA_ALIGN_UP((size_t) px_size * bg_w * bg_h, align),
+              .pic_w = bg_w,
+              .pic_h = bg_h,
+              .block_offset_x = bg_off_x,
+              .block_offset_y = bg_off_y,
+              .blend_cm = ppa_cf,
+          },
+      .bg_rgb_swap = 0,
+      .bg_byte_swap = 0,
+      .bg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
+      .bg_alpha_fix_val = (uint8_t) (255 - opa),
+      .fg_rgb_swap = 0,
+      .fg_byte_swap = 0,
+      .fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
+      .fg_alpha_fix_val = opa,
+      .mode = PPA_TRANS_MODE_BLOCKING,
+  };
 
-    esp_err_t err = ppa_do_blend(s_blend_handle, &cfg);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG_V9, "ppa_do_blend failed: %d", err);
-    }
+  esp_err_t err = ppa_do_blend(s_blend_handle, &cfg);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG_V9, "ppa_do_blend failed: %d", err);
+  }
 }
 
-static void ppa_fill(void *bg_buf, lv_color_format_t color_format, uint32_t px_size,
-                     const lv_area_t *bg_area, const lv_area_t *block_area, lv_color_t color)
-{
-    uint16_t bg_w = lv_area_get_width(bg_area);
-    uint16_t bg_h = lv_area_get_height(bg_area);
-    size_t align = ppa_align();
-    ppa_fill_color_mode_t ppa_cf = lv_color_format_to_ppa_fill(color_format);
+static void ppa_fill(void *bg_buf, lv_color_format_t color_format, uint32_t px_size, const lv_area_t *bg_area,
+                     const lv_area_t *block_area, lv_color_t color) {
+  uint16_t bg_w = lv_area_get_width(bg_area);
+  uint16_t bg_h = lv_area_get_height(bg_area);
+  size_t align = ppa_align();
+  ppa_fill_color_mode_t ppa_cf = lv_color_format_to_ppa_fill(color_format);
 
-    lv_color32_t c32 = lv_color_to_32(color, LV_OPA_COVER);
-    uint32_t argb = ((uint32_t)c32.alpha << 24) | ((uint32_t)c32.red << 16) |
-                    ((uint32_t)c32.green << 8) | ((uint32_t)c32.blue);
+  lv_color32_t c32 = lv_color_to_32(color, LV_OPA_COVER);
+  uint32_t argb =
+      ((uint32_t) c32.alpha << 24) | ((uint32_t) c32.red << 16) | ((uint32_t) c32.green << 8) | ((uint32_t) c32.blue);
 
-    ppa_fill_oper_config_t cfg = {
-        .out = {
-            .buffer = bg_buf,
-            .buffer_size = LVGL_PORT_PPA_ALIGN_UP((size_t)px_size * bg_w * bg_h, align),
-            .pic_w = bg_w,
-            .pic_h = bg_h,
-            .block_offset_x = (uint32_t)(block_area->x1 - bg_area->x1),
-            .block_offset_y = (uint32_t)(block_area->y1 - bg_area->y1),
-            .fill_cm = ppa_cf,
-        },
-        .fill_block_w = (uint32_t)lv_area_get_width(block_area),
-        .fill_block_h = (uint32_t)lv_area_get_height(block_area),
-        .mode = PPA_TRANS_MODE_BLOCKING,
-    };
-    cfg.fill_argb_color.val = argb;
+  ppa_fill_oper_config_t cfg = {
+      .out =
+          {
+              .buffer = bg_buf,
+              .buffer_size = LVGL_PORT_PPA_ALIGN_UP((size_t) px_size * bg_w * bg_h, align),
+              .pic_w = bg_w,
+              .pic_h = bg_h,
+              .block_offset_x = (uint32_t) (block_area->x1 - bg_area->x1),
+              .block_offset_y = (uint32_t) (block_area->y1 - bg_area->y1),
+              .fill_cm = ppa_cf,
+          },
+      .fill_block_w = (uint32_t) lv_area_get_width(block_area),
+      .fill_block_h = (uint32_t) lv_area_get_height(block_area),
+      .mode = PPA_TRANS_MODE_BLOCKING,
+  };
+  cfg.fill_argb_color.val = argb;
 
-    esp_err_t err = ppa_do_fill(s_fill_handle, &cfg);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG_V9, "ppa_do_fill failed: %d", err);
-    }
+  esp_err_t err = ppa_do_fill(s_fill_handle, &cfg);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG_V9, "ppa_do_fill failed: %d", err);
+  }
 }
 
-static void lv_draw_ppa_v9_sw_fallback(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc)
-{
-    lv_layer_t *layer = t->target_layer;
-    if (!layer || !layer->draw_buf) {
-        return;
-    }
+static void lv_draw_ppa_v9_sw_fallback(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc) {
+  lv_layer_t *layer = t->target_layer;
+  if (!layer || !layer->draw_buf) {
+    return;
+  }
 
-    lv_area_t blend_area;
-    if (!lv_area_intersect(&blend_area, dsc->blend_area, &t->clip_area)) {
-        return;
-    }
+  lv_area_t blend_area;
+  if (!lv_area_intersect(&blend_area, dsc->blend_area, &t->clip_area)) {
+    return;
+  }
 
-    uint32_t layer_stride = layer->draw_buf->header.stride;
+  uint32_t layer_stride = layer->draw_buf->header.stride;
 
-    if (dsc->src_buf == NULL) {
-        lv_draw_sw_blend_fill_dsc_t fill_dsc;
-        lv_memzero(&fill_dsc, sizeof(fill_dsc));
-        fill_dsc.dest_w = lv_area_get_width(&blend_area);
-        fill_dsc.dest_h = lv_area_get_height(&blend_area);
-        fill_dsc.dest_stride = layer_stride;
-        fill_dsc.opa = dsc->opa;
-        fill_dsc.color = dsc->color;
-        if (dsc->mask_buf == NULL || dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) {
-            fill_dsc.mask_buf = NULL;
-        } else {
-            fill_dsc.mask_buf = dsc->mask_buf;
-            fill_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : (uint32_t)lv_area_get_width(dsc->mask_area);
-            fill_dsc.mask_buf += fill_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) +
-                                 (blend_area.x1 - dsc->mask_area->x1);
-        }
-
-        fill_dsc.relative_area = blend_area;
-        lv_area_move(&fill_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
-        fill_dsc.dest_buf = lv_draw_layer_go_to_xy(layer,
-                                                   blend_area.x1 - layer->buf_area.x1,
-                                                   blend_area.y1 - layer->buf_area.y1);
-        if (layer->color_format == LV_COLOR_FORMAT_RGB888) {
-            lv_draw_sw_blend_color_to_rgb888(&fill_dsc, lv_color_format_get_size(layer->color_format));
-        } else {
-            lv_draw_sw_blend_color_to_rgb565(&fill_dsc);
-        }
-        return;
-    }
-
-    lv_draw_sw_blend_image_dsc_t image_dsc;
-    lv_memzero(&image_dsc, sizeof(image_dsc));
-    image_dsc.dest_w = lv_area_get_width(&blend_area);
-    image_dsc.dest_h = lv_area_get_height(&blend_area);
-    image_dsc.dest_stride = layer_stride;
-    image_dsc.opa = dsc->opa;
-    image_dsc.blend_mode = dsc->blend_mode;
-    const lv_area_t *src_area = dsc->src_area ? dsc->src_area : dsc->blend_area;
-    uint32_t src_px_size = lv_color_format_get_size(dsc->src_color_format);
-    image_dsc.src_stride = dsc->src_stride ? dsc->src_stride : (lv_area_get_width(src_area) * src_px_size);
-    image_dsc.src_color_format = dsc->src_color_format;
-
-    const uint8_t *src_buf = (const uint8_t *)dsc->src_buf;
-    src_buf += (size_t)(blend_area.y1 - src_area->y1) * image_dsc.src_stride;
-    src_buf += (size_t)(blend_area.x1 - src_area->x1) * src_px_size;
-    image_dsc.src_buf = src_buf;
-
+  if (dsc->src_buf == NULL) {
+    lv_draw_sw_blend_fill_dsc_t fill_dsc;
+    lv_memzero(&fill_dsc, sizeof(fill_dsc));
+    fill_dsc.dest_w = lv_area_get_width(&blend_area);
+    fill_dsc.dest_h = lv_area_get_height(&blend_area);
+    fill_dsc.dest_stride = layer_stride;
+    fill_dsc.opa = dsc->opa;
+    fill_dsc.color = dsc->color;
     if (dsc->mask_buf == NULL || dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) {
-        image_dsc.mask_buf = NULL;
+      fill_dsc.mask_buf = NULL;
     } else {
-        image_dsc.mask_buf = dsc->mask_buf;
-        image_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : (uint32_t)lv_area_get_width(dsc->mask_area);
-        image_dsc.mask_buf += image_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) +
-                              (blend_area.x1 - dsc->mask_area->x1);
+      fill_dsc.mask_buf = dsc->mask_buf;
+      fill_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : (uint32_t) lv_area_get_width(dsc->mask_area);
+      fill_dsc.mask_buf +=
+          fill_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) + (blend_area.x1 - dsc->mask_area->x1);
     }
 
-    image_dsc.relative_area = blend_area;
-    lv_area_move(&image_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
-    if (src_area) {
-        image_dsc.src_area = *src_area;
-        lv_area_move(&image_dsc.src_area, -layer->buf_area.x1, -layer->buf_area.y1);
-    } else {
-        lv_memset(&image_dsc.src_area, 0, sizeof(image_dsc.src_area));
-    }
-    image_dsc.dest_buf = lv_draw_layer_go_to_xy(layer,
-                                                blend_area.x1 - layer->buf_area.x1,
-                                                blend_area.y1 - layer->buf_area.y1);
-
+    fill_dsc.relative_area = blend_area;
+    lv_area_move(&fill_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
+    fill_dsc.dest_buf =
+        lv_draw_layer_go_to_xy(layer, blend_area.x1 - layer->buf_area.x1, blend_area.y1 - layer->buf_area.y1);
     if (layer->color_format == LV_COLOR_FORMAT_RGB888) {
-        lv_draw_sw_blend_image_to_rgb888(&image_dsc, lv_color_format_get_size(layer->color_format));
+      lv_draw_sw_blend_color_to_rgb888(&fill_dsc, lv_color_format_get_size(layer->color_format));
     } else {
-        lv_draw_sw_blend_image_to_rgb565(&image_dsc);
+      lv_draw_sw_blend_color_to_rgb565(&fill_dsc);
     }
+    return;
+  }
+
+  lv_draw_sw_blend_image_dsc_t image_dsc;
+  lv_memzero(&image_dsc, sizeof(image_dsc));
+  image_dsc.dest_w = lv_area_get_width(&blend_area);
+  image_dsc.dest_h = lv_area_get_height(&blend_area);
+  image_dsc.dest_stride = layer_stride;
+  image_dsc.opa = dsc->opa;
+  image_dsc.blend_mode = dsc->blend_mode;
+  const lv_area_t *src_area = dsc->src_area ? dsc->src_area : dsc->blend_area;
+  uint32_t src_px_size = lv_color_format_get_size(dsc->src_color_format);
+  image_dsc.src_stride = dsc->src_stride ? dsc->src_stride : (lv_area_get_width(src_area) * src_px_size);
+  image_dsc.src_color_format = dsc->src_color_format;
+
+  const uint8_t *src_buf = (const uint8_t *) dsc->src_buf;
+  src_buf += (size_t) (blend_area.y1 - src_area->y1) * image_dsc.src_stride;
+  src_buf += (size_t) (blend_area.x1 - src_area->x1) * src_px_size;
+  image_dsc.src_buf = src_buf;
+
+  if (dsc->mask_buf == NULL || dsc->mask_res == LV_DRAW_SW_MASK_RES_FULL_COVER) {
+    image_dsc.mask_buf = NULL;
+  } else {
+    image_dsc.mask_buf = dsc->mask_buf;
+    image_dsc.mask_stride = dsc->mask_stride ? dsc->mask_stride : (uint32_t) lv_area_get_width(dsc->mask_area);
+    image_dsc.mask_buf +=
+        image_dsc.mask_stride * (blend_area.y1 - dsc->mask_area->y1) + (blend_area.x1 - dsc->mask_area->x1);
+  }
+
+  image_dsc.relative_area = blend_area;
+  lv_area_move(&image_dsc.relative_area, -layer->buf_area.x1, -layer->buf_area.y1);
+  if (src_area) {
+    image_dsc.src_area = *src_area;
+    lv_area_move(&image_dsc.src_area, -layer->buf_area.x1, -layer->buf_area.y1);
+  } else {
+    lv_memset(&image_dsc.src_area, 0, sizeof(image_dsc.src_area));
+  }
+  image_dsc.dest_buf =
+      lv_draw_layer_go_to_xy(layer, blend_area.x1 - layer->buf_area.x1, blend_area.y1 - layer->buf_area.y1);
+
+  if (layer->color_format == LV_COLOR_FORMAT_RGB888) {
+    lv_draw_sw_blend_image_to_rgb888(&image_dsc, lv_color_format_get_size(layer->color_format));
+  } else {
+    lv_draw_sw_blend_image_to_rgb565(&image_dsc);
+  }
 }
 
 /* Wrap the SW fallback so we don't have to instrument every call site. */
-static inline void lv_draw_ppa_v9_sw_fallback_tracked(lv_draw_task_t *t,
-                                                       const lv_draw_sw_blend_dsc_t *dsc) {
-    s_ppa_sw_fallback++;
-    lv_draw_ppa_v9_sw_fallback(t, dsc);
+static inline void lv_draw_ppa_v9_sw_fallback_tracked(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc) {
+  s_ppa_sw_fallback++;
+  lv_draw_ppa_v9_sw_fallback(t, dsc);
 }
 #define lv_draw_ppa_v9_sw_fallback(t, dsc) lv_draw_ppa_v9_sw_fallback_tracked((t), (dsc))
 
-static void lv_draw_ppa_v9_handler(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc)
-{
-    ppa_stats_maybe_log();
-    lv_layer_t *layer = t->target_layer;
-    if (!layer || !layer->draw_buf ||
-            (layer->color_format != LV_COLOR_FORMAT_RGB565 && layer->color_format != LV_COLOR_FORMAT_RGB888)) {
-        lv_draw_ppa_v9_sw_fallback(t, dsc);
-        return;
-    }
-
-    uint32_t dst_px_size = lv_color_format_get_size(layer->color_format);
-    if (dst_px_size == 0) {
-        lv_draw_ppa_v9_sw_fallback(t, dsc);
-        return;
-    }
-
-    lv_area_t block_area;
-    if (!_lv_area_intersect(&block_area, dsc->blend_area, &t->clip_area)) {
-        return;
-    }
-
-    if (dsc->mask_buf && dsc->mask_res != LV_DRAW_SW_MASK_RES_FULL_COVER &&
-            dsc->mask_res != LV_DRAW_SW_MASK_RES_UNKNOWN) {
-        lv_draw_ppa_v9_sw_fallback(t, dsc);
-        return;
-    }
-
-    if (lv_area_get_size(&block_area) <= LVGL_PORT_PPA_MIN_AREA_PX) {
-        lv_draw_ppa_v9_sw_fallback(t, dsc);
-        return;
-    }
-
-    void *bg_buf = layer->draw_buf->data;
-    size_t align = ppa_align();
-    if (!bg_buf || ((uintptr_t)bg_buf % align) != 0) {
-        lv_draw_ppa_v9_sw_fallback(t, dsc);
-        return;
-    }
-
-    if (block_area.x1 < layer->buf_area.x1 || block_area.y1 < layer->buf_area.y1 ||
-            block_area.x2 > layer->buf_area.x2 || block_area.y2 > layer->buf_area.y2) {
-        lv_draw_ppa_v9_sw_fallback(t, dsc);
-        return;
-    }
-
-    ppa_cache_sync_region(&block_area, &layer->buf_area, bg_buf, dst_px_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
-
-    if (dsc->src_buf) {
-        if (dsc->src_color_format != layer->color_format) {
-            lv_draw_ppa_v9_sw_fallback(t, dsc);
-            return;
-        }
-
-        const lv_area_t *src_area = dsc->src_area ? dsc->src_area : dsc->blend_area;
-        uint32_t src_px_size = lv_color_format_get_size(dsc->src_color_format);
-        size_t src_stride = dsc->src_stride ? dsc->src_stride : (lv_area_get_width(src_area) * src_px_size);
-
-        if (src_px_size == 0 || (src_stride % src_px_size) != 0) {
-            lv_draw_ppa_v9_sw_fallback(t, dsc);
-            return;
-        }
-
-        int32_t src_off_x = block_area.x1 - src_area->x1;
-        int32_t src_off_y = block_area.y1 - src_area->y1;
-        if (src_off_x < 0 || src_off_y < 0) {
-            lv_draw_ppa_v9_sw_fallback(t, dsc);
-            return;
-        }
-
-        const uint8_t *src_ptr8 = (const uint8_t *)dsc->src_buf +
-                                  (size_t)src_off_y * src_stride +
-                                  (size_t)src_off_x * src_px_size;
-        uintptr_t src_addr = (uintptr_t)src_ptr8;
-        uintptr_t src_aligned = src_addr & ~(align - 1);
-        size_t src_total = LVGL_PORT_PPA_ALIGN_UP(
-                               ((size_t)(lv_area_get_height(&block_area) - 1) * src_stride +
-                                (size_t)lv_area_get_width(&block_area) * src_px_size) +
-                               (src_addr - src_aligned), align);
-        if (esp_ptr_external_ram((void *)dsc->src_buf)) {
-            esp_cache_msync((void *)src_aligned, src_total,
-                            ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
-        }
-
-        uint16_t src_stride_px = src_stride / src_px_size;
-        s_ppa_hw_blends++;
-        ppa_blend(bg_buf, layer->color_format, dst_px_size, &layer->buf_area, dsc->src_buf,
-                  src_area, src_stride_px, &block_area, dsc->opa);
-
-        ppa_cache_invalidate(&block_area, &layer->buf_area, bg_buf, dst_px_size);
-        return;
-    }
-
-    if (dsc->opa >= LV_OPA_MAX) {
-        s_ppa_hw_fills++;
-        ppa_fill(bg_buf, layer->color_format, dst_px_size, &layer->buf_area, &block_area, dsc->color);
-        ppa_cache_invalidate(&block_area, &layer->buf_area, bg_buf, dst_px_size);
-        return;
-    }
-
+static void lv_draw_ppa_v9_handler(lv_draw_task_t *t, const lv_draw_sw_blend_dsc_t *dsc) {
+  ppa_stats_maybe_log();
+  lv_layer_t *layer = t->target_layer;
+  if (!layer || !layer->draw_buf ||
+      (layer->color_format != LV_COLOR_FORMAT_RGB565 && layer->color_format != LV_COLOR_FORMAT_RGB888)) {
     lv_draw_ppa_v9_sw_fallback(t, dsc);
+    return;
+  }
+
+  uint32_t dst_px_size = lv_color_format_get_size(layer->color_format);
+  if (dst_px_size == 0) {
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+    return;
+  }
+
+  lv_area_t block_area;
+  if (!_lv_area_intersect(&block_area, dsc->blend_area, &t->clip_area)) {
+    return;
+  }
+
+  if (dsc->mask_buf && dsc->mask_res != LV_DRAW_SW_MASK_RES_FULL_COVER &&
+      dsc->mask_res != LV_DRAW_SW_MASK_RES_UNKNOWN) {
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+    return;
+  }
+
+  if (lv_area_get_size(&block_area) <= LVGL_PORT_PPA_MIN_AREA_PX) {
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+    return;
+  }
+
+  void *bg_buf = layer->draw_buf->data;
+  size_t align = ppa_align();
+  if (!bg_buf || ((uintptr_t) bg_buf % align) != 0) {
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+    return;
+  }
+
+  if (block_area.x1 < layer->buf_area.x1 || block_area.y1 < layer->buf_area.y1 || block_area.x2 > layer->buf_area.x2 ||
+      block_area.y2 > layer->buf_area.y2) {
+    lv_draw_ppa_v9_sw_fallback(t, dsc);
+    return;
+  }
+
+  ppa_cache_sync_region(&block_area, &layer->buf_area, bg_buf, dst_px_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+
+  if (dsc->src_buf) {
+    if (dsc->src_color_format != layer->color_format) {
+      lv_draw_ppa_v9_sw_fallback(t, dsc);
+      return;
+    }
+
+    const lv_area_t *src_area = dsc->src_area ? dsc->src_area : dsc->blend_area;
+    uint32_t src_px_size = lv_color_format_get_size(dsc->src_color_format);
+    size_t src_stride = dsc->src_stride ? dsc->src_stride : (lv_area_get_width(src_area) * src_px_size);
+
+    if (src_px_size == 0 || (src_stride % src_px_size) != 0) {
+      lv_draw_ppa_v9_sw_fallback(t, dsc);
+      return;
+    }
+
+    int32_t src_off_x = block_area.x1 - src_area->x1;
+    int32_t src_off_y = block_area.y1 - src_area->y1;
+    if (src_off_x < 0 || src_off_y < 0) {
+      lv_draw_ppa_v9_sw_fallback(t, dsc);
+      return;
+    }
+
+    const uint8_t *src_ptr8 =
+        (const uint8_t *) dsc->src_buf + (size_t) src_off_y * src_stride + (size_t) src_off_x * src_px_size;
+    uintptr_t src_addr = (uintptr_t) src_ptr8;
+    uintptr_t src_aligned = src_addr & ~(align - 1);
+    size_t src_total = LVGL_PORT_PPA_ALIGN_UP(((size_t) (lv_area_get_height(&block_area) - 1) * src_stride +
+                                               (size_t) lv_area_get_width(&block_area) * src_px_size) +
+                                                  (src_addr - src_aligned),
+                                              align);
+    if (esp_ptr_external_ram((void *) dsc->src_buf)) {
+      esp_cache_msync((void *) src_aligned, src_total, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_UNALIGNED);
+    }
+
+    uint16_t src_stride_px = src_stride / src_px_size;
+    s_ppa_hw_blends++;
+    ppa_blend(bg_buf, layer->color_format, dst_px_size, &layer->buf_area, dsc->src_buf, src_area, src_stride_px,
+              &block_area, dsc->opa);
+
+    ppa_cache_invalidate(&block_area, &layer->buf_area, bg_buf, dst_px_size);
+    return;
+  }
+
+  if (dsc->opa >= LV_OPA_MAX) {
+    s_ppa_hw_fills++;
+    ppa_fill(bg_buf, layer->color_format, dst_px_size, &layer->buf_area, &block_area, dsc->color);
+    ppa_cache_invalidate(&block_area, &layer->buf_area, bg_buf, dst_px_size);
+    return;
+  }
+
+  lv_draw_ppa_v9_sw_fallback(t, dsc);
 }
 
-void lvgl_port_ppa_v9_init(lv_display_t *display)
-{
-    if (!display ||
-            (lv_display_get_color_format(display) != LV_COLOR_FORMAT_RGB565 &&
-             lv_display_get_color_format(display) != LV_COLOR_FORMAT_RGB888)) {
-        ESP_LOGD(TAG_V9, "skip: display format unsupported by PPA v9 blend handler");
-        return;
-    }
+void lvgl_port_ppa_v9_init(lv_display_t *display) {
+  if (!display || (lv_display_get_color_format(display) != LV_COLOR_FORMAT_RGB565 &&
+                   lv_display_get_color_format(display) != LV_COLOR_FORMAT_RGB888)) {
+    ESP_LOGD(TAG_V9, "skip: display format unsupported by PPA v9 blend handler");
+    return;
+  }
 
-    if (s_blend_handle == NULL && s_fill_handle == NULL) {
-        ppa_client_config_t blend_cfg = {
-            .oper_type = PPA_OPERATION_BLEND,
-            .max_pending_trans_num = 1,
-            .data_burst_length = PPA_DATA_BURST_LENGTH_128,
-        };
-        ppa_client_config_t fill_cfg = {
-            .oper_type = PPA_OPERATION_FILL,
-            .max_pending_trans_num = 1,
-            .data_burst_length = PPA_DATA_BURST_LENGTH_128,
-        };
-        esp_err_t err = ppa_register_client(&blend_cfg, &s_blend_handle);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG_V9, "ppa blend client register failed: %d", err);
-            s_blend_handle = NULL;
-            return;
-        }
-        err = ppa_register_client(&fill_cfg, &s_fill_handle);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG_V9, "ppa fill client register failed: %d", err);
-            ppa_unregister_client(s_blend_handle);
-            s_blend_handle = NULL;
-            s_fill_handle = NULL;
-            return;
-        }
+  if (s_blend_handle == NULL && s_fill_handle == NULL) {
+    ppa_client_config_t blend_cfg = {
+        .oper_type = PPA_OPERATION_BLEND,
+        .max_pending_trans_num = 1,
+        .data_burst_length = PPA_DATA_BURST_LENGTH_128,
+    };
+    ppa_client_config_t fill_cfg = {
+        .oper_type = PPA_OPERATION_FILL,
+        .max_pending_trans_num = 1,
+        .data_burst_length = PPA_DATA_BURST_LENGTH_128,
+    };
+    esp_err_t err = ppa_register_client(&blend_cfg, &s_blend_handle);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG_V9, "ppa blend client register failed: %d", err);
+      s_blend_handle = NULL;
+      return;
     }
+    err = ppa_register_client(&fill_cfg, &s_fill_handle);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG_V9, "ppa fill client register failed: %d", err);
+      ppa_unregister_client(s_blend_handle);
+      s_blend_handle = NULL;
+      s_fill_handle = NULL;
+      return;
+    }
+  }
 
-    if (!s_handler_registered) {
-        lv_draw_sw_register_blend_handler(&s_custom_handler_rgb565);
-        lv_draw_sw_register_blend_handler(&s_custom_handler_rgb888);
-        s_handler_registered = true;
-        ESP_LOGD(TAG, "PPA v9 blend handler registered for RGB565/RGB888");
-    }
+  if (!s_handler_registered) {
+    lv_draw_sw_register_blend_handler(&s_custom_handler_rgb565);
+    lv_draw_sw_register_blend_handler(&s_custom_handler_rgb888);
+    s_handler_registered = true;
+    ESP_LOGD(TAG, "PPA v9 blend handler registered for RGB565/RGB888");
+  }
 }
 
 #else /* !CONFIG_SOC_PPA_SUPPORTED */
 
-void lvgl_port_ppa_v9_init(lv_display_t *display)
-{
-    (void)display;
-}
+void lvgl_port_ppa_v9_init(lv_display_t *display) { (void) display; }
 
 #endif /* CONFIG_SOC_PPA_SUPPORTED */

--- a/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.h
+++ b/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.h
@@ -1,0 +1,26 @@
+/**
+ * @file lvgl_ppa_accel_v9.h
+ * LVGL v9 PPA hardware blend handler (Espressif esp-iot-solution port)
+ *
+ * Registers a custom SW blend handler that routes RGB565 blend/fill
+ * operations to ESP32-P4 PPA. Complements the higher-level draw unit
+ * in lv_draw_ppa.c by accelerating all SW blend code paths (text,
+ * gradients-after-rasterize, rect edges, etc.).
+ */
+
+#ifndef LVGL_PPA_ACCEL_V9_H
+#define LVGL_PPA_ACCEL_V9_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lvgl.h"
+
+void lvgl_port_ppa_v9_init(lv_display_t *display);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LVGL_PPA_ACCEL_V9_H */

--- a/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.h
+++ b/esphome/components/lvgl/ppa/lvgl_ppa_accel_v9.h
@@ -8,6 +8,9 @@
  * gradients-after-rasterize, rect edges, etc.).
  */
 
+#pragma once
+// namespace esphome::lvgl -- ESPHome lint marker; this header exposes C linkage.
+
 #ifndef LVGL_PPA_ACCEL_V9_H
 #define LVGL_PPA_ACCEL_V9_H
 


### PR DESCRIPTION
# What does this implement/fix?

This adds an optional ESP32-P4 PPA-backed LVGL draw path for ESPHome's LVGL component.

The branch wires LVGL's PPA support into ESPHome builds, adds the PPA draw unit sources, supports RGB888 image paths, and exposes opt-in configuration flags. The default behavior stays conservative: PPA acceleration is disabled unless `use_ppa` or `use_ppa_img` is explicitly enabled.

Implemented by Tomasz Witke (@kyvaith).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) - [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) - [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/6748

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Validated as part of downstream ESP32-P4 LVGL display work using an RGB888 MIPI DSI display. This standalone branch was also checked locally against current `esphome/esphome:dev`.

## Example entry for `config.yaml`:

```yaml
lvgl:
  displays:
    - my_display
  color_depth: 32
  use_ppa: true
  use_ppa_img: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

Local validation performed:

- `git diff --check upstream/dev...lvgl/esp32p4-ppa-draw-unit`
- `python -m py_compile` for changed Python files
