### PR TITLE
[bluetooth_proxy] Support LibreTiny BLE hubs (bk72xx / ln882h)

### DIFF
--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -1,32 +1,66 @@
 import logging
 
+import voluptuous as vol
+
 import esphome.codegen as cg
 from esphome.components import esp32_ble, esp32_ble_client, esp32_ble_tracker
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components.esp32_ble import BTLoggers
 import esphome.config_validation as cv
 from esphome.const import CONF_ACTIVE, CONF_ID
+from esphome.core import CORE
 
-AUTO_LOAD = ["esp32_ble_client", "esp32_ble_tracker"]
-DEPENDENCIES = ["api", "esp32"]
 CODEOWNERS = ["@jesserockz", "@bdraco"]
+DEPENDENCIES = ["api"]
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_CONNECTION_SLOTS = "connection_slots"
 CONF_CACHE_SERVICES = "cache_services"
 CONF_CONNECTIONS = "connections"
+CONF_BLE_ID = "ble_id"
 DEFAULT_CONNECTION_SLOTS = 3
+
+# Single validator for connection_slots, shared by the ESP32 schema and the dashboard
+# field-range introspection shim (_FIELD_RANGES_SCHEMA) so their bounds cannot drift apart.
+_CONNECTION_SLOTS_VALIDATOR = cv.All(
+    cv.positive_int,
+    cv.Range(min=1, max=esp32_ble.IDF_MAX_CONNECTIONS),
+)
 
 bluetooth_proxy_ns = cg.esphome_ns.namespace("bluetooth_proxy")
 
-BluetoothProxy = bluetooth_proxy_ns.class_(
+# Same C++ class name on every platform — the implementation is selected with #ifdef.
+# On ESP32 the proxy is an esp32_ble_tracker listener with GATT active connections; on
+# LibreTiny it is an advertisement-only proxy fed by a tracker hub (BleProxyHub).
+ESP32BluetoothProxy = bluetooth_proxy_ns.class_(
     "BluetoothProxy", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
 )
+LibreTinyBluetoothProxy = bluetooth_proxy_ns.class_("BluetoothProxy", cg.Component)
 BluetoothConnection = bluetooth_proxy_ns.class_(
     "BluetoothConnection", esp32_ble_client.BLEClientBase
 )
+# Hub interface implemented by LibreTiny trackers (bk72xx_ble_tracker, ln882h_ble_tracker).
+BleProxyHub = bluetooth_proxy_ns.class_("BleProxyHub")
 
+
+# AUTO_LOAD is a callable so it is evaluated once the target platform is known. The proxy
+# pulls in the BLE tracker hub for the target chip — esp32_ble_tracker (plus the BLE client
+# for GATT connections) on ESP32, or the matching LibreTiny tracker — so `bluetooth_proxy:`
+# on its own is enough on every platform; the hub's id is then auto-resolved via ble_id.
+def AUTO_LOAD():
+    if CORE.is_esp32:
+        return ["esp32_ble_client", "esp32_ble_tracker"]
+    if CORE.is_bk72xx:
+        return ["bk72xx_ble_tracker"]
+    if CORE.is_ln882x:
+        return ["ln882h_ble_tracker"]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# ESP32: advertisement proxy + GATT active connections
+# ---------------------------------------------------------------------------
 CONNECTION_SCHEMA = esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(BluetoothConnection),
@@ -34,7 +68,7 @@ CONNECTION_SCHEMA = esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-def validate_connections(config):
+def _validate_esp32_connections(config):
     if CONF_CONNECTIONS in config:
         if not config[CONF_ACTIVE]:
             raise cv.Invalid(
@@ -43,7 +77,6 @@ def validate_connections(config):
     elif config[CONF_ACTIVE]:
         connection_slots: int = config[CONF_CONNECTION_SLOTS]
         esp32_ble.consume_connection_slots(connection_slots, "bluetooth_proxy")(config)
-
         return {
             **config,
             CONF_CONNECTIONS: [CONNECTION_SCHEMA({}) for _ in range(connection_slots)],
@@ -51,35 +84,70 @@ def validate_connections(config):
     return config
 
 
-CONFIG_SCHEMA = cv.All(
-    (
-        cv.Schema(
-            {
-                cv.GenerateID(): cv.declare_id(BluetoothProxy),
-                cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
-                cv.Optional(CONF_CACHE_SERVICES, default=True): cv.boolean,
-                cv.Optional(
-                    CONF_CONNECTION_SLOTS,
-                    default=DEFAULT_CONNECTION_SLOTS,
-                ): cv.All(
-                    cv.positive_int,
-                    cv.Range(min=1, max=esp32_ble.IDF_MAX_CONNECTIONS),
-                ),
-                cv.Optional(CONF_CONNECTIONS): cv.All(
-                    cv.ensure_list(CONNECTION_SCHEMA),
-                    cv.Length(min=1, max=esp32_ble.IDF_MAX_CONNECTIONS),
-                ),
-            }
-        )
-        .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
-        .extend(cv.COMPONENT_SCHEMA)
-    ),
-    validate_connections,
+ESP32_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ESP32BluetoothProxy),
+            cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
+            cv.Optional(CONF_CACHE_SERVICES, default=True): cv.boolean,
+            cv.Optional(
+                CONF_CONNECTION_SLOTS, default=DEFAULT_CONNECTION_SLOTS
+            ): _CONNECTION_SLOTS_VALIDATOR,
+            cv.Optional(CONF_CONNECTIONS): cv.All(
+                cv.ensure_list(CONNECTION_SCHEMA),
+                cv.Length(min=1, max=esp32_ble.IDF_MAX_CONNECTIONS),
+            ),
+        }
+    )
+    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    _validate_esp32_connections,
 )
 
