### PR TITLE
Add Rheem climate

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -419,6 +419,7 @@ esphome/components/resampler/speaker/* @kahrendt
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz
 esphome/components/rgbct/* @jesserockz
+esphome/components/rheem/* @amet
 esphome/components/ring_buffer/* @kahrendt
 esphome/components/router/speaker/* @kahrendt
 esphome/components/rp2040/* @jesserockz

--- a/esphome/components/rheem/climate.py
+++ b/esphome/components/rheem/climate.py
@@ -1,0 +1,14 @@
+import esphome.codegen as cg
+from esphome.components import climate_ir
+
+AUTO_LOAD = ["climate_ir"]
+CODEOWNERS = ["@amet"]
+
+rheem_ns = cg.esphome_ns.namespace("rheem")
+RheemClimate = rheem_ns.class_("RheemClimate", climate_ir.ClimateIR)
+
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(RheemClimate)
+
+
+async def to_code(config):
+    await climate_ir.new_climate_ir(config)

--- a/esphome/components/rheem/rheem.cpp
+++ b/esphome/components/rheem/rheem.cpp
@@ -1,0 +1,249 @@
+#include "rheem.h"
+#include "esphome/core/log.h"
+
+namespace esphome::rheem {
+
+static const char *const TAG = "rheem.climate";
+
+const uint16_t RHEEM_STATE_LENGTH = 14;
+const uint16_t RHEEM_BITS = RHEEM_STATE_LENGTH * 8;
+
+const uint8_t RHEEM_HEAT = 1;
+const uint8_t RHEEM_DRY = 2;
+const uint8_t RHEEM_COOL = 3;
+const uint8_t RHEEM_FAN = 7;
+const uint8_t RHEEM_AUTO = 8;
+
+const uint8_t RHEEM_FAN_AUTO = 0;
+const uint8_t RHEEM_FAN_LOW = 2;
+const uint8_t RHEEM_FAN_MED = 3;
+const uint8_t RHEEM_FAN_HIGH = 5;
+
+const uint8_t RHEEM_VSWING_MASK = 0x38;
+const uint8_t RHEEM_POWER_MASK = 0x04;
+
+const uint8_t RHEEM_HALF_DEGREE = 0b00100000;
+
+const uint16_t RHEEM_HEADER_MARK = 3100;
+const uint16_t RHEEM_HEADER_SPACE = 1650;
+const uint16_t RHEEM_BIT_MARK = 500;
+const uint16_t RHEEM_ONE_SPACE = 1100;
+const uint16_t RHEEM_ZERO_SPACE = 350;
+const uint32_t RHEEM_GAP = RHEEM_HEADER_SPACE;
+
+void RheemClimate::transmit_state() {
+  uint8_t remote_state[RHEEM_STATE_LENGTH] = {0};
+
+  // A known good state. (On, Cool, 24C)
+  remote_state[0] = 0x23;
+  remote_state[1] = 0xCB;
+  remote_state[2] = 0x26;
+  remote_state[3] = 0x01;
+  remote_state[5] = 0x24;
+  remote_state[6] = 0x03;
+  remote_state[7] = 0x07;
+  remote_state[8] = 0x40;
+
+  // Set mode
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      remote_state[6] &= 0xF0;
+      remote_state[6] |= RHEEM_AUTO;
+      break;
+    case climate::CLIMATE_MODE_COOL:
+      remote_state[6] &= 0xF0;
+      remote_state[6] |= RHEEM_COOL;
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      remote_state[6] &= 0xF0;
+      remote_state[6] |= RHEEM_HEAT;
+      break;
+    case climate::CLIMATE_MODE_DRY:
+      remote_state[6] &= 0xF0;
+      remote_state[6] |= RHEEM_DRY;
+      break;
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      remote_state[6] &= 0xF0;
+      remote_state[6] |= RHEEM_FAN;
+      break;
+    case climate::CLIMATE_MODE_OFF:
+    default:
+      remote_state[5] &= ~RHEEM_POWER_MASK;
+      break;
+  }
+
+  // Set temperature
+  // Make sure we have desired temp in the correct range.
+  float safecelsius = std::max(this->target_temperature, RHEEM_TEMP_MIN);
+  safecelsius = std::min(safecelsius, RHEEM_TEMP_MAX);
+  // Convert to integer nr. of half degrees.
+  auto half_degrees = static_cast<uint8_t>(safecelsius * 2);
+  if (half_degrees & 1) {                    // Do we have a half degree celsius?
+    remote_state[12] |= RHEEM_HALF_DEGREE;  // Add 0.5 degrees
+  } else {
+    remote_state[12] &= ~RHEEM_HALF_DEGREE;  // Clear the half degree.
+  }
+  remote_state[7] &= 0xF0;  // Clear temp bits.
+  remote_state[7] |= ((uint8_t) RHEEM_TEMP_MAX - half_degrees / 2);
+
+  // Set fan
+  uint8_t selected_fan;
+  switch (this->fan_mode.value_or(climate::CLIMATE_FAN_ON)) {
+    case climate::CLIMATE_FAN_HIGH:
+      selected_fan = RHEEM_FAN_HIGH;
+      break;
+    case climate::CLIMATE_FAN_MEDIUM:
+      selected_fan = RHEEM_FAN_MED;
+      break;
+    case climate::CLIMATE_FAN_LOW:
+      selected_fan = RHEEM_FAN_LOW;
+      break;
+    case climate::CLIMATE_FAN_AUTO:
+    default:
+      selected_fan = RHEEM_FAN_AUTO;
+  }
+  remote_state[8] |= selected_fan;
+
+  // Set swing
+  if (this->swing_mode == climate::CLIMATE_SWING_VERTICAL) {
+    remote_state[8] |= RHEEM_VSWING_MASK;
+  }
+
+  // Set mute
+  if (this->mute) {
+    remote_state[4] = 0x70; // 01110000 -> Mute Active
+  } else {
+    remote_state[4] = 0x4C; // 01001100 -> Mute Inactive (Standard Fan Mode)
+  }
+
+  // Calculate & set the checksum for the current internal state of the remote.
+  // Stored the checksum value in the last byte.
+  for (uint8_t checksum_byte = 0; checksum_byte < RHEEM_STATE_LENGTH - 1; checksum_byte++)
+    remote_state[RHEEM_STATE_LENGTH - 1] += remote_state[checksum_byte];
+
+  ESP_LOGI(TAG, "Sending: %02X %02X %02X %02X   %02X %02X %02X %02X   %02X %02X %02X %02X   %02X %02X", remote_state[0],
+           remote_state[1], remote_state[2], remote_state[3], remote_state[4], remote_state[5], remote_state[6],
+           remote_state[7], remote_state[8], remote_state[9], remote_state[10], remote_state[11], remote_state[12],
+           remote_state[13]);
+
+  auto transmit = this->transmitter_->transmit();
+  auto *data = transmit.get_data();
+
+  data->set_carrier_frequency(38000);
+
+  // Header
+  data->mark(RHEEM_HEADER_MARK);
+  data->space(RHEEM_HEADER_SPACE);
+  // Data
+  for (uint8_t i : remote_state) {
+    for (uint8_t j = 0; j < 8; j++) {
+      data->mark(RHEEM_BIT_MARK);
+      bool bit = i & (1 << j);
+      data->space(bit ? RHEEM_ONE_SPACE : RHEEM_ZERO_SPACE);
+    }
+  }
+  // Footer
+  data->mark(RHEEM_BIT_MARK);
+  data->space(RHEEM_GAP);
+
+  transmit.perform();
+}
+
+bool RheemClimate::on_receive(remote_base::RemoteReceiveData data) {
+  // Validate header
+  if (!data.expect_item(RHEEM_HEADER_MARK, RHEEM_HEADER_SPACE)) {
+    ESP_LOGVV(TAG, "Header fail");
+    return false;
+  }
+
+  uint8_t remote_state[RHEEM_STATE_LENGTH] = {0};
+  // Read all bytes.
+  for (int i = 0; i < RHEEM_STATE_LENGTH; i++) {
+    // Read bit
+    for (int j = 0; j < 8; j++) {
+      if (data.expect_item(RHEEM_BIT_MARK, RHEEM_ONE_SPACE)) {
+        remote_state[i] |= 1 << j;
+      } else if (!data.expect_item(RHEEM_BIT_MARK, RHEEM_ZERO_SPACE)) {
+        ESP_LOGVV(TAG, "Byte %d bit %d fail", i, j);
+        return false;
+      }
+    }
+  }
+  // Validate footer
+  if (!data.expect_mark(RHEEM_BIT_MARK)) {
+    ESP_LOGVV(TAG, "Footer fail");
+    return false;
+  }
+
+  uint8_t checksum = 0;
+  // Calculate & set the checksum for the current internal state of the remote.
+  // Stored the checksum value in the last byte.
+  for (uint8_t checksum_byte = 0; checksum_byte < RHEEM_STATE_LENGTH - 1; checksum_byte++)
+    checksum += remote_state[checksum_byte];
+  if (checksum != remote_state[RHEEM_STATE_LENGTH - 1]) {
+    ESP_LOGVV(TAG, "Checksum fail");
+    return false;
+  }
+
+  ESP_LOGV(TAG, "Received: %02X %02X %02X %02X   %02X %02X %02X %02X   %02X %02X %02X %02X   %02X %02X",
+           remote_state[0], remote_state[1], remote_state[2], remote_state[3], remote_state[4], remote_state[5],
+           remote_state[6], remote_state[7], remote_state[8], remote_state[9], remote_state[10], remote_state[11],
+           remote_state[12], remote_state[13]);
+
+  // two first bytes are constant
+  if (remote_state[0] != 0x23 || remote_state[1] != 0xCB)
+    return false;
+
+  if ((remote_state[5] & RHEEM_POWER_MASK) == 0) {
+    this->mode = climate::CLIMATE_MODE_OFF;
+  } else {
+    auto mode = remote_state[6] & 0x0F;
+    switch (mode) {
+      case RHEEM_HEAT:
+        this->mode = climate::CLIMATE_MODE_HEAT;
+        break;
+      case RHEEM_COOL:
+        this->mode = climate::CLIMATE_MODE_COOL;
+        break;
+      case RHEEM_DRY:
+        this->mode = climate::CLIMATE_MODE_DRY;
+        break;
+      case RHEEM_FAN:
+        this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      case RHEEM_AUTO:
+        this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+        break;
+    }
+  }
+  auto temp = RHEEM_TEMP_MAX - remote_state[7];
+  if (remote_state[12] & RHEEM_HALF_DEGREE)
+    temp += .5f;
+  this->target_temperature = temp;
+  auto fan = remote_state[8] & 0x7;
+  switch (fan) {
+    case RHEEM_FAN_HIGH:
+      this->fan_mode = climate::CLIMATE_FAN_HIGH;
+      break;
+    case RHEEM_FAN_MED:
+      this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+      break;
+    case RHEEM_FAN_LOW:
+      this->fan_mode = climate::CLIMATE_FAN_LOW;
+      break;
+    case RHEEM_FAN_AUTO:
+    default:
+      this->fan_mode = climate::CLIMATE_FAN_AUTO;
+      break;
+  }
+  if ((remote_state[8] & RHEEM_VSWING_MASK) == RHEEM_VSWING_MASK) {
+    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+  } else {
+    this->swing_mode = climate::CLIMATE_SWING_OFF;
+  }
+
+  this->publish_state();
+  return true;
+}
+
+}  // namespace esphome::rheem

--- a/esphome/components/rheem/rheem.cpp
+++ b/esphome/components/rheem/rheem.cpp
@@ -78,7 +78,7 @@ void RheemClimate::transmit_state() {
   safecelsius = std::min(safecelsius, RHEEM_TEMP_MAX);
   // Convert to integer nr. of half degrees.
   auto half_degrees = static_cast<uint8_t>(safecelsius * 2);
-  if (half_degrees & 1) {                    // Do we have a half degree celsius?
+  if (half_degrees & 1) {                   // Do we have a half degree celsius?
     remote_state[12] |= RHEEM_HALF_DEGREE;  // Add 0.5 degrees
   } else {
     remote_state[12] &= ~RHEEM_HALF_DEGREE;  // Clear the half degree.
@@ -111,9 +111,9 @@ void RheemClimate::transmit_state() {
 
   // Set mute
   if (this->mute) {
-    remote_state[4] = 0x70; // 01110000 -> Mute Active
+    remote_state[4] = 0x70;  // 01110000 -> Mute Active
   } else {
-    remote_state[4] = 0x4C; // 01001100 -> Mute Inactive (Standard Fan Mode)
+    remote_state[4] = 0x4C;  // 01001100 -> Mute Inactive (Standard Fan Mode)
   }
 
   // Calculate & set the checksum for the current internal state of the remote.

--- a/esphome/components/rheem/rheem.h
+++ b/esphome/components/rheem/rheem.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/components/climate_ir/climate_ir.h"
+
+namespace esphome::rheem {
+
+// Temperature
+const float RHEEM_TEMP_MAX = 31.0;
+const float RHEEM_TEMP_MIN = 16.0;
+
+class RheemClimate : public climate_ir::ClimateIR {
+ public:
+  RheemClimate()
+      : climate_ir::ClimateIR(RHEEM_TEMP_MIN, RHEEM_TEMP_MAX, .5f, true, true,
+                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
+                               climate::CLIMATE_FAN_HIGH},
+                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {
+
+        this->mute = true;
+      }
+
+ bool mute{true}; // sets mute to true, its used to lower the fan speed below min
+
+// Exposed function for YAML switch component to manipulate states
+ void set_mute_state(bool state) { 
+  this->mute = state; 
+  this->transmit_state();
+ }
+
+// climate::ClimateTraits traits() override;
+ protected:
+  /// Transmit via IR the state of this climate controller.
+  void transmit_state() override;
+  /// Handle received IR Buffer
+  bool on_receive(remote_base::RemoteReceiveData data) override;
+};
+
+}  // namespace esphome::rheem

--- a/esphome/components/rheem/rheem.h
+++ b/esphome/components/rheem/rheem.h
@@ -15,19 +15,18 @@ class RheemClimate : public climate_ir::ClimateIR {
                               {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
                                climate::CLIMATE_FAN_HIGH},
                               {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {
+    this->mute = true;
+  }
 
-        this->mute = true;
-      }
+  bool mute{true};  // sets mute to true, its used to lower the fan speed below min
 
- bool mute{true}; // sets mute to true, its used to lower the fan speed below min
+  // Exposed function for YAML switch component to manipulate states
+  void set_mute_state(bool state) {
+    this->mute = state;
+    this->transmit_state();
+  }
 
-// Exposed function for YAML switch component to manipulate states
- void set_mute_state(bool state) { 
-  this->mute = state; 
-  this->transmit_state();
- }
-
-// climate::ClimateTraits traits() override;
+  // climate::ClimateTraits traits() override;
  protected:
   /// Transmit via IR the state of this climate controller.
   void transmit_state() override;

--- a/tests/components/rheem/common.yaml
+++ b/tests/components/rheem/common.yaml
@@ -1,0 +1,28 @@
+sensor:
+  - platform: template
+    id: rheem_sensor
+    lambda: "return 21;"
+
+climate:
+  - platform: rheem
+    name: RHEEM Climate with Sensor
+    supports_heat: true
+    supports_cool: true
+    sensor: rheem_sensor
+    transmitter_id: xmitr
+
+switch:
+  - platform: template
+    name: "Mute Mode"
+    icon: "mdi:toggle-switch"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return ((rheem::RheemClimate*)id(rheem_sensor))->mute;
+
+    turn_on_action:
+      - lambda: |-
+          ((rheem::RheemClimate*)id(rheem_sensor))->set_mute_state(true);
+    turn_off_action:
+      - lambda: |-
+          ((rheem::RheemClimate*)id(rheem_sensor))->set_mute_state(false);
+

--- a/tests/components/rheem/common.yaml
+++ b/tests/components/rheem/common.yaml
@@ -25,4 +25,3 @@ switch:
     turn_off_action:
       - lambda: |-
           ((rheem::RheemClimate*)id(rheem_sensor))->set_mute_state(false);
-

--- a/tests/components/rheem/test.esp32-idf.yaml
+++ b/tests/components/rheem/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/rheem/test.esp8266-ard.yaml
+++ b/tests/components/rheem/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
Add Rheem climate

# What does this implement/fix?

adds Rheem climate

used tcl112 as base, starting point for other rheem devices.

- adds mute button

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other



## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: rheem
    name: "Rheem AC Control"
    sensor: current_temp
    id: my_rheem_ac
    # This receiver id links directly to the remote_transmitter component
    transmitter_id: rheem_tx
    
    # Optional: Visual limits for the Home Assistant UI card
    visual:
      min_temperature: 16 °C
      max_temperature: 30 °C
      temperature_step: 1.0 °C


switch:
  - platform: template
    name: "Mute Mode"
    icon: "mdi:toggle-switch"
    restore_mode: ALWAYS_ON
    lambda: |-
      return ((rheem::RheemClimate*)id(my_rheem_ac))->mute;

    turn_on_action:
      - lambda: |-
          ((rheem::RheemClimate*)id(my_rheem_ac))->set_mute_state(true);
    turn_off_action:
      - lambda: |-
          ((rheem::RheemClimate*)id(my_rheem_ac))->set_mute_state(false);

```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [x ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
