### PR TITLE
[i2s_audio] [micro_wake_word] [resampler] Implement full duplex for Voice Assistant targeting ESP32-P4

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -412,6 +412,7 @@ esphome/components/rc522/* @glmnet
 esphome/components/rc522_i2c/* @glmnet
 esphome/components/rc522_spi/* @glmnet
 esphome/components/rd03d/* @jasstrong
+esphome/components/resampler/microphone/* @kyvaith
 esphome/components/resampler/speaker/* @kahrendt
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz

--- a/esphome/components/audio/audio_resampler.cpp
+++ b/esphome/components/audio/audio_resampler.cpp
@@ -33,6 +33,14 @@ esp_err_t AudioResampler::add_sink(std::weak_ptr<ring_buffer::RingBuffer> &outpu
   return ESP_ERR_NO_MEM;
 }
 
+esp_err_t AudioResampler::add_sink(AudioSinkCallback *callback) {
+  if (this->output_transfer_buffer_ != nullptr) {
+    this->output_transfer_buffer_->set_sink(callback);
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+
 #ifdef USE_SPEAKER
 esp_err_t AudioResampler::add_sink(speaker::Speaker *speaker) {
   if (this->output_transfer_buffer_ != nullptr) {

--- a/esphome/components/audio/audio_resampler.h
+++ b/esphome/components/audio/audio_resampler.h
@@ -49,6 +49,11 @@ class AudioResampler {
   /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
   esp_err_t add_sink(std::weak_ptr<ring_buffer::RingBuffer> &output_ring_buffer);
 
+  /// @brief Adds a sink callback for resampled audio.
+  /// @param callback pointer to callback implementation
+  /// @return ESP_OK if successsful, ESP_ERR_NO_MEM if the transfer buffer wasn't allocated
+  esp_err_t add_sink(AudioSinkCallback *callback);
+
 #ifdef USE_SPEAKER
   /// @brief Adds a sink speaker for decoded audio.
   /// @param speaker pointer to speaker component

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -41,6 +41,7 @@ CONF_I2S_AUDIO = "i2s_audio"
 CONF_I2S_AUDIO_ID = "i2s_audio_id"
 
 CONF_I2S_MODE = "i2s_mode"
+CONF_FULL_DUPLEX = "full_duplex"
 CONF_PRIMARY = "primary"
 CONF_SECONDARY = "secondary"
 
@@ -204,6 +205,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
         cv.Optional(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
         cv.Optional(CONF_I2S_MCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_FULL_DUPLEX, default=False): cv.boolean,
     },
 )
 
@@ -296,3 +298,4 @@ async def to_code(config):
         cg.add(var.set_bclk_pin(config[CONF_I2S_BCLK_PIN]))
     if CONF_I2S_MCLK_PIN in config:
         cg.add(var.set_mclk_pin(config[CONF_I2S_MCLK_PIN]))
+    cg.add(var.set_full_duplex(config[CONF_FULL_DUPLEX]))

--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -1,0 +1,211 @@
+#include "i2s_audio.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/log.h"
+
+#include <cstring>
+#include <memory>
+
+#include "esp_timer.h"
+
+namespace esphome::i2s_audio {
+
+static const char *const TAG = "i2s_audio";
+
+esp_err_t I2SAudioComponent::allocate_full_duplex_channels_(const i2s_chan_config_t &chan_cfg) {
+  if (this->rx_handle_ != nullptr && this->tx_handle_ != nullptr) {
+    return ESP_OK;
+  }
+  if (!this->full_duplex_) {
+    return ESP_ERR_INVALID_STATE;
+  }
+  if (this->din_pin_ == I2S_GPIO_UNUSED || this->dout_pin_ == I2S_GPIO_UNUSED) {
+    ESP_LOGE(TAG, "Full duplex requires both DIN and DOUT pins on the same I2S bus");
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  esp_err_t err = i2s_new_channel(&chan_cfg, &this->tx_handle_, &this->rx_handle_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Full duplex channel allocation failed: %s", esp_err_to_name(err));
+    this->tx_handle_ = nullptr;
+    this->rx_handle_ = nullptr;
+    this->full_duplex_dma_desc_num_ = 0;
+  } else {
+    this->full_duplex_dma_desc_num_ = chan_cfg.dma_desc_num;
+  }
+  return err;
+}
+
+esp_err_t I2SAudioComponent::initialize_full_duplex_channels_(const i2s_std_config_t &std_cfg) {
+  if (this->tx_handle_ == nullptr || this->rx_handle_ == nullptr) {
+    return ESP_ERR_INVALID_STATE;
+  }
+
+  if (!this->tx_channel_initialized_) {
+    esp_err_t err = i2s_channel_init_std_mode(this->tx_handle_, &std_cfg);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to initialize full duplex TX channel: %s", esp_err_to_name(err));
+      return err;
+    }
+    this->tx_channel_initialized_ = true;
+  }
+
+  if (!this->rx_channel_initialized_) {
+    esp_err_t err = i2s_channel_init_std_mode(this->rx_handle_, &std_cfg);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to initialize full duplex RX channel: %s", esp_err_to_name(err));
+      return err;
+    }
+    this->rx_channel_initialized_ = true;
+  }
+
+  return ESP_OK;
+}
+
+esp_err_t I2SAudioComponent::setup_full_duplex_rx_channel(const i2s_chan_config_t &chan_cfg,
+                                                          const i2s_std_config_t &std_cfg,
+                                                          i2s_chan_handle_t *rx_handle) {
+  esp_err_t err = this->allocate_full_duplex_channels_(chan_cfg);
+  if (err != ESP_OK) {
+    return err;
+  }
+  err = this->initialize_full_duplex_channels_(std_cfg);
+  if (err == ESP_OK) {
+    *rx_handle = this->rx_handle_;
+  }
+  return err;
+}
+
+esp_err_t I2SAudioComponent::setup_full_duplex_tx_channel(const i2s_chan_config_t &chan_cfg,
+                                                          const i2s_std_config_t &std_cfg,
+                                                          i2s_chan_handle_t *tx_handle) {
+  esp_err_t err = this->allocate_full_duplex_channels_(chan_cfg);
+  if (err != ESP_OK) {
+    return err;
+  }
+  err = this->initialize_full_duplex_channels_(std_cfg);
+  if (err == ESP_OK) {
+    *tx_handle = this->tx_handle_;
+  }
+  return err;
+}
+
+esp_err_t I2SAudioComponent::ensure_full_duplex_tx_running() {
+  if (!this->full_duplex_) {
+    return ESP_ERR_INVALID_STATE;
+  }
+  if (this->tx_handle_ == nullptr || !this->tx_channel_initialized_) {
+    return ESP_ERR_INVALID_STATE;
+  }
+  if (this->full_duplex_tx_enabled_) {
+    return ESP_OK;
+  }
+
+  i2s_chan_info_t chan_info;
+  size_t dma_buffer_bytes = 0;
+  if (i2s_channel_get_info(this->tx_handle_, &chan_info) == ESP_OK && chan_info.total_dma_buf_size > 0 &&
+      this->full_duplex_dma_desc_num_ > 0) {
+    dma_buffer_bytes = chan_info.total_dma_buf_size / this->full_duplex_dma_desc_num_;
+  }
+  if (dma_buffer_bytes == 0) {
+    ESP_LOGE(TAG, "Full duplex TX clock start failed: no DMA buffer size available");
+    return ESP_ERR_INVALID_SIZE;
+  }
+
+  if (!this->full_duplex_tx_callback_registered_) {
+    const i2s_event_callbacks_t callbacks = {.on_sent = I2SAudioComponent::full_duplex_on_sent_cb};
+    esp_err_t err = i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Full duplex TX callback registration failed: %s", esp_err_to_name(err));
+      return err;
+    }
+    this->full_duplex_tx_callback_registered_ = true;
+  }
+
+  auto silence_buffer = std::make_unique<uint8_t[]>(dma_buffer_bytes);
+  if (silence_buffer == nullptr) {
+    return ESP_ERR_NO_MEM;
+  }
+  memset(silence_buffer.get(), 0, dma_buffer_bytes);
+
+  for (size_t i = 0; i < this->full_duplex_dma_desc_num_; i++) {
+    size_t bytes_loaded = 0;
+    esp_err_t err = i2s_channel_preload_data(this->tx_handle_, silence_buffer.get(), dma_buffer_bytes, &bytes_loaded);
+    if (err != ESP_OK || bytes_loaded != dma_buffer_bytes) {
+      ESP_LOGW(TAG, "Full duplex TX silence preload failed: %s (%u/%u bytes)", esp_err_to_name(err),
+               (unsigned) bytes_loaded, (unsigned) dma_buffer_bytes);
+      break;
+    }
+  }
+
+  esp_err_t err = i2s_channel_enable(this->tx_handle_);
+  if (err == ESP_OK || err == ESP_ERR_INVALID_STATE) {
+    this->full_duplex_tx_enabled_ = true;
+    ESP_LOGD(TAG, "Full duplex TX clock is running");
+    return ESP_OK;
+  }
+  ESP_LOGE(TAG, "Full duplex TX clock enable failed: %s", esp_err_to_name(err));
+  return err;
+}
+
+void I2SAudioComponent::attach_full_duplex_tx_event_queue(QueueHandle_t queue, EventGroupHandle_t event_group,
+                                                          EventBits_t overflow_bits) {
+  this->full_duplex_tx_event_queue_ = queue;
+  this->full_duplex_tx_event_group_ = event_group;
+  this->full_duplex_tx_overflow_bits_ = overflow_bits;
+}
+
+void I2SAudioComponent::detach_full_duplex_tx_event_queue(QueueHandle_t queue) {
+  if (this->full_duplex_tx_event_queue_ == queue) {
+    this->full_duplex_tx_event_queue_ = nullptr;
+    this->full_duplex_tx_event_group_ = nullptr;
+    this->full_duplex_tx_overflow_bits_ = 0;
+  }
+}
+
+bool IRAM_ATTR I2SAudioComponent::full_duplex_on_sent_cb(i2s_chan_handle_t handle, i2s_event_data_t *event,
+                                                         void *user_ctx) {
+  (void) handle;
+  (void) event;
+  auto *component = static_cast<I2SAudioComponent *>(user_ctx);
+  QueueHandle_t queue = component->full_duplex_tx_event_queue_;
+  if (queue == nullptr) {
+    return false;
+  }
+
+  int64_t now = esp_timer_get_time();
+  BaseType_t need_yield1 = pdFALSE;
+  BaseType_t need_yield2 = pdFALSE;
+  BaseType_t need_yield3 = pdFALSE;
+
+  if (xQueueIsQueueFullFromISR(queue)) {
+    int64_t dummy;
+    xQueueReceiveFromISR(queue, &dummy, &need_yield1);
+    if (component->full_duplex_tx_event_group_ != nullptr && component->full_duplex_tx_overflow_bits_ != 0) {
+      xEventGroupSetBitsFromISR(component->full_duplex_tx_event_group_, component->full_duplex_tx_overflow_bits_,
+                                &need_yield2);
+    }
+  }
+
+  xQueueSendToBackFromISR(queue, &now, &need_yield3);
+  return need_yield1 | need_yield2 | need_yield3;
+}
+
+void I2SAudioComponent::release_full_duplex_rx_channel(i2s_chan_handle_t rx_handle) {
+  if (rx_handle == this->rx_handle_ && this->full_duplex_rx_enabled_) {
+    i2s_channel_disable(this->rx_handle_);
+    this->full_duplex_rx_enabled_ = false;
+  }
+}
+
+void I2SAudioComponent::release_full_duplex_tx_channel(i2s_chan_handle_t tx_handle) {
+  (void) tx_handle;
+  // Keep TX enabled in full-duplex mode. The TX channel is the clock source for
+  // external ADCs such as ES7210, and disabling it makes RX reads time out until
+  // playback starts again.
+}
+
+}  // namespace esphome::i2s_audio
+
+#endif  // USE_ESP32

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -7,6 +7,8 @@
 #include "esphome/core/helpers.h"
 #include <esp_idf_version.h>
 #include <driver/i2s_std.h>
+#include <freertos/event_groups.h>
+#include <freertos/queue.h>
 
 namespace esphome::i2s_audio {
 
@@ -50,11 +52,27 @@ class I2SAudioComponent : public Component {
                 .ws_inv = false,
             }};
   }
+  i2s_std_gpio_config_t get_full_duplex_pin_config() const {
+    return {.mclk = (gpio_num_t) this->mclk_pin_,
+            .bclk = (gpio_num_t) this->bclk_pin_,
+            .ws = (gpio_num_t) this->lrclk_pin_,
+            .dout = (gpio_num_t) this->dout_pin_,
+            .din = (gpio_num_t) this->din_pin_,
+            .invert_flags = {
+                .mclk_inv = false,
+                .bclk_inv = false,
+                .ws_inv = false,
+            }};
+  }
 
   void set_mclk_pin(int pin) { this->mclk_pin_ = pin; }
   void set_bclk_pin(int pin) { this->bclk_pin_ = pin; }
   void set_lrclk_pin(int pin) { this->lrclk_pin_ = pin; }
+  void set_din_pin(int pin) { this->din_pin_ = pin; }
+  void set_dout_pin(int pin) { this->dout_pin_ = pin; }
   void set_port(int port) { this->port_ = port; }
+  void set_full_duplex(bool full_duplex) { this->full_duplex_ = full_duplex; }
+  bool is_full_duplex() const { return this->full_duplex_; }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   int get_port() const { return this->port_; }
 #else
@@ -65,15 +83,47 @@ class I2SAudioComponent : public Component {
   bool try_lock() { return this->lock_.try_lock(); }
   void unlock() { this->lock_.unlock(); }
 
+  esp_err_t setup_full_duplex_rx_channel(const i2s_chan_config_t &chan_cfg, const i2s_std_config_t &std_cfg,
+                                         i2s_chan_handle_t *rx_handle);
+  esp_err_t setup_full_duplex_tx_channel(const i2s_chan_config_t &chan_cfg, const i2s_std_config_t &std_cfg,
+                                         i2s_chan_handle_t *tx_handle);
+  esp_err_t ensure_full_duplex_tx_running();
+  void attach_full_duplex_tx_event_queue(QueueHandle_t queue, EventGroupHandle_t event_group,
+                                         EventBits_t overflow_bits);
+  void detach_full_duplex_tx_event_queue(QueueHandle_t queue);
+  size_t get_full_duplex_dma_desc_num() const { return this->full_duplex_dma_desc_num_; }
+  void mark_full_duplex_rx_running() { this->full_duplex_rx_enabled_ = true; }
+  void release_full_duplex_rx_channel(i2s_chan_handle_t rx_handle);
+  void release_full_duplex_tx_channel(i2s_chan_handle_t tx_handle);
+
  protected:
+  esp_err_t allocate_full_duplex_channels_(const i2s_chan_config_t &chan_cfg);
+  esp_err_t initialize_full_duplex_channels_(const i2s_std_config_t &std_cfg);
+  static bool full_duplex_on_sent_cb(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx);
+
   Mutex lock_;
 
   I2SAudioIn *audio_in_{nullptr};
   I2SAudioOut *audio_out_{nullptr};
   int mclk_pin_{I2S_GPIO_UNUSED};
   int bclk_pin_{I2S_GPIO_UNUSED};
+  int din_pin_{I2S_GPIO_UNUSED};
+  int dout_pin_{I2S_GPIO_UNUSED};
   int lrclk_pin_;
   int port_{};
+  bool full_duplex_{false};
+
+  i2s_chan_handle_t rx_handle_{nullptr};
+  i2s_chan_handle_t tx_handle_{nullptr};
+  bool rx_channel_initialized_{false};
+  bool tx_channel_initialized_{false};
+  bool full_duplex_tx_enabled_{false};
+  bool full_duplex_rx_enabled_{false};
+  bool full_duplex_tx_callback_registered_{false};
+  size_t full_duplex_dma_desc_num_{0};
+  QueueHandle_t full_duplex_tx_event_queue_{nullptr};
+  EventGroupHandle_t full_duplex_tx_event_group_{nullptr};
+  EventBits_t full_duplex_tx_overflow_bits_{0};
 };
 
 }  // namespace esphome::i2s_audio

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
 
 from .. import (
     CONF_ADC_TYPE,
+    CONF_I2S_AUDIO_ID,
     CONF_I2S_DIN_PIN,
     CONF_LEFT,
     CONF_MONO,
@@ -141,6 +142,8 @@ async def to_code(config):
     await microphone.register_microphone(var, config)
 
     cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
+    parent = await cg.get_variable(config[CONF_I2S_AUDIO_ID])
+    cg.add(parent.set_din_pin(config[CONF_I2S_DIN_PIN]))
     cg.add(var.set_pdm(config[CONF_PDM]))
 
     cg.add(var.set_correct_dc_offset(config[CONF_CORRECT_DC_OFFSET]))

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -95,6 +95,72 @@ void I2SAudioMicrophone::start() {
 }
 
 bool I2SAudioMicrophone::start_driver_() {
+  if (this->parent_->is_full_duplex()) {
+    if (this->pdm_) {
+      ESP_LOGE(TAG, "Full duplex I2S microphone does not support PDM mode");
+      return false;
+    }
+
+    esp_err_t err;
+    i2s_chan_config_t chan_cfg = {
+        .id = this->parent_->get_port(),
+        .role = this->i2s_role_,
+        .dma_desc_num = 4,
+        .dma_frame_num = 256,
+        .auto_clear = false,
+        .intr_priority = 3,
+    };
+
+    i2s_clock_src_t clk_src = I2S_CLK_SRC_DEFAULT;
+#if SOC_CLK_APLL_SUPPORTED
+    if (this->use_apll_) {
+      clk_src = i2s_clock_src_t::I2S_CLK_SRC_APLL;
+    }
+#endif
+
+    i2s_std_gpio_config_t pin_config = this->parent_->get_full_duplex_pin_config();
+    pin_config.din = this->din_pin_;
+
+    i2s_std_clk_config_t clk_cfg = {
+        .sample_rate_hz = this->sample_rate_,
+        .clk_src = clk_src,
+        .mclk_multiple = this->mclk_multiple_,
+    };
+    i2s_std_slot_config_t std_slot_cfg =
+        I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG((i2s_data_bit_width_t) this->slot_bit_width_, this->slot_mode_);
+    std_slot_cfg.slot_bit_width = this->slot_bit_width_;
+    std_slot_cfg.slot_mask = this->std_slot_mask_;
+
+    i2s_std_config_t std_cfg = {
+        .clk_cfg = clk_cfg,
+        .slot_cfg = std_slot_cfg,
+        .gpio_cfg = pin_config,
+    };
+
+    err = this->parent_->setup_full_duplex_rx_channel(chan_cfg, std_cfg, &this->rx_handle_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Error setting up full duplex RX channel: %s", esp_err_to_name(err));
+      return false;
+    }
+
+    err = this->parent_->ensure_full_duplex_tx_running();
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Error starting full duplex TX clock: %s", esp_err_to_name(err));
+      return false;
+    }
+
+    err = i2s_channel_enable(this->rx_handle_);
+    if (err == ESP_OK || err == ESP_ERR_INVALID_STATE) {
+      this->parent_->mark_full_duplex_rx_running();
+    } else {
+      ESP_LOGE(TAG, "Enabling full duplex RX failed: %s", esp_err_to_name(err));
+      return false;
+    }
+
+    this->configure_stream_settings_();
+    return true;
+  }
+
   if (!this->parent_->try_lock()) {
     return false;  // Waiting for another i2s to return lock
   }
@@ -211,6 +277,14 @@ void I2SAudioMicrophone::stop_driver_() {
   // ensures that we stop/unload the driver when it only partially starts.
 
   esp_err_t err;
+  if (this->parent_->is_full_duplex()) {
+    if (this->rx_handle_ != nullptr) {
+      this->parent_->release_full_duplex_rx_channel(this->rx_handle_);
+      this->rx_handle_ = nullptr;
+    }
+    return;
+  }
+
   if (this->rx_handle_ != nullptr) {
     /* Have to stop the channel before deleting it */
     err = i2s_channel_disable(this->rx_handle_);

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -55,7 +55,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   TaskHandle_t task_handle_{nullptr};
 
   gpio_num_t din_pin_{I2S_GPIO_UNUSED};
