### PR TITLE
[remote_base] Fix NEC command_repeats to send repeat frames

### DIFF
--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -28,17 +28,26 @@ void NECProtocol::encode(RemoteTransmitData *dst, const NECData &data) {
     }
   }
 
-  for (uint16_t repeats = 0; repeats < data.command_repeats; repeats++) {
-    for (uint16_t mask = 1; mask; mask <<= 1) {
-      if (data.command & mask) {
-        dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
-      } else {
-        dst->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
-      }
+  for (uint16_t mask = 1; mask; mask <<= 1) {
+    if (data.command & mask) {
+      dst->item(BIT_HIGH_US, BIT_ONE_LOW_US);
+    } else {
+      dst->item(BIT_HIGH_US, BIT_ZERO_LOW_US);
     }
   }
 
   dst->mark(BIT_HIGH_US);
+
+  if (data.command_repeats > 1) {
+    dst->space(40500);
+    for (uint16_t repeats = 1; repeats < data.command_repeats; repeats++) {
+      dst->item(HEADER_HIGH_US, HEADER_LOW_US / 2);
+      dst->mark(BIT_HIGH_US);
+      if (repeats + 1 < data.command_repeats) {
+        dst->space(96187);
+      }
+    }
+  }
 }
 optional<NECData> NECProtocol::decode(RemoteReceiveData src) {
   NECData data{
@@ -69,27 +78,18 @@ optional<NECData> NECProtocol::decode(RemoteReceiveData src) {
     }
   }
 
-  while (src.peek_item(BIT_HIGH_US, BIT_ONE_LOW_US) || src.peek_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
-    uint16_t command = 0;
-    for (uint16_t mask = 1; mask; mask <<= 1) {
-      if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
-        command |= mask;
-      } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
-        command &= ~mask;
-      } else {
-        return {};
-      }
-    }
-
-    // Make sure the extra/repeated data matches original command
-    if (command != data.command) {
-      return {};
-    }
-
-    data.command_repeats += 1;
+  if (!src.expect_mark(BIT_HIGH_US)) {
+    return {};
   }
 
-  src.expect_mark(BIT_HIGH_US);
+  while (src.expect_space(40500) || src.expect_space(96187)) {
+    if (src.expect_item(HEADER_HIGH_US, HEADER_LOW_US / 2) && src.expect_mark(BIT_HIGH_US)) {
+      data.command_repeats += 1;
+    } else {
+      break;
+    }
+  }
+
   return data;
 }
 void NECProtocol::dump(const NECData &data) {

--- a/tests/components/remote_base/nec_protocol_test.cpp
+++ b/tests/components/remote_base/nec_protocol_test.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include "esphome/components/remote_base/nec_protocol.h"
+
+namespace esphome {
+namespace remote_base {
+namespace testing {
+
+TEST(NECProtocolTest, EncodeWithoutRepeats) {
+  NECProtocol protocol;
+  NECData data{
+      .address = 0x7F80,
+      .command = 0xF20D,
+      .command_repeats = 1,
+  };
+  RemoteTransmitData dst;
+  protocol.encode(&dst, data);
+
+  // We won't verify the exact bits of address and command,
+  // but we will verify the structure (header, bits, final mark).
+  auto data_vec = dst.get_data();
+  // Header: 9000 mark, 4500 space
+  EXPECT_EQ(data_vec[0], 9000);
+  EXPECT_EQ(data_vec[1], -4500);
+
+  // Address (16 bits) + Command (16 bits) = 32 bits
+  // Each bit is 2 items (mark + space)
+  // Total items = 2 (header) + 32 * 2 + 1 (final mark) = 67 items
+  EXPECT_EQ(data_vec.size(), 67);
+
+  // Final mark
+  EXPECT_EQ(data_vec[66], 560);
+}
+
+TEST(NECProtocolTest, EncodeWithRepeats) {
+  NECProtocol protocol;
+  NECData data{
+      .address = 0x7F80,
+      .command = 0xF20D,
+      .command_repeats = 3,
+  };
+  RemoteTransmitData dst;
+  protocol.encode(&dst, data);
+
+  auto data_vec = dst.get_data();
+
+  // First 67 items are the initial transmission (Header + 32 bits + final mark)
+  // Then space(40500) -> 1 item
+  // Then repeat code 1: item(9000, 2250), mark(560) -> 3 items
+  // Then space(96187) -> 1 item
+  // Then repeat code 2: item(9000, 2250), mark(560) -> 3 items
+  // Total = 67 + 1 + 3 + 1 + 3 = 75 items
+
+  EXPECT_EQ(data_vec.size(), 75);
+
+  // Verify repeat structure
+  EXPECT_EQ(data_vec[67], -40500);  // 40.5ms space
+  EXPECT_EQ(data_vec[68], 9000);    // Repeat header high
+  EXPECT_EQ(data_vec[69], -2250);   // Repeat header low
+  EXPECT_EQ(data_vec[70], 560);     // Repeat mark
+
+  EXPECT_EQ(data_vec[71], -96187);  // 96.1875ms space
+  EXPECT_EQ(data_vec[72], 9000);    // Repeat header high
+  EXPECT_EQ(data_vec[73], -2250);   // Repeat header low
+  EXPECT_EQ(data_vec[74], 560);     // Repeat mark
+}
+
+TEST(NECProtocolTest, DecodeWithoutRepeats) {
+  NECProtocol protocol;
+  NECData encode_data{
+      .address = 0x1234,
+      .command = 0x5678,
+      .command_repeats = 1,
+  };
+  RemoteTransmitData tx;
+  protocol.encode(&tx, encode_data);
+
+  RemoteReceiveData rx(tx.get_data(), 25, TOLERANCE_MODE_PERCENTAGE);
+  auto decoded = protocol.decode(rx);
+
+  ASSERT_TRUE(decoded.has_value());
+  EXPECT_EQ(decoded->address, 0x1234);
+  EXPECT_EQ(decoded->command, 0x5678);
+  EXPECT_EQ(decoded->command_repeats, 1);
+}
+
+TEST(NECProtocolTest, DecodeWithRepeats) {
+  NECProtocol protocol;
+  NECData encode_data{
+      .address = 0x1234,
+      .command = 0x5678,
+      .command_repeats = 4,
+  };
+  RemoteTransmitData tx;
+  protocol.encode(&tx, encode_data);
+
+  RemoteReceiveData rx(tx.get_data(), 25, TOLERANCE_MODE_PERCENTAGE);
+  auto decoded = protocol.decode(rx);
+
+  ASSERT_TRUE(decoded.has_value());
+  EXPECT_EQ(decoded->address, 0x1234);
+  EXPECT_EQ(decoded->command, 0x5678);
+  EXPECT_EQ(decoded->command_repeats, 4);
+}
+
+}  // namespace testing
+}  // namespace remote_base
+}  // namespace esphome

--- a/tests/components/remote_base/nec_protocol_test.cpp
+++ b/tests/components/remote_base/nec_protocol_test.cpp
@@ -2,9 +2,7 @@
 #include <vector>
 #include "esphome/components/remote_base/nec_protocol.h"
 
-namespace esphome {
-namespace remote_base {
-namespace testing {
+namespace esphome::remote_base::testing {
 
 TEST(NECProtocolTest, EncodeWithoutRepeats) {
   NECProtocol protocol;
@@ -79,9 +77,11 @@ TEST(NECProtocolTest, DecodeWithoutRepeats) {
   auto decoded = protocol.decode(rx);
 
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->address, 0x1234);
-  EXPECT_EQ(decoded->command, 0x5678);
-  EXPECT_EQ(decoded->command_repeats, 1);
+  if (decoded.has_value()) {
+    EXPECT_EQ(decoded->address, 0x1234);
+    EXPECT_EQ(decoded->command, 0x5678);
+    EXPECT_EQ(decoded->command_repeats, 1);
+  }
 }
 
 TEST(NECProtocolTest, DecodeWithRepeats) {
@@ -98,11 +98,11 @@ TEST(NECProtocolTest, DecodeWithRepeats) {
   auto decoded = protocol.decode(rx);
 
   ASSERT_TRUE(decoded.has_value());
-  EXPECT_EQ(decoded->address, 0x1234);
-  EXPECT_EQ(decoded->command, 0x5678);
-  EXPECT_EQ(decoded->command_repeats, 4);
+  if (decoded.has_value()) {
+    EXPECT_EQ(decoded->address, 0x1234);
+    EXPECT_EQ(decoded->command, 0x5678);
+    EXPECT_EQ(decoded->command_repeats, 4);
+  }
 }
 
-}  // namespace testing
-}  // namespace remote_base
-}  // namespace esphome
+}  // namespace esphome::remote_base::testing


### PR DESCRIPTION
## What does this implement/fix?

Fix NEC `command_repeats` handling in `remote_base`.

ESPHome currently re-sends the full command payload for repeats and expects duplicated command data when decoding. This PR changes NEC handling to send and recognize standard NEC repeat frames instead.

Fixes esphome/issues#6603.

Also adds unit tests covering encode/decode behavior with and without repeats.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**
- fixes esphome/issues#6603

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**
- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  pin: GPIO4
  carrier_duty_percent: 50%

button:
  - platform: template
    name: "Send NEC"
    on_press:
      - remote_transmitter.transmit_nec:
          address: 0x1234
          command: 0x5678
          command_repeats: 3
