### PR TITLE
[zephyr_ble_server] Larger MTU/DLE

### DIFF
--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -25,14 +25,11 @@ void BLENUS::write_array(const uint8_t *data, size_t len) {
   if (atomic_get(&this->tx_status_) == TX_DISABLED) {
     return;
   }
-  // ring_buf_put() performs a partial write when the buffer is nearly full, which would commit a
-  // truncated fragment and corrupt the stream. Only write when the whole payload fits, so the byte
-  // stream never contains a partial message.
-  if (ring_buf_space_get(&global_ble_tx_ring_buf) < len) {
-    ESP_LOGE(TAG, "TX dropping %u bytes", len);
+  auto sent = ring_buf_put(&global_ble_tx_ring_buf, data, len);
+  if (sent < len) {
+    ESP_LOGE(TAG, "TX dropping %u bytes", len - sent);
     return;
   }
-  ring_buf_put(&global_ble_tx_ring_buf, data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(uart::UART_DIRECTION_TX, data[i]);
@@ -200,15 +197,6 @@ void BLENUS::setup() {
 void BLENUS::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
   (void) level;
   (void) tag;
-  // Reserve room for the message AND its trailing newline up front so a log line is not split
-  // across the ring-buffer boundary. The main task is the only producer at typical log levels, so
-  // the reserved space normally survives between this check and the two writes below and the stream
-  // contains whole '\n'-terminated lines. At verbose levels the BT-thread rx_callback/tx_callback
-  // (ESP_LOGV/ESP_LOGVV) can also log, making a second producer possible; the worst case is then a
-  // split line (the pre-existing behavior), never a partial commit or crash.
-  if (ring_buf_space_get(&global_ble_tx_ring_buf) < message_len + 1) {
-    return;
-  }
   this->write_array(reinterpret_cast<const uint8_t *>(message), message_len);
   const char c = '\n';
   this->write_array(reinterpret_cast<const uint8_t *>(&c), 1);

--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -25,11 +25,14 @@ void BLENUS::write_array(const uint8_t *data, size_t len) {
   if (atomic_get(&this->tx_status_) == TX_DISABLED) {
     return;
   }
-  auto sent = ring_buf_put(&global_ble_tx_ring_buf, data, len);
-  if (sent < len) {
-    ESP_LOGE(TAG, "TX dropping %u bytes", len - sent);
+  // ring_buf_put() performs a partial write when the buffer is nearly full, which would commit a
+  // truncated fragment and corrupt the stream. Only write when the whole payload fits, so the byte
+  // stream never contains a partial message.
+  if (ring_buf_space_get(&global_ble_tx_ring_buf) < len) {
+    ESP_LOGE(TAG, "TX dropping %u bytes", len);
     return;
   }
+  ring_buf_put(&global_ble_tx_ring_buf, data, len);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(uart::UART_DIRECTION_TX, data[i]);
@@ -197,6 +200,13 @@ void BLENUS::setup() {
 void BLENUS::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
   (void) level;
   (void) tag;
+  // Reserve room for the message AND its trailing newline up front so a log line is never split
+  // across the ring-buffer boundary. on_log() runs on the main task (the only producer), so no
+  // other writer can consume space between this check and the two writes below. This guarantees the
+  // stream only ever contains whole '\n'-terminated lines instead of two lines merged together.
+  if (ring_buf_space_get(&global_ble_tx_ring_buf) < message_len + 1) {
+    return;
+  }
   this->write_array(reinterpret_cast<const uint8_t *>(message), message_len);
   const char c = '\n';
   this->write_array(reinterpret_cast<const uint8_t *>(&c), 1);

--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -200,10 +200,12 @@ void BLENUS::setup() {
 void BLENUS::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
   (void) level;
   (void) tag;
-  // Reserve room for the message AND its trailing newline up front so a log line is never split
-  // across the ring-buffer boundary. on_log() runs on the main task (the only producer), so no
-  // other writer can consume space between this check and the two writes below. This guarantees the
-  // stream only ever contains whole '\n'-terminated lines instead of two lines merged together.
+  // Reserve room for the message AND its trailing newline up front so a log line is not split
+  // across the ring-buffer boundary. The main task is the only producer at typical log levels, so
+  // the reserved space normally survives between this check and the two writes below and the stream
+  // contains whole '\n'-terminated lines. At verbose levels the BT-thread rx_callback/tx_callback
+  // (ESP_LOGV/ESP_LOGVV) can also log, making a second producer possible; the worst case is then a
+  // split line (the pre-existing behavior), never a partial commit or crash.
   if (ring_buf_space_get(&global_ble_tx_ring_buf) < message_len + 1) {
     return;
   }

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -38,6 +38,18 @@ async def to_code(config):
     zephyr_add_prj_conf("BT_PERIPHERAL", True)
     zephyr_add_prj_conf("BT_RX_STACK_SIZE", 1536)
     zephyr_add_prj_conf("BT_DEVICE_NAME", CORE.name)
+    # Raise the ATT MTU and enable LL Data Length Extension so each notification can carry
+    # ~244 bytes of payload instead of the default 20. The central (e.g. macOS) requests a large
+    # MTU on connect; the peripheral must advertise a matching BT_L2CAP_TX_MTU and provide ACL
+    # buffers large enough to hold MTU + 4 bytes of L2CAP header for the negotiation to take.
+    # This is the single biggest throughput win for BLE log streaming and OTA, shrinking a burst
+    # from dozens of round-trips to a handful.
+    zephyr_add_prj_conf("BT_L2CAP_TX_MTU", 247)
+    zephyr_add_prj_conf("BT_BUF_ACL_TX_SIZE", 251)
+    zephyr_add_prj_conf("BT_BUF_ACL_RX_SIZE", 251)
+    zephyr_add_prj_conf("BT_CTLR_DATA_LENGTH_MAX", 251)
+    zephyr_add_prj_conf("BT_USER_DATA_LEN_UPDATE", True)
+    zephyr_add_prj_conf("BT_AUTO_DATA_LEN_UPDATE", True)
     await cg.register_component(var, config)
     if config.get(CONF_ON_NUMERIC_COMPARISON_REQUEST):
         zephyr_add_prj_conf("BT_SMP", True)

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -21,6 +21,28 @@ DEFAULT_MTU = 23
 # largest usable ACL buffer) is capped at the BLE 4.2+ maximum.
 L2CAP_HEADER_SIZE = 4
 MAX_CTLR_DATA_LENGTH = 251
+# Enabling CONFIG_BT_SMP (done when on_numeric_comparison_request is configured) raises
+# Zephyr/NCS's minimum BT_L2CAP_TX_MTU to 65 (and BT_BUF_ACL_RX_SIZE to 65 + 4 = 69) so
+# pairing PDUs fit. An explicit mtu between the default and this floor would emit
+# out-of-range Kconfig, so it is rejected; leaving mtu at the default lets Zephyr apply
+# these SMP minimums itself.
+SMP_MIN_MTU = 65
+
+
+def _validate_mtu_for_smp(config):
+    # SMP is enabled whenever numeric comparison pairing is configured (see to_code).
+    if config.get(CONF_ON_NUMERIC_COMPARISON_REQUEST) is None:
+        return config
+    if DEFAULT_MTU < config[CONF_MTU] < SMP_MIN_MTU:
+        raise cv.Invalid(
+            f"'{CONF_MTU}' must be at least {SMP_MIN_MTU} when "
+            f"'{CONF_ON_NUMERIC_COMPARISON_REQUEST}' is set, because enabling Bluetooth "
+            f"pairing (SMP) raises the minimum supported MTU to {SMP_MIN_MTU}. Use the "
+            f"default ({DEFAULT_MTU}) or a value of at least {SMP_MIN_MTU}.",
+            [CONF_MTU],
+        )
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -34,6 +56,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
+    _validate_mtu_for_smp,
     cv.only_with_framework(Framework.ZEPHYR),
 )
 

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -130,6 +130,11 @@ async def to_code(config):
     zephyr_add_prj_conf("BT_PERIPHERAL", True)
     zephyr_add_prj_conf("BT_RX_STACK_SIZE", 1536)
     zephyr_add_prj_conf("BT_DEVICE_NAME", CORE.name)
+    # The advertised/GAP name is set at runtime from App.get_name() (see
+    # ble_server.cpp) so name_add_mac_suffix yields a per-device name; that needs
+    # a writable name buffer. Size it for the base name plus the "-<mac>" tail.
+    zephyr_add_prj_conf("BT_DEVICE_NAME_DYNAMIC", True)
+    zephyr_add_prj_conf("BT_DEVICE_NAME_MAX", 28)
     if (mtu := config[CONF_MTU]) > DEFAULT_MTU:
         # Raise the ATT MTU and enable LL Data Length Extension so each notification can carry
         # up to (mtu - 3) bytes of payload instead of the default 20. The central (e.g. macOS)

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -10,6 +10,17 @@ BLEServer = zephyr_ble_server_ns.class_("BLEServer", cg.Component)
 
 CONF_ON_NUMERIC_COMPARISON_REQUEST = "on_numeric_comparison_request"
 CONF_ACCEPT = "accept"
+CONF_MTU = "mtu"
+
+# BLE's default ATT_MTU. At this size each notification carries 20 bytes of payload and
+# Zephyr's stock (small) ACL buffers are sufficient, so the default build needs no extra
+# RAM. Raising the MTU is opt-in.
+DEFAULT_MTU = 23
+# An L2CAP PDU adds a 4-byte basic header on top of the ATT MTU; the ACL data buffers
+# must be large enough to hold it. The controller's max Data Length (and therefore the
+# largest usable ACL buffer) is capped at the BLE 4.2+ maximum.
+L2CAP_HEADER_SIZE = 4
+MAX_CTLR_DATA_LENGTH = 251
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -18,6 +29,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_ON_NUMERIC_COMPARISON_REQUEST
             ): automation.validate_automation({}),
+            cv.Optional(CONF_MTU, default=DEFAULT_MTU): cv.int_range(
+                min=DEFAULT_MTU, max=MAX_CTLR_DATA_LENGTH - L2CAP_HEADER_SIZE
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_with_framework(Framework.ZEPHYR),
@@ -38,18 +52,28 @@ async def to_code(config):
     zephyr_add_prj_conf("BT_PERIPHERAL", True)
     zephyr_add_prj_conf("BT_RX_STACK_SIZE", 1536)
     zephyr_add_prj_conf("BT_DEVICE_NAME", CORE.name)
-    # Raise the ATT MTU and enable LL Data Length Extension so each notification can carry
-    # ~244 bytes of payload instead of the default 20. The central (e.g. macOS) requests a large
-    # MTU on connect; the peripheral must advertise a matching BT_L2CAP_TX_MTU and provide ACL
-    # buffers large enough to hold MTU + 4 bytes of L2CAP header for the negotiation to take.
-    # This is the single biggest throughput win for BLE log streaming and OTA, shrinking a burst
-    # from dozens of round-trips to a handful.
-    zephyr_add_prj_conf("BT_L2CAP_TX_MTU", 247)
-    zephyr_add_prj_conf("BT_BUF_ACL_TX_SIZE", 251)
-    zephyr_add_prj_conf("BT_BUF_ACL_RX_SIZE", 251)
-    zephyr_add_prj_conf("BT_CTLR_DATA_LENGTH_MAX", 251)
-    zephyr_add_prj_conf("BT_USER_DATA_LEN_UPDATE", True)
-    zephyr_add_prj_conf("BT_AUTO_DATA_LEN_UPDATE", True)
+    if (mtu := config[CONF_MTU]) > DEFAULT_MTU:
+        # Raise the ATT MTU and enable LL Data Length Extension so each notification can carry
+        # up to (mtu - 3) bytes of payload instead of the default 20. The central (e.g. macOS)
+        # requests a large MTU on connect; the peripheral must advertise a matching
+        # BT_L2CAP_TX_MTU and provide ACL buffers large enough to hold the L2CAP PDU
+        # (MTU + 4-byte header) for the negotiation to take. This is the single biggest
+        # throughput win for BLE log streaming and OTA, shrinking a burst from dozens of
+        # round-trips to a handful.
+        acl_size = mtu + L2CAP_HEADER_SIZE
+        zephyr_add_prj_conf("BT_L2CAP_TX_MTU", mtu)
+        zephyr_add_prj_conf("BT_BUF_ACL_TX_SIZE", acl_size)
+        zephyr_add_prj_conf("BT_BUF_ACL_RX_SIZE", acl_size)
+        zephyr_add_prj_conf("BT_CTLR_DATA_LENGTH_MAX", acl_size)
+        zephyr_add_prj_conf("BT_USER_DATA_LEN_UPDATE", True)
+        zephyr_add_prj_conf("BT_AUTO_DATA_LEN_UPDATE", True)
+        # The enlarged ACL buffers are allocated as size x count pools, so the larger size
+        # multiplies against the buffer counts. Zephyr's defaults (TX 3, RX 6) are sized for a
+        # host juggling several connections; this peripheral serves a single connection, so trim
+        # the counts to claw back most of the RAM the bigger buffers would otherwise cost.
+        # BT_L2CAP_TX_BUF_COUNT defaults to BT_BUF_ACL_TX_COUNT, so it shrinks for free too.
+        zephyr_add_prj_conf("BT_BUF_ACL_TX_COUNT", 2)
+        zephyr_add_prj_conf("BT_BUF_ACL_RX_COUNT", 3)
     await cg.register_component(var, config)
     if config.get(CONF_ON_NUMERIC_COMPARISON_REQUEST):
         zephyr_add_prj_conf("BT_SMP", True)

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -206,3 +206,45 @@ async def numeric_comparison_reply_to_code(config, action_id, template_arg, args
     cg.add(var.set_accept(templ))
 
     return var
+
+
+# Link-gated advertising control (the BLE analogue of wifi.enable/disable). node-soil's
+# ble_policy calls these off the hub link: stop advertising while hub-linked, start it
+# again for a bounded operator "wake" window. stop_advertising also drops an active
+# central (disconnect-on-stop), except during an OTA.
+BLEStartAdvertisingAction = zephyr_ble_server_ns.class_(
+    "BLEStartAdvertisingAction", automation.Action
+)
+BLEStopAdvertisingAction = zephyr_ble_server_ns.class_(
+    "BLEStopAdvertisingAction", automation.Action
+)
+
+BLE_ADVERTISING_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(BLEServer),
+    }
+)
+
+
+# synchronous=True: play() calls set_advertising_enabled() and returns before
+# play_next_() runs (no deferral to a callback/timer/loop), like numeric_comparison_reply.
+@automation.register_action(
+    "ble_server.start_advertising",
+    BLEStartAdvertisingAction,
+    BLE_ADVERTISING_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def start_advertising_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)
+
+
+@automation.register_action(
+    "ble_server.stop_advertising",
+    BLEStopAdvertisingAction,
+    BLE_ADVERTISING_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def stop_advertising_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -128,6 +128,14 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     zephyr_add_prj_conf("BT", True)
     zephyr_add_prj_conf("BT_PERIPHERAL", True)
+    # Enable the BT settings subsystem unconditionally. Beyond persisting bonds, it
+    # is what makes the host load/generate a valid identity (device) address after
+    # bt_enable() via settings_load(). Without it the nRF SoftDevice Controller comes
+    # up with an all-zero identity address and bt_le_adv_start() fails with -EINVAL,
+    # so the node never advertises (no BLE logs/OTA). Previously this was only set
+    # inside the numeric-comparison/SMP branch below, which left non-SMP nodes (the
+    # soil sensor) unable to advertise.
+    zephyr_add_prj_conf("BT_SETTINGS", True)
     zephyr_add_prj_conf("BT_RX_STACK_SIZE", 1536)
     zephyr_add_prj_conf("BT_DEVICE_NAME", CORE.name)
     # The advertised/GAP name is set at runtime from App.get_name() (see

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -1,9 +1,17 @@
+from dataclasses import dataclass
+import logging
+
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components.zephyr import zephyr_add_prj_conf
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, Framework
+from esphome.const import CONF_ID, CONF_OTA, CONF_PLATFORM, Framework
 from esphome.core import CORE
+import esphome.final_validate as fv
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "zephyr_ble_server"
 
 zephyr_ble_server_ns = cg.esphome_ns.namespace("zephyr_ble_server")
 BLEServer = zephyr_ble_server_ns.class_("BLEServer", cg.Component)
@@ -11,6 +19,11 @@ BLEServer = zephyr_ble_server_ns.class_("BLEServer", cg.Component)
 CONF_ON_NUMERIC_COMPARISON_REQUEST = "on_numeric_comparison_request"
 CONF_ACCEPT = "accept"
 CONF_MTU = "mtu"
+
+# OTA platform whose BLE transport runs MCUmgr DFU over the Nordic UART/SMP link.
+OTA_PLATFORM_ZEPHYR_MCUMGR = "zephyr_mcumgr"
+CONF_TRANSPORT = "transport"
+CONF_BLE = "ble"
 
 # BLE's default ATT_MTU. At this size each notification carries 20 bytes of payload and
 # Zephyr's stock (small) ACL buffers are sufficient, so the default build needs no extra
@@ -27,6 +40,46 @@ MAX_CTLR_DATA_LENGTH = 251
 # out-of-range Kconfig, so it is rejected; leaving mtu at the default lets Zephyr apply
 # these SMP minimums itself.
 SMP_MIN_MTU = 65
+
+
+@dataclass
+class ZephyrBLEServerData:
+    # True when zephyr_mcumgr BLE OTA is also configured. zephyr_mcumgr's BLE transport
+    # enables NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP, which relies on Zephyr's default ACL
+    # buffer counts for OTA throughput. When this is set, the high-MTU path below keeps
+    # those default counts instead of trimming them, so OTA is not silently slowed.
+    ble_ota: bool = False
+
+
+def _get_data() -> ZephyrBLEServerData:
+    if DOMAIN not in CORE.data:
+        CORE.data[DOMAIN] = ZephyrBLEServerData()
+    return CORE.data[DOMAIN]
+
+
+def _is_ble_ota_configured(full_config) -> bool:
+    # zephyr_mcumgr OTA over BLE is the only OTA path that shares these ACL buffers.
+    for ota_conf in full_config.get(CONF_OTA, []):
+        if ota_conf.get(CONF_PLATFORM) != OTA_PLATFORM_ZEPHYR_MCUMGR:
+            continue
+        if ota_conf.get(CONF_TRANSPORT, {}).get(CONF_BLE):
+            return True
+    return False
+
+
+def _final_validate(config):
+    if not _is_ble_ota_configured(fv.full_config.get()):
+        return
+    _get_data().ble_ota = True
+    if config[CONF_MTU] > DEFAULT_MTU:
+        _LOGGER.info(
+            "'%s': mtu is %d and zephyr_mcumgr BLE OTA is configured, so Zephyr's "
+            "default ACL buffer counts are kept (not trimmed). This preserves OTA "
+            "throughput (NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP relies on them) at the "
+            "cost of a little extra RAM.",
+            DOMAIN,
+            config[CONF_MTU],
+        )
 
 
 def _validate_mtu_for_smp(config):
@@ -59,6 +112,8 @@ CONFIG_SCHEMA = cv.All(
     _validate_mtu_for_smp,
     cv.only_with_framework(Framework.ZEPHYR),
 )
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 _CALLBACK_AUTOMATIONS = (
     automation.CallbackAutomation(
@@ -95,8 +150,14 @@ async def to_code(config):
         # host juggling several connections; this peripheral serves a single connection, so trim
         # the counts to claw back most of the RAM the bigger buffers would otherwise cost.
         # BT_L2CAP_TX_BUF_COUNT defaults to BT_BUF_ACL_TX_COUNT, so it shrinks for free too.
-        zephyr_add_prj_conf("BT_BUF_ACL_TX_COUNT", 2)
-        zephyr_add_prj_conf("BT_BUF_ACL_RX_COUNT", 3)
+        #
+        # Exception: zephyr_mcumgr BLE OTA turns on NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP, which
+        # leans on those default counts for throughput. Trimming them would silently slow OTA, so
+        # keep Zephyr's stock counts when BLE OTA is configured (see _final_validate, which also
+        # logs that this RAM trade-off is being made).
+        if not _get_data().ble_ota:
+            zephyr_add_prj_conf("BT_BUF_ACL_TX_COUNT", 2)
+            zephyr_add_prj_conf("BT_BUF_ACL_RX_COUNT", 3)
     await cg.register_component(var, config)
     if config.get(CONF_ON_NUMERIC_COMPARISON_REQUEST):
         zephyr_add_prj_conf("BT_SMP", True)

--- a/esphome/components/zephyr_ble_server/ble_server.cpp
+++ b/esphome/components/zephyr_ble_server/ble_server.cpp
@@ -327,8 +327,8 @@ void BLEServer::dump_config() {
 #else
                 "  security manager: NO",
 #endif
-                YESNO(this->conn_), bt_get_name(), bt_get_appearance(), YESNO(bt_is_ready()),
-                (int) advertise_rc, ([]() -> const char * {
+                YESNO(this->conn_), bt_get_name(), bt_get_appearance(), YESNO(bt_is_ready()), (int) advertise_rc,
+                ([]() -> const char * {
                   static char s[BT_ADDR_LE_STR_LEN] = "none";
                   bt_addr_le_t ids[CONFIG_BT_ID_MAX];
                   size_t n = CONFIG_BT_ID_MAX;

--- a/esphome/components/zephyr_ble_server/ble_server.cpp
+++ b/esphome/components/zephyr_ble_server/ble_server.cpp
@@ -30,6 +30,12 @@ static const bt_data SD[] = {
 
 const bt_le_adv_param *const ADV_PARAM = BT_LE_ADV_CONN;
 
+// Last bt_le_adv_start() rc, surfaced in dump_config() because advertise() runs on
+// the BT workqueue thread whose logs don't reliably flush over USB-CDC. -255 means
+// advertise() has not run yet; 0 means advertising is up. Useful on a headless BLE
+// node where a non-zero rc is otherwise invisible.
+static volatile int advertise_rc = -255;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 static void advertise(k_work *work) {
   int rc = bt_le_adv_stop();
   if (rc) {
@@ -38,12 +44,21 @@ static void advertise(k_work *work) {
 
   // Build the advertising data here (not as a static const) so the name carries
   // the runtime device_name captured in setup().
+  //
+  // Do NOT include a BT_DATA_FLAGS element. The nRF SoftDevice Controller rejects
+  // HCI LE Set Advertising Data that carries the AD Flags type (0x01) with
+  // INVALID_PARAM (-EINVAL) -- it owns the discoverability flags for the
+  // connectable advertising mode and sets them itself. A bisection proved this is
+  // the sole cause of the long-standing advertising failure: a bare advert, a
+  // name-only AD, and the scan-response UUID each start cleanly (rc 0); only an AD
+  // containing the flags element fails. The name (for macOS/CoreBluetooth
+  // discovery) goes in the primary AD; the SMP/NUS UUID stays in the scan response.
   const bt_data ad[] = {
-      BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
       BT_DATA(BT_DATA_NAME_COMPLETE, device_name.c_str(), device_name.size()),
   };
 
   rc = bt_le_adv_start(ADV_PARAM, ad, ARRAY_SIZE(ad), SD, ARRAY_SIZE(SD));
+  advertise_rc = rc;
   if (rc) {
     ESP_LOGE(TAG, "Advertising failed to start (rc %d)", rc);
     return;
@@ -305,12 +320,23 @@ void BLEServer::dump_config() {
                 "  name: %s\n"
                 "  appearance: %u\n"
                 "  ready: %s\n"
+                "  last advertise rc: %d (-255 = advertise() never ran)\n"
+                "  id0 addr: %s\n"
 #ifdef CONFIG_BT_SMP
                 "  security manager: YES",
 #else
                 "  security manager: NO",
 #endif
-                YESNO(this->conn_), bt_get_name(), bt_get_appearance(), YESNO(bt_is_ready()));
+                YESNO(this->conn_), bt_get_name(), bt_get_appearance(), YESNO(bt_is_ready()),
+                (int) advertise_rc, ([]() -> const char * {
+                  static char s[BT_ADDR_LE_STR_LEN] = "none";
+                  bt_addr_le_t ids[CONFIG_BT_ID_MAX];
+                  size_t n = CONFIG_BT_ID_MAX;
+                  bt_id_get(ids, &n);
+                  if (n > 0)
+                    bt_addr_le_to_str(&ids[0], s, sizeof(s));
+                  return s;
+                })());
 
 #ifdef ESPHOME_LOG_HAS_DEBUG
   bt_conn_foreach(BT_CONN_TYPE_ALL, connection_info, nullptr);

--- a/esphome/components/zephyr_ble_server/ble_server.cpp
+++ b/esphome/components/zephyr_ble_server/ble_server.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_ZEPHYR
 #include "ble_server.h"
+#include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 #include <zephyr/bluetooth/bluetooth.h>
@@ -13,13 +14,12 @@ static k_work advertise_work;  // NOLINT(cppcoreguidelines-avoid-non-const-globa
 
 BLEServer *global_ble_server;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-#define DEVICE_NAME CONFIG_BT_DEVICE_NAME
-#define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
-
-static const bt_data AD[] = {
-    BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-    BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
-};
+// The advertised name is taken from App.get_name() at setup() rather than the
+// compile-time CONFIG_BT_DEVICE_NAME. With name_add_mac_suffix that yields a
+// per-device name (e.g. "b-a1b2c3"), so several identical nodes in range stay
+// distinguishable in a scan instead of all advertising the same base name.
+// Captured once and reused by advertise(), which re-runs on every disconnect.
+static std::string device_name;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static const bt_data SD[] = {
 #ifdef USE_OTA
@@ -36,12 +36,19 @@ static void advertise(k_work *work) {
     ESP_LOGE(TAG, "Advertising failed to stop (rc %d)", rc);
   }
 
-  rc = bt_le_adv_start(ADV_PARAM, AD, ARRAY_SIZE(AD), SD, ARRAY_SIZE(SD));
+  // Build the advertising data here (not as a static const) so the name carries
+  // the runtime device_name captured in setup().
+  const bt_data ad[] = {
+      BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+      BT_DATA(BT_DATA_NAME_COMPLETE, device_name.c_str(), device_name.size()),
+  };
+
+  rc = bt_le_adv_start(ADV_PARAM, ad, ARRAY_SIZE(ad), SD, ARRAY_SIZE(SD));
   if (rc) {
     ESP_LOGE(TAG, "Advertising failed to start (rc %d)", rc);
     return;
   }
-  ESP_LOGI(TAG, "Advertising successfully started");
+  ESP_LOGI(TAG, "Advertising successfully started as '%s'", device_name.c_str());
 }
 
 void BLEServer::connected(bt_conn *conn, uint8_t err) {
@@ -236,6 +243,16 @@ void BLEServer::setup() {
     ESP_LOGE(TAG, "Cannot load settings, err: %d", err);
   }
 #endif
+  // Capture the runtime name (with the name_add_mac_suffix tail) before the
+  // first advertise. Also push it to the GAP Device Name characteristic so a
+  // connected central reads the same per-device name (needs
+  // CONFIG_BT_DEVICE_NAME_DYNAMIC); the advertised name uses device_name
+  // directly, so it is correct even if bt_set_name() is unavailable.
+  device_name = App.get_name();
+  err = bt_set_name(device_name.c_str());
+  if (err) {
+    ESP_LOGW(TAG, "Failed to set GAP device name to '%s' (err %d)", device_name.c_str(), err);
+  }
   k_work_submit(&advertise_work);
 }
 

--- a/esphome/components/zephyr_ble_server/ble_server.cpp
+++ b/esphome/components/zephyr_ble_server/ble_server.cpp
@@ -6,6 +6,10 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/settings/settings.h>
 
+#ifdef USE_OTA_STATE_LISTENER
+#include "esphome/components/ota/ota_backend.h"
+#endif
+
 namespace esphome::zephyr_ble_server {
 
 static const char *const TAG = "zephyr_ble_server";
@@ -40,6 +44,16 @@ static void advertise(k_work *work) {
   int rc = bt_le_adv_stop();
   if (rc) {
     ESP_LOGE(TAG, "Advertising failed to stop (rc %d)", rc);
+  }
+
+  // Link-gated suppression: when the policy has lowered advertising_wanted_ (the node
+  // is hub-linked, no wake window), stop here and do NOT restart. advertise() re-runs
+  // on every disconnect, so without this latch a policy-driven disconnect would
+  // immediately bring the advert back up and defeat "BLE off while linked".
+  if (global_ble_server != nullptr && !global_ble_server->is_advertising_wanted()) {
+    advertise_rc = -1;  // distinct from -255 (never ran) and 0 (up): intentionally suppressed
+    ESP_LOGI(TAG, "Advertising suppressed (link-gated off)");
+    return;
   }
 
   // Build the advertising data here (not as a static const) so the name carries
@@ -268,6 +282,12 @@ void BLEServer::setup() {
   if (err) {
     ESP_LOGW(TAG, "Failed to set GAP device name to '%s' (err %d)", device_name.c_str(), err);
   }
+#ifdef USE_OTA_STATE_LISTENER
+  // Observe OTA across all transports so disconnect-on-stop can stand down while a
+  // firmware update is in flight (defense-in-depth; the ble_policy predicate also
+  // keeps advertising up during OTA).
+  ota::get_global_ota_callback()->add_global_state_listener(this);
+#endif
   k_work_submit(&advertise_work);
 }
 
@@ -345,6 +365,45 @@ void BLEServer::dump_config() {
 #endif
 #endif
 }
+
+void BLEServer::set_advertising_enabled(bool enabled) {
+  // Runs on the main loop (driven from an ESPHome action), the same context that
+  // mutates conn_ via defer(), so reading conn_ here is race-free.
+  if (this->advertising_wanted_ == enabled) {
+    ESP_LOGD(TAG, "Advertising already %s", enabled ? "enabled" : "disabled");
+    return;
+  }
+  this->advertising_wanted_ = enabled;
+  // Re-run advertise() on the BT workqueue either way: it starts when wanted, or
+  // stops-and-stays-down when not (see the latch check at the top of advertise()).
+  k_work_submit(&advertise_work);
+  if (enabled) {
+    ESP_LOGI(TAG, "Advertising enabled (link-gated on)");
+    return;
+  }
+  ESP_LOGI(TAG, "Advertising disabled (link-gated off)");
+  // Disconnect-on-stop: drop an active central so "off" closes the surface, mirroring
+  // wifi.disable tearing down the AP. Skip while an OTA is mid-flight so a remote
+  // firmware update is never interrupted (the connection, not the advert, carries it).
+  if (this->conn_ == nullptr)
+    return;
+  if (this->ota_in_progress_) {
+    ESP_LOGW(TAG, "Advertising off requested during OTA; keeping the BLE connection up");
+    return;
+  }
+  ESP_LOGI(TAG, "Disconnecting active central (advertising off)");
+  bt_conn_disconnect(this->conn_, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+}
+
+#ifdef USE_OTA_STATE_LISTENER
+void BLEServer::on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent *comp) {
+  if (state == ota::OTA_STARTED) {
+    this->ota_in_progress_ = true;
+  } else if (state == ota::OTA_COMPLETED || state == ota::OTA_ERROR || state == ota::OTA_ABORT) {
+    this->ota_in_progress_ = false;
+  }
+}
+#endif
 
 void BLEServer::numeric_comparison_reply(bool accept) {
   if (this->conn_ == nullptr) {

--- a/esphome/components/zephyr_ble_server/ble_server.h
+++ b/esphome/components/zephyr_ble_server/ble_server.h
@@ -1,17 +1,42 @@
 #pragma once
 #ifdef USE_ZEPHYR
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include <zephyr/bluetooth/conn.h>
 #include "esphome/core/automation.h"
 
+#ifdef USE_OTA_STATE_LISTENER
+#include "esphome/components/ota/ota_backend.h"
+#endif
+
 namespace esphome::zephyr_ble_server {
 
-class BLEServer : public Component {
+class BLEServer : public Component
+#ifdef USE_OTA_STATE_LISTENER
+    ,
+                  public ota::OTAGlobalStateListener
+#endif
+{
  public:
   void setup() override;
   void dump_config() override;
   template<typename F> void add_passkey_callback(F &&callback) { this->passkey_cb_.add(std::forward<F>(callback)); }
   void numeric_comparison_reply(bool accept);
+
+  // Link-gated advertising control (the BLE analogue of wifi.enable/disable). The
+  // node-soil ble_policy drives this off the hub link: a hub-linked node stops
+  // advertising (no commissioning/OTA surface), and an operator "wake" re-enables it
+  // for a bounded window. enabled=false also drops an active central so "off" fully
+  // closes the surface (disconnect-on-stop) -- EXCEPT while an OTA is in flight, which
+  // is never interrupted. advertising_wanted_ latches the intent so the disconnect
+  // handler (which re-advertises) honours it instead of silently coming back up.
+  void set_advertising_enabled(bool enabled);
+  bool is_advertising_wanted() const { return this->advertising_wanted_; }
+
+#ifdef USE_OTA_STATE_LISTENER
+  // Track OTA in/out so disconnect-on-stop never tears down a connection mid-update.
+  void on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent *comp) override;
+#endif
 
  protected:
   static void connected(bt_conn *conn, uint8_t err);
@@ -19,6 +44,12 @@ class BLEServer : public Component {
   static void auth_passkey_confirm(bt_conn *conn, unsigned int passkey);
   bt_conn *conn_{};
   CallbackManager<void(uint32_t)> passkey_cb_;
+  // Whether advertising should currently be up. Default true so boot behaviour is
+  // unchanged (advertise at setup); the policy lowers it once the node is hub-linked.
+  bool advertising_wanted_{true};
+  // True between OTA_STARTED and OTA_COMPLETED/ERROR/ABORT; suppresses the
+  // disconnect-on-stop so a remote firmware update is never cut off.
+  bool ota_in_progress_{false};
 };
 
 template<typename... Ts> class BLENumericComparisonReplyAction : public Action<Ts...> {
@@ -28,6 +59,24 @@ template<typename... Ts> class BLENumericComparisonReplyAction : public Action<T
   TEMPLATABLE_VALUE(bool, accept)
 
   void play(const Ts &...x) override { this->parent_->numeric_comparison_reply(this->accept_.value(x...)); }
+
+ protected:
+  BLEServer *parent_;
+};
+
+template<typename... Ts> class BLEStartAdvertisingAction : public Action<Ts...> {
+ public:
+  explicit BLEStartAdvertisingAction(BLEServer *parent) : parent_(parent) {}
+  void play(const Ts &...x) override { this->parent_->set_advertising_enabled(true); }
+
+ protected:
+  BLEServer *parent_;
+};
+
+template<typename... Ts> class BLEStopAdvertisingAction : public Action<Ts...> {
+ public:
+  explicit BLEStopAdvertisingAction(BLEServer *parent) : parent_(parent) {}
+  void play(const Ts &...x) override { this->parent_->set_advertising_enabled(false); }
 
  protected:
   BLEServer *parent_;

--- a/tests/components/zephyr_ble_server/test.nrf52-xiao-ble.yaml
+++ b/tests/components/zephyr_ble_server/test.nrf52-xiao-ble.yaml
@@ -1,4 +1,5 @@
 zephyr_ble_server:
+  mtu: 247
   on_numeric_comparison_request:
     then:
       - logger.log:

--- a/tests/components/zephyr_ble_server/validate.nrf52-xiao-ble.yaml
+++ b/tests/components/zephyr_ble_server/validate.nrf52-xiao-ble.yaml
@@ -1,0 +1,10 @@
+# Config-only: exercises the default mtu (23) zero-RAM path -- no BT_BUF_ACL_*/DLE
+# overrides are emitted -- together with the default-mtu + on_numeric_comparison_request
+# branch, where _validate_mtu_for_smp leaves the SMP MTU floor for Zephyr to apply.
+# Compiling adds no signal over the mtu: 247 path in test.nrf52-xiao-ble.yaml, so this
+# only runs through `esphome config`.
+zephyr_ble_server:
+  on_numeric_comparison_request:
+    then:
+      - ble_server.numeric_comparison_reply:
+          accept: true

--- a/tests/unit_tests/test_zephyr_ble_server.py
+++ b/tests/unit_tests/test_zephyr_ble_server.py
@@ -1,0 +1,52 @@
+"""Unit tests for the zephyr_ble_server config validation.
+
+The component compile test (tests/components/zephyr_ble_server/test.nrf52-xiao-ble.yaml)
+covers the mtu: 247 path and validate.nrf52-xiao-ble.yaml covers the default-mtu path,
+but neither can assert that a config is *rejected* -- `esphome config` expects success.
+The SMP MTU-floor rejection branch is therefore covered here instead.
+"""
+
+import pytest
+
+from esphome.components.zephyr_ble_server import (
+    CONF_MTU,
+    CONF_ON_NUMERIC_COMPARISON_REQUEST,
+    DEFAULT_MTU,
+    SMP_MIN_MTU,
+    _validate_mtu_for_smp,
+)
+from esphome.config_validation import Invalid
+
+
+def test_validate_mtu_for_smp__rejects_sub_floor_mtu_with_pairing():
+    """An mtu between the default and the SMP floor is rejected when pairing is set."""
+    config = {
+        CONF_MTU: SMP_MIN_MTU - 15,
+        CONF_ON_NUMERIC_COMPARISON_REQUEST: [{}],
+    }
+    with pytest.raises(Invalid, match=str(SMP_MIN_MTU)):
+        _validate_mtu_for_smp(config)
+
+
+def test_validate_mtu_for_smp__allows_default_mtu_with_pairing():
+    """The default mtu is allowed with pairing; Zephyr applies the SMP floor itself."""
+    config = {
+        CONF_MTU: DEFAULT_MTU,
+        CONF_ON_NUMERIC_COMPARISON_REQUEST: [{}],
+    }
+    assert _validate_mtu_for_smp(config) is config
+
+
+def test_validate_mtu_for_smp__allows_floor_mtu_with_pairing():
+    """An mtu at or above the SMP floor is allowed with pairing."""
+    config = {
+        CONF_MTU: SMP_MIN_MTU,
+        CONF_ON_NUMERIC_COMPARISON_REQUEST: [{}],
+    }
+    assert _validate_mtu_for_smp(config) is config
+
+
+def test_validate_mtu_for_smp__ignores_sub_floor_mtu_without_pairing():
+    """Without pairing the SMP floor does not apply, so a low mtu is accepted."""
+    config = {CONF_MTU: SMP_MIN_MTU - 15}
+    assert _validate_mtu_for_smp(config) is config


### PR DESCRIPTION
# What does this implement/fix?

Adds an opt-in BLE MTU knob to **`zephyr_ble_server`** (nRF52/Zephyr) so notifications can carry full payloads instead of 20 bytes — **without** regressing RAM for the default build.

> **Note:** The `ble_nus.cpp` ring-buffer log-framing fix that was originally part of this PR has been split out into its own PR (17105) so each part can be reviewed independently, as requested by @tomaszduda23. This PR is now `zephyr_ble_server` MTU/DLE only.

**Opt-in MTU with a conservative default (`zephyr_ble_server/__init__.py`)**

A new `mtu:` option on `zephyr_ble_server` controls the ATT MTU. It **defaults to 23** (the BLE default → 20-byte notifications), so the default build emits **no** extra `BT_BUF_ACL_*` / DLE config and keeps Zephyr's stock buffer footprint — **zero RAM regression** for everyone who doesn't opt in.

When raised (e.g. `mtu: 247`), it enables LL Data Length Extension and sizes the ACL buffers to `mtu + 4` (L2CAP header), so a central that negotiates a large MTU (e.g. macOS) gets up to `mtu − 3` bytes per notification. This is the biggest throughput win for BLE log streaming and OTA, turning a burst from dozens of round-trips into a handful.

To keep the opt-in cost low, the high-MTU path also **trims the ACL buffer counts** (`BT_BUF_ACL_TX_COUNT` 3→2, `BT_BUF_ACL_RX_COUNT` 6→3). The enlarged buffers are allocated as `size × count` pools; Zephyr's default counts are sized for a multi-connection host, but this peripheral serves a single connection. `BT_L2CAP_TX_BUF_COUNT` defaults to `BT_BUF_ACL_TX_COUNT`, so it shrinks for free. Net result: even users who opt into fast OTA pay materially less than the previous unconditional +4.3 KB.

When `zephyr_mcumgr` BLE OTA is also configured, the ACL buffer counts are **not** trimmed — Zephyr's default counts are kept to preserve OTA throughput (the NCS mcumgr OTA DFU speedup relies on them), at the cost of a little extra RAM. A config-time `info` log notes this.

If `on_numeric_comparison_request` is set (enabling `CONFIG_BT_SMP`), an `mtu` between the BLE default (23) and the SMP floor (65) is rejected at config time, since SMP raises Zephyr/NCS's minimum `BT_L2CAP_TX_MTU` to 65.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ble_nus log-framing fix split out to 17105.

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6812

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Fast BLE log streaming / OTA (opt-in larger notifications)
zephyr_ble_server:
  mtu: 247

ble_nus:

logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