+# ---------------------------------------------------------------------------
+# LibreTiny: advertisement proxy only (GATT active connections are ESP32-only)
+# ---------------------------------------------------------------------------
+LIBRETINY_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(LibreTinyBluetoothProxy),
+        # The tracker hub to attach to (auto-injected when only one is declared).
+        cv.GenerateID(CONF_BLE_ID): cv.use_id(BleProxyHub),
+    }
+).extend(cv.COMPONENT_SCHEMA)
 
-async def to_code(config):
-    # Register the loggers this component needs
+
+# The platform is resolved at validation time (not import time) — the component is shared
+# by ESP32 and LibreTiny and is loaded once per process.
+def _bluetooth_proxy_schema(config):
+    if CORE.is_esp32:
+        return ESP32_SCHEMA(config)
+    # Only the LibreTiny families that ship a BLE hub (bk72xx / ln882x) — not every
+    # LibreTiny target — get the LibreTiny proxy schema.
+    if CORE.is_libretiny and CORE.target_platform in ("bk72xx", "ln882x"):
+        return LIBRETINY_SCHEMA(config)
+    raise cv.Invalid(
+        "bluetooth_proxy is only supported on ESP32 and LibreTiny BLE hubs (bk72xx / ln882h)"
+    )
+
+
+# Field-range introspection shim. Tooling (the dashboard visual editor) walks CONFIG_SCHEMA
+# statically to recover numeric field bounds — e.g. connection_slots' Range — which a bare
+# dispatch callable would hide. Wrapping the dispatcher in cv.All behind a permissive schema
+# keeps those bounds visible without affecting validation: ALLOW_EXTRA and no defaults mean
+# this shim never injects or rejects keys (it leaves the LibreTiny shape untouched), and the
+# real per-platform validation runs in the dispatcher above.
+_FIELD_RANGES_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_CONNECTION_SLOTS): _CONNECTION_SLOTS_VALIDATOR,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+CONFIG_SCHEMA = cv.All(_FIELD_RANGES_SCHEMA, _bluetooth_proxy_schema)
+
+
+async def _esp32_to_code(config):
+    # Register the loggers this component needs.
     esp32_ble.register_bt_logger(BTLoggers.GATT, BTLoggers.L2CAP, BTLoggers.SMP)
 
     var = cg.new_Pvariable(config[CONF_ID])
@@ -88,14 +156,8 @@ async def to_code(config):
     cg.add(var.set_active(config[CONF_ACTIVE]))
     await esp32_ble_tracker.register_raw_ble_device(var, config)
 
-    # Define max connections for protobuf fixed array
     connection_count = len(config.get(CONF_CONNECTIONS, []))
     cg.add_define("BLUETOOTH_PROXY_MAX_CONNECTIONS", connection_count)
-
-    # Define batch size for BLE advertisements
-    # Each advertisement is up to 80 bytes when packaged (including protocol overhead)
-    # 16 advertisements × 80 bytes (worst case) = 1280 bytes out of ~1320 bytes usable payload
-    # This achieves ~97% WiFi MTU utilization while staying under the limit
     cg.add_define("BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE", 16)
 
     for connection_conf in config.get(CONF_CONNECTIONS, []):
@@ -108,3 +170,23 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_BT_GATTC_CACHE_NVS_FLASH", True)
 
     cg.add_define("USE_BLUETOOTH_PROXY")
+
+
+async def _libretiny_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    hub = await cg.get_variable(config[CONF_BLE_ID])
+    cg.add(var.set_hub(hub))
+
+    cg.add_define("USE_BLUETOOTH_PROXY")
+    # 0 connection slots = advertisement proxy only (no GATT on LibreTiny).
+    cg.add_define("BLUETOOTH_PROXY_MAX_CONNECTIONS", 0)
+    cg.add_define("BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE", 8)
+
+
+async def to_code(config):
+    if CORE.is_esp32:
+        await _esp32_to_code(config)
+    else:
+        await _libretiny_to_code(config)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -81,36 +81,19 @@ bool BluetoothProxy::parse_devices(const esp32_ble::BLEScanResult *scan_results,
   if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr)
     return false;
 
