### PR TITLE
[debug] Check reboot source pref on ESP_RST_WDT and guard against empty source

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -65,11 +65,15 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
 
   unsigned reason = esp_reset_reason();
   if (reason < sizeof(RESET_REASONS) / sizeof(RESET_REASONS[0])) {
-    if (reason == ESP_RST_SW) {
+    if (reason == ESP_RST_SW || reason == ESP_RST_WDT) {
+      // On some ESP32-S3 configurations (e.g. SPIRAM with fetch-instructions/rodata),
+      // esp_restart() intermittently produces RTCWDT_RTC_RST (ESP_RST_WDT) instead of
+      // ESP_RST_SW. Check the stored reboot source for both reset reasons so a software
+      // reboot that ends up as WDT still reports the correct source.
       auto pref = global_preferences->make_preference(REBOOT_MAX_LEN,
                                                       fnv1_hash_extend(fnv1_hash(REBOOT_KEY), App.get_name().c_str()));
       char reboot_source[REBOOT_MAX_LEN]{};
-      if (pref.load(&reboot_source)) {
+      if (pref.load(&reboot_source) && reboot_source[0] != '\0') {
         reboot_source[REBOOT_MAX_LEN - 1] = '\0';
         snprintf(buf, size, "Reboot request from %s", reboot_source);
       } else {


### PR DESCRIPTION
## What does this implement/fix?

Fixes two issues in the debug component's reset reason reporting on ESP32:

### 1. ESP_RST_WDT not checking stored reboot source
On some ESP32-S3 configurations (specifically with `CONFIG_SPIRAM_FETCH_INSTRUCTIONS` + `CONFIG_SPIRAM_RODATA`), `esp_restart()` intermittently produces `RTCWDT_RTC_RST` (`ESP_RST_WDT`) instead of `ESP_RST_SW`. When this happens, the stored reboot source is never read and the reset reason is reported as "other watchdogs" instead of "Reboot request from \<source\>".

This PR adds `ESP_RST_WDT` to the check so the stored pref is consulted for both reset reasons. If no source was stored, it falls back to the original string ("other watchdogs" for WDT, "software via esp_restart" for SW).

### 2. Empty reboot source producing truncated string
If `App.get_current_component()` returns `nullptr` during `on_shutdown()`, an empty buffer is saved. On the next boot, `pref.load()` succeeds (the key exists) but the source is empty, resulting in "Reboot request from " with no source. Added a `reboot_source[0] != '\0'` guard to fall back to the default string.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**
- N/A (discussed on Discord #general-support, thread: "Reset reason")

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**
- N/A (no user-facing config changes)

## Test Environment
- [x] ESP32 IDF

## Example entry for `config.yaml`:
```yaml
debug:
  update_interval: 5s

text_sensor:
  - platform: debug
    reset_reason:
      name: "Reset Reason"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
