### PR TITLE
[mitsubishi_cn105] Ignore stale status after writes

### DIFF
--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
@@ -135,6 +135,8 @@ bool MitsubishiCN105::update() {
   switch (this->state_) {
     case State::WAITING_FOR_SCHEDULED_STATUS_UPDATE:
       if (this->pending_updates_.any()) {
+        this->status_update_wait_credit_ms_ =
+            std::min(this->update_interval_ms_, get_loop_time_ms() - this->operation_start_ms_);
         this->set_state_(State::APPLYING_SETTINGS);
         return false;
       }
@@ -225,6 +227,10 @@ void MitsubishiCN105::did_transition_(State to) {
       break;
 
     case State::STATUS_UPDATED: {
+      if (this->current_status_msg_type_ == STATUS_MSG_SETTINGS) {
+        this->sent_updates_.clear(UpdateFlag::POWER, UpdateFlag::TEMPERATURE, UpdateFlag::MODE, UpdateFlag::FAN,
+                                  UpdateFlag::VANE, UpdateFlag::WIDE_VANE);
+      }
       if (this->pending_updates_.any() && this->is_status_initialized()) {
         this->set_state_(State::APPLYING_SETTINGS);
       } else if (this->current_status_msg_type_ == STATUS_MSG_SETTINGS && this->should_request_room_temperature_()) {
@@ -235,8 +241,10 @@ void MitsubishiCN105::did_transition_(State to) {
       }
       break;
     }
+
     case State::SCHEDULE_NEXT_STATUS_UPDATE:
-      this->operation_start_ms_ = get_loop_time_ms();
+      this->operation_start_ms_ = get_loop_time_ms() - this->status_update_wait_credit_ms_;
+      this->status_update_wait_credit_ms_ = 0;
       this->current_status_msg_type_ = STATUS_MSG_SETTINGS;
       this->set_state_(State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
       break;
@@ -251,6 +259,9 @@ void MitsubishiCN105::did_transition_(State to) {
 
     case State::READ_TIMEOUT:
       this->frame_parser_.reset();
+      this->status_update_wait_credit_ms_ = 0;
+      this->sent_updates_.clear(UpdateFlag::POWER, UpdateFlag::TEMPERATURE, UpdateFlag::MODE, UpdateFlag::FAN,
+                                UpdateFlag::VANE, UpdateFlag::WIDE_VANE);
       this->set_state_(State::CONNECTING);
       break;
 
@@ -349,30 +360,30 @@ bool MitsubishiCN105::parse_status_settings_(const uint8_t *payload, size_t len)
     return false;
   }
 
-  if (!this->pending_updates_.contains(UpdateFlag::POWER)) {
+  if (!this->has_outstanding_update_(UpdateFlag::POWER)) {
     this->status_.power_on = payload[2] != 0;
   }
 
   this->use_temperature_encoding_b_ = payload[10] != 0;
-  if (!this->pending_updates_.contains(UpdateFlag::TEMPERATURE)) {
+  if (!this->has_outstanding_update_(UpdateFlag::TEMPERATURE)) {
     this->status_.target_temperature = decode_temperature(-payload[4], payload[10], TARGET_TEMPERATURE_ENC_A_OFFSET);
   }
 
-  if (!this->pending_updates_.contains(UpdateFlag::MODE)) {
+  if (!this->has_outstanding_update_(UpdateFlag::MODE)) {
     const bool i_see = payload[3] > 0x08;
     this->status_.mode = PROTOCOL_MODE_MAP.lookup(payload[3] - (i_see ? 0x08 : 0));
   }
 
-  if (!this->pending_updates_.contains(UpdateFlag::FAN)) {
+  if (!this->has_outstanding_update_(UpdateFlag::FAN)) {
     this->status_.fan_mode = PROTOCOL_FAN_MODE_MAP.lookup(payload[5]);
   }
 
-  if (!this->pending_updates_.contains(UpdateFlag::VANE)) {
+  if (!this->has_outstanding_update_(UpdateFlag::VANE)) {
     this->status_.vane_mode = PROTOCOL_VANE_MODE_MAP.lookup(payload[6]);
   }
 
   this->set_wide_vane_high_bit_ = (payload[9] & 0xF0) == 0x80;
-  if (!this->pending_updates_.contains(UpdateFlag::WIDE_VANE)) {
+  if (!this->has_outstanding_update_(UpdateFlag::WIDE_VANE)) {
     this->status_.wide_vane_mode = PROTOCOL_WIDE_VANE_MODE_MAP.lookup(payload[9] & 0x0F);
   }
 
@@ -481,6 +492,7 @@ void MitsubishiCN105::apply_settings_() {
     if (this->pending_updates_.contains(UpdateFlag::POWER)) {
       payload[1] |= 0x01;
       payload[3] = this->status_.power_on ? 0x01 : 0x00;
+      this->sent_updates_.set(UpdateFlag::POWER);
     }
 
     if (this->pending_updates_.contains(UpdateFlag::TEMPERATURE)) {
@@ -491,21 +503,25 @@ void MitsubishiCN105::apply_settings_() {
         payload[5] =
             static_cast<uint8_t>(TARGET_TEMPERATURE_ENC_A_OFFSET - std::round(this->status_.target_temperature));
       }
+      this->sent_updates_.set(UpdateFlag::TEMPERATURE);
     }
 
     if (this->pending_updates_.contains(UpdateFlag::MODE) &&
         PROTOCOL_MODE_MAP.reverse_lookup(this->status_.mode, payload[4])) {
       payload[1] |= 0x02;
+      this->sent_updates_.set(UpdateFlag::MODE);
     }
 
     if (this->pending_updates_.contains(UpdateFlag::FAN) &&
         PROTOCOL_FAN_MODE_MAP.reverse_lookup(this->status_.fan_mode, payload[6])) {
       payload[1] |= 0x08;
+      this->sent_updates_.set(UpdateFlag::FAN);
     }
 
     if (this->pending_updates_.contains(UpdateFlag::VANE) &&
         PROTOCOL_VANE_MODE_MAP.reverse_lookup(this->status_.vane_mode, payload[7])) {
       payload[1] |= 0x10;
+      this->sent_updates_.set(UpdateFlag::VANE);
     }
 
     if (this->pending_updates_.contains(UpdateFlag::WIDE_VANE) &&
@@ -514,6 +530,7 @@ void MitsubishiCN105::apply_settings_() {
       if (this->set_wide_vane_high_bit_) {
         payload[13] |= 0x80;
       }
+      this->sent_updates_.set(UpdateFlag::WIDE_VANE);
     }
 
     this->pending_updates_.clear(UpdateFlag::POWER, UpdateFlag::TEMPERATURE, UpdateFlag::MODE, UpdateFlag::FAN,

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
@@ -135,8 +135,6 @@ bool MitsubishiCN105::update() {
   switch (this->state_) {
     case State::WAITING_FOR_SCHEDULED_STATUS_UPDATE:
       if (this->pending_updates_.any()) {
-        this->status_update_wait_credit_ms_ =
-            std::min(this->update_interval_ms_, get_loop_time_ms() - this->operation_start_ms_);
         this->set_state_(State::APPLYING_SETTINGS);
         return false;
       }
@@ -237,10 +235,8 @@ void MitsubishiCN105::did_transition_(State to) {
       }
       break;
     }
-
     case State::SCHEDULE_NEXT_STATUS_UPDATE:
-      this->operation_start_ms_ = get_loop_time_ms() - this->status_update_wait_credit_ms_;
-      this->status_update_wait_credit_ms_ = 0;
+      this->operation_start_ms_ = get_loop_time_ms();
       this->current_status_msg_type_ = STATUS_MSG_SETTINGS;
       this->set_state_(State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
       break;
@@ -255,7 +251,6 @@ void MitsubishiCN105::did_transition_(State to) {
 
     case State::READ_TIMEOUT:
       this->frame_parser_.reset();
-      this->status_update_wait_credit_ms_ = 0;
       this->set_state_(State::CONNECTING);
       break;
 

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.h
@@ -163,7 +163,6 @@ class MitsubishiCN105 {
 
   uart::UARTDevice &device_;
   uint32_t update_interval_ms_{1000};
-  uint32_t status_update_wait_credit_ms_{0};
   uint32_t operation_start_ms_{0};
   uint32_t room_temperature_min_interval_ms_{60000};
   std::optional<uint32_t> last_room_temperature_update_ms_;

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.h
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.h
@@ -156,6 +156,9 @@ class MitsubishiCN105 {
   bool should_request_room_temperature_() const;
   void apply_settings_();
   bool has_timed_out_(uint32_t timeout) const { return ((get_loop_time_ms() - this->operation_start_ms_) >= timeout); }
+  bool has_outstanding_update_(UpdateFlag flag) const {
+    return this->pending_updates_.contains(flag) || this->sent_updates_.contains(flag);
+  }
   void set_remote_temperature_half_deg_(uint8_t temperature_half_deg);
   template<typename T> void send_packet_(const T &packet) { this->send_packet_(packet.data(), packet.size()); }
   static bool should_transition(State from, State to);
@@ -163,12 +166,14 @@ class MitsubishiCN105 {
 
   uart::UARTDevice &device_;
   uint32_t update_interval_ms_{1000};
+  uint32_t status_update_wait_credit_ms_{0};
   uint32_t operation_start_ms_{0};
   uint32_t room_temperature_min_interval_ms_{60000};
   std::optional<uint32_t> last_room_temperature_update_ms_;
   Status status_{};
   State state_{State::NOT_CONNECTED};
   UpdateFlags pending_updates_;
+  UpdateFlags sent_updates_;
   bool use_temperature_encoding_b_{false};
   bool set_wide_vane_high_bit_{false};
   FrameParser frame_parser_;

--- a/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_tests.cpp
+++ b/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_tests.cpp
@@ -435,12 +435,14 @@ TEST(MitsubishiCN105Tests, WriteInterruptsWaitingForNextStatusUpdate) {
   ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
   EXPECT_EQ(ctx.sut.operation_start_ms_, 5000);
+  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 
   // Nothing to do in update (rx empty, no timeout)
   ctx.sut.set_current_time(5500);
   ASSERT_FALSE(ctx.sut.update());
   EXPECT_TRUE(ctx.uart.tx.empty());
   EXPECT_EQ(ctx.sut.operation_start_ms_, 5000);
+  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 
   // Write new values
   ctx.sut.use_temperature_encoding_b_ = true;
@@ -453,6 +455,7 @@ TEST(MitsubishiCN105Tests, WriteInterruptsWaitingForNextStatusUpdate) {
   // Waiting for next status update must be interrupted and new values send to AC
   ctx.sut.set_current_time(6000);
   ASSERT_FALSE(ctx.sut.update());
+  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 1000);
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
   EXPECT_THAT(ctx.uart.tx, ::testing::ElementsAre(0xFC, 0x41, 0x01, 0x30, 0x10, 0x01, 0x1F, 0x00, 0x00, 0x01, 0x00,
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xB2, 0x00, 0xAB));
@@ -462,14 +465,31 @@ TEST(MitsubishiCN105Tests, WriteInterruptsWaitingForNextStatusUpdate) {
   ctx.sut.set_current_time(6500);
   ASSERT_FALSE(ctx.sut.update());
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
-  EXPECT_EQ(ctx.sut.operation_start_ms_, 6500);
+  EXPECT_EQ(ctx.sut.operation_start_ms_, 6500 - 1000);
+  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 }
 
-TEST(MitsubishiCN105Tests, WriteAckRestartsStatusUpdateInterval) {
+TEST(MitsubishiCN105Tests, StaleSettingsResponsesDoNotRevertWrittenMode) {
   auto ctx = TestContext{};
   ctx.sut.set_update_interval(4000);
-  ctx.sut.set_current_time(1000);
+  ctx.sut.set_room_temperature_min_interval(SCHEDULER_DONT_RUN);
+  ctx.sut.status_.power_on = false;
+  ctx.sut.status_.target_temperature = 24.0f;
+  ctx.sut.status_.mode = MitsubishiCN105::Mode::HEAT;
+  ctx.sut.status_.fan_mode = MitsubishiCN105::FanMode::AUTO;
+  ctx.sut.status_.vane_mode = MitsubishiCN105::VaneMode::POSITION_4;
+  ctx.sut.status_.wide_vane_mode = MitsubishiCN105::WideVaneMode::SWING;
 
+  auto push_stale_settings = [&ctx]() {
+    ctx.uart.push_rx({0xFC, 0x62, 0x01, 0x30, 0x10, 0x02, 0x00, 0x00, 0x00, 0x01, 0x07,
+                      0x00, 0x04, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x43});
+  };
+  auto push_write_ack = [&ctx]() {
+    ctx.uart.push_rx({0xFC, 0x61, 0x01, 0x30, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E});
+  };
+
+  ctx.sut.set_current_time(1000);
   ctx.sut.state_ = TestableMitsubishiCN105::State::STATUS_UPDATED;
   ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
 
@@ -479,26 +499,84 @@ TEST(MitsubishiCN105Tests, WriteAckRestartsStatusUpdateInterval) {
   ctx.sut.set_mode(MitsubishiCN105::Mode::COOL);
   ASSERT_FALSE(ctx.sut.update());
   ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
+  ASSERT_TRUE(ctx.sut.sent_updates_.contains(TestableMitsubishiCN105::UpdateFlag::POWER));
+  ASSERT_TRUE(ctx.sut.sent_updates_.contains(TestableMitsubishiCN105::UpdateFlag::MODE));
 
-  ctx.uart.push_rx({0xFC, 0x61, 0x01, 0x30, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E});
+  // An unsolicited stale response before the ACK must not consume the protection.
+  push_stale_settings();
+  ctx.sut.set_current_time(4950);
+  ASSERT_FALSE(ctx.sut.update());
+  EXPECT_TRUE(ctx.sut.status().power_on);
+  EXPECT_EQ(ctx.sut.status().mode, MitsubishiCN105::Mode::COOL);
+  EXPECT_TRUE(ctx.sut.sent_updates_.contains(TestableMitsubishiCN105::UpdateFlag::MODE));
+  EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
+
+  push_write_ack();
   ctx.sut.set_current_time(5000);
   ASSERT_FALSE(ctx.sut.update());
   ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
 
+  // Preserved wait credit makes the next status request run shortly after the ACK.
   ctx.uart.tx.clear();
-
-  // The previous polling wait must not make the next status request run early.
   ctx.sut.set_current_time(5100);
   ASSERT_FALSE(ctx.sut.update());
-  ASSERT_TRUE(ctx.uart.tx.empty());
-  ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
+  ASSERT_FALSE(ctx.uart.tx.empty());
+  ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::UPDATING_STATUS);
 
-  ctx.sut.set_current_time(8999);
+  // The first requested response can still contain the old mode, so keep the written values.
+  push_stale_settings();
+  ctx.sut.set_current_time(5101);
   ASSERT_FALSE(ctx.sut.update());
-  ASSERT_TRUE(ctx.uart.tx.empty());
+  EXPECT_TRUE(ctx.sut.status().power_on);
+  EXPECT_EQ(ctx.sut.status().mode, MitsubishiCN105::Mode::COOL);
+  EXPECT_FALSE(ctx.sut.sent_updates_.any());
 
-  ctx.sut.set_current_time(9000);
+  // A later response is accepted so a write that did not take effect is eventually reported.
+  ctx.uart.tx.clear();
+  ctx.sut.set_current_time(9101);
+  ASSERT_FALSE(ctx.sut.update());
+  ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::UPDATING_STATUS);
+  push_stale_settings();
+  ctx.sut.set_current_time(9102);
+  ASSERT_TRUE(ctx.sut.update());
+  EXPECT_FALSE(ctx.sut.status().power_on);
+  EXPECT_EQ(ctx.sut.status().mode, MitsubishiCN105::Mode::HEAT);
+}
+
+TEST(MitsubishiCN105Tests, FrequentRemoteTemperatureWritesPreserveStatusPollProgress) {
+  auto ctx = TestContext{};
+  ctx.sut.set_update_interval(4000);
+  ctx.sut.set_current_time(1000);
+  ctx.sut.state_ = TestableMitsubishiCN105::State::STATUS_UPDATED;
+  ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
+
+  auto write_remote_temperature = [&ctx](uint32_t write_time, uint32_t ack_time, float temperature) {
+    ctx.sut.set_current_time(write_time);
+    ctx.sut.set_remote_temperature(temperature);
+    EXPECT_FALSE(ctx.sut.update());
+    EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
+    EXPECT_FALSE(ctx.sut.sent_updates_.any());
+
+    ctx.uart.tx.clear();
+    ctx.uart.push_rx({0xFC, 0x61, 0x01, 0x30, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E});
+    ctx.sut.set_current_time(ack_time);
+    EXPECT_FALSE(ctx.sut.update());
+    EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
+    ctx.uart.tx.clear();
+  };
+
+  write_remote_temperature(2000, 2100, 20.0f);
+  write_remote_temperature(3000, 3100, 20.5f);
+  write_remote_temperature(4000, 4100, 21.0f);
+  write_remote_temperature(5000, 5100, 21.5f);
+
+  EXPECT_EQ(ctx.sut.operation_start_ms_, 1400);
+  ctx.sut.set_current_time(5399);
+  ASSERT_FALSE(ctx.sut.update());
+  EXPECT_TRUE(ctx.uart.tx.empty());
+
+  ctx.sut.set_current_time(5400);
   ASSERT_FALSE(ctx.sut.update());
   EXPECT_FALSE(ctx.uart.tx.empty());
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::UPDATING_STATUS);
@@ -541,7 +619,6 @@ TEST(MitsubishiCN105Tests, SetAndClearRemoteRoomTemp) {
 
 TEST(MitsubishiCN105Tests, ApplyQueuedSettingsThenRemoteRoomTempInSecondWrite) {
   auto ctx = TestContext{};
-  ctx.sut.set_current_time(1000);
 
   // Queue normal settings plus remote temperature together.
   ctx.sut.use_temperature_encoding_b_ = true;
@@ -567,22 +644,20 @@ TEST(MitsubishiCN105Tests, ApplyQueuedSettingsThenRemoteRoomTempInSecondWrite) {
   ctx.uart.tx.clear();
   ctx.uart.push_rx({0xFC, 0x61, 0x01, 0x30, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E});
-  ctx.sut.set_current_time(1100);
   ASSERT_FALSE(ctx.sut.update());
 
   EXPECT_TRUE(ctx.sut.pending_updates_.contains(TestableMitsubishiCN105::UpdateFlag::REMOTE_TEMPERATURE));
 
   // The next apply sends the remote-temperature packet and clears the last pending flag.
   ctx.uart.tx.clear();
-  ctx.sut.set_current_time(1101);
-  ASSERT_FALSE(ctx.sut.update());
+  ctx.sut.set_state(TestableMitsubishiCN105::State::APPLYING_SETTINGS);
 
   EXPECT_THAT(ctx.uart.tx, ::testing::ElementsAre(0xFC, 0x41, 0x01, 0x30, 0x10, 0x07, 0x01, 0x29, 0xB9, 0x00, 0x00,
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x94));
   EXPECT_FALSE(ctx.sut.pending_updates_.any());
 }
 
-TEST(MitsubishiCN105Tests, WriteTimeoutReconnects) {
+TEST(MitsubishiCN105Tests, WriteTimeoutClearsOutstandingUpdateStateOnReconnect) {
   auto ctx = TestContext{};
   ctx.sut.set_update_interval(2000);
   ctx.sut.set_current_time(5000);
@@ -592,8 +667,9 @@ TEST(MitsubishiCN105Tests, WriteTimeoutReconnects) {
   ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
   ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
   ASSERT_EQ(ctx.sut.operation_start_ms_, 5000);
+  ASSERT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 
-  // Interrupt that wait with a write.
+  // Interrupt that wait with a write so credit is accumulated.
   ctx.sut.use_temperature_encoding_b_ = true;
   ctx.sut.set_power(false);
   ctx.sut.set_target_temperature(25.0f);
@@ -603,12 +679,17 @@ TEST(MitsubishiCN105Tests, WriteTimeoutReconnects) {
   ASSERT_FALSE(ctx.sut.update());
   ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
   ASSERT_EQ(ctx.sut.operation_start_ms_, 6000);
+  ASSERT_EQ(ctx.sut.status_update_wait_credit_ms_, 1000);
+  ASSERT_TRUE(ctx.sut.sent_updates_.any());
 
-  // Do not ACK the write. Advance time far enough to force timeout/reconnect.
+  // Do not ACK the write. Advance time far enough to force timeout/reconnect
+  // handling and verify that outstanding update state is cleared during recovery.
   ctx.sut.set_current_time(36000);
   ASSERT_FALSE(ctx.sut.update());
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::CONNECTING);
-  EXPECT_EQ(ctx.sut.operation_start_ms_, 36000);
+  ASSERT_EQ(ctx.sut.operation_start_ms_, 36000);
+  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
+  EXPECT_FALSE(ctx.sut.sent_updates_.any());
 }
 
 TEST(MitsubishiCN105Tests, SetOutOfRangeRemoteRoomTempIsIgnored) {

--- a/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_tests.cpp
+++ b/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_tests.cpp
@@ -435,14 +435,12 @@ TEST(MitsubishiCN105Tests, WriteInterruptsWaitingForNextStatusUpdate) {
   ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
   EXPECT_EQ(ctx.sut.operation_start_ms_, 5000);
-  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 
   // Nothing to do in update (rx empty, no timeout)
   ctx.sut.set_current_time(5500);
   ASSERT_FALSE(ctx.sut.update());
   EXPECT_TRUE(ctx.uart.tx.empty());
   EXPECT_EQ(ctx.sut.operation_start_ms_, 5000);
-  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 
   // Write new values
   ctx.sut.use_temperature_encoding_b_ = true;
@@ -455,7 +453,6 @@ TEST(MitsubishiCN105Tests, WriteInterruptsWaitingForNextStatusUpdate) {
   // Waiting for next status update must be interrupted and new values send to AC
   ctx.sut.set_current_time(6000);
   ASSERT_FALSE(ctx.sut.update());
-  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 1000);
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
   EXPECT_THAT(ctx.uart.tx, ::testing::ElementsAre(0xFC, 0x41, 0x01, 0x30, 0x10, 0x01, 0x1F, 0x00, 0x00, 0x01, 0x00,
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xB2, 0x00, 0xAB));
@@ -465,8 +462,46 @@ TEST(MitsubishiCN105Tests, WriteInterruptsWaitingForNextStatusUpdate) {
   ctx.sut.set_current_time(6500);
   ASSERT_FALSE(ctx.sut.update());
   EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
-  EXPECT_EQ(ctx.sut.operation_start_ms_, 6500 - 1000);
-  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
+  EXPECT_EQ(ctx.sut.operation_start_ms_, 6500);
+}
+
+TEST(MitsubishiCN105Tests, WriteAckRestartsStatusUpdateInterval) {
+  auto ctx = TestContext{};
+  ctx.sut.set_update_interval(4000);
+  ctx.sut.set_current_time(1000);
+
+  ctx.sut.state_ = TestableMitsubishiCN105::State::STATUS_UPDATED;
+  ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
+
+  // Send a mode change just before the scheduled status update.
+  ctx.sut.set_current_time(4900);
+  ctx.sut.set_power(true);
+  ctx.sut.set_mode(MitsubishiCN105::Mode::COOL);
+  ASSERT_FALSE(ctx.sut.update());
+  ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
+
+  ctx.uart.push_rx({0xFC, 0x61, 0x01, 0x30, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E});
+  ctx.sut.set_current_time(5000);
+  ASSERT_FALSE(ctx.sut.update());
+  ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
+
+  ctx.uart.tx.clear();
+
+  // The previous polling wait must not make the next status request run early.
+  ctx.sut.set_current_time(5100);
+  ASSERT_FALSE(ctx.sut.update());
+  ASSERT_TRUE(ctx.uart.tx.empty());
+  ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
+
+  ctx.sut.set_current_time(8999);
+  ASSERT_FALSE(ctx.sut.update());
+  ASSERT_TRUE(ctx.uart.tx.empty());
+
+  ctx.sut.set_current_time(9000);
+  ASSERT_FALSE(ctx.sut.update());
+  EXPECT_FALSE(ctx.uart.tx.empty());
+  EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::UPDATING_STATUS);
 }
 
 TEST(MitsubishiCN105Tests, SetAndClearRemoteRoomTemp) {
@@ -506,6 +541,7 @@ TEST(MitsubishiCN105Tests, SetAndClearRemoteRoomTemp) {
 
 TEST(MitsubishiCN105Tests, ApplyQueuedSettingsThenRemoteRoomTempInSecondWrite) {
   auto ctx = TestContext{};
+  ctx.sut.set_current_time(1000);
 
   // Queue normal settings plus remote temperature together.
   ctx.sut.use_temperature_encoding_b_ = true;
@@ -531,20 +567,22 @@ TEST(MitsubishiCN105Tests, ApplyQueuedSettingsThenRemoteRoomTempInSecondWrite) {
   ctx.uart.tx.clear();
   ctx.uart.push_rx({0xFC, 0x61, 0x01, 0x30, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E});
+  ctx.sut.set_current_time(1100);
   ASSERT_FALSE(ctx.sut.update());
 
   EXPECT_TRUE(ctx.sut.pending_updates_.contains(TestableMitsubishiCN105::UpdateFlag::REMOTE_TEMPERATURE));
 
   // The next apply sends the remote-temperature packet and clears the last pending flag.
   ctx.uart.tx.clear();
-  ctx.sut.set_state(TestableMitsubishiCN105::State::APPLYING_SETTINGS);
+  ctx.sut.set_current_time(1101);
+  ASSERT_FALSE(ctx.sut.update());
 
   EXPECT_THAT(ctx.uart.tx, ::testing::ElementsAre(0xFC, 0x41, 0x01, 0x30, 0x10, 0x07, 0x01, 0x29, 0xB9, 0x00, 0x00,
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x94));
   EXPECT_FALSE(ctx.sut.pending_updates_.any());
 }
 
-TEST(MitsubishiCN105Tests, WriteTimeoutClearsStatusUpdateWaitCreditOnReconnect) {
+TEST(MitsubishiCN105Tests, WriteTimeoutReconnects) {
   auto ctx = TestContext{};
   ctx.sut.set_update_interval(2000);
   ctx.sut.set_current_time(5000);
@@ -554,9 +592,8 @@ TEST(MitsubishiCN105Tests, WriteTimeoutClearsStatusUpdateWaitCreditOnReconnect) 
   ctx.sut.set_state(TestableMitsubishiCN105::State::SCHEDULE_NEXT_STATUS_UPDATE);
   ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::WAITING_FOR_SCHEDULED_STATUS_UPDATE);
   ASSERT_EQ(ctx.sut.operation_start_ms_, 5000);
-  ASSERT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
 
-  // Interrupt that wait with a write so credit is accumulated.
+  // Interrupt that wait with a write.
   ctx.sut.use_temperature_encoding_b_ = true;
   ctx.sut.set_power(false);
   ctx.sut.set_target_temperature(25.0f);
@@ -566,15 +603,12 @@ TEST(MitsubishiCN105Tests, WriteTimeoutClearsStatusUpdateWaitCreditOnReconnect) 
   ASSERT_FALSE(ctx.sut.update());
   ASSERT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
   ASSERT_EQ(ctx.sut.operation_start_ms_, 6000);
-  ASSERT_EQ(ctx.sut.status_update_wait_credit_ms_, 1000);
 
-  // Do not ACK the write. Advance time far enough to force timeout/reconnect
-  // handling and verify that stale wait credit is cleared during recovery.
+  // Do not ACK the write. Advance time far enough to force timeout/reconnect.
   ctx.sut.set_current_time(36000);
   ASSERT_FALSE(ctx.sut.update());
-  EXPECT_NE(ctx.sut.state_, TestableMitsubishiCN105::State::APPLYING_SETTINGS);
-  ASSERT_EQ(ctx.sut.operation_start_ms_, 36000);
-  EXPECT_EQ(ctx.sut.status_update_wait_credit_ms_, 0);
+  EXPECT_EQ(ctx.sut.state_, TestableMitsubishiCN105::State::CONNECTING);
+  EXPECT_EQ(ctx.sut.operation_start_ms_, 36000);
 }
 
 TEST(MitsubishiCN105Tests, SetOutOfRangeRemoteRoomTempIsIgnored) {

--- a/tests/components/mitsubishi_cn105/common.h
+++ b/tests/components/mitsubishi_cn105/common.h
@@ -52,7 +52,6 @@ class TestableMitsubishiCN105 : public MitsubishiCN105 {
   using MitsubishiCN105::operation_start_ms_;
   using MitsubishiCN105::use_temperature_encoding_b_;
   using MitsubishiCN105::set_wide_vane_high_bit_;
-  using MitsubishiCN105::status_update_wait_credit_ms_;
   using MitsubishiCN105::pending_updates_;
 
   void set_state(State s) { this->set_state_(s); }

--- a/tests/components/mitsubishi_cn105/common.h
+++ b/tests/components/mitsubishi_cn105/common.h
@@ -52,7 +52,9 @@ class TestableMitsubishiCN105 : public MitsubishiCN105 {
   using MitsubishiCN105::operation_start_ms_;
   using MitsubishiCN105::use_temperature_encoding_b_;
   using MitsubishiCN105::set_wide_vane_high_bit_;
+  using MitsubishiCN105::status_update_wait_credit_ms_;
   using MitsubishiCN105::pending_updates_;
+  using MitsubishiCN105::sent_updates_;
 
   void set_state(State s) { this->set_state_(s); }
   void apply_settings() { this->apply_settings_(); }


### PR DESCRIPTION
# What does this implement/fix?

Prevents the first stale status response after a settings write from reverting the state published to Home Assistant. Poll scheduling remains unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) - [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) - [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) - [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: mitsubishi_cn105
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