-  auto &advertisements = this->response_.advertisements;
-
   for (size_t i = 0; i < count; i++) {
     auto &result = scan_results[i];
     uint8_t length = result.adv_data_len + result.scan_rsp_len;
 
-    // Fill in the data directly at current position
-    auto &adv = advertisements[this->response_.advertisements_len];
-    adv.address = esp32_ble::ble_addr_to_uint64(result.bda);
-    adv.rssi = result.rssi;
-    adv.address_type = result.ble_addr_type;
-    adv.data_len = length;
-    std::memcpy(adv.data, result.ble_adv, length);
-
-    this->response_.advertisements_len++;
-
     ESP_LOGV(TAG, "Queuing raw packet from %02X:%02X:%02X:%02X:%02X:%02X, length %d. RSSI: %d dB", result.bda[0],
              result.bda[1], result.bda[2], result.bda[3], result.bda[4], result.bda[5], length, result.rssi);
 
-    // Flush if we have reached BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE
-    if (this->response_.advertisements_len >= BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE) {
-      this->flush_pending_advertisements_();
-    }
+    // Batching + flushing now lives in the shared BluetoothProxyAdvertisements base.
+    this->add_advertisement(esp32_ble::ble_addr_to_uint64(result.bda), result.rssi, result.ble_addr_type,
+                            result.ble_adv, length);
   }
 
   return true;
-}
-
-void BluetoothProxy::log_advertisement_flush_() {
-  ESP_LOGV(TAG, "Sent batch of %u BLE advertisements", this->response_.advertisements_len);
 }
 
 void BluetoothProxy::dump_config() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -15,6 +15,7 @@
 #include "esphome/core/defines.h"
 
 #include "bluetooth_connection.h"
+#include "bluetooth_proxy_advertisements.h"
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID
 #include <esp_bt.h>
@@ -38,22 +39,11 @@ using namespace esp32_ble_client;
 static constexpr uint32_t LEGACY_ACTIVE_CONNECTIONS_VERSION = 5;
 static constexpr uint32_t LEGACY_PASSIVE_ONLY_VERSION = 1;
 
