### PR TITLE
[lis3dh] Add LIS3DH accelerometer component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -299,6 +299,7 @@ esphome/components/libretiny_pwm/* @kuba2k2
 esphome/components/light/* @esphome/core
 esphome/components/lightwaverf/* @max246
 esphome/components/lilygo_t5_47/touchscreen/* @jesserockz
+esphome/components/lis3dh/* @zebble
 esphome/components/lm75b/* @beormund
 esphome/components/ln882h_ble/* @Bl00d-B0b
 esphome/components/ln882h_ble_tracker/* @Bl00d-B0b

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -294,6 +294,7 @@ esphome/components/libretiny_pwm/* @kuba2k2
 esphome/components/light/* @esphome/core
 esphome/components/lightwaverf/* @max246
 esphome/components/lilygo_t5_47/touchscreen/* @jesserockz
+esphome/components/lis3dh/* @zebble
 esphome/components/lm75b/* @beormund
 esphome/components/ln882x/* @lamauny
 esphome/components/lock/* @esphome/core

--- a/esphome/components/lis3dh/__init__.py
+++ b/esphome/components/lis3dh/__init__.py
@@ -1,0 +1,14 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+from esphome.components.motion import MotionComponent
+
+CODEOWNERS = ["@zebble"]
+DEPENDENCIES = ["i2c", "motion"]
+
+CONF_LIS3DH_ID = "lis3dh_id"
+
+#  C++ namespace / class
+lis3dh_ns = cg.esphome_ns.namespace("lis3dh")
+LIS3DHComponent = lis3dh_ns.class_("LIS3DHComponent", MotionComponent, i2c.I2CDevice)
+
+CONFIG_SCHEMA = {}

--- a/esphome/components/lis3dh/lis3dh.cpp
+++ b/esphome/components/lis3dh/lis3dh.cpp
@@ -1,4 +1,5 @@
 #include "lis3dh.h"
+#include <algorithm>
 #include "esphome/core/log.h"
 #include <cmath>
 
@@ -80,8 +81,11 @@ bool LIS3DHComponent::setup_interrupt_() {
     return false;
 
   // Convert the threshold from g to the 7-bit INT1_THS value for the active range.
+  // A threshold of zero is treated as always exceeded, which would hold the pad
+  // asserted, so keep the smallest step the range can express.
   int32_t raw = lroundf(this->interrupt_threshold_g_ * 1000.0f / THRESHOLD_LSB_MG[this->range_]);
-  uint8_t threshold = raw > 0x7F ? 0x7F : (uint8_t) raw;
+  uint8_t threshold = (uint8_t) std::clamp<int32_t>(raw, 1, 0x7F);
+  this->interrupt_threshold_raw_ = threshold;
 
   if (!this->write_byte(LIS3DH_REG_INT1_CFG, this->interrupt_axes_cfg_) ||
       !this->write_byte(LIS3DH_REG_INT1_THS, threshold) ||
@@ -129,14 +133,24 @@ void LIS3DHComponent::dump_config() {
 
   static constexpr const char *const RANGE_STRS[] = {"±2g", "±4g", "±8g", "±16g"};
   static constexpr const char *const MODE_STRS[] = {"low power (8-bit)", "normal (10-bit)", "high resolution (12-bit)"};
+  static constexpr const char *const RATE_STRS[] = {"powered down", "1Hz",   "10Hz",  "25Hz",   "50Hz",
+                                                    "100Hz",        "200Hz", "400Hz", "1620Hz", "1344Hz"};
   ESP_LOGCONFIG(TAG,
                 "  Range: %s\n"
-                "  Operating mode: %s",
-                RANGE_STRS[this->range_], MODE_STRS[this->operating_mode_]);
+                "  Operating mode: %s\n"
+                "  Data rate: %s",
+                RANGE_STRS[this->range_], MODE_STRS[this->operating_mode_], RATE_STRS[this->data_rate_]);
   if (this->interrupt_enabled_) {
-    ESP_LOGCONFIG(TAG, "  Motion interrupt: %s (%s%s)", this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? "INT1" : "INT2",
+    // The threshold is reported as written, since converting it from g depends
+    // on the range and rounds.
+    ESP_LOGCONFIG(TAG,
+                  "  Motion interrupt: %s (%s%s%s)\n"
+                  "    Threshold: %.3fg (%u)\n"
+                  "    Duration: %u samples",
+                  this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? "INT1" : "INT2",
                   this->interrupt_active_high_ ? "active high" : "active low",
-                  this->interrupt_high_pass_ ? ", high-pass" : "");
+                  this->interrupt_high_pass_ ? ", high-pass" : "", this->interrupt_latched_ ? ", latched" : "",
+                  this->interrupt_threshold_g_, this->interrupt_threshold_raw_, this->interrupt_duration_);
   }
   MotionComponent::dump_config();
 }

--- a/esphome/components/lis3dh/lis3dh.cpp
+++ b/esphome/components/lis3dh/lis3dh.cpp
@@ -147,9 +147,10 @@ void LIS3DHComponent::dump_config() {
                   "  Motion interrupt: %s (%s%s%s)\n"
                   "    Threshold: %.3fg (%u)\n"
                   "    Duration: %u samples",
-                  this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? "INT1" : "INT2",
-                  this->interrupt_active_high_ ? "active high" : "active low",
-                  this->interrupt_high_pass_ ? ", high-pass" : "", this->interrupt_latched_ ? ", latched" : "",
+                  this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? LOG_STR_LITERAL("INT1") : LOG_STR_LITERAL("INT2"),
+                  this->interrupt_active_high_ ? LOG_STR_LITERAL("active high") : LOG_STR_LITERAL("active low"),
+                  this->interrupt_high_pass_ ? LOG_STR_LITERAL(", high-pass") : LOG_STR_LITERAL(""),
+                  this->interrupt_latched_ ? LOG_STR_LITERAL(", latched") : LOG_STR_LITERAL(""),
                   this->interrupt_threshold_g_, this->interrupt_threshold_raw_, this->interrupt_duration_);
   }
   MotionComponent::dump_config();

--- a/esphome/components/lis3dh/lis3dh.cpp
+++ b/esphome/components/lis3dh/lis3dh.cpp
@@ -80,7 +80,7 @@ bool LIS3DHComponent::setup_interrupt_() {
     return false;
 
   // Convert the threshold from g to the 7-bit INT1_THS value for the active range.
-  long raw = lroundf(this->interrupt_threshold_g_ * 1000.0f / THRESHOLD_LSB_MG[this->range_]);
+  int32_t raw = lroundf(this->interrupt_threshold_g_ * 1000.0f / THRESHOLD_LSB_MG[this->range_]);
   uint8_t threshold = raw > 0x7F ? 0x7F : (uint8_t) raw;
 
   if (!this->write_byte(LIS3DH_REG_INT1_CFG, this->interrupt_axes_cfg_) ||

--- a/esphome/components/lis3dh/lis3dh.cpp
+++ b/esphome/components/lis3dh/lis3dh.cpp
@@ -72,6 +72,13 @@ bool LIS3DHComponent::setup_temperature_() {
 }
 
 bool LIS3DHComponent::setup_interrupt_() {
+  // High-pass filter the interrupt (IA1) input so the ~1 g of gravity is removed
+  // from the threshold comparison. The output data registers stay unfiltered
+  // (FDS = 0), so acceleration / pitch / roll still report the full gravity vector.
+  uint8_t ctrl_reg2 = this->interrupt_high_pass_ ? LIS3DH_CTRL_REG2_HP_IA1 : 0x00;
+  if (!this->write_byte(LIS3DH_REG_CTRL_REG2, ctrl_reg2))
+    return false;
+
   // Convert the threshold from g to the 7-bit INT1_THS value for the active range.
   long raw = lroundf(this->interrupt_threshold_g_ * 1000.0f / THRESHOLD_LSB_MG[this->range_]);
   uint8_t threshold = raw > 0x7F ? 0x7F : (uint8_t) raw;
@@ -99,6 +106,13 @@ bool LIS3DHComponent::setup_interrupt_() {
   if (!this->write_byte(LIS3DH_REG_CTRL_REG3, ctrl_reg3) || !this->write_byte(LIS3DH_REG_CTRL_REG6, ctrl_reg6))
     return false;
 
+  // With the high-pass filter enabled, reading REFERENCE captures the current
+  // acceleration as the filter's zero point (removing the standing gravity bias).
+  if (this->interrupt_high_pass_) {
+    uint8_t reference = 0;
+    this->read_byte(LIS3DH_REG_REFERENCE, &reference);
+  }
+
   // Clear any latched request left over from the motion that woke the device.
   uint8_t src = 0;
   this->read_byte(LIS3DH_REG_INT1_SRC, &src);
@@ -120,8 +134,9 @@ void LIS3DHComponent::dump_config() {
                 "  Operating mode: %s",
                 RANGE_STRS[this->range_], MODE_STRS[this->operating_mode_]);
   if (this->interrupt_enabled_) {
-    ESP_LOGCONFIG(TAG, "  Motion interrupt: %s (%s)", this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? "INT1" : "INT2",
-                  this->interrupt_active_high_ ? "active high" : "active low");
+    ESP_LOGCONFIG(TAG, "  Motion interrupt: %s (%s%s)", this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? "INT1" : "INT2",
+                  this->interrupt_active_high_ ? "active high" : "active low",
+                  this->interrupt_high_pass_ ? ", high-pass" : "");
   }
   MotionComponent::dump_config();
 }

--- a/esphome/components/lis3dh/lis3dh.cpp
+++ b/esphome/components/lis3dh/lis3dh.cpp
@@ -1,0 +1,167 @@
+#include "lis3dh.h"
+#include "esphome/core/log.h"
+#include <cmath>
+
+namespace esphome::lis3dh {
+
+static const char *const TAG = "lis3dh";
+
+// Acceleration sensitivity in mg per digit, indexed by [operating_mode][range].
+// The "digit" is the right-justified sample, so the raw register value must be
+// shifted down by RESOLUTION_SHIFT first. Values are taken from the datasheet
+// (note the ±16g column does not follow the doubling pattern).
+static constexpr float SENSITIVITY_MG[3][4] = {
+    {16.0f, 32.0f, 64.0f, 192.0f},  // low power (8-bit)
+    {4.0f, 8.0f, 16.0f, 48.0f},     // normal (10-bit)
+    {1.0f, 2.0f, 4.0f, 12.0f},      // high resolution (12-bit)
+};
+
+// Number of unused low bits in the left-justified 16-bit sample, per mode.
+static constexpr uint8_t RESOLUTION_SHIFT[3] = {8, 6, 4};
+
+// Motion interrupt threshold LSB in mg, indexed by range.
+static constexpr float THRESHOLD_LSB_MG[4] = {16.0f, 32.0f, 62.0f, 186.0f};
+
+void LIS3DHComponent::setup() {
+  MotionComponent::setup();
+
+  uint8_t who_am_i = 0;
+  if (!this->read_byte(LIS3DH_REG_WHO_AM_I, &who_am_i)) {
+    ESP_LOGE(TAG, "Failed to read chip ID - check wiring / address");
+    this->mark_failed();
+    return;
+  }
+  if (who_am_i != LIS3DH_WHO_AM_I_VALUE) {
+    ESP_LOGE(TAG, "Wrong chip ID: 0x%02X (expected 0x%02X)", who_am_i, LIS3DH_WHO_AM_I_VALUE);
+    this->mark_failed();
+    return;
+  }
+
+  if (!this->setup_accelerometer_() || !this->setup_temperature_()) {
+    ESP_LOGE(TAG, "Failed to configure sensor");
+    this->mark_failed();
+    return;
+  }
+  if (this->interrupt_enabled_ && !this->setup_interrupt_()) {
+    ESP_LOGE(TAG, "Failed to configure motion interrupt");
+    this->mark_failed();
+    return;
+  }
+}
+
+bool LIS3DHComponent::setup_accelerometer_() {
+  // CTRL_REG1: output data rate, low-power flag and axis enable.
+  uint8_t ctrl_reg1 = ((uint8_t) this->data_rate_ << 4) | LIS3DH_CTRL_REG1_AXES_EN;
+  if (this->operating_mode_ == LIS3DH_MODE_LOW_POWER)
+    ctrl_reg1 |= LIS3DH_CTRL_REG1_LPEN;
+  if (!this->write_byte(LIS3DH_REG_CTRL_REG1, ctrl_reg1))
+    return false;
+
+  // CTRL_REG4: block data update, full-scale range and high-resolution flag.
+  uint8_t ctrl_reg4 = LIS3DH_CTRL_REG4_BDU | ((uint8_t) this->range_ << 4);
+  if (this->operating_mode_ == LIS3DH_MODE_HIGH_RESOLUTION)
+    ctrl_reg4 |= LIS3DH_CTRL_REG4_HR;
+  return this->write_byte(LIS3DH_REG_CTRL_REG4, ctrl_reg4);
+}
+
+bool LIS3DHComponent::setup_temperature_() {
+  // Only power the ADC / temperature sensor when a temperature sensor is used.
+  uint8_t temp_cfg =
+      this->temperature_callback_.empty() ? 0x00 : (uint8_t) (LIS3DH_TEMP_CFG_ADC_EN | LIS3DH_TEMP_CFG_TEMP_EN);
+  return this->write_byte(LIS3DH_REG_TEMP_CFG, temp_cfg);
+}
+
+bool LIS3DHComponent::setup_interrupt_() {
+  // Convert the threshold from g to the 7-bit INT1_THS value for the active range.
+  long raw = lroundf(this->interrupt_threshold_g_ * 1000.0f / THRESHOLD_LSB_MG[this->range_]);
+  uint8_t threshold = raw > 0x7F ? 0x7F : (uint8_t) raw;
+
+  if (!this->write_byte(LIS3DH_REG_INT1_CFG, this->interrupt_axes_cfg_) ||
+      !this->write_byte(LIS3DH_REG_INT1_THS, threshold) ||
+      !this->write_byte(LIS3DH_REG_INT1_DURATION, this->interrupt_duration_))
+    return false;
+
+  // Latch the request so a brief movement keeps the pad asserted until INT1_SRC is read.
+  uint8_t ctrl_reg5 = this->interrupt_latched_ ? LIS3DH_CTRL_REG5_LIR_INT1 : 0;
+  if (!this->write_byte(LIS3DH_REG_CTRL_REG5, ctrl_reg5))
+    return false;
+
+  // Route the IA1 engine to the chosen physical pad and set the pad polarity.
+  uint8_t ctrl_reg3 = 0;
+  uint8_t ctrl_reg6 = 0;
+  if (this->interrupt_pin_ == LIS3DH_INT_PIN_INT1) {
+    ctrl_reg3 |= LIS3DH_CTRL_REG3_I1_IA1;
+  } else {
+    ctrl_reg6 |= LIS3DH_CTRL_REG6_I2_IA1;
+  }
+  if (!this->interrupt_active_high_)
+    ctrl_reg6 |= LIS3DH_CTRL_REG6_INT_POLARITY;
+  if (!this->write_byte(LIS3DH_REG_CTRL_REG3, ctrl_reg3) || !this->write_byte(LIS3DH_REG_CTRL_REG6, ctrl_reg6))
+    return false;
+
+  // Clear any latched request left over from the motion that woke the device.
+  uint8_t src = 0;
+  this->read_byte(LIS3DH_REG_INT1_SRC, &src);
+  return true;
+}
+
+void LIS3DHComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "LIS3DH:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+    return;
+  }
+
+  static constexpr const char *const RANGE_STRS[] = {"±2g", "±4g", "±8g", "±16g"};
+  static constexpr const char *const MODE_STRS[] = {"low power (8-bit)", "normal (10-bit)", "high resolution (12-bit)"};
+  ESP_LOGCONFIG(TAG,
+                "  Range: %s\n"
+                "  Operating mode: %s",
+                RANGE_STRS[this->range_], MODE_STRS[this->operating_mode_]);
+  if (this->interrupt_enabled_) {
+    ESP_LOGCONFIG(TAG, "  Motion interrupt: %s (%s)", this->interrupt_pin_ == LIS3DH_INT_PIN_INT1 ? "INT1" : "INT2",
+                  this->interrupt_active_high_ ? "active high" : "active low");
+  }
+  MotionComponent::dump_config();
+}
+
+bool LIS3DHComponent::update_data(motion::MotionData &data) {
+  if (this->is_failed())
+    return false;
+
+  uint8_t raw[6];
+  if (!this->read_bytes(LIS3DH_REG_OUT_X_L | LIS3DH_AUTO_INCREMENT, raw, 6)) {
+    ESP_LOGW(TAG, "Failed to read acceleration data");
+    return false;
+  }
+
+  const uint8_t shift = RESOLUTION_SHIFT[this->operating_mode_];
+  const float scale = SENSITIVITY_MG[this->operating_mode_][this->range_] / 1000.0f;  // g per digit
+
+  // Data is little-endian and left-justified in a signed 16-bit register.
+  int16_t raw_x = (int16_t) encode_uint16(raw[1], raw[0]);
+  int16_t raw_y = (int16_t) encode_uint16(raw[3], raw[2]);
+  int16_t raw_z = (int16_t) encode_uint16(raw[5], raw[4]);
+  ESP_LOGV(TAG, "Read raw accel data: %d, %d, %d", raw_x, raw_y, raw_z);
+  data.acceleration[motion::X_AXIS] = (raw_x >> shift) * scale;
+  data.acceleration[motion::Y_AXIS] = (raw_y >> shift) * scale;
+  data.acceleration[motion::Z_AXIS] = (raw_z >> shift) * scale;
+
+  if (!this->temperature_callback_.empty())
+    this->publish_temperature_();
+  return true;
+}
+
+void LIS3DHComponent::publish_temperature_() {
+  uint8_t raw[2];
+  if (!this->read_bytes(LIS3DH_REG_OUT_ADC3_L | LIS3DH_AUTO_INCREMENT, raw, 2)) {
+    ESP_LOGW(TAG, "Failed to read temperature data");
+    return;
+  }
+  // The temperature occupies the high byte as a signed, relative value (~1 °C per count).
+  float temperature = (int8_t) raw[1] + LIS3DH_TEMP_REFERENCE_C;
+  this->temperature_callback_.call(temperature);
+}
+
+}  // namespace esphome::lis3dh

--- a/esphome/components/lis3dh/lis3dh.h
+++ b/esphome/components/lis3dh/lis3dh.h
@@ -122,6 +122,7 @@ class LIS3DHComponent : public motion::MotionComponent, public i2c::I2CDevice {
 
   LIS3DHRange range_{LIS3DH_RANGE_2G};
   LIS3DHDataRate data_rate_{LIS3DH_DATA_RATE_100HZ};
+  uint8_t interrupt_threshold_raw_{0};  // what the g threshold became, for dump_config
   LIS3DHOperatingMode operating_mode_{LIS3DH_MODE_HIGH_RESOLUTION};
 
   // Motion (activity) interrupt configuration.

--- a/esphome/components/lis3dh/lis3dh.h
+++ b/esphome/components/lis3dh/lis3dh.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "esphome/components/motion/motion_component.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::lis3dh {
+
+//  Register map (see ST datasheet DocID18198)
+static constexpr uint8_t LIS3DH_REG_OUT_ADC3_L = 0x0C;  // temperature (ADC3) low byte
+static constexpr uint8_t LIS3DH_REG_WHO_AM_I = 0x0F;
+static constexpr uint8_t LIS3DH_REG_TEMP_CFG = 0x1F;
+static constexpr uint8_t LIS3DH_REG_CTRL_REG1 = 0x20;  // ODR / low-power / axis enable
+static constexpr uint8_t LIS3DH_REG_CTRL_REG3 = 0x22;  // INT1 pad routing
+static constexpr uint8_t LIS3DH_REG_CTRL_REG4 = 0x23;  // BDU / full-scale / high-resolution
+static constexpr uint8_t LIS3DH_REG_CTRL_REG5 = 0x24;  // interrupt latching
+static constexpr uint8_t LIS3DH_REG_CTRL_REG6 = 0x25;  // INT2 pad routing / polarity
+static constexpr uint8_t LIS3DH_REG_OUT_X_L = 0x28;    // acceleration data block (auto-increment)
+static constexpr uint8_t LIS3DH_REG_INT1_CFG = 0x30;
+static constexpr uint8_t LIS3DH_REG_INT1_SRC = 0x31;
+static constexpr uint8_t LIS3DH_REG_INT1_THS = 0x32;
+static constexpr uint8_t LIS3DH_REG_INT1_DURATION = 0x33;
+
+static constexpr uint8_t LIS3DH_WHO_AM_I_VALUE = 0x33;
+
+// Sub-address auto-increment bit: OR into the register for multi-byte reads.
+static constexpr uint8_t LIS3DH_AUTO_INCREMENT = 0x80;
+
+// CTRL_REG1
+static constexpr uint8_t LIS3DH_CTRL_REG1_AXES_EN = 0x07;  // Xen | Yen | Zen
+static constexpr uint8_t LIS3DH_CTRL_REG1_LPEN = 0x08;     // low-power enable
+// CTRL_REG4
+static constexpr uint8_t LIS3DH_CTRL_REG4_HR = 0x08;   // high-resolution enable
+static constexpr uint8_t LIS3DH_CTRL_REG4_BDU = 0x80;  // block data update
+// CTRL_REG5
+static constexpr uint8_t LIS3DH_CTRL_REG5_LIR_INT1 = 0x08;  // latch IA1 interrupt
+// CTRL_REG3 / CTRL_REG6 interrupt routing
+static constexpr uint8_t LIS3DH_CTRL_REG3_I1_IA1 = 0x40;        // route IA1 to INT1 pad
+static constexpr uint8_t LIS3DH_CTRL_REG6_I2_IA1 = 0x40;        // route IA1 to INT2 pad
+static constexpr uint8_t LIS3DH_CTRL_REG6_INT_POLARITY = 0x02;  // 1 = active low
+// INT1_CFG high-event bits
+static constexpr uint8_t LIS3DH_INT_CFG_XHIE = 0x02;
+static constexpr uint8_t LIS3DH_INT_CFG_YHIE = 0x08;
+static constexpr uint8_t LIS3DH_INT_CFG_ZHIE = 0x20;
+// TEMP_CFG_REG
+static constexpr uint8_t LIS3DH_TEMP_CFG_ADC_EN = 0x80;
+static constexpr uint8_t LIS3DH_TEMP_CFG_TEMP_EN = 0x40;
+
+// The temperature sensor is uncalibrated and reports relative changes only,
+// so this fixed reference is just a rough starting point for the °C output.
+static constexpr float LIS3DH_TEMP_REFERENCE_C = 25.0f;
+
+// Full-scale range: value is the index into the sensitivity tables and the
+// FS field of CTRL_REG4 (shifted left by 4).
+enum LIS3DHRange : uint8_t {
+  LIS3DH_RANGE_2G = 0,
+  LIS3DH_RANGE_4G = 1,
+  LIS3DH_RANGE_8G = 2,
+  LIS3DH_RANGE_16G = 3,
+};
+
+// Output data rate: value is the ODR field of CTRL_REG1 (bits 7:4).
+enum LIS3DHDataRate : uint8_t {
+  LIS3DH_DATA_RATE_1HZ = 0x1,
+  LIS3DH_DATA_RATE_10HZ = 0x2,
+  LIS3DH_DATA_RATE_25HZ = 0x3,
+  LIS3DH_DATA_RATE_50HZ = 0x4,
+  LIS3DH_DATA_RATE_100HZ = 0x5,
+  LIS3DH_DATA_RATE_200HZ = 0x6,
+  LIS3DH_DATA_RATE_400HZ = 0x7,
+  LIS3DH_DATA_RATE_1620HZ = 0x8,  // low-power mode only
+  LIS3DH_DATA_RATE_1344HZ = 0x9,  // 1344 Hz normal/HR, 5376 Hz low-power
+};
+
+// Operating mode: selects the resolution (and thus power usage).
+enum LIS3DHOperatingMode : uint8_t {
+  LIS3DH_MODE_LOW_POWER = 0,        // 8-bit
+  LIS3DH_MODE_NORMAL = 1,           // 10-bit
+  LIS3DH_MODE_HIGH_RESOLUTION = 2,  // 12-bit
+};
+
+// Physical interrupt pad the motion interrupt is routed to.
+enum LIS3DHInterruptPin : uint8_t {
+  LIS3DH_INT_PIN_INT1 = 0,
+  LIS3DH_INT_PIN_INT2 = 1,
+};
+
+class LIS3DHComponent : public motion::MotionComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  void set_range(LIS3DHRange range) { this->range_ = range; }
+  void set_data_rate(LIS3DHDataRate data_rate) { this->data_rate_ = data_rate; }
+  void set_operating_mode(LIS3DHOperatingMode mode) { this->operating_mode_ = mode; }
+  void set_interrupt(LIS3DHInterruptPin pin, float threshold_g, uint8_t duration, bool x, bool y, bool z, bool latched,
+                     bool active_high) {
+    this->interrupt_enabled_ = true;
+    this->interrupt_pin_ = pin;
+    this->interrupt_threshold_g_ = threshold_g;
+    this->interrupt_duration_ = duration;
+    this->interrupt_axes_cfg_ =
+        (x ? LIS3DH_INT_CFG_XHIE : 0) | (y ? LIS3DH_INT_CFG_YHIE : 0) | (z ? LIS3DH_INT_CFG_ZHIE : 0);
+    this->interrupt_latched_ = latched;
+    this->interrupt_active_high_ = active_high;
+  }
+
+  template<typename F> void add_temperature_listener(F &&cb) { this->temperature_callback_.add(std::forward<F>(cb)); }
+
+ protected:
+  bool update_data(motion::MotionData &data) override;
+  bool setup_accelerometer_();
+  bool setup_temperature_();
+  bool setup_interrupt_();
+  void publish_temperature_();
+
+  LIS3DHRange range_{LIS3DH_RANGE_2G};
+  LIS3DHDataRate data_rate_{LIS3DH_DATA_RATE_100HZ};
+  LIS3DHOperatingMode operating_mode_{LIS3DH_MODE_HIGH_RESOLUTION};
+
+  // Motion (activity) interrupt configuration.
+  bool interrupt_enabled_{false};
+  LIS3DHInterruptPin interrupt_pin_{LIS3DH_INT_PIN_INT1};
+  float interrupt_threshold_g_{0.0f};
+  uint8_t interrupt_duration_{0};
+  uint8_t interrupt_axes_cfg_{0};
+  bool interrupt_latched_{true};
+  bool interrupt_active_high_{true};
+
+  LazyCallbackManager<void(float)> temperature_callback_{};
+};
+
+}  // namespace esphome::lis3dh

--- a/esphome/components/lis3dh/lis3dh.h
+++ b/esphome/components/lis3dh/lis3dh.h
@@ -12,10 +12,12 @@ static constexpr uint8_t LIS3DH_REG_OUT_ADC3_L = 0x0C;  // temperature (ADC3) lo
 static constexpr uint8_t LIS3DH_REG_WHO_AM_I = 0x0F;
 static constexpr uint8_t LIS3DH_REG_TEMP_CFG = 0x1F;
 static constexpr uint8_t LIS3DH_REG_CTRL_REG1 = 0x20;  // ODR / low-power / axis enable
+static constexpr uint8_t LIS3DH_REG_CTRL_REG2 = 0x21;  // high-pass filter
 static constexpr uint8_t LIS3DH_REG_CTRL_REG3 = 0x22;  // INT1 pad routing
 static constexpr uint8_t LIS3DH_REG_CTRL_REG4 = 0x23;  // BDU / full-scale / high-resolution
 static constexpr uint8_t LIS3DH_REG_CTRL_REG5 = 0x24;  // interrupt latching
 static constexpr uint8_t LIS3DH_REG_CTRL_REG6 = 0x25;  // INT2 pad routing / polarity
+static constexpr uint8_t LIS3DH_REG_REFERENCE = 0x26;  // high-pass filter reference
 static constexpr uint8_t LIS3DH_REG_OUT_X_L = 0x28;    // acceleration data block (auto-increment)
 static constexpr uint8_t LIS3DH_REG_INT1_CFG = 0x30;
 static constexpr uint8_t LIS3DH_REG_INT1_SRC = 0x31;
@@ -30,6 +32,8 @@ static constexpr uint8_t LIS3DH_AUTO_INCREMENT = 0x80;
 // CTRL_REG1
 static constexpr uint8_t LIS3DH_CTRL_REG1_AXES_EN = 0x07;  // Xen | Yen | Zen
 static constexpr uint8_t LIS3DH_CTRL_REG1_LPEN = 0x08;     // low-power enable
+// CTRL_REG2
+static constexpr uint8_t LIS3DH_CTRL_REG2_HP_IA1 = 0x01;  // high-pass filter the IA1 interrupt
 // CTRL_REG4
 static constexpr uint8_t LIS3DH_CTRL_REG4_HR = 0x08;   // high-resolution enable
 static constexpr uint8_t LIS3DH_CTRL_REG4_BDU = 0x80;  // block data update
@@ -95,7 +99,7 @@ class LIS3DHComponent : public motion::MotionComponent, public i2c::I2CDevice {
   void set_data_rate(LIS3DHDataRate data_rate) { this->data_rate_ = data_rate; }
   void set_operating_mode(LIS3DHOperatingMode mode) { this->operating_mode_ = mode; }
   void set_interrupt(LIS3DHInterruptPin pin, float threshold_g, uint8_t duration, bool x, bool y, bool z, bool latched,
-                     bool active_high) {
+                     bool active_high, bool high_pass) {
     this->interrupt_enabled_ = true;
     this->interrupt_pin_ = pin;
     this->interrupt_threshold_g_ = threshold_g;
@@ -104,6 +108,7 @@ class LIS3DHComponent : public motion::MotionComponent, public i2c::I2CDevice {
         (x ? LIS3DH_INT_CFG_XHIE : 0) | (y ? LIS3DH_INT_CFG_YHIE : 0) | (z ? LIS3DH_INT_CFG_ZHIE : 0);
     this->interrupt_latched_ = latched;
     this->interrupt_active_high_ = active_high;
+    this->interrupt_high_pass_ = high_pass;
   }
 
   template<typename F> void add_temperature_listener(F &&cb) { this->temperature_callback_.add(std::forward<F>(cb)); }
@@ -127,6 +132,7 @@ class LIS3DHComponent : public motion::MotionComponent, public i2c::I2CDevice {
   uint8_t interrupt_axes_cfg_{0};
   bool interrupt_latched_{true};
   bool interrupt_active_high_{true};
+  bool interrupt_high_pass_{false};
 
   LazyCallbackManager<void(float)> temperature_callback_{};
 };

--- a/esphome/components/lis3dh/motion.py
+++ b/esphome/components/lis3dh/motion.py
@@ -4,6 +4,7 @@ from esphome.components.const import CONF_ACCELEROMETER_ODR, CONF_ACCELEROMETER_
 from esphome.components.motion import motion_schema, new_motion_component
 import esphome.config_validation as cv
 from esphome.const import CONF_DURATION, CONF_INTERRUPT, CONF_PIN, CONF_THRESHOLD
+from esphome.types import ConfigType
 
 from . import LIS3DHComponent, lis3dh_ns
 
@@ -88,18 +89,20 @@ INTERRUPT_SCHEMA = cv.Schema(
 )
 
 
-def _validate_odr_mode(config):
+def _validate_odr_mode(config: ConfigType) -> ConfigType:
     # Two output data rates are tied to the operating mode (they share a register
     # code whose meaning depends on the mode): 1620Hz exists only in low-power
     # mode, and code 1344Hz becomes 5376Hz in low-power mode.
+    # A validated enum is the option's name, not the value it maps to, so these
+    # are compared as the names.
     odr = config[CONF_ACCELEROMETER_ODR]
-    low_power = config[CONF_OPERATING_MODE] is OPERATING_MODE_OPTIONS["LOW_POWER"]
-    if odr is DATA_RATE_OPTIONS["1620HZ"] and not low_power:
+    low_power = config[CONF_OPERATING_MODE] == "LOW_POWER"
+    if odr == "1620HZ" and not low_power:
         raise cv.Invalid(
             "'1620HZ' is only available with 'operating_mode: LOW_POWER'",
             path=[CONF_ACCELEROMETER_ODR],
         )
-    if odr is DATA_RATE_OPTIONS["1344HZ"] and low_power:
+    if odr == "1344HZ" and low_power:
         raise cv.Invalid(
             "'1344HZ' is not available with 'operating_mode: LOW_POWER' "
             "(that combination runs at 5376Hz)",

--- a/esphome/components/lis3dh/motion.py
+++ b/esphome/components/lis3dh/motion.py
@@ -87,8 +87,28 @@ INTERRUPT_SCHEMA = cv.Schema(
     }
 )
 
+def _validate_odr_mode(config):
+    # Two output data rates are tied to the operating mode (they share a register
+    # code whose meaning depends on the mode): 1620Hz exists only in low-power
+    # mode, and code 1344Hz becomes 5376Hz in low-power mode.
+    odr = config[CONF_ACCELEROMETER_ODR]
+    low_power = config[CONF_OPERATING_MODE] is OPERATING_MODE_OPTIONS["LOW_POWER"]
+    if odr is DATA_RATE_OPTIONS["1620HZ"] and not low_power:
+        raise cv.Invalid(
+            "'1620HZ' is only available with 'operating_mode: LOW_POWER'",
+            path=[CONF_ACCELEROMETER_ODR],
+        )
+    if odr is DATA_RATE_OPTIONS["1344HZ"] and low_power:
+        raise cv.Invalid(
+            "'1344HZ' is not available with 'operating_mode: LOW_POWER' "
+            "(that combination runs at 5376Hz)",
+            path=[CONF_ACCELEROMETER_ODR],
+        )
+    return config
+
+
 #  Top-level CONFIG_SCHEMA
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     motion_schema(LIS3DHComponent, has_accel=True, has_gyro=False)
     .extend(
         {
@@ -104,7 +124,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_INTERRUPT): INTERRUPT_SCHEMA,
         }
     )
-    .extend(i2c.i2c_device_schema(0x18))
+    .extend(i2c.i2c_device_schema(0x18)),
+    _validate_odr_mode,
 )
 
 

--- a/esphome/components/lis3dh/motion.py
+++ b/esphome/components/lis3dh/motion.py
@@ -11,6 +11,7 @@ CONF_OPERATING_MODE = "operating_mode"
 CONF_AXES = "axes"
 CONF_LATCHED = "latched"
 CONF_ACTIVE_HIGH = "active_high"
+CONF_HIGH_PASS_FILTER = "high_pass_filter"
 
 #  Enum proxies (must match the C++ enum values exactly)
 LIS3DHRange = lis3dh_ns.enum("LIS3DHRange")
@@ -65,9 +66,11 @@ def _axes(value):
 # The motion (activity) interrupt keeps the physical INT pad asserted while the
 # device is moving. Wire the pad to a GPIO and use it as the `wakeup_pin` of the
 # `deep_sleep` component to wake an ESP32 from deep sleep on motion.
-# The threshold is compared against the total measured acceleration, which
-# always includes the ~1 g of gravity, so it should be set above 1 g to avoid
-# triggering while the device is at rest.
+#
+# By default the threshold is compared against the total measured acceleration,
+# which always includes the ~1 g of gravity, so it must be set above 1 g to avoid
+# triggering at rest. Enable `high_pass_filter` to remove gravity from the
+# comparison, which lets you use a small threshold (the change in acceleration).
 INTERRUPT_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_PIN, default="INT1"): cv.enum(
@@ -80,6 +83,7 @@ INTERRUPT_SCHEMA = cv.Schema(
         cv.Optional(CONF_AXES, default=AXES): _axes,
         cv.Optional(CONF_LATCHED, default=True): cv.boolean,
         cv.Optional(CONF_ACTIVE_HIGH, default=True): cv.boolean,
+        cv.Optional(CONF_HIGH_PASS_FILTER, default=False): cv.boolean,
     }
 )
 
@@ -125,5 +129,6 @@ async def to_code(config):
                 "z" in axes,
                 interrupt[CONF_LATCHED],
                 interrupt[CONF_ACTIVE_HIGH],
+                interrupt[CONF_HIGH_PASS_FILTER],
             )
         )

--- a/esphome/components/lis3dh/motion.py
+++ b/esphome/components/lis3dh/motion.py
@@ -87,6 +87,7 @@ INTERRUPT_SCHEMA = cv.Schema(
     }
 )
 
+
 def _validate_odr_mode(config):
     # Two output data rates are tied to the operating mode (they share a register
     # code whose meaning depends on the mode): 1620Hz exists only in low-power

--- a/esphome/components/lis3dh/motion.py
+++ b/esphome/components/lis3dh/motion.py
@@ -1,0 +1,129 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+from esphome.components.const import CONF_ACCELEROMETER_ODR, CONF_ACCELEROMETER_RANGE
+from esphome.components.motion import motion_schema, new_motion_component
+import esphome.config_validation as cv
+from esphome.const import CONF_DURATION, CONF_INTERRUPT, CONF_PIN, CONF_THRESHOLD
+
+from . import LIS3DHComponent, lis3dh_ns
+
+CONF_OPERATING_MODE = "operating_mode"
+CONF_AXES = "axes"
+CONF_LATCHED = "latched"
+CONF_ACTIVE_HIGH = "active_high"
+
+#  Enum proxies (must match the C++ enum values exactly)
+LIS3DHRange = lis3dh_ns.enum("LIS3DHRange")
+RANGE_OPTIONS = {
+    "2G": LIS3DHRange.LIS3DH_RANGE_2G,
+    "4G": LIS3DHRange.LIS3DH_RANGE_4G,
+    "8G": LIS3DHRange.LIS3DH_RANGE_8G,
+    "16G": LIS3DHRange.LIS3DH_RANGE_16G,
+}
+
+LIS3DHDataRate = lis3dh_ns.enum("LIS3DHDataRate")
+DATA_RATE_OPTIONS = {
+    "1HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_1HZ,
+    "10HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_10HZ,
+    "25HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_25HZ,
+    "50HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_50HZ,
+    "100HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_100HZ,
+    "200HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_200HZ,
+    "400HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_400HZ,
+    # 1620HZ is only available in low-power mode.
+    "1620HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_1620HZ,
+    # 1344HZ in normal / high-resolution mode; 5376HZ in low-power mode.
+    "1344HZ": LIS3DHDataRate.LIS3DH_DATA_RATE_1344HZ,
+}
+
+LIS3DHOperatingMode = lis3dh_ns.enum("LIS3DHOperatingMode")
+OPERATING_MODE_OPTIONS = {
+    "LOW_POWER": LIS3DHOperatingMode.LIS3DH_MODE_LOW_POWER,
+    "NORMAL": LIS3DHOperatingMode.LIS3DH_MODE_NORMAL,
+    "HIGH_RESOLUTION": LIS3DHOperatingMode.LIS3DH_MODE_HIGH_RESOLUTION,
+}
+
+LIS3DHInterruptPin = lis3dh_ns.enum("LIS3DHInterruptPin")
+INTERRUPT_PIN_OPTIONS = {
+    "INT1": LIS3DHInterruptPin.LIS3DH_INT_PIN_INT1,
+    "INT2": LIS3DHInterruptPin.LIS3DH_INT_PIN_INT2,
+}
+
+AXES = ["x", "y", "z"]
+
+
+def _axes(value):
+    """A list of one or more of the axes 'x', 'y' and 'z'."""
+    value = cv.ensure_list(cv.one_of(*AXES, lower=True))(value)
+    if not value:
+        raise cv.Invalid("Specify at least one axis")
+    if len(set(value)) != len(value):
+        raise cv.Invalid("Each axis may be listed only once")
+    return value
+
+
+# The motion (activity) interrupt keeps the physical INT pad asserted while the
+# device is moving. Wire the pad to a GPIO and use it as the `wakeup_pin` of the
+# `deep_sleep` component to wake an ESP32 from deep sleep on motion.
+# The threshold is compared against the total measured acceleration, which
+# always includes the ~1 g of gravity, so it should be set above 1 g to avoid
+# triggering while the device is at rest.
+INTERRUPT_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_PIN, default="INT1"): cv.enum(
+            INTERRUPT_PIN_OPTIONS, upper=True
+        ),
+        cv.Optional(CONF_THRESHOLD, default="1.1g"): cv.All(
+            cv.float_with_unit("acceleration", "(g|G)?"), cv.positive_float
+        ),
+        cv.Optional(CONF_DURATION, default=0): cv.int_range(min=0, max=127),
+        cv.Optional(CONF_AXES, default=AXES): _axes,
+        cv.Optional(CONF_LATCHED, default=True): cv.boolean,
+        cv.Optional(CONF_ACTIVE_HIGH, default=True): cv.boolean,
+    }
+)
+
+#  Top-level CONFIG_SCHEMA
+CONFIG_SCHEMA = (
+    motion_schema(LIS3DHComponent, has_accel=True, has_gyro=False)
+    .extend(
+        {
+            cv.Optional(CONF_ACCELEROMETER_RANGE, default="2G"): cv.enum(
+                RANGE_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_ACCELEROMETER_ODR, default="100HZ"): cv.enum(
+                DATA_RATE_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_OPERATING_MODE, default="HIGH_RESOLUTION"): cv.enum(
+                OPERATING_MODE_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_INTERRUPT): INTERRUPT_SCHEMA,
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x18))
+)
+
+
+#  Code generation
+async def to_code(config):
+    var = await new_motion_component(config)
+    await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_range(config[CONF_ACCELEROMETER_RANGE]))
+    cg.add(var.set_data_rate(config[CONF_ACCELEROMETER_ODR]))
+    cg.add(var.set_operating_mode(config[CONF_OPERATING_MODE]))
+
+    if (interrupt := config.get(CONF_INTERRUPT)) is not None:
+        axes = interrupt[CONF_AXES]
+        cg.add(
+            var.set_interrupt(
+                interrupt[CONF_PIN],
+                interrupt[CONF_THRESHOLD],
+                interrupt[CONF_DURATION],
+                "x" in axes,
+                "y" in axes,
+                "z" in axes,
+                interrupt[CONF_LATCHED],
+                interrupt[CONF_ACTIVE_HIGH],
+            )
+        )

--- a/esphome/components/lis3dh/sensor.py
+++ b/esphome/components/lis3dh/sensor.py
@@ -3,6 +3,7 @@ from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_TEMPERATURE,
+    CONF_TYPE,
     DEVICE_CLASS_TEMPERATURE,
     ICON_THERMOMETER,
     STATE_CLASS_MEASUREMENT,
@@ -14,26 +15,26 @@ from . import CONF_LIS3DH_ID, LIS3DHComponent
 
 # The LIS3DH temperature sensor is uncalibrated and only reports relative
 # changes (roughly 1 °C per count), so a single decimal of accuracy is plenty.
-CONFIG_SCHEMA = cv.Schema(
+CONFIG_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    icon=ICON_THERMOMETER,
+    accuracy_decimals=1,
+    state_class=STATE_CLASS_MEASUREMENT,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+).extend(
     {
+        cv.Optional(CONF_TYPE): cv.one_of(CONF_TEMPERATURE),
         cv.GenerateID(CONF_LIS3DH_ID): cv.use_id(LIS3DHComponent),
-        cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_THERMOMETER,
-            accuracy_decimals=1,
-            state_class=STATE_CLASS_MEASUREMENT,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-        ),
     }
 )
 
 
 async def to_code(config):
+    var = await sensor.new_sensor(config)
     parent = await cg.get_variable(config[CONF_LIS3DH_ID])
-    sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
     data = MockObj("x")
     value_lambda = await cg.process_lambda(
-        sens.publish_state(data),
+        var.publish_state(data),
         [(cg.float_, str(data))],
     )
     cg.add(parent.add_temperature_listener(value_lambda))

--- a/esphome/components/lis3dh/sensor.py
+++ b/esphome/components/lis3dh/sensor.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_TEMPERATURE,
+    ICON_THERMOMETER,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+)
+from esphome.cpp_generator import MockObj
+
+from . import CONF_LIS3DH_ID, LIS3DHComponent
+
+# The LIS3DH temperature sensor is uncalibrated and only reports relative
+# changes (roughly 1 °C per count), so a single decimal of accuracy is plenty.
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LIS3DH_ID): cv.use_id(LIS3DHComponent),
+        cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon=ICON_THERMOMETER,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_LIS3DH_ID])
+    sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    data = MockObj("x")
+    value_lambda = await cg.process_lambda(
+        sens.publish_state(data),
+        [(cg.float_, str(data))],
+    )
+    cg.add(parent.add_temperature_listener(value_lambda))

--- a/tests/component_tests/lis3dh/test_motion.py
+++ b/tests/component_tests/lis3dh/test_motion.py
@@ -1,0 +1,64 @@
+"""Tests for the lis3dh output data rate and operating mode cross-check.
+
+Two of the rates are only meaningful in one operating mode, because the register
+code they share means something different in each. Getting the check wrong is
+quiet: the part is configured for a rate it cannot deliver in that mode, and the
+readings are scaled by the wrong sensitivity rather than anything failing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome.components.lis3dh.motion import (
+    CONF_ACCELEROMETER_ODR,
+    CONF_OPERATING_MODE,
+    _validate_odr_mode,
+)
+import esphome.config_validation as cv
+from esphome.types import ConfigType
+
+
+def _config(odr: str, mode: str) -> ConfigType:
+    """The two keys the cross-check reads, as validation leaves them.
+
+    cv.enum keeps the option's name, so these are the names rather than the
+    values they map to - which is the whole point of the check being written
+    this way.
+    """
+    return {
+        CONF_ACCELEROMETER_ODR: cv.enum({odr: None}, upper=True)(odr),
+        CONF_OPERATING_MODE: cv.enum({mode: None}, upper=True)(mode),
+    }
+
+
+@pytest.mark.parametrize(
+    ("odr", "mode"),
+    [
+        ("1620HZ", "LOW_POWER"),
+        ("1344HZ", "NORMAL"),
+        ("1344HZ", "HIGH_RESOLUTION"),
+        ("100HZ", "LOW_POWER"),
+        ("100HZ", "HIGH_RESOLUTION"),
+        ("400HZ", "NORMAL"),
+    ],
+)
+def test_allowed_combinations(odr: str, mode: str) -> None:
+    _validate_odr_mode(_config(odr, mode))
+
+
+@pytest.mark.parametrize("mode", ["NORMAL", "HIGH_RESOLUTION"])
+def test_1620hz_needs_low_power(mode: str) -> None:
+    """1620Hz exists only in low power mode."""
+    with pytest.raises(
+        cv.Invalid, match="only available with 'operating_mode: LOW_POWER'"
+    ):
+        _validate_odr_mode(_config("1620HZ", mode))
+
+
+def test_1344hz_is_rejected_in_low_power() -> None:
+    """The same register code runs at 5376Hz in low power mode."""
+    with pytest.raises(
+        cv.Invalid, match="not available with 'operating_mode: LOW_POWER'"
+    ):
+        _validate_odr_mode(_config("1344HZ", "LOW_POWER"))

--- a/tests/components/lis3dh/common.yaml
+++ b/tests/components/lis3dh/common.yaml
@@ -1,5 +1,6 @@
 motion:
   - platform: lis3dh
+    id: lis3dh_main
     i2c_id: i2c_bus
     address: 0x18
     # Full-scale range: 2G | 4G | 8G | 16G
@@ -23,23 +24,48 @@ motion:
       active_high: true
       high_pass_filter: false
 
+  # A second device covering the other side of each option: low power mode with
+  # the rate that only exists there, routed to INT2, active low, unlatched, and
+  # with the high-pass filter on.
+  - platform: lis3dh
+    id: lis3dh_low_power
+    i2c_id: i2c_bus
+    address: 0x19
+    accelerometer_range: 16G
+    accelerometer_odr: 1620HZ
+    operating_mode: LOW_POWER
+    interrupt:
+      pin: INT2
+      threshold: 0.05g
+      duration: 2
+      axes: [z]
+      latched: false
+      active_high: false
+      high_pass_filter: true
+
 sensor:
   - platform: lis3dh
+    lis3dh_id: lis3dh_main
     type: temperature
     name: "LIS3DH Temperature"
 
   - platform: motion
+    motion_id: lis3dh_main
     type: acceleration_x
     name: "Accel X"
   - platform: motion
+    motion_id: lis3dh_main
     type: acceleration_y
     name: "Accel Y"
   - platform: motion
+    motion_id: lis3dh_main
     type: acceleration_z
     name: "Accel Z"
   - platform: motion
+    motion_id: lis3dh_main
     type: pitch
     name: "Pitch"
   - platform: motion
+    motion_id: lis3dh_main
     type: roll
     name: "Roll"

--- a/tests/components/lis3dh/common.yaml
+++ b/tests/components/lis3dh/common.yaml
@@ -25,8 +25,8 @@ motion:
 
 sensor:
   - platform: lis3dh
-    temperature:
-      name: "LIS3DH Temperature"
+    type: temperature
+    name: "LIS3DH Temperature"
 
   - platform: motion
     type: acceleration_x

--- a/tests/components/lis3dh/common.yaml
+++ b/tests/components/lis3dh/common.yaml
@@ -1,0 +1,44 @@
+motion:
+  - platform: lis3dh
+    i2c_id: i2c_bus
+    address: 0x18
+    # Full-scale range: 2G | 4G | 8G | 16G
+    accelerometer_range: 2G
+    # Output data rate: 1HZ | 10HZ | 25HZ | 50HZ | 100HZ | 200HZ | 400HZ | 1620HZ | 1344HZ
+    accelerometer_odr: 100HZ
+    # Resolution / power mode: LOW_POWER | NORMAL | HIGH_RESOLUTION
+    operating_mode: HIGH_RESOLUTION
+    axis_map:
+      x: y
+      y: x
+      z: -z
+    # Motion (activity) interrupt - keeps the INT pad asserted while moving so it
+    # can be used as the deep_sleep wakeup_pin.
+    interrupt:
+      pin: INT1
+      threshold: 1.1g
+      duration: 0
+      axes: [x, y, z]
+      latched: true
+      active_high: true
+
+sensor:
+  - platform: lis3dh
+    temperature:
+      name: "LIS3DH Temperature"
+
+  - platform: motion
+    type: acceleration_x
+    name: "Accel X"
+  - platform: motion
+    type: acceleration_y
+    name: "Accel Y"
+  - platform: motion
+    type: acceleration_z
+    name: "Accel Z"
+  - platform: motion
+    type: pitch
+    name: "Pitch"
+  - platform: motion
+    type: roll
+    name: "Roll"

--- a/tests/components/lis3dh/common.yaml
+++ b/tests/components/lis3dh/common.yaml
@@ -21,6 +21,7 @@ motion:
       axes: [x, y, z]
       latched: true
       active_high: true
+      high_pass_filter: false
 
 sensor:
   - platform: lis3dh

--- a/tests/components/lis3dh/test.esp32-idf.yaml
+++ b/tests/components/lis3dh/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis3dh/test.esp32-idf.yaml
+++ b/tests/components/lis3dh/test.esp32-idf.yaml
@@ -1,4 +1,3 @@
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
-
-<<: !include common.yaml
+  lis3dh: !include common.yaml

--- a/tests/components/lis3dh/test.esp8266-ard.yaml
+++ b/tests/components/lis3dh/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis3dh/test.esp8266-ard.yaml
+++ b/tests/components/lis3dh/test.esp8266-ard.yaml
@@ -1,4 +1,3 @@
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
-
-<<: !include common.yaml
+  lis3dh: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `lis3dh` component for the STMicroelectronics LIS3DH 3-axis accelerometer over I2C, built on the shared `motion` platform (so it gains the standard acceleration / pitch / roll sensors, axis mapping and calibration).

Features:
- 3-axis acceleration through the `motion` sensor platform, with configurable full-scale range (±2/4/8/16 g), output data rate and operating mode (low-power / normal / high-resolution).
- On-chip temperature sensor (relative / uncalibrated), exposed via a `sensor` platform.
- Motion (activity) interrupt that drives the INT1 or INT2 pad on movement, with configurable threshold, duration, axes, latching, pad polarity and an optional high-pass filter (removes the standing gravity component from the threshold comparison). This lets the INT pad be wired to a `deep_sleep` `wakeup_pin` to wake an ESP32 from deep sleep on motion.

Tested on real hardware (an OMOTE ESP32-S3 remote sharing the I2C bus with a touch controller, keypad expander and fuel gauge): live acceleration and temperature read correctly (≈1 g magnitude at rest), and the full deep-sleep → motion-wake cycle works.

Planned follow-ups (kept out of this PR to keep it focused): click/tap detection, an `on_motion` trigger / binary sensor for use while awake, 6D orientation, activity auto-sleep, FIFO and SPI support.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6918

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO21
  scl: GPIO22

motion:
  - platform: lis3dh
    address: 0x18
    accelerometer_range: 2G
    accelerometer_odr: 100HZ
    operating_mode: HIGH_RESOLUTION
    # Optional motion interrupt (drives the INT pad; use as a deep_sleep wakeup_pin)
    interrupt:
      pin: INT1
      threshold: 1.1g
      axes: [x, y, z]
      high_pass_filter: false

sensor:
  - platform: lis3dh
    type: temperature
    name: "Accel Temperature"
  - platform: motion
    type: acceleration_x
    name: "Accel X"
  - platform: motion
    type: acceleration_y
    name: "Accel Y"
  - platform: motion
    type: acceleration_z
    name: "Accel Z"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io). (see linked PR above)