### PR TITLE
[mitsubishi_cn105] Mark configurable classes as final

### DIFF
--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.cpp
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.cpp
@@ -84,7 +84,7 @@ climate::ClimateTraits MitsubishiCN105Climate::traits() {
     traits.add_supported_fan_mode(p.second);
   }
 
-  traits.set_supported_swing_modes(this->supported_swing_modes_);
+  traits.set_supported_swing_modes(this->swing_mode_manager_.supported_swing_modes());
 
   traits.set_visual_min_temperature(16.0f);
   traits.set_visual_max_temperature(31.0f);
@@ -117,33 +117,11 @@ void MitsubishiCN105Climate::control(const climate::ClimateCall &call) {
   }
 
   if (const auto swing_mode = call.get_swing_mode()) {
-    auto vane = this->last_non_swing_vane_mode_;
-    auto wide = this->last_non_swing_wide_vane_mode_;
-
-    switch (*swing_mode) {
-      case climate::CLIMATE_SWING_BOTH:
-        vane = MitsubishiCN105::VaneMode::SWING;
-        wide = MitsubishiCN105::WideVaneMode::SWING;
-        break;
-
-      case climate::CLIMATE_SWING_VERTICAL:
-        vane = MitsubishiCN105::VaneMode::SWING;
-        break;
-
-      case climate::CLIMATE_SWING_HORIZONTAL:
-        wide = MitsubishiCN105::WideVaneMode::SWING;
-        break;
-
-      case climate::CLIMATE_SWING_OFF:
-      default:
-        break;
+    if (const auto vane = this->swing_mode_manager_.vane_from(*swing_mode)) {
+      this->hp_.set_vane_mode(*vane);
     }
-
-    if (this->supported_swing_modes_.count(climate::CLIMATE_SWING_VERTICAL)) {
-      this->hp_.set_vane_mode(vane);
-    }
-    if (this->supported_swing_modes_.count(climate::CLIMATE_SWING_HORIZONTAL)) {
-      this->hp_.set_wide_vane_mode(wide);
+    if (const auto wide = this->swing_mode_manager_.wide_vane_from(*swing_mode)) {
+      this->hp_.set_wide_vane_mode(*wide);
     }
   }
 
@@ -176,58 +154,31 @@ void MitsubishiCN105Climate::apply_values_() {
     ESP_LOGD(TAG, "Unable to map fan mode");
   }
 
-  if (!this->supported_swing_modes_.empty()) {
-    bool vertical_swinging = false;
-    bool horizontal_swinging = false;
-
-    if (this->supported_swing_modes_.count(climate::CLIMATE_SWING_VERTICAL)) {
-      if (status.vane_mode == MitsubishiCN105::VaneMode::SWING) {
-        vertical_swinging = true;
-      } else if (status.vane_mode != MitsubishiCN105::VaneMode::UNKNOWN) {
-        this->last_non_swing_vane_mode_ = status.vane_mode;
-      }
-    }
-
-    if (this->supported_swing_modes_.count(climate::CLIMATE_SWING_HORIZONTAL)) {
-      if (status.wide_vane_mode == MitsubishiCN105::WideVaneMode::SWING) {
-        horizontal_swinging = true;
-      } else if (status.wide_vane_mode != MitsubishiCN105::WideVaneMode::UNKNOWN) {
-        this->last_non_swing_wide_vane_mode_ = status.wide_vane_mode;
-      }
-    }
-
-    if (vertical_swinging && horizontal_swinging) {
-      this->swing_mode = climate::CLIMATE_SWING_BOTH;
-    } else if (vertical_swinging) {
-      this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-    } else if (horizontal_swinging) {
-      this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-    } else {
-      this->swing_mode = climate::CLIMATE_SWING_OFF;
-    }
+  if (const auto swing_mode = this->swing_mode_manager_.swing_mode_from(status.vane_mode, status.wide_vane_mode)) {
+    this->swing_mode = *swing_mode;
   }
 
   this->publish_state();
 }
 
 void MitsubishiCN105Climate::set_supported_swing_mode(climate::ClimateSwingMode mode) {
-  this->supported_swing_modes_.clear();
+  this->swing_mode_manager_.supported_swing_modes().clear();
   switch (mode) {
     case climate::CLIMATE_SWING_VERTICAL:
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_OFF);
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_VERTICAL);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_OFF);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_VERTICAL);
       break;
 
     case climate::CLIMATE_SWING_HORIZONTAL:
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_OFF);
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_HORIZONTAL);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_OFF);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_HORIZONTAL);
       break;
 
     case climate::CLIMATE_SWING_BOTH:
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_OFF);
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_VERTICAL);
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_HORIZONTAL);
-      this->supported_swing_modes_.insert(climate::CLIMATE_SWING_BOTH);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_OFF);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_VERTICAL);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_HORIZONTAL);
+      this->swing_mode_manager_.supported_swing_modes().insert(climate::CLIMATE_SWING_BOTH);
       break;
 
     case climate::CLIMATE_SWING_OFF:

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
@@ -5,6 +5,7 @@
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/uart/uart.h"
 #include "mitsubishi_cn105.h"