-  i2s_chan_handle_t rx_handle_;
+  i2s_chan_handle_t rx_handle_{nullptr};
   bool pdm_{false};
 
   bool correct_dc_offset_;

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -15,6 +15,7 @@ from esphome.const import (
 )
 
 from .. import (
+    CONF_I2S_AUDIO_ID,
     CONF_I2S_DOUT_PIN,
     CONF_I2S_MODE,
     CONF_LEFT,
@@ -242,6 +243,8 @@ async def to_code(config):
     await speaker.register_speaker(var, config)
 
     cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
+    parent = await cg.get_variable(config[CONF_I2S_AUDIO_ID])
+    cg.add(parent.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
 
     is_spdif = config.get(CONF_SPDIF_MODE, False)
     if is_spdif:

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -253,20 +253,30 @@ void I2SAudioSpeakerBase::stop_(bool wait_on_empty) {
 
 esp_err_t I2SAudioSpeakerBase::init_i2s_channel_(const i2s_chan_config_t &chan_cfg, const i2s_std_config_t &std_cfg,
                                                  size_t event_queue_size) {
-  esp_err_t err = i2s_new_channel(&chan_cfg, &this->tx_handle_, NULL);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "I2S channel allocation failed: %s", esp_err_to_name(err));
-    this->parent_->unlock();
-    return err;
-  }
+  esp_err_t err = ESP_OK;
+  if (this->parent_->is_full_duplex()) {
+    err = this->parent_->setup_full_duplex_tx_channel(chan_cfg, std_cfg, &this->tx_handle_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Full duplex TX setup failed: %s", esp_err_to_name(err));
+      this->tx_handle_ = nullptr;
+      return err;
+    }
+  } else {
+    err = i2s_new_channel(&chan_cfg, &this->tx_handle_, NULL);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "I2S channel allocation failed: %s", esp_err_to_name(err));
+      this->parent_->unlock();
+      return err;
+    }
 
-  err = i2s_channel_init_std_mode(this->tx_handle_, &std_cfg);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to initialize I2S channel");
-    i2s_del_channel(this->tx_handle_);
-    this->tx_handle_ = nullptr;
-    this->parent_->unlock();
-    return err;
+    err = i2s_channel_init_std_mode(this->tx_handle_, &std_cfg);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to initialize I2S channel");
+      i2s_del_channel(this->tx_handle_);
+      this->tx_handle_ = nullptr;
+      this->parent_->unlock();
+      return err;
+    }
   }
 
   if (this->i2s_event_queue_ == nullptr) {
@@ -286,9 +296,13 @@ esp_err_t I2SAudioSpeakerBase::init_i2s_channel_(const i2s_chan_config_t &chan_c
 
   if (this->i2s_event_queue_ == nullptr || this->write_records_queue_ == nullptr) {
     ESP_LOGE(TAG, "Failed to allocate I2S event queue(s)");
-    i2s_del_channel(this->tx_handle_);
+    if (this->parent_->is_full_duplex()) {
+      this->parent_->release_full_duplex_tx_channel(this->tx_handle_);
+    } else {
+      i2s_del_channel(this->tx_handle_);
+      this->parent_->unlock();
+    }
     this->tx_handle_ = nullptr;
-    this->parent_->unlock();
     return ESP_ERR_NO_MEM;
   }
 
@@ -297,6 +311,12 @@ esp_err_t I2SAudioSpeakerBase::init_i2s_channel_(const i2s_chan_config_t &chan_c
 
 void I2SAudioSpeakerBase::stop_i2s_driver_() {
   if (this->tx_handle_ != nullptr) {
+    if (this->parent_->is_full_duplex()) {
+      this->parent_->release_full_duplex_tx_channel(this->tx_handle_);
+      this->tx_handle_ = nullptr;
+      return;
+    }
+
     i2s_channel_disable(this->tx_handle_);
     i2s_del_channel(this->tx_handle_);
     this->tx_handle_ = nullptr;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
@@ -11,8 +11,6 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-#include "esp_timer.h"
-
 namespace esphome::i2s_audio {
 
 static const char *const TAG = "i2s_audio.speaker.std";
@@ -67,6 +65,7 @@ void I2SAudioSpeaker::dump_config() {
 void I2SAudioSpeaker::run_speaker_task() {
   xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::TASK_STARTING);
 
+  const bool full_duplex = this->parent_->is_full_duplex();
   const uint32_t dma_buffers_duration_ms = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT;
   // Ensure ring buffer duration is at least the duration of all DMA buffers
   const uint32_t ring_buffer_duration = std::max(dma_buffers_duration_ms, this->buffer_duration_ms_);
@@ -82,12 +81,18 @@ void I2SAudioSpeaker::run_speaker_task() {
   // the L1 cache (e.g. ESP32-P4), rounds the buffer to the cache line. Read the size the driver actually
   // allocated so preload, silence padding, and the write/event lockstep all match it exactly. The channel is
   // in the READY state here because start_i2s_driver() initialized it before this task was created.
-  size_t dma_buffer_bytes;
+  size_t dma_buffer_bytes = 0;
   i2s_chan_info_t chan_info;
   if (i2s_channel_get_info(this->tx_handle_, &chan_info) == ESP_OK && chan_info.total_dma_buf_size > 0) {
-    // total_dma_buf_size spans all DMA_BUFFERS_COUNT descriptors and is an exact multiple of the count.
-    dma_buffer_bytes = chan_info.total_dma_buf_size / DMA_BUFFERS_COUNT;
-  } else {
+    // total_dma_buf_size spans all descriptors allocated for this channel. In full-duplex mode the microphone can be
+    // the first user of the shared channel, so the real descriptor count may not match this speaker's local default.
+    const size_t dma_desc_num =
+        full_duplex ? this->parent_->get_full_duplex_dma_desc_num() : static_cast<size_t>(DMA_BUFFERS_COUNT);
+    if (dma_desc_num > 0) {
+      dma_buffer_bytes = chan_info.total_dma_buf_size / dma_desc_num;
+    }
+  }
+  if (dma_buffer_bytes == 0) {
     // Should not happen for a READY channel; fall back to the requested size.
     dma_buffer_bytes = this->current_stream_info_.frames_to_bytes(dma_buffer_frames(this->current_stream_info_));
   }
@@ -115,7 +120,22 @@ void I2SAudioSpeaker::run_speaker_task() {
     }
   }
 
-  if (successful_setup) {
+  if (successful_setup && full_duplex) {
+    const size_t dma_desc_num = this->parent_->get_full_duplex_dma_desc_num();
+    for (size_t i = 0; i < dma_desc_num; i++) {
+      uint32_t zero_real_frames = 0;
+      if (xQueueSend(this->write_records_queue_, &zero_real_frames, 0) != pdTRUE) {
+        ESP_LOGV(TAG, "Failed to seed full duplex preload write record");
+        successful_setup = false;
+        break;
+      }
+    }
+    if (successful_setup) {
+      this->parent_->attach_full_duplex_tx_event_queue(
+          this->i2s_event_queue_, this->event_group_,
+          SpeakerEventGroupBits::ERR_DROPPED_EVENT | SpeakerEventGroupBits::COMMAND_STOP);
+    }
+  } else if (successful_setup) {
     // Preload every DMA descriptor with silence and push a matching zero-real-frames record per buffer.
     // This guarantees that every on_sent event has a corresponding write record from the start, so
     // ``i2s_event_queue_`` and ``write_records_queue_`` stay in lockstep for the entire task lifetime.
@@ -141,10 +161,15 @@ void I2SAudioSpeaker::run_speaker_task() {
   if (successful_setup) {
     // Register the on_sent callback BEFORE enabling the channel so the very first transmitted buffer
     // generates a queued event that pairs with the first preloaded silence record.
-    const i2s_event_callbacks_t callbacks = {.on_sent = i2s_on_sent_cb};
-    i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
-
-    if (i2s_channel_enable(this->tx_handle_) != ESP_OK) {
+    esp_err_t enable_err = ESP_OK;
+    if (full_duplex) {
+      enable_err = this->parent_->ensure_full_duplex_tx_running();
+    } else {
+      const i2s_event_callbacks_t callbacks = {.on_sent = i2s_on_sent_cb};
+      i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
+      enable_err = i2s_channel_enable(this->tx_handle_);
+    }
+    if (enable_err != ESP_OK) {
       ESP_LOGV(TAG, "Failed to enable I2S channel");
       successful_setup = false;
     }
@@ -197,7 +222,8 @@ void I2SAudioSpeaker::run_speaker_task() {
 
       // Drain ISR-stamped completion events. Each event corresponds 1:1 with a write_records_queue_
       // entry by construction (preloaded records at startup, plus exactly one record pushed per
-      // iteration alongside exactly one DMA-buffer-sized write).
+      // iteration alongside exactly one DMA-buffer-sized write). In full-duplex mode the parent bus
+      // owns the callback because TX can already be running to clock the microphone.
       int64_t write_timestamp;
       bool lockstep_broken = false;
       while (xQueueReceive(this->i2s_event_queue_, &write_timestamp, 0)) {
@@ -308,6 +334,10 @@ void I2SAudioSpeaker::run_speaker_task() {
     }
   }
 
+  if (full_duplex) {
+    this->parent_->detach_full_duplex_tx_event_queue(this->i2s_event_queue_);
+  }
+
   xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::TASK_STOPPING);
 
   audio_source.reset();
@@ -353,7 +383,7 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver(audio::AudioStreamInfo &audio_stream
   }
 #endif  // USE_ESP32_VARIANT_ESP32
 
-  if (!this->parent_->try_lock()) {
+  if (!this->parent_->is_full_duplex() && !this->parent_->try_lock()) {
     ESP_LOGE(TAG, "Parent bus is busy");
     return ESP_ERR_INVALID_STATE;
   }

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -42,6 +42,7 @@ CONF_FEATURE_STEP_SIZE = "feature_step_size"
 CONF_MODELS = "models"
 CONF_ON_WAKE_WORD_DETECTED = "on_wake_word_detected"
 CONF_PROBABILITY_CUTOFF = "probability_cutoff"
+CONF_RING_BUFFER_DURATION = "ring_buffer_duration"
 CONF_SLIDING_WINDOW_AVERAGE_SIZE = "sliding_window_average_size"
 CONF_SLIDING_WINDOW_SIZE = "sliding_window_size"
 CONF_STOP_AFTER_DETECTION = "stop_after_detection"
@@ -359,6 +360,9 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_VAD): _maybe_empty_vad_schema,
             cv.Optional(CONF_STOP_AFTER_DETECTION, default=True): cv.boolean,
+            cv.Optional(
+                CONF_RING_BUFFER_DURATION, default="120ms"
+            ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_TASK_STACK_IN_PSRAM): psram.validate_task_stack_in_psram,
             cv.Optional(CONF_MODEL): cv.invalid(
                 f"The {CONF_MODEL} parameter has moved to be a list element under the {CONF_MODELS} parameter."
@@ -521,6 +525,7 @@ async def to_code(config):
             cg.add(var.add_wake_word_model(wake_word_model))
 
     cg.add(var.set_features_step_size(manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE]))
+    cg.add(var.set_ring_buffer_duration(config[CONF_RING_BUFFER_DURATION]))
     cg.add(var.set_stop_after_detection(config[CONF_STOP_AFTER_DETECTION]))
 
     if on_wake_word_detection_config := config.get(CONF_ON_WAKE_WORD_DETECTED):

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -21,8 +21,6 @@ static const ssize_t DETECTION_QUEUE_LENGTH = 5;
 
 static const size_t DATA_TIMEOUT_MS = 50;
 
-static const uint32_t RING_BUFFER_DURATION_MS = 120;
-
 #ifdef CONFIG_IDF_TARGET_ESP32P4
 // ESP32-P4 PIE-optimized esp-nn kernels (e.g. depthwise_conv_s8_ch1_pie) require
 // significantly more stack than other variants, causing stack protection faults at 3072.
@@ -156,7 +154,7 @@ void MicroWakeWord::inference_task(void *params) {
     if (!(xEventGroupGetBits(this_mww->event_group_) & ERROR_BITS)) {
       // Round ring buffer size down to a frame multiple so the wrap boundary never splits an int16 sample.
       const size_t ring_buffer_size =
-          (stream_info.ms_to_bytes(RING_BUFFER_DURATION_MS) / bytes_per_frame) * bytes_per_frame;
+          (stream_info.ms_to_bytes(this_mww->ring_buffer_duration_ms_) / bytes_per_frame) * bytes_per_frame;
       std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = ring_buffer::RingBuffer::create(ring_buffer_size);
       if (temp_ring_buffer == nullptr) {
         xEventGroupSetBits(this_mww->event_group_, EventGroupBits::ERROR_MEMORY);

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -54,6 +54,10 @@ class MicroWakeWord : public Component
 
   void set_features_step_size(uint8_t step_size) { this->features_step_size_ = step_size; }
 
+  void set_ring_buffer_duration(uint32_t ring_buffer_duration_ms) {
+    this->ring_buffer_duration_ms_ = ring_buffer_duration_ms;
+  }
+
   void set_microphone_source(microphone::MicrophoneSource *microphone_source) {
     this->microphone_source_ = microphone_source;
   }
@@ -99,6 +103,7 @@ class MicroWakeWord : public Component
   bool task_stack_in_psram_{false};
 
   uint8_t features_step_size_;
+  uint32_t ring_buffer_duration_ms_{120};
 
   // Audio frontend handles generating spectrogram features
   struct FrontendConfig frontend_config_;

--- a/esphome/components/resampler/microphone/__init__.py
+++ b/esphome/components/resampler/microphone/__init__.py
@@ -62,9 +62,9 @@ CONFIG_SCHEMA = cv.All(
 
 FINAL_VALIDATE_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_MICROPHONE): microphone.final_validate_microphone_source_schema(
-            "resampler_microphone"
-        ),
+        cv.Required(
+            CONF_MICROPHONE
+        ): microphone.final_validate_microphone_source_schema("resampler_microphone"),
     },
     extra=cv.ALLOW_EXTRA,
 )

--- a/esphome/components/resampler/microphone/__init__.py
+++ b/esphome/components/resampler/microphone/__init__.py
@@ -1,0 +1,89 @@
+import esphome.codegen as cg
+from esphome.components import audio, microphone, psram
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_BUFFER_DURATION,
+    CONF_CHANNELS,
+    CONF_FILTERS,
+    CONF_ID,
+    CONF_MICROPHONE,
+    CONF_SAMPLE_RATE,
+    CONF_TASK_STACK_IN_PSRAM,
+    PLATFORM_ESP32,
+)
+
+AUTO_LOAD = ["audio"]
+CODEOWNERS = ["@kahrendt"]
+
+resampler_ns = cg.esphome_ns.namespace("resampler")
+ResamplerMicrophone = resampler_ns.class_(
+    "ResamplerMicrophone", cg.Component, microphone.Microphone
+)
+
+CONF_TAPS = "taps"
+
+
+def _set_stream_limits(config):
+    audio.set_stream_limits(
+        max_channels=len(config[CONF_MICROPHONE][CONF_CHANNELS]),
+        min_sample_rate=config[CONF_SAMPLE_RATE],
+        max_sample_rate=config[CONF_SAMPLE_RATE],
+    )(config)
+    return config
+
+
+def _validate_taps(taps):
+    value = cv.int_range(min=16, max=128)(taps)
+    if value % 4 != 0:
+        raise cv.Invalid("Number of taps must be divisible by 4")
+    return value
+
+
+CONFIG_SCHEMA = cv.All(
+    microphone.MICROPHONE_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ResamplerMicrophone),
+            cv.Required(CONF_MICROPHONE): microphone.microphone_source_schema(
+                min_channels=1,
+                max_channels=3,
+            ),
+            cv.Optional(
+                CONF_BUFFER_DURATION, default="100ms"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_TASK_STACK_IN_PSRAM): psram.validate_task_stack_in_psram,
+            cv.Optional(CONF_FILTERS, default=16): cv.int_range(min=2, max=1024),
+            cv.Optional(CONF_TAPS, default=16): _validate_taps,
+            cv.Optional(CONF_SAMPLE_RATE, default=16000): cv.int_range(min=1),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_on([PLATFORM_ESP32]),
+    _set_stream_limits,
+)
+
+FINAL_VALIDATE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_MICROPHONE): microphone.final_validate_microphone_source_schema(
+            "resampler_microphone"
+        ),
+    },
+    extra=cv.ALLOW_EXTRA,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await microphone.register_microphone(var, config)
+
+    mic_source = await microphone.microphone_source_to_code(config[CONF_MICROPHONE])
+    cg.add(var.set_microphone_source(mic_source))
+
+    cg.add(var.set_buffer_duration(config[CONF_BUFFER_DURATION]))
+
+    if config.get(CONF_TASK_STACK_IN_PSRAM):
+        cg.add(var.set_task_stack_in_psram(True))
+        psram.request_external_task_stack()
+
+    cg.add(var.set_target_sample_rate(config[CONF_SAMPLE_RATE]))
+    cg.add(var.set_filters(config[CONF_FILTERS]))
+    cg.add(var.set_taps(config[CONF_TAPS]))

--- a/esphome/components/resampler/microphone/__init__.py
+++ b/esphome/components/resampler/microphone/__init__.py
@@ -13,7 +13,7 @@ from esphome.const import (
 )
 
 AUTO_LOAD = ["audio"]
-CODEOWNERS = ["@kahrendt"]
+CODEOWNERS = ["@kyvaith"]
 
 resampler_ns = cg.esphome_ns.namespace("resampler")
 ResamplerMicrophone = resampler_ns.class_(

--- a/esphome/components/resampler/microphone/resampler_microphone.cpp
+++ b/esphome/components/resampler/microphone/resampler_microphone.cpp
@@ -1,0 +1,261 @@
+#include "resampler_microphone.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/log.h"
+
+#include <algorithm>
+
+namespace esphome::resampler {
+
+static const UBaseType_t MAX_LISTENERS = 16;
+static const UBaseType_t RESAMPLER_TASK_PRIORITY = 5;
+static const uint32_t TASK_STACK_SIZE = 3072;
+static const uint32_t TRANSFER_BUFFER_DURATION_MS = 16;
+static const char *const TAG = "resampler_microphone";
+
+enum ResamplingEventGroupBits : uint32_t {
+  COMMAND_STOP = (1 << 0),
+  TASK_STARTING = (1 << 10),
+  TASK_RUNNING = (1 << 11),
+  TASK_STOPPING = (1 << 12),
+  TASK_STOPPED = (1 << 13),
+  WARNING_FULL_RING_BUFFER = (1 << 17),
+  ERR_ESP_NO_MEM = (1 << 19),
+  ERR_ESP_NOT_SUPPORTED = (1 << 20),
+  ERR_ESP_FAIL = (1 << 21),
+  ALL_BITS = 0x00FFFFFF,
+};
+
+void ResamplerMicrophone::setup() {
+  this->event_group_ = xEventGroupCreate();
+  if (this->event_group_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create event group");
+    this->mark_failed();
+    return;
+  }
+
+  this->active_listeners_semaphore_ = xSemaphoreCreateCounting(MAX_LISTENERS, MAX_LISTENERS);
+  if (this->active_listeners_semaphore_ == nullptr) {
+    ESP_LOGE(TAG, "Creating semaphore failed");
+    this->mark_failed();
+    return;
+  }
+
+  this->microphone_source_->add_data_callback([this](const std::vector<uint8_t> &data) {
+    if (this->state_ == microphone::STATE_STOPPED) {
+      return;
+    }
+    if (this->requires_resampling_()) {
+      std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->ring_buffer_.lock();
+      if (temp_ring_buffer == nullptr) {
+        return;
+      }
+      if (temp_ring_buffer->free() < data.size()) {
+        xEventGroupSetBits(this->event_group_, ResamplingEventGroupBits::WARNING_FULL_RING_BUFFER);
+        temp_ring_buffer->reset();
+      }
+      temp_ring_buffer->write(data.data(), data.size());
+    } else if (this->data_callbacks_.size() > 0) {
+      this->data_callbacks_.call(data);
+    }
+  });
+
+  this->configure_stream_settings_();
+}
+
+void ResamplerMicrophone::loop() {
+  uint32_t event_group_bits = xEventGroupGetBits(this->event_group_);
+
+  if (event_group_bits & ResamplingEventGroupBits::TASK_STARTING) {
+    ESP_LOGD(TAG, "Starting");
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::TASK_STARTING);
+  }
+
+  if (event_group_bits & ResamplingEventGroupBits::TASK_RUNNING) {
+    ESP_LOGD(TAG, "Started");
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::TASK_RUNNING);
+    this->state_ = microphone::STATE_RUNNING;
+    this->status_clear_error();
+  }
+
+  if (event_group_bits & ResamplingEventGroupBits::TASK_STOPPING) {
+    ESP_LOGD(TAG, "Stopping");
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::TASK_STOPPING);
+  }
+
+  if (event_group_bits & ResamplingEventGroupBits::TASK_STOPPED) {
+    ESP_LOGD(TAG, "Stopped");
+    this->task_.deallocate();
+    this->ring_buffer_.reset();
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ALL_BITS);
+    this->status_clear_error();
+    this->state_ = microphone::STATE_STOPPED;
+  }
+
+  if (event_group_bits & ResamplingEventGroupBits::WARNING_FULL_RING_BUFFER) {
+    ESP_LOGW(TAG, "Ring buffer full, resetting it");
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::WARNING_FULL_RING_BUFFER);
+  }
+
+  if (event_group_bits & ResamplingEventGroupBits::ERR_ESP_NO_MEM) {
+    ESP_LOGE(TAG, "Not enough memory");
+    this->status_set_error(LOG_STR("Not enough memory"));
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ERR_ESP_NO_MEM);
+  }
+  if (event_group_bits & ResamplingEventGroupBits::ERR_ESP_NOT_SUPPORTED) {
+    ESP_LOGE(TAG, "Unsupported stream");
+    this->status_set_error(LOG_STR("Unsupported stream"));
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ERR_ESP_NOT_SUPPORTED);
+  }
+  if (event_group_bits & ResamplingEventGroupBits::ERR_ESP_FAIL) {
+    ESP_LOGE(TAG, "Resampler failure");
+    this->status_set_error(LOG_STR("Resampler failure"));
+    xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ERR_ESP_FAIL);
+  }
+
+  if ((uxSemaphoreGetCount(this->active_listeners_semaphore_) < MAX_LISTENERS) &&
+      (this->state_ == microphone::STATE_STOPPED)) {
+    this->state_ = microphone::STATE_STARTING;
+  }
+
+  if ((uxSemaphoreGetCount(this->active_listeners_semaphore_) == MAX_LISTENERS) &&
+      (this->state_ == microphone::STATE_RUNNING)) {
+    this->state_ = microphone::STATE_STOPPING;
+  }
+
+  switch (this->state_) {
+    case microphone::STATE_STARTING:
+      if (this->status_has_error()) {
+        break;
+      }
+      this->configure_stream_settings_();
+      if (this->requires_resampling_()) {
+        if (!this->task_.is_created()) {
+          if (this->start_task_() != ESP_OK) {
+            ESP_LOGE(TAG, "Task failed to start, retrying in 1 second");
+            this->status_momentary_error("task_fail", 1000);
+          } else {
+            this->microphone_source_->start();
+          }
+        }
+      } else {
+        this->microphone_source_->start();
+        this->state_ = microphone::STATE_RUNNING;
+      }
+      break;
+    case microphone::STATE_RUNNING:
+      break;
+    case microphone::STATE_STOPPING:
+      this->microphone_source_->stop();
+      if (this->requires_resampling_()) {
+        xEventGroupSetBits(this->event_group_, ResamplingEventGroupBits::COMMAND_STOP);
+      } else {
+        this->state_ = microphone::STATE_STOPPED;
+      }
+      break;
+    case microphone::STATE_STOPPED:
+      break;
+  }
+}
+
+void ResamplerMicrophone::start() {
+  if (this->is_failed())
+    return;
+  xSemaphoreTake(this->active_listeners_semaphore_, 0);
+}
+
+void ResamplerMicrophone::stop() {
+  if (this->state_ == microphone::STATE_STOPPED || this->is_failed())
+    return;
+  xSemaphoreGive(this->active_listeners_semaphore_);
+}
+
+size_t ResamplerMicrophone::audio_sink_write(uint8_t *data, size_t length, TickType_t ticks_to_wait) {
+  (void) ticks_to_wait;
+  if (length == 0 || this->data_callbacks_.size() == 0) {
+    return length;
+  }
+  std::vector<uint8_t> output(data, data + length);
+  this->data_callbacks_.call(output);
+  return length;
+}
+
+esp_err_t ResamplerMicrophone::start_task_() {
+  if (this->task_.create(resample_task, "resample_mic", TASK_STACK_SIZE, (void *) this, RESAMPLER_TASK_PRIORITY,
+                         this->task_stack_in_psram_)) {
+    return ESP_OK;
+  }
+  return ESP_ERR_NO_MEM;
+}
+
+void ResamplerMicrophone::configure_stream_settings_() {
+  audio::AudioStreamInfo source_stream_info = this->microphone_source_->get_audio_stream_info();
+  this->audio_stream_info_ =
+      audio::AudioStreamInfo(source_stream_info.get_bits_per_sample(), source_stream_info.get_channels(),
+                             this->target_sample_rate_);
+}
+
+bool ResamplerMicrophone::requires_resampling_() const {
+  return this->microphone_source_->get_audio_stream_info().get_sample_rate() != this->target_sample_rate_;
+}
+
+void ResamplerMicrophone::resample_task(void *params) {
+  auto *this_resampler = static_cast<ResamplerMicrophone *>(params);
+  xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::TASK_STARTING);
+
+  audio::AudioStreamInfo source_stream_info = this_resampler->microphone_source_->get_audio_stream_info();
+  std::unique_ptr<audio::AudioResampler> resampler = make_unique<audio::AudioResampler>(
+      source_stream_info.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS),
+      this_resampler->audio_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
+
+  esp_err_t err = resampler->start(source_stream_info, this_resampler->audio_stream_info_, this_resampler->taps_,
+                                   this_resampler->filters_);
+  if (err == ESP_OK) {
+    std::unique_ptr<ring_buffer::RingBuffer> ring_buffer =
+        ring_buffer::RingBuffer::create(source_stream_info.ms_to_bytes(this_resampler->buffer_duration_ms_));
+    if (ring_buffer == nullptr) {
+      err = ESP_ERR_NO_MEM;
+    } else {
+      std::shared_ptr<ring_buffer::RingBuffer> shared_ring_buffer(std::move(ring_buffer));
+      this_resampler->ring_buffer_ = shared_ring_buffer;
+      err = resampler->add_source(this_resampler->ring_buffer_);
+      if (err == ESP_OK) {
+        err = resampler->add_sink(this_resampler);
+      }
+    }
+  }
+
+  if (err == ESP_OK) {
+    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::TASK_RUNNING);
+  } else if (err == ESP_ERR_NO_MEM) {
+    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_NO_MEM);
+  } else if (err == ESP_ERR_NOT_SUPPORTED) {
+    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_NOT_SUPPORTED);
+  } else {
+    xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_FAIL);
+  }
+
+  while (err == ESP_OK) {
+    if (xEventGroupGetBits(this_resampler->event_group_) & ResamplingEventGroupBits::COMMAND_STOP) {
+      break;
+    }
+
+    int32_t ms_differential = 0;
+    audio::AudioResamplerState state = resampler->resample(false, &ms_differential);
+    if (state == audio::AudioResamplerState::FAILED) {
+      xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::ERR_ESP_FAIL);
+      break;
+    }
+  }
+
+  xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::TASK_STOPPING);
+  resampler.reset();
+  xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::TASK_STOPPED);
+
+  vTaskSuspend(nullptr);
+}
+
+}  // namespace esphome::resampler
+
+#endif  // USE_ESP32

