### PR TITLE
[runtime_image] Improve error logging

### DIFF
--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -1,4 +1,5 @@
 #include "online_image.h"
+#include "esphome/components/runtime_image/image_decoder.h"
 #include "esphome/core/log.h"
 #include <algorithm>
 
@@ -181,7 +182,7 @@ void OnlineImage::loop() {
       auto consumed = this->feed_data(this->download_buffer_.data(), this->download_buffer_.unread());
 
       if (consumed < 0) {
-        ESP_LOGE(TAG, "Error decoding image: %d", consumed);
+        ESP_LOGE(TAG, "Error decoding image: %s", esphome::runtime_image::decode_error_to_string(consumed));
         this->end_connection_();
         this->download_error_callback_.call();
         return;

--- a/esphome/components/runtime_image/image_decoder.h
+++ b/esphome/components/runtime_image/image_decoder.h
@@ -7,7 +7,23 @@ enum DecodeError : int {
   DECODE_ERROR_INVALID_TYPE = -1,
   DECODE_ERROR_UNSUPPORTED_FORMAT = -2,
   DECODE_ERROR_OUT_OF_MEMORY = -3,
+  DECODE_ERROR_INTERNAL_DECODER_ERROR = -4,
 };
+
+constexpr const char *decode_error_to_string(int error) {
+  switch (error) {
+    case DECODE_ERROR_INVALID_TYPE:
+      return "Invalid type";
+    case DECODE_ERROR_UNSUPPORTED_FORMAT:
+      return "Unsupported format";
+    case DECODE_ERROR_OUT_OF_MEMORY:
+      return "Out of memory";
+    case DECODE_ERROR_INTERNAL_DECODER_ERROR:
+      return "Internal decoder error";
+    default:
+      return "Unknown error";
+  }
+}
 
 class RuntimeImage;
 

--- a/esphome/components/runtime_image/jpeg_decoder.cpp
+++ b/esphome/components/runtime_image/jpeg_decoder.cpp
@@ -89,9 +89,21 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
     return DECODE_ERROR_OUT_OF_MEMORY;
   }
   if (!this->jpeg_.decode(0, 0, 0)) {
-    ESP_LOGE(TAG, "Error while decoding.");
+    auto error = this->jpeg_.getLastError();
+    ESP_LOGE(TAG, "Error while decoding: %d", error);
     this->jpeg_.close();
-    return DECODE_ERROR_UNSUPPORTED_FORMAT;
+    switch (error) {
+      case JPEG_ERROR_MEMORY:
+        return DECODE_ERROR_OUT_OF_MEMORY;
+      case JPEG_UNSUPPORTED_FEATURE:
+        return DECODE_ERROR_UNSUPPORTED_FORMAT;
+      case JPEG_INVALID_FILE:
+      case JPEG_INVALID_PARAMETER:
+        return DECODE_ERROR_INVALID_TYPE;
+      case JPEG_DECODE_ERROR:
+      default:
+        return DECODE_ERROR_INTERNAL_DECODER_ERROR;
+    }
   }
   this->decoded_bytes_ = size;
   this->jpeg_.close();

--- a/esphome/components/runtime_image/png_decoder.cpp
+++ b/esphome/components/runtime_image/png_decoder.cpp
@@ -95,6 +95,7 @@ int HOT PngDecoder::decode(uint8_t *buffer, size_t size) {
   auto fed = pngle_feed(this->pngle_, buffer, size);
   if (fed < 0) {
     ESP_LOGE(TAG, "Error decoding image: %s", pngle_error(this->pngle_));
+    return DECODE_ERROR_INTERNAL_DECODER_ERROR;
   } else {
     this->decoded_bytes_ += fed;
   }


### PR DESCRIPTION
# What does this implement/fix?

For JPEG images, print out the actual error reported by the decoding library, instead of a generic "UNSUPORTED_FORMAT" error.

Also, for PNG errors, return an decoder error, instead of the library result, to keep it consistent with other decoders

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
online_image:
  - url: https://upload.wikimedia.org/wikipedia/commons/b/b4/JPEG_example_JPG_RIP_100.jpg
    id: jpeg_image
    format: JPEG
    buffer_size: 65535
    resize: 256x256
    type: RGB565

display:
  - platform: sdl
    lambda: |-
        it.image(10, 10, id(jpeg_image));

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