+#include "mitsubishi_cn105_swing_mode_manager.h"
 
 namespace esphome::mitsubishi_cn105 {
 
@@ -31,9 +32,7 @@ class MitsubishiCN105Climate final : public climate::Climate, public Component, 
   void apply_values_();
 
   MitsubishiCN105 hp_;
-  climate::ClimateSwingModeMask supported_swing_modes_{};
-  MitsubishiCN105::VaneMode last_non_swing_vane_mode_{MitsubishiCN105::VaneMode::AUTO};
-  MitsubishiCN105::WideVaneMode last_non_swing_wide_vane_mode_{MitsubishiCN105::WideVaneMode::CENTER};
+  SwingModeManager swing_mode_manager_;
 };
 
 template<typename... Ts>

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h
@@ -8,7 +8,7 @@
 
 namespace esphome::mitsubishi_cn105 {
 
-class MitsubishiCN105Climate : public climate::Climate, public Component, public uart::UARTDevice {
+class MitsubishiCN105Climate final : public climate::Climate, public Component, public uart::UARTDevice {
  public:
   explicit MitsubishiCN105Climate() : hp_(*this) {}
 
@@ -37,7 +37,7 @@ class MitsubishiCN105Climate : public climate::Climate, public Component, public
 };
 
 template<typename... Ts>
-class SetRemoteTemperatureAction : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
+class SetRemoteTemperatureAction final : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
  public:
   TEMPLATABLE_VALUE(float, temperature)
 
@@ -45,7 +45,7 @@ class SetRemoteTemperatureAction : public Action<Ts...>, public Parented<Mitsubi
 };
 
 template<typename... Ts>
-class ClearRemoteTemperatureAction : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
+class ClearRemoteTemperatureAction final : public Action<Ts...>, public Parented<MitsubishiCN105Climate> {
  public:
   void play(const Ts &...x) override { this->parent_->clear_remote_temperature(); }
 };

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105_swing_mode_manager.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105_swing_mode_manager.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <optional>
+
+#include "esphome/components/climate/climate.h"
+#include "mitsubishi_cn105.h"
+
+namespace esphome::mitsubishi_cn105 {
+
+class SwingModeManager {
+ public:
+  const climate::ClimateSwingModeMask &supported_swing_modes() const { return this->supported_swing_modes_; }
+  climate::ClimateSwingModeMask &supported_swing_modes() { return this->supported_swing_modes_; }
+
+  std::optional<MitsubishiCN105::VaneMode> vane_from(climate::ClimateSwingMode swing_mode) const {
+    if (!this->supported_swing_modes_.count(climate::CLIMATE_SWING_VERTICAL)) {
+      return std::nullopt;
+    }
+
+    switch (swing_mode) {
+      case climate::CLIMATE_SWING_BOTH:
+      case climate::CLIMATE_SWING_VERTICAL:
+        return MitsubishiCN105::VaneMode::SWING;
+
+      case climate::CLIMATE_SWING_HORIZONTAL:
+      case climate::CLIMATE_SWING_OFF:
+      default:
+        return this->last_non_swing_vane_mode_;
+    }
+  }
+
+  std::optional<MitsubishiCN105::WideVaneMode> wide_vane_from(climate::ClimateSwingMode swing_mode) const {
+    if (!this->supported_swing_modes_.count(climate::CLIMATE_SWING_HORIZONTAL)) {
+      return std::nullopt;
+    }
+
+    switch (swing_mode) {
+      case climate::CLIMATE_SWING_BOTH:
+      case climate::CLIMATE_SWING_HORIZONTAL:
+        return MitsubishiCN105::WideVaneMode::SWING;
+
+      case climate::CLIMATE_SWING_VERTICAL:
+      case climate::CLIMATE_SWING_OFF:
+      default:
+        return this->last_non_swing_wide_vane_mode_;
+    }
+  }
+
+  std::optional<climate::ClimateSwingMode> swing_mode_from(MitsubishiCN105::VaneMode vane_mode,
+                                                           MitsubishiCN105::WideVaneMode wide_vane_mode) {
+    if (this->supported_swing_modes_.empty()) {
+      return std::nullopt;
+    }
+
+    bool vertical_swinging = false;
+    bool horizontal_swinging = false;
+
+    if (this->supported_swing_modes_.count(climate::CLIMATE_SWING_VERTICAL)) {
+      if (vane_mode == MitsubishiCN105::VaneMode::SWING) {
+        vertical_swinging = true;
+      } else if (vane_mode != MitsubishiCN105::VaneMode::UNKNOWN) {
+        this->last_non_swing_vane_mode_ = vane_mode;
+      }
+    }
+
+    if (this->supported_swing_modes_.count(climate::CLIMATE_SWING_HORIZONTAL)) {
+      if (wide_vane_mode == MitsubishiCN105::WideVaneMode::SWING) {
+        horizontal_swinging = true;
+      } else if (wide_vane_mode != MitsubishiCN105::WideVaneMode::UNKNOWN) {
+        this->last_non_swing_wide_vane_mode_ = wide_vane_mode;
+      }
+    }
+
+    if (vertical_swinging && horizontal_swinging) {
+      return climate::CLIMATE_SWING_BOTH;
+    }
+    if (vertical_swinging) {
+      return climate::CLIMATE_SWING_VERTICAL;
+    }
+    if (horizontal_swinging) {
+      return climate::CLIMATE_SWING_HORIZONTAL;
+    }
+    return climate::CLIMATE_SWING_OFF;
+  }
+
+ protected:
+  climate::ClimateSwingModeMask supported_swing_modes_{};
+  MitsubishiCN105::VaneMode last_non_swing_vane_mode_{MitsubishiCN105::VaneMode::AUTO};
+  MitsubishiCN105::WideVaneMode last_non_swing_wide_vane_mode_{MitsubishiCN105::WideVaneMode::CENTER};
+};
+
+}  // namespace esphome::mitsubishi_cn105

--- a/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_climate_tests.cpp
+++ b/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_climate_tests.cpp
@@ -1,9 +1,11 @@
 #include "../common.h"
 
+#include "esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h"
+
 namespace esphome::mitsubishi_cn105::testing {
 
 TEST(MitsubishiCN105ClimateTests, SupportedSwingModeOffLeavesTraitsEmpty) {
-  TestableMitsubishiCN105Climate sut;
+  MitsubishiCN105Climate sut;
 
   sut.set_supported_swing_mode(climate::CLIMATE_SWING_OFF);
 
@@ -11,7 +13,7 @@ TEST(MitsubishiCN105ClimateTests, SupportedSwingModeOffLeavesTraitsEmpty) {
 }
 
 TEST(MitsubishiCN105ClimateTests, SupportedSwingModeVerticalExposesOffAndVertical) {
-  TestableMitsubishiCN105Climate sut;
+  MitsubishiCN105Climate sut;
 
   sut.set_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
 
@@ -22,7 +24,7 @@ TEST(MitsubishiCN105ClimateTests, SupportedSwingModeVerticalExposesOffAndVertica
 }
 
 TEST(MitsubishiCN105ClimateTests, SupportedSwingModeHorizontalExposesOffAndHorizontal) {
-  TestableMitsubishiCN105Climate sut;
+  MitsubishiCN105Climate sut;
 
   sut.set_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
 
@@ -33,7 +35,7 @@ TEST(MitsubishiCN105ClimateTests, SupportedSwingModeHorizontalExposesOffAndHoriz
 }
 
 TEST(MitsubishiCN105ClimateTests, SupportedSwingModeBothExposesAllExpectedModes) {
-  TestableMitsubishiCN105Climate sut;
+  MitsubishiCN105Climate sut;
 
   sut.set_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
 
@@ -41,125 +43,6 @@ TEST(MitsubishiCN105ClimateTests, SupportedSwingModeBothExposesAllExpectedModes)
   EXPECT_TRUE(sut.traits().supports_swing_mode(climate::CLIMATE_SWING_VERTICAL));
   EXPECT_TRUE(sut.traits().supports_swing_mode(climate::CLIMATE_SWING_HORIZONTAL));
   EXPECT_TRUE(sut.traits().supports_swing_mode(climate::CLIMATE_SWING_BOTH));
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesMapsVerticalSwingWhenSupported) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::SWING;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::CENTER;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_VERTICAL);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesMapsHorizontalSwingWhenSupported) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::AUTO;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::SWING;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_HORIZONTAL);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesMapsBothSwingWhenSupported) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::SWING;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::SWING;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_BOTH);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesMapsSwingOffWhenNoSwingActive) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::POSITION_3;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::CENTER;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_OFF);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesRemembersLastNonSwingPositions) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::POSITION_4;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::RIGHT;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.last_non_swing_vane_mode_, MitsubishiCN105::VaneMode::POSITION_4);
-  EXPECT_EQ(sut.last_non_swing_wide_vane_mode_, MitsubishiCN105::WideVaneMode::RIGHT);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::SWING;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::SWING;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.last_non_swing_vane_mode_, MitsubishiCN105::VaneMode::POSITION_4);
-  EXPECT_EQ(sut.last_non_swing_wide_vane_mode_, MitsubishiCN105::WideVaneMode::RIGHT);
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_BOTH);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesDoesNotOverwriteRememberedPositionWithUnknownValues) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
-
-  sut.last_non_swing_vane_mode_ = MitsubishiCN105::VaneMode::POSITION_2;
-  sut.last_non_swing_wide_vane_mode_ = MitsubishiCN105::WideVaneMode::LEFT;
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::UNKNOWN;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::UNKNOWN;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.last_non_swing_vane_mode_, MitsubishiCN105::VaneMode::POSITION_2);
-  EXPECT_EQ(sut.last_non_swing_wide_vane_mode_, MitsubishiCN105::WideVaneMode::LEFT);
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_OFF);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesIgnoresUnsupportedVerticalSwingState) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::SWING;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::CENTER;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_OFF);
-}
-
-TEST(MitsubishiCN105ClimateTests, ApplyValuesIgnoresUnsupportedHorizontalSwingState) {
-  TestableMitsubishiCN105Climate sut;
-
-  sut.set_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
-
-  sut.status().vane_mode = MitsubishiCN105::VaneMode::AUTO;
-  sut.status().wide_vane_mode = MitsubishiCN105::WideVaneMode::SWING;
-
-  sut.apply_values_();
-
-  EXPECT_EQ(sut.swing_mode, climate::CLIMATE_SWING_OFF);
 }
 
 }  // namespace esphome::mitsubishi_cn105::testing