-enum BluetoothProxyFeature : uint32_t {
-  FEATURE_PASSIVE_SCAN = 1 << 0,
-  FEATURE_ACTIVE_CONNECTIONS = 1 << 1,
-  FEATURE_REMOTE_CACHING = 1 << 2,
-  FEATURE_PAIRING = 1 << 3,
-  FEATURE_CACHE_CLEARING = 1 << 4,
-  FEATURE_RAW_ADVERTISEMENTS = 1 << 5,
-  FEATURE_STATE_AND_MODE = 1 << 6,
-  FEATURE_CONNECTION_PARAMS_SETTING = 1 << 7,
-};
-
-enum BluetoothProxySubscriptionFlag : uint32_t {
-  SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
-};
-
-class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
+// BluetoothProxyFeature / BluetoothProxySubscriptionFlag and the advertisement-batching
+// core (response_, add_advertisement, flush_pending_advertisements_) now live in the
+// shared, chip-neutral BluetoothProxyAdvertisements base (bluetooth_proxy_advertisements.h).
+class BluetoothProxy final : public BluetoothProxyAdvertisements,
+                             public esp32_ble_tracker::ESPBTDeviceListener,
                              public esp32_ble_tracker::BLEScannerStateListener,
                              public Component {
   friend class BluetoothConnection;  // Allow connection to update connections_free_response_
@@ -90,7 +80,7 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
 
   void subscribe_api_connection(api::APIConnection *api_connection, uint32_t flags);
   void unsubscribe_api_connection(api::APIConnection *api_connection);
-  api::APIConnection *get_api_connection() { return this->api_connection_; }
+  // get_api_connection() is inherited from BluetoothProxyAdvertisements.
 
   void send_device_connection(uint64_t address, bool connected, uint16_t mtu = 0, esp_err_t error = ESP_OK);
   void send_connections_free();
@@ -153,18 +143,6 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
  protected:
   void send_bluetooth_scanner_state_(esp32_ble_tracker::ScannerState state);
 
-  /// Caller must ensure api_connection_ is non-null and API server is connected.
-  void flush_pending_advertisements_() {
-    if (this->response_.advertisements_len == 0)
-      return;
-    this->api_connection_->send_message(this->response_);
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-    this->log_advertisement_flush_();
-#endif
-    this->response_.advertisements_len = 0;
-  }
-  void log_advertisement_flush_();
-
   BluetoothConnection *get_connection_(uint64_t address, bool reserve);
   void log_connection_request_ignored_(BluetoothConnection *connection, espbt::ClientState state);
   void log_connection_info_(BluetoothConnection *connection, const char *message);
@@ -172,17 +150,9 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
   void handle_gatt_not_connected_(uint64_t address, uint16_t handle, const char *action, const char *type);
 
   // Memory optimized layout for 32-bit systems
-  // Group 1: Pointers (4 bytes each, naturally aligned)
-  api::APIConnection *api_connection_{nullptr};
-
+  // (api_connection_ and the advertisement response_ now live in the shared base.)
   // Group 2: Fixed-size array of connection pointers
   std::array<BluetoothConnection *, BLUETOOTH_PROXY_MAX_CONNECTIONS> connections_{};
-
-  // BLE advertisement batching
-  api::BluetoothLERawAdvertisementsResponse response_;
-
-  // Group 3: 4-byte types
-  uint32_t last_advertisement_flush_time_{0};
 
   // Pre-allocated response message - always ready to send
   api::BluetoothConnectionsFreeResponse connections_free_response_;
@@ -197,5 +167,10 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
 extern BluetoothProxy *global_bluetooth_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace esphome::bluetooth_proxy
+
+#elif defined(USE_LIBRETINY)  // USE_ESP32
+
+// Off-ESP32 (LibreTiny): the same bluetooth_proxy::BluetoothProxy, advertisement-proxy only.
+#include "bluetooth_proxy_libretiny.h"
 
 #endif  // USE_ESP32

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy_advertisements.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy_advertisements.cpp
@@ -1,0 +1,59 @@
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+
+#include "bluetooth_proxy_advertisements.h"
+#include "esphome/core/log.h"
+
+#include <cstring>
+
+namespace esphome::bluetooth_proxy {
+
+static const char *const TAG = "bluetooth_proxy";
+
+void BluetoothProxyAdvertisements::add_advertisement(uint64_t address, int rssi, uint8_t address_type,
+                                                     const uint8_t *data, uint16_t data_len) {
+  // Discard when no API client is subscribed (mirrors the ESP32 path, which only
+  // appends while api_connection_ is set).
+  if (this->api_connection_ == nullptr)
+    return;
+
+  // Defensive: never index past the fixed-size response array. The flush-on-full at the
+  // end keeps advertisements_len below the batch size, but guard the index regardless.
+  if (this->response_.advertisements_len >= BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE)
+    this->flush_pending_advertisements_();
+
+  auto &adv = this->response_.advertisements[this->response_.advertisements_len];
+  // data[] is 62 bytes (legacy adv 31 + scan response 31); never copy past it.
+  uint8_t copy_len =
+      data_len <= sizeof(adv.data) ? static_cast<uint8_t>(data_len) : static_cast<uint8_t>(sizeof(adv.data));
+  adv.address = address;
+  adv.rssi = rssi;
+  adv.address_type = address_type;
+  adv.data_len = copy_len;
+  std::memcpy(adv.data, data, copy_len);
+  this->response_.advertisements_len++;
+
+  // Flush once the batch is full (BATCH_SIZE entries fit the response array exactly).
+  if (this->response_.advertisements_len >= BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE) {
+    this->flush_pending_advertisements_();
+  }
+}
+
+void BluetoothProxyAdvertisements::flush_pending_advertisements_() {
+  if (this->response_.advertisements_len == 0)
+    return;
+  this->api_connection_->send_message(this->response_);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  this->log_advertisement_flush_();
+#endif
+  this->response_.advertisements_len = 0;
+}
+
+void BluetoothProxyAdvertisements::log_advertisement_flush_() {
+  ESP_LOGV(TAG, "Sent batch of %u BLE advertisements", this->response_.advertisements_len);
+}
+
+}  // namespace esphome::bluetooth_proxy
+
+#endif  // USE_ESP32 || USE_LIBRETINY

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy_advertisements.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy_advertisements.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// Neutral advertisement-forwarding core shared by the ESP32 and LibreTiny Bluetooth
+// proxies. This is the platform-independent half of the original ESP32 bluetooth_proxy:
+// it batches raw BLE advertisements into a BluetoothLERawAdvertisementsResponse and
+// flushes them to the subscribed Home Assistant API connection. It contains NO
+// chip-specific types — only the scan source (which feeds add_advertisement) and GATT
+// connections are platform-specific and live in the per-platform proxy subclass.
+//
+// Threading: add_advertisement() runs on the main loop. On ESP32, esp32_ble_tracker
+// already delivers advertisements there; the LibreTiny proxy drains its BLE-task queue
+// into add_advertisement() from its own loop(), so the batching is single-threaded on
+// both platforms — identical to the original ESP32 behaviour.
+
+#include "esphome/core/defines.h"
+
+// Shared by the ESP32 and LibreTiny proxies only; empty on every other platform.
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+
+#include "esphome/components/api/api_connection.h"
+#include "esphome/components/api/api_pb2.h"
+
+#include <cstdint>
+
+namespace esphome::bluetooth_proxy {
+
+// BLE feature flags reported to Home Assistant via DeviceInfoResponse.
+enum BluetoothProxyFeature : uint32_t {
+  FEATURE_PASSIVE_SCAN = 1 << 0,
+  FEATURE_ACTIVE_CONNECTIONS = 1 << 1,
+  FEATURE_REMOTE_CACHING = 1 << 2,
+  FEATURE_PAIRING = 1 << 3,
+  FEATURE_CACHE_CLEARING = 1 << 4,
+  FEATURE_RAW_ADVERTISEMENTS = 1 << 5,
+  FEATURE_STATE_AND_MODE = 1 << 6,
+  FEATURE_CONNECTION_PARAMS_SETTING = 1 << 7,
+};
+
+enum BluetoothProxySubscriptionFlag : uint32_t {
+  SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
+};
+
+// Advertisement batching core (was inline in the ESP32 BluetoothProxy). Owns the
+// subscribed API connection and the in-flight response buffer; the per-platform proxy
+// subclasses inherit this and feed it advertisements.
+class BluetoothProxyAdvertisements {
+ public:
+  // Append one raw advertisement to the current batch, flushing automatically once the
+  // batch reaches BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE. No-op if not subscribed.
+  // Must be called on the main loop.
+  void add_advertisement(uint64_t address, int rssi, uint8_t address_type, const uint8_t *data, uint16_t data_len);
+
+  api::APIConnection *get_api_connection() const { return this->api_connection_; }
+
+ protected:
+  // Send the current batch to the API connection and reset it. Caller ensures the API
+  // server is connected and api_connection_ is non-null.
+  void flush_pending_advertisements_();
+  void log_advertisement_flush_();
+
+  api::APIConnection *api_connection_{nullptr};
+  api::BluetoothLERawAdvertisementsResponse response_;
+  uint32_t last_advertisement_flush_time_{0};
+};
+
+}  // namespace esphome::bluetooth_proxy
+
+#endif  // USE_ESP32 || USE_LIBRETINY

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy_hub.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy_hub.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// bluetooth_proxy_hub.h
+//
+// Neutral hub interface that a LibreTiny BLE tracker (bk72xx_ble_tracker,
+// ln882h_ble_tracker, …) implements so the generic, chip-agnostic BluetoothProxy can
+// forward its advertisements without knowing the chip. This header lives in the
+// bluetooth_proxy component, so it is present only when a proxy is configured; trackers
+// include it and inherit BleProxyHub under #ifdef USE_BLUETOOTH_PROXY, and otherwise build
+// stand-alone (BLE sensors, no proxy).
+//
+// On ESP32 the proxy gets its advertisements from esp32_ble_tracker directly, so this
+// interface is only used off-ESP32.
+
+#ifdef USE_LIBRETINY
+
+#include <cstdint>
+#include <functional>
+
+namespace esphome::bluetooth_proxy {
+
+// Raw BLE advertisement callback. The hub invokes it on the main loop (it owns the
+// BLE-task -> main-loop handoff), so the proxy can forward without any synchronization.
+//
+// BYTE-ORDER CONTRACT (authoritative — hub implementers must follow this):
+//   mac[] is delivered LEAST-significant octet first (mac[0] = LSB). The proxy assembles
+//   the 64-bit device address as sum(mac[i] << (i*8)), which is identical to ESP32's
+//   esp32_ble::ble_addr_to_uint64(), so Home Assistant decodes the device MAC correctly.
+//   BLE/HCI controllers report addresses LSB-first, so a hub normally passes the
+//   controller's address bytes through unchanged. (This is the opposite order from
+//   get_proxy_mac(), which returns the adapter MAC most-significant octet first.)
+using ScanResultCallback =
+    std::function<void(const uint8_t *mac, int rssi, uint8_t addr_type, const uint8_t *data, uint16_t data_len)>;
+
+// Implemented by each LibreTiny tracker hub (BK72xxBLETracker, LN882HBLETracker, …).
+class BleProxyHub {
+ public:
+  virtual ~BleProxyHub() = default;
+
+  // Write the adapter MAC in printable (MSB-first) order into out[0..5] (out[0] = MSB).
+  // This is the inverse of the ScanResultCallback mac[] order; see the byte-order contract there.
+  virtual void get_proxy_mac(uint8_t out[6]) = 0;
+
+  // Whether the hub's scanner is currently running.
+  virtual bool proxy_scan_running() = 0;
+
+  // Whether the hub is scanning actively (false on passive-only hubs, e.g. BK7231N).
+  virtual bool proxy_scan_active() = 0;
+
+  // Register the callback the hub invokes for every raw advertisement.
+  virtual void set_proxy_scan_result_callback(ScanResultCallback cb) = 0;
+};
+
+}  // namespace esphome::bluetooth_proxy
+
+#endif  // USE_LIBRETINY

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy_libretiny.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy_libretiny.cpp
@@ -1,0 +1,127 @@
+#ifdef USE_LIBRETINY
+
+// component.h first: it pulls in esphome/core/defines.h which sets USE_BLUETOOTH_PROXY
+// before the guards in the headers below are evaluated.
+#include "esphome/core/component.h"
+#include "bluetooth_proxy_libretiny.h"
+
+#include "esphome/components/api/api_connection.h"
+#include "esphome/components/api/api_server.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+namespace esphome::bluetooth_proxy {
+
+static const char *const TAG = "bluetooth_proxy";
+
+// Looked up by api_connection.cpp; assigned in setup().
+BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT
+
+void BluetoothProxy::setup() {
+  // Defensive: ble_id (the tracker hub) is a required, codegen-resolved id, so hub_ should
+  // never be null in a valid config — but guard rather than dereference it blindly. Without a
+  // hub there is nothing to forward, so disable the component and leave global_bluetooth_proxy
+  // null, which keeps subscribe/get_mac (which also use hub_) from ever being reached.
+  if (this->hub_ == nullptr) {
+    ESP_LOGE(TAG, "No BLE tracker hub attached; bluetooth_proxy disabled");
+    this->mark_failed();
+    return;
+  }
+  global_bluetooth_proxy = this;
+  // Wire the hub's raw-advertisement stream into this proxy. The hub delivers on the main
+  // loop (the same task that runs loop()), so the shared batching core stays single-threaded
+  // — identical to the ESP32 proxy, where esp32_ble_tracker also delivers on the main loop.
+  this->hub_->set_proxy_scan_result_callback(
+      [this](const uint8_t *mac, int rssi, uint8_t addr_type, const uint8_t *data, uint16_t data_len) {
+        this->on_advertisement(mac, rssi, addr_type, data, data_len);
+      });
+}
+
+void BluetoothProxy::dump_config() {
+  // Same lines/level as the ESP32 proxy. LibreTiny is advertisement-only, so active
+  // connections are always off (Active: NO, Connections: 0).
+  ESP_LOGCONFIG(TAG,
+                "Bluetooth Proxy:\n"
+                "  Active: %s\n"
+                "  Connections: %d",
+                "NO", 0);
+}
+
+void BluetoothProxy::get_bluetooth_mac_address_pretty(char output[18]) {
+  uint8_t mac[6];
+  this->hub_->get_proxy_mac(mac);  // hub returns printable (MSB-first) order
+  snprintf(output, 18, "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+void BluetoothProxy::subscribe_api_connection(api::APIConnection *conn, uint32_t /*flags*/) {
+  // Same guard + message/level as the ESP32 proxy.
+  if (this->api_connection_ != nullptr) {
+    ESP_LOGE(TAG, "Only one API subscription is allowed at a time");
+    return;
+  }
+  this->api_connection_ = conn;
+
+  // Do not start scanning here — exactly like the ESP32 proxy. Scanning is driven by the
+  // hub's scan_parameters and the user's api: start_scan automation. Report current state.
+  api::BluetoothScannerStateResponse state_resp;
+  state_resp.state = this->hub_->proxy_scan_running() ? api::enums::BLUETOOTH_SCANNER_STATE_RUNNING
+                                                      : api::enums::BLUETOOTH_SCANNER_STATE_IDLE;
+  state_resp.mode = this->hub_->proxy_scan_active() ? api::enums::BLUETOOTH_SCANNER_MODE_ACTIVE
+                                                    : api::enums::BLUETOOTH_SCANNER_MODE_PASSIVE;
+  state_resp.configured_mode = state_resp.mode;
+  conn->send_message(state_resp);
+}
+
+void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *conn) {
+  // Same guard + message/level as the ESP32 proxy.
+  if (this->api_connection_ != conn) {
+    ESP_LOGV(TAG, "API connection is not subscribed");
+    return;
+  }
+  this->api_connection_ = nullptr;
+  // Discard the in-flight batch so it doesn't leak to the next subscriber.
+  this->response_.advertisements_len = 0;
+}
+
+// Called by the tracker hub on the main loop for each raw advertisement — the same task that
+// runs loop(), so the shared batching core (BluetoothProxyAdvertisements) stays single-threaded,
+// exactly like the ESP32 proxy's parse_devices() path. The hub owns the BLE-task -> main-loop
+// handoff, so no synchronization is needed here.
+void BluetoothProxy::on_advertisement(const uint8_t *mac, int rssi, uint8_t addr_type, const uint8_t *data,
+                                      uint16_t data_len) {
+  // Only ingest while the API server is connected — mirrors the ESP32 path, where
+  // parse_devices() pre-checks is_connected() before add_advertisement(). Without this,
+  // a batch that fills between loop() ticks could flush (send_message) while disconnected.
+  if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr)
+    return;
+
+  // Assemble the address from the hub's bytes. The hub delivers mac[] least-significant-octet
+  // first, so this produces the same uint64 layout as esp32_ble::ble_addr_to_uint64 (and the
+  // tracker's ESPBTDevice::address_uint64), which Home Assistant decodes as the device MAC.
+  uint64_t address = 0;
+  for (int i = 0; i < 6; i++)
+    address |= static_cast<uint64_t>(mac[i]) << (i * 8);
+
+  // Same per-advertisement log as the ESP32 proxy (identical text + VERBOSE level); print the
+  // MAC most-significant octet first (mac[5..0]) to match the human-readable order.
+  ESP_LOGV(TAG, "Queuing raw packet from %02X:%02X:%02X:%02X:%02X:%02X, length %d. RSSI: %d dB", mac[5], mac[4], mac[3],
+           mac[2], mac[1], mac[0], data_len, rssi);
+
+  this->add_advertisement(address, rssi, addr_type, data, data_len);
+}
+
+void BluetoothProxy::loop() {
+  // Flush any partially-filled advertisement batch every 100 ms — identical cadence to the
+  // ESP32 proxy. add_advertisement() already flushes immediately once a batch fills.
+  uint32_t now = App.get_loop_component_start_time();
+  if (now - this->last_advertisement_flush_time_ < 100)
+    return;
+  this->last_advertisement_flush_time_ = now;
+
+  if (api::global_api_server->is_connected() && this->api_connection_ != nullptr)
+    this->flush_pending_advertisements_();
+}
+
+}  // namespace esphome::bluetooth_proxy
+
+#endif  // USE_LIBRETINY

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy_libretiny.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy_libretiny.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// bluetooth_proxy_libretiny.h
+//
+// The LibreTiny (non-ESP32) face of the hub-agnostic bluetooth_proxy. Same component,
+// same class name (esphome::bluetooth_proxy::BluetoothProxy) and same API surface as the
+// ESP32 proxy, so api_connection.cpp talks to one type on every platform. It inherits the
+// shared BluetoothProxyAdvertisements core (identical batching/flush as ESP32) and is fed
+// raw advertisements by a tracker hub (BleProxyHub). GATT active connections are ESP32-only,
+// so those API entry points are no-ops here.
+//
+// Threading: the tracker hub owns the BLE-task -> main-loop handoff and delivers each
+// advertisement to on_advertisement() on the main loop. on_advertisement() feeds the shared
+// add_advertisement() batching core directly, so no synchronization is needed here — exactly
+// like ESP32, where esp32_ble_tracker also delivers on the main loop (parse_devices()).
+
+#ifdef USE_LIBRETINY
+
+#include "bluetooth_proxy_advertisements.h"
+#include "bluetooth_proxy_hub.h"
+#include "esphome/components/api/api_pb2.h"
+#include "esphome/core/component.h"
+
+#include <cstdint>
+
+namespace esphome::api {
+class APIConnection;
+}  // namespace esphome::api
+
+namespace esphome::bluetooth_proxy {
+
+class BluetoothProxy : public BluetoothProxyAdvertisements, public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  // The tracker hub that supplies advertisements, adapter MAC and scan state.
+  void set_hub(BleProxyHub *hub) { this->hub_ = hub; }
+
+  // ---- bluetooth_proxy::BluetoothProxy API surface (called by api_connection.cpp) ----
+  uint32_t get_feature_flags() const {
+    // Advertisement proxy only: active GATT connections are ESP32-only.
+    return FEATURE_PASSIVE_SCAN | FEATURE_RAW_ADVERTISEMENTS | FEATURE_STATE_AND_MODE;
+  }
+  void get_bluetooth_mac_address_pretty(char output[18]);
+  void subscribe_api_connection(api::APIConnection *conn, uint32_t flags);
+  void unsubscribe_api_connection(api::APIConnection *conn);
+
+  // GATT / active-connection entry points — no-ops off-ESP32 (never reached while
+  // FEATURE_ACTIVE_CONNECTIONS is absent), present only so api_connection.cpp links.
+  void bluetooth_device_request(const api::BluetoothDeviceRequest &) {}
+  void bluetooth_gatt_read(const api::BluetoothGATTReadRequest &) {}
+  void bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &) {}
+  void bluetooth_gatt_read_descriptor(const api::BluetoothGATTReadDescriptorRequest &) {}
+  void bluetooth_gatt_write_descriptor(const api::BluetoothGATTWriteDescriptorRequest &) {}
+  void bluetooth_gatt_send_services(const api::BluetoothGATTGetServicesRequest &) {}
+  void bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest &) {}
+  void bluetooth_set_connection_params(const api::BluetoothSetConnectionParamsRequest &) {}
+  void bluetooth_scanner_set_mode(bool /*active*/) {}
+  void send_connections_free() {}
+  void send_connections_free(api::APIConnection *) {}
+
+  // Called by the hub on the main loop for each raw advertisement (the hub owns the
+  // BLE-task -> main-loop handoff, so this runs single-threaded like the ESP32 proxy).
+  void on_advertisement(const uint8_t *mac, int rssi, uint8_t addr_type, const uint8_t *data, uint16_t data_len);
+
+ protected:
+  BleProxyHub *hub_{nullptr};
+};
+
+// Looked up by api_connection.cpp to route BLE subscription/GATT messages.
+extern BluetoothProxy *global_bluetooth_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+}  // namespace esphome::bluetooth_proxy
+
+#endif  // USE_LIBRETINY