--- a/esphome/components/resampler/microphone/resampler_microphone.cpp
+++ b/esphome/components/resampler/microphone/resampler_microphone.cpp
@@ -191,9 +191,8 @@ esp_err_t ResamplerMicrophone::start_task_() {
 
 void ResamplerMicrophone::configure_stream_settings_() {
   audio::AudioStreamInfo source_stream_info = this->microphone_source_->get_audio_stream_info();
-  this->audio_stream_info_ =
-      audio::AudioStreamInfo(source_stream_info.get_bits_per_sample(), source_stream_info.get_channels(),
-                             this->target_sample_rate_);
+  this->audio_stream_info_ = audio::AudioStreamInfo(source_stream_info.get_bits_per_sample(),
+                                                    source_stream_info.get_channels(), this->target_sample_rate_);
 }
 
 bool ResamplerMicrophone::requires_resampling_() const {
@@ -205,9 +204,9 @@ void ResamplerMicrophone::resample_task(void *params) {
   xEventGroupSetBits(this_resampler->event_group_, ResamplingEventGroupBits::TASK_STARTING);
 
   audio::AudioStreamInfo source_stream_info = this_resampler->microphone_source_->get_audio_stream_info();
-  std::unique_ptr<audio::AudioResampler> resampler = make_unique<audio::AudioResampler>(
-      source_stream_info.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS),
-      this_resampler->audio_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
+  std::unique_ptr<audio::AudioResampler> resampler =
+      make_unique<audio::AudioResampler>(source_stream_info.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS),
+                                         this_resampler->audio_stream_info_.ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
 
   esp_err_t err = resampler->start(source_stream_info, this_resampler->audio_stream_info_, this_resampler->taps_,
                                    this_resampler->filters_);

--- a/esphome/components/resampler/microphone/resampler_microphone.h
+++ b/esphome/components/resampler/microphone/resampler_microphone.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "esphome/components/audio/audio_resampler.h"
+#include "esphome/components/microphone/microphone_source.h"
+#include "esphome/components/ring_buffer/ring_buffer.h"
+#include "esphome/core/component.h"
+#include "esphome/core/static_task.h"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <freertos/semphr.h>
+
+namespace esphome::resampler {
+
+class ResamplerMicrophone : public Component, public microphone::Microphone, public audio::AudioSinkCallback {
+ public:
+  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
+  void setup() override;
+  void loop() override;
+
+  void start() override;
+  void stop() override;
+
+  size_t audio_sink_write(uint8_t *data, size_t length, TickType_t ticks_to_wait) override;
+
+  void set_microphone_source(microphone::MicrophoneSource *microphone_source) {
+    this->microphone_source_ = microphone_source;
+  }
+  void set_task_stack_in_psram(bool task_stack_in_psram) { this->task_stack_in_psram_ = task_stack_in_psram; }
+  void set_target_sample_rate(uint32_t target_sample_rate) { this->target_sample_rate_ = target_sample_rate; }
+  void set_filters(uint16_t filters) { this->filters_ = filters; }
+  void set_taps(uint16_t taps) { this->taps_ = taps; }
+  void set_buffer_duration(uint32_t buffer_duration_ms) { this->buffer_duration_ms_ = buffer_duration_ms; }
+
+ protected:
+  esp_err_t start_task_();
+  bool requires_resampling_() const;
+  void configure_stream_settings_();
+  static void resample_task(void *params);
+
+  uint32_t target_sample_rate_;
+  uint32_t buffer_duration_ms_;
+  uint16_t taps_;
+  uint16_t filters_;
+  bool task_stack_in_psram_{false};
+
+  EventGroupHandle_t event_group_{nullptr};
+  SemaphoreHandle_t active_listeners_semaphore_{nullptr};
+  microphone::MicrophoneSource *microphone_source_{nullptr};
+
+  StaticTask task_;
+  std::weak_ptr<ring_buffer::RingBuffer> ring_buffer_;
+};
+
+}  // namespace esphome::resampler
+
+#endif  // USE_ESP32

--- a/tests/components/i2s_audio/common.yaml
+++ b/tests/components/i2s_audio/common.yaml
@@ -2,3 +2,4 @@ i2s_audio:
   i2s_bclk_pin: ${i2s_bclk_pin}
   i2s_lrclk_pin: ${i2s_lrclk_pin}
   i2s_mclk_pin: ${i2s_mclk_pin}
+  full_duplex: true

--- a/tests/components/micro_wake_word/common.yaml
+++ b/tests/components/micro_wake_word/common.yaml
@@ -12,6 +12,7 @@ microphone:
 
 micro_wake_word:
   microphone: echo_microphone
+  ring_buffer_duration: 500ms
   task_stack_in_psram: true
   on_wake_word_detected:
     - logger.log: "Wake word detected"

--- a/tests/components/resampler/common.yaml
+++ b/tests/components/resampler/common.yaml
@@ -7,3 +7,18 @@ speaker:
   - platform: resampler
     id: resampler_speaker_id
     output_speaker: resampler_i2s_speaker_id
+
+microphone:
+  - platform: i2s_audio
+    id: resampler_i2s_microphone_id
+    i2s_audio_id: i2s_audio_bus
+    adc_type: external
+    i2s_din_pin: ${din_pin}
+    pdm: false
+    bits_per_sample: 16bit
+  - platform: resampler
+    id: resampler_microphone_id
+    microphone:
+      microphone: resampler_i2s_microphone_id
+      channels: [0]
+    sample_rate: 16000

--- a/tests/components/resampler/test.esp32-idf.yaml
+++ b/tests/components/resampler/test.esp32-idf.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  din_pin: GPIO36
   dout_pin: GPIO21
 
 packages:

--- a/tests/components/resampler/test.esp32-s3-idf.yaml
+++ b/tests/components/resampler/test.esp32-s3-idf.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  din_pin: GPIO17
   dout_pin: GPIO16
 
 packages:


### PR DESCRIPTION
﻿# What does this implement/fix?

Adds support for ESP-IDF full duplex I2S audio use cases, primarily targeting ESP32-P4 voice assistant devices that need microphone capture and speaker playback to share the same I2S bus.

This PR includes:

- `i2s_audio.full_duplex`, which allocates RX and TX channels together and keeps TX running as a clock source for external ADCs while microphone capture is active.
- Full-duplex-aware I2S microphone and speaker handling, including DMA descriptor tracking and speaker timestamp forwarding from the shared TX callback.
- A new `resampler` microphone platform that can convert microphone audio to the sample rate expected by voice/wake-word consumers.
- `micro_wake_word.ring_buffer_duration`, keeping the previous `120ms` default while allowing burstier microphone sources to use a larger internal inference ring buffer.
- Component tests covering the new options and resampler microphone configuration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- [[i2s_audio] ESP32-P4: Microphone "Driver failed to start" retry loop when sharing I2S bus with speaker (micro_wake_word + voice_assistant)](https://github.com/esphome/esphome/issues/16043)
- [Support duplex audio on a single I2S bus](https://github.com/esphome/backlog/issues/19)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6754

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
i2s_audio:
  - id: i2s_audio_bus
    i2s_bclk_pin: GPIOXX
    i2s_lrclk_pin: GPIOXX
    i2s_mclk_pin: GPIOXX
    full_duplex: true

microphone:
  - platform: i2s_audio
    id: raw_microphone
    i2s_audio_id: i2s_audio_bus
    adc_type: external
    i2s_din_pin: GPIOXX
    pdm: false
    sample_rate: 48000
    channel: stereo
    bits_per_sample: 16bit
  - platform: resampler
    id: voice_microphone
    microphone:
      microphone: raw_microphone
      channels: [0]
    sample_rate: 16000
    buffer_duration: 500ms

speaker:
  - platform: i2s_audio
    id: i2s_speaker
    i2s_audio_id: i2s_audio_bus
    dac_type: external
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    channel: stereo
    bits_per_sample: 16bit
    timeout: never

micro_wake_word:
  microphone: voice_microphone
  ring_buffer_duration: 500ms
  models:
    - model: okay_nabu
```

Local validation:

```bash
python -m py_compile esphome/components/i2s_audio/__init__.py esphome/components/i2s_audio/microphone/__init__.py esphome/components/i2s_audio/speaker/__init__.py esphome/components/micro_wake_word/__init__.py esphome/components/resampler/microphone/__init__.py
python -m ruff check esphome/components/i2s_audio/__init__.py esphome/components/i2s_audio/microphone/__init__.py esphome/components/i2s_audio/speaker/__init__.py esphome/components/micro_wake_word/__init__.py esphome/components/resampler/microphone/__init__.py
python script/test_build_components.py -e config -c resampler,i2s_audio,micro_wake_word -t esp32-idf --no-grouping
python script/test_build_components.py -e compile -c resampler,i2s_audio,micro_wake_word -t esp32-idf --no-grouping
```

Notes:

- `python script/clang-format ...` could not be run locally because `clang-format` is not installed in this Windows environment.

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
