### PR TITLE
[climate_ir_lg] Fix swing command to not include climate state

### DIFF
--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -48,7 +48,6 @@ void LgIrClimate::transmit_state() {
     this->send_swing_cmd_ = false;
     remote_state |= COMMAND_SWING;
     this->transmit_(remote_state);
-    this->publish_state();
     return;
   } else {
     bool climate_is_off = (this->mode_before_ == climate::CLIMATE_MODE_OFF);
@@ -107,7 +106,6 @@ void LgIrClimate::transmit_state() {
   }
 
   this->transmit_(remote_state);
-  this->publish_state();
 }
 
 bool LgIrClimate::on_receive(remote_base::RemoteReceiveData data) {

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -43,8 +43,13 @@ void LgIrClimate::transmit_state() {
 
   // Set command
   if (this->send_swing_cmd_) {
+    // The real remote's swing button sends this fixed code on its own, with no fan-speed or
+    // temperature payload, so transmit it immediately instead of falling through below.
     this->send_swing_cmd_ = false;
     remote_state |= COMMAND_SWING;
+    this->transmit_(remote_state);
+    this->publish_state();
+    return;
   } else {
     bool climate_is_off = (this->mode_before_ == climate::CLIMATE_MODE_OFF);
     switch (this->mode) {

--- a/tests/components/climate_ir_lg/climate/lg_ir_climate_tests.cpp
+++ b/tests/components/climate_ir_lg/climate/lg_ir_climate_tests.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+#include "../common.h"
+
+namespace esphome::climate_ir_lg::testing {
+
+// The swing command is a distinct, self-contained IR code: the real remote transmits it
+// on its own, independent of the unit's current mode, target temperature, or fan speed.
+TEST(LgIrClimateTests, SwingCommandIsIndependentOfClimateState) {
+  constexpr uint32_t bit_one_low = 1600;
+
+  LgIrClimate sut;
+  MockRemoteTransmitter transmitter;
+  sut.set_transmitter(&transmitter);
+  sut.set_header_high(8000);
+  sut.set_header_low(4000);
+  sut.set_bit_high(600);
+  sut.set_bit_one_low(bit_one_low);
+  sut.set_bit_zero_low(550);
+
+  // Put the unit in a distinctive state (COOL, non-default temperature and fan speed) to prove
+  // the swing command below is transmitted independently of it.
+  climate::ClimateCall on_call(&sut);
+  on_call.set_mode(climate::CLIMATE_MODE_COOL);
+  on_call.set_target_temperature(20);
+  on_call.set_fan_mode(climate::CLIMATE_FAN_HIGH);
+  sut.control(on_call);
+
+  // Toggle swing -- this must be the fixed swing code below, unaffected by the state set above.
+  climate::ClimateCall swing_call(&sut);
+  swing_call.set_swing_mode(climate::CLIMATE_SWING_VERTICAL);
+  sut.control(swing_call);
+
+  uint32_t transmitted = decode_lg_frame(transmitter.last_data, bit_one_low);
+
+  // The swing command is always this exact fixed code, regardless of climate state.
+  EXPECT_EQ(transmitted, 0x8810001u);
+}
+
+}  // namespace esphome::climate_ir_lg::testing

--- a/tests/components/climate_ir_lg/climate/lg_ir_climate_tests.cpp
+++ b/tests/components/climate_ir_lg/climate/lg_ir_climate_tests.cpp
@@ -30,6 +30,10 @@ TEST(LgIrClimateTests, SwingCommandIsIndependentOfClimateState) {
   swing_call.set_swing_mode(climate::CLIMATE_SWING_VERTICAL);
   sut.control(swing_call);
 
+  // A complete LG frame is header (2) + 28 bit pairs (56) + trailing mark (1).
+  // Guard against out-of-bounds reads in decode_lg_frame() if the transmission failed.
+  ASSERT_GE(transmitter.last_data.size(), 2u + 28u * 2u + 1u);
+
   uint32_t transmitted = decode_lg_frame(transmitter.last_data, bit_one_low);
 
   // The swing command is always this exact fixed code, regardless of climate state.

--- a/tests/components/climate_ir_lg/common.h
+++ b/tests/components/climate_ir_lg/common.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "esphome/components/climate_ir_lg/climate_ir_lg.h"
+#include "esphome/components/remote_base/remote_base.h"
+
+namespace esphome::climate_ir_lg::testing {
+
+// Records the raw mark/space timings instead of driving real IR hardware.
+class MockRemoteTransmitter : public remote_base::RemoteTransmitterBase {
+ public:
+  MockRemoteTransmitter() : RemoteTransmitterBase(nullptr) {}
+
+  std::vector<int32_t> last_data;
+
+ protected:
+  void send_internal(uint32_t send_times, uint32_t send_wait) override { this->last_data = this->temp_.get_data(); }
+};
+
+// Decodes the raw mark/space timings produced by LgIrClimate::transmit_() back into the
+// 28-bit value that was transmitted (header + bits, ignoring the trailing mark).
+inline uint32_t decode_lg_frame(const std::vector<int32_t> &data, uint32_t bit_one_low) {
+  uint32_t value = 0;
+  // data[0]/data[1] are the header mark/space; each bit thereafter is a mark/space pair.
+  for (size_t i = 0; i < 28; i++) {
+    int32_t space = data[2 + 2 * i + 1];
+    value = (value << 1) | (static_cast<uint32_t>(-space) == bit_one_low ? 1 : 0);
+  }
+  return value;
+}
+
+}  // namespace esphome::climate_ir_lg::testing


### PR DESCRIPTION
# What does this implement/fix?

`LgIrClimate::transmit_state()` sets the swing-toggle command bit but doesn't
return afterward, so execution falls through into the fan-speed and (for
COOL/HEAT modes) temperature logic below. That ORs extra bits into the frame
that the real remote's swing button never sends — the real remote transmits a
single fixed code (`0x8810001` after checksum) with no fan-speed or
temperature payload. AC units that validate the swing frame against that
fixed code ignore the corrupted one, so `swing_mode` calls silently do
nothing on some units.

This is a regression from #3712, which restructured the command-building
`if`/`else` in `transmit_state()` and unintentionally hoisted the
fan-speed/temperature blocks out of the `else` branch, making them
unconditional. Before #3712, those blocks were nested inside the `else`, so
a swing transmission structurally could never reach them.

It also reproduces (and appears to be the root cause of) point 2 in #10867,
where a transmitted swing frame of `0x8810056` (swing + leaked `FAN_AUTO`
bits + checksum) is correctly received but doesn't match the fixed code the
unit expects.

The fix: transmit the swing command immediately and `return`, matching the
original (pre-#3712) control flow, so the swing frame is never mixed with
fan/temperature bits.

**Note:** I'm a software developer, but not a C++ developer. I used AI to help me write the fix. Let me know if I'm doing something wrong, and I'll address it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10867 (point 2 describes this exact symptom)
- Regression introduced in #3712

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — no user-facing config/behavior change, just a correctness fix.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Manually verified against a physical **LG JETCOOL US-H126TNW1** unit
(remote: **AKB73756220**), flashed to an ESP32 Super Mini. With the fix
applied, swing toggling responds correctly on real hardware; mode, fan speed,
and temperature commands are unaffected.

The fix is also applied and running in my personal retrofit project:
https://github.com/MatiasFernandez/bgh-smart-control-retrofit
(`components/climate_ir_lg/`), which carries this same change as a local
custom component ahead of this PR.

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