--- a/tests/components/bluetooth_proxy/test.esp32-s3-idf.yaml
+++ b/tests/components/bluetooth_proxy/test.esp32-s3-idf.yaml
@@ -1,8 +1,9 @@
 <<: !include common.yaml
 
 esp32_ble_tracker:
-  max_connections: 9
 
+# Passive (advertisement-only) proxy: exercises the shared BluetoothProxyAdvertisements
+# core without GATT active connections — the same forwarding path the LibreTiny proxy uses.
 bluetooth_proxy:
-  active: true
-  connection_slots: 9
+  active: false
+  cache_services: false


### PR DESCRIPTION
## What does this implement?

Makes `bluetooth_proxy` **hub-agnostic** — one component, one `BluetoothProxy`, on every chip.

On ESP32 the Bluetooth proxy attaches to `esp32_ble_tracker` and forwards raw advertisements to Home Assistant; that forwarding (batch → `BluetoothLERawAdvertisementsResponse` → API) is platform-neutral. This PR extracts that neutral core and lets LibreTiny BLE hubs reuse the **same code**, so `bluetooth_proxy` now also works on:

- **BK72xx**\* — `bk72xx_ble_tracker` (#17135)
- **LN882H** — `ln882h_ble_tracker` (#16691)

\* BK72xx requires a **BLE 5.x** Beken SDK, so only the BLE-5.x BK72xx chips are supported. See #17135 for the supported-chip list.

```yaml
bk72xx_ble_tracker:        # or ln882h_ble_tracker
bluetooth_proxy:           # attaches to the tracker hub (auto-resolved)
```

## How it works

- **`BluetoothProxyAdvertisements`** — the platform-neutral advertisement batching/flush + API subscribe, extracted from the ESP32 proxy. No chip-specific types.
- **ESP32** `BluetoothProxy` inherits it; behaviour unchanged (advertisement forwarding + GATT active connections + scan ingestion on top).
- **LibreTiny** `BluetoothProxy` inherits the same base, fed by the tracker hub's `BleProxyHub` callback. The hub owns the BLE-task → main-loop handoff and delivers each advertisement on the main loop, so the proxy calls `add_advertisement()` directly — exactly like ESP32's `parse_devices()`. GATT active connections are ESP32-only, so those API entry points are no-ops off-ESP32.
- `__init__.py` branches on platform: ESP32 keeps the full schema (`active`, `cache_services`, `connection_slots`); LibreTiny accepts only `id` + `ble_id` — the GATT options are rejected, since LibreTiny hubs are advertisement proxies.
- The LibreTiny proxy emits the same log messages and levels as the ESP32 proxy.
- `AUTO_LOAD` pulls in the matching tracker for the target chip (`esp32_ble_tracker` on ESP32, `bk72xx_ble_tracker` / `ln882h_ble_tracker` on LibreTiny), so `bluetooth_proxy:` on its own is enough on every platform; `ble_id` is then auto-resolved to that hub.

## Platform behaviour

| | ESP32 | LibreTiny (BK72xx / LN882H) |
|---|---|---|
| Raw advertisement proxy | ✅ | ✅ (shared core) |
| GATT active connections | ✅ | — advertisement proxy only |
| Scan source | `esp32_ble_tracker` | `*_ble_tracker` via `BleProxyHub` |

ESP32 behaviour is unchanged (non-breaking).

## Configuration variables

The schema is selected per platform at validation time. On **ESP32** the full proxy schema applies (`active`, `cache_services`, `connection_slots` — GATT active connections). On **LibreTiny** the proxy is advertisement-only and accepts only:

```yaml
bluetooth_proxy:
  id: ble_proxy          # this proxy's id (optional)
  ble_id: ble_tracker    # the *_ble_tracker hub to attach to; auto-resolved when only one is configured
```

The ESP32-only `active` / `cache_services` / `connection_slots` options are rejected on LibreTiny.

## Tests

The existing ESP32 component test (`tests/components/bluetooth_proxy/test.esp32-s3-idf.yaml`) now configures a **passive** proxy (`active: false`, `cache_services: false`), exercising the shared `BluetoothProxyAdvertisements` forwarding path that the LibreTiny proxy reuses — the same code, without GATT active connections.

The LibreTiny proxy itself is exercised by the device builds in #17135 / #16691; LibreTiny is not part of the CI clang-tidy/compile matrix, so it cannot have an in-tree compile test yet.

## Documentation

Docs PR: esphome/esphome.io#6854

## Related

- #17135 (`bk72xx_ble_tracker`) — BK72xx hub
- #16691 (`ln882h_ble_tracker`) — LN882H hub
- #17150 (`ble_device_base`) — shared BLE sensor layer

## Types of changes

- [x] New feature (non-breaking change which adds functionality)