--- a/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_swing_mode_manager_tests.cpp
+++ b/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_swing_mode_manager_tests.cpp
@@ -1,0 +1,129 @@
+#include "../common.h"
+
+#include "esphome/components/mitsubishi_cn105/mitsubishi_cn105_swing_mode_manager.h"
+
+namespace esphome::mitsubishi_cn105::testing {
+
+static SwingModeManager make_swing_mode_manager(std::initializer_list<climate::ClimateSwingMode> supported_modes) {
+  SwingModeManager manager;
+  for (const auto mode : supported_modes) {
+    manager.supported_swing_modes().insert(mode);
+  }
+  return manager;
+}
+
+TEST(SwingModeManagerTests, StatusMapsVerticalSwingWhenSupported) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::SWING, MitsubishiCN105::WideVaneMode::CENTER);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_VERTICAL});
+}
+
+TEST(SwingModeManagerTests, StatusMapsHorizontalSwingWhenSupported) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::AUTO, MitsubishiCN105::WideVaneMode::SWING);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_HORIZONTAL});
+}
+
+TEST(SwingModeManagerTests, StatusMapsBothSwingWhenSupported) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::SWING, MitsubishiCN105::WideVaneMode::SWING);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_BOTH});
+}
+
+TEST(SwingModeManagerTests, StatusMapsSwingOffWhenNoSwingActive) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::POSITION_3, MitsubishiCN105::WideVaneMode::CENTER);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_OFF});
+}
+
+TEST(SwingModeManagerTests, RemembersLastNonSwingPositions) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+
+  manager.swing_mode_from(MitsubishiCN105::VaneMode::POSITION_4, MitsubishiCN105::WideVaneMode::RIGHT);
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::SWING, MitsubishiCN105::WideVaneMode::SWING);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_BOTH});
+  EXPECT_EQ(manager.vane_from(climate::CLIMATE_SWING_OFF), std::optional{MitsubishiCN105::VaneMode::POSITION_4});
+  EXPECT_EQ(manager.wide_vane_from(climate::CLIMATE_SWING_OFF), std::optional{MitsubishiCN105::WideVaneMode::RIGHT});
+}
+
+TEST(SwingModeManagerTests, UnknownValuesDoNotOverwriteRememberedPositions) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+
+  manager.swing_mode_from(MitsubishiCN105::VaneMode::POSITION_2, MitsubishiCN105::WideVaneMode::LEFT);
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::UNKNOWN, MitsubishiCN105::WideVaneMode::UNKNOWN);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_OFF});
+  EXPECT_EQ(manager.vane_from(climate::CLIMATE_SWING_OFF), std::optional{MitsubishiCN105::VaneMode::POSITION_2});
+  EXPECT_EQ(manager.wide_vane_from(climate::CLIMATE_SWING_OFF), std::optional{MitsubishiCN105::WideVaneMode::LEFT});
+}
+
+TEST(SwingModeManagerTests, UnsupportedVerticalSwingStateIsIgnored) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::SWING, MitsubishiCN105::WideVaneMode::CENTER);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_OFF});
+}
+
+TEST(SwingModeManagerTests, UnsupportedHorizontalSwingStateIsIgnored) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::AUTO, MitsubishiCN105::WideVaneMode::SWING);
+
+  EXPECT_EQ(swing_mode, std::optional{climate::CLIMATE_SWING_OFF});
+}
+
+TEST(SwingModeManagerTests, SwingModeFromReturnsNulloptWhenNoSwingModesSupported) {
+  auto manager = make_swing_mode_manager({});
+
+  const auto swing_mode =
+      manager.swing_mode_from(MitsubishiCN105::VaneMode::SWING, MitsubishiCN105::WideVaneMode::SWING);
+
+  EXPECT_FALSE(swing_mode.has_value());
+}
+
+TEST(SwingModeManagerTests, VaneFromSwingModeReturnsNulloptWhenVerticalUnsupported) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL});
+
+  EXPECT_FALSE(manager.vane_from(climate::CLIMATE_SWING_VERTICAL).has_value());
+}
+
+TEST(SwingModeManagerTests, WideVaneFromSwingModeReturnsNulloptWhenHorizontalUnsupported) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
+
+  EXPECT_FALSE(manager.wide_vane_from(climate::CLIMATE_SWING_HORIZONTAL).has_value());
+}
+
+TEST(SwingModeManagerTests, VaneAndWideVaneFromSwingModeMapSwingModes) {
+  auto manager = make_swing_mode_manager({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                          climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
+
+  EXPECT_EQ(manager.vane_from(climate::CLIMATE_SWING_VERTICAL), std::optional{MitsubishiCN105::VaneMode::SWING});
+  EXPECT_EQ(manager.vane_from(climate::CLIMATE_SWING_BOTH), std::optional{MitsubishiCN105::VaneMode::SWING});
+  EXPECT_EQ(manager.wide_vane_from(climate::CLIMATE_SWING_HORIZONTAL),
+            std::optional{MitsubishiCN105::WideVaneMode::SWING});
+  EXPECT_EQ(manager.wide_vane_from(climate::CLIMATE_SWING_BOTH), std::optional{MitsubishiCN105::WideVaneMode::SWING});
+}
+
+}  // namespace esphome::mitsubishi_cn105::testing

--- a/tests/components/mitsubishi_cn105/common.h
+++ b/tests/components/mitsubishi_cn105/common.h
@@ -8,7 +8,6 @@
 #include <vector>
 #include "esphome/components/uart/uart_component.h"
 #include "esphome/components/mitsubishi_cn105/mitsubishi_cn105.h"
-#include "esphome/components/mitsubishi_cn105/mitsubishi_cn105_climate.h"
 
 namespace esphome::mitsubishi_cn105::testing {
 
@@ -58,15 +57,6 @@ class TestableMitsubishiCN105 : public MitsubishiCN105 {
   static inline uint32_t test_loop_time_ms = 0;
 
   void set_current_time(uint32_t ms) { test_loop_time_ms = ms; }
-};
-
-class TestableMitsubishiCN105Climate : public MitsubishiCN105Climate {
- public:
-  using MitsubishiCN105Climate::apply_values_;
-  using MitsubishiCN105Climate::last_non_swing_vane_mode_;
-  using MitsubishiCN105Climate::last_non_swing_wide_vane_mode_;
-
-  MitsubishiCN105::Status &status() { return static_cast<TestableMitsubishiCN105 &>(this->hp_).status_; }
 };
 
 }  // namespace esphome::mitsubishi_cn105::testing


### PR DESCRIPTION
# What does this implement/fix?

Adds the C++ `final` specifier to the leaf, user-configurable `mitsubishi_cn105` classes (`MitsubishiCN105Climate`, `SetRemoteTemperatureAction`, `ClearRemoteTemperatureAction`), so they can no longer be subclassed by external components.

`mitsubishi_cn105` was pulled out of the mechanical "mark configurable classes as final" series PR #16962 (part 11/21) because it can't be handled by a purely mechanical addition. Tracked as an exception in #17143.

> **Draft — open question:** `tests/components/mitsubishi_cn105/common.h` defines `TestableMitsubishiCN105Climate : public MitsubishiCN105Climate` to reach the protected `apply_values_()`, `last_non_swing_vane_mode_`, `last_non_swing_wide_vane_mode_`, and `hp_` members from the climate unit tests. Marking `MitsubishiCN105Climate` `final` breaks that subclass, so the C++ test will not compile until the test is reworked (e.g. friend-based access instead of subclassing). This mirrors the same unresolved decision in #17131 (ld2450). Holding as a draft pending that decision. Note `MitsubishiCN105` (the non-climate helper) is also subclassed by the tests (`TestableMitsubishiCN105`) and is intentionally left non-`final`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/developers.esphome.io#157

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
