### PR TITLE
[rf_bridge] Fix bucket sniffing with Portisch firmware

### DIFF
--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -18,6 +18,16 @@ void RFBridgeComponent::ack_() {
 }
 
 bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
+  if (this->bucket_frame_candidate_ && byte == RF_CODE_START) {
+    // A queued next frame proves the trailing 0x55 really was the bucket
+    // frame's terminator: Portisch builds pulse entries from alternating
+    // signal edges, so the two level bits inside one pulse byte are always
+    // opposite — 0xAA (two high-level nibbles) cannot occur in pulse data.
+    // Finalize before this byte starts the new frame, so back-to-back
+    // deliveries are split even when loop() never observed a quiet gap
+    // between them.
+    this->finish_bucket_frame_();
+  }
   size_t at = this->rx_buffer_.size();
   this->rx_buffer_.push_back(byte);
   const uint8_t *raw = &this->rx_buffer_[0];
@@ -84,26 +94,21 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
       break;
     }
     case RF_CODE_RFIN_BUCKET: {
-      if (byte != RF_CODE_STOP) {
-        return true;
+      if (at == 2) {
+        // The count byte: Portisch sends at most 7 buckets + sync, so 0 or
+        // >8 cannot be a genuine capture — reject before it can occupy the
+        // buffer for a full frame timeout.
+        return byte != 0 && byte <= B1_MAX_BUCKET_COUNT;
       }
-
-      uint8_t buckets = raw[2] << 1;
-      std::string str;
-      char next_byte[3];  // 2 hex chars + null
-
-      for (uint32_t i = 0; i <= at; i++) {
-        buf_append_printf(next_byte, sizeof(next_byte), 0, "%02X", raw[i]);
-        str += next_byte;
-        if ((i > 3) && buckets) {
-          buckets--;
-        }
-        if ((i < 3) || (buckets % 2) || (i == at - 1)) {
-          str += " ";
-        }
-      }
-      ESP_LOGI(TAG, "Received RFBridge Bucket: %s", str.c_str());
-      break;
+      // 0x55 is legal DATA inside a B1 frame: bucket durations are sent
+      // with only their HIGH byte masked to 7 bits, so a duration such as
+      // 0x0155 puts a raw 0x55 low byte inside the table — the first 0x55
+      // must therefore not end the capture. The header declares the table
+      // length (raw[2] pairs), so a 0x55 there is always data; one at or
+      // past the first pulse index is a terminator CANDIDATE, confirmed
+      // once the UART goes quiet (finish_bucket_frame_ in loop()).
+      this->bucket_frame_candidate_ = byte == RF_CODE_STOP && at >= 3 + static_cast<size_t>(raw[2]) * 2;
+      return true;
     }
     default:
       ESP_LOGW(TAG, "Unknown action: 0x%02X", action);
@@ -119,6 +124,47 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
   return false;
 }
 
+void RFBridgeComponent::finish_bucket_frame_() {
+  if (this->rx_buffer_.size() < 4) {
+    // The candidate flag requires a header + non-empty bucket table, so
+    // this cannot happen while flag and buffer stay consistent; guard the
+    // raw[2] / size-1 reads against any future divergence anyway.
+    this->rx_buffer_.clear();
+    this->bucket_frame_candidate_ = false;
+    return;
+  }
+  const uint8_t *raw = this->rx_buffer_.data();
+  const size_t at = this->rx_buffer_.size() - 1;
+
+  uint8_t buckets = raw[2] << 1;
+  std::string str;
+  char next_byte[3];  // 2 hex chars + null
+
+  for (uint32_t i = 0; i <= at; i++) {
+    buf_append_printf(next_byte, sizeof(next_byte), 0, "%02X", raw[i]);
+    str += next_byte;
+    if ((i > 3) && buckets) {
+      buckets--;
+    }
+    if ((i < 3) || (buckets % 2) || (i == at - 1)) {
+      str += " ";
+    }
+  }
+  ESP_LOGI(TAG, "Received RFBridge Bucket: %s", str.c_str());
+
+  // Deliberately NOT ACKed: Portisch's B1 command handler leaves its
+  // last_sniffing_command at the previous mode (RF_CODE_RFIN), and its
+  // host-ACK handler re-arms sniffing from that stale value — so ACKing a
+  // bucket delivery silently reverts the radio to standard sniffing and
+  // ends bucket capture. Its delivery path is fire-and-forget and never
+  // waits for a host ACK. Stock Itead firmware never sends B1 frames, so
+  // suppressing this ACK cannot change stock-firmware behavior.
+  // https://github.com/esphome/esphome/issues/17682
+
+  this->rx_buffer_.clear();
+  this->bucket_frame_candidate_ = false;
+}
+
 void RFBridgeComponent::write_byte_str_(const std::string &codes) {
   uint8_t code;
   int size = codes.length();
@@ -130,12 +176,31 @@ void RFBridgeComponent::write_byte_str_(const std::string &codes) {
 
 void RFBridgeComponent::loop() {
   const uint32_t now = App.get_loop_component_start_time();
-  if (now - this->last_bridge_byte_ > 50) {
+  size_t avail = this->available();
+  if (avail == 0 && this->bucket_frame_candidate_ && now - this->last_bridge_byte_ > BUCKET_CANDIDATE_QUIET_MS) {
+    // The trailing 0x55 was followed by UART quiet, so it really was the
+    // frame terminator and not an interior data byte.
+    this->finish_bucket_frame_();
+    this->last_bridge_byte_ = now;
+  }
+  const bool receiving_bucket = this->rx_buffer_.size() >= 2 && this->rx_buffer_[1] == RF_CODE_RFIN_BUCKET;
+  if (receiving_bucket) {
+    // Never declare an in-progress bucket frame dead while its continuation
+    // bytes are already queued: a stalled loop() otherwise discards a live
+    // frame that the UART buffer proves is still arriving.
+    if (avail == 0 && now - this->last_bridge_byte_ > BUCKET_FRAME_TIMEOUT_MS) {
+      ESP_LOGD(TAG, "Discarding incomplete RFBridge Bucket frame (%u bytes)",
+               static_cast<unsigned>(this->rx_buffer_.size()));
+      this->rx_buffer_.clear();
+      this->bucket_frame_candidate_ = false;
+      this->last_bridge_byte_ = now;
+    }
+  } else if (now - this->last_bridge_byte_ > 50) {
     this->rx_buffer_.clear();
+    this->bucket_frame_candidate_ = false;
     this->last_bridge_byte_ = now;
   }
 
-  size_t avail = this->available();
   while (avail > 0) {
     uint8_t buf[64];
     size_t to_read = std::min(avail, sizeof(buf));
@@ -146,12 +211,14 @@ void RFBridgeComponent::loop() {
     for (size_t i = 0; i < to_read; i++) {
       if (this->rx_buffer_.size() > MAX_RX_BUFFER_SIZE) {
         this->rx_buffer_.clear();
+        this->bucket_frame_candidate_ = false;
       }
       if (this->parse_bridge_byte_(buf[i])) {
         ESP_LOGVV(TAG, "Parsed: 0x%02X", buf[i]);
         this->last_bridge_byte_ = now;
       } else {
         this->rx_buffer_.clear();
+        this->bucket_frame_candidate_ = false;
       }
     }
   }

--- a/esphome/components/rf_bridge/rf_bridge.h
+++ b/esphome/components/rf_bridge/rf_bridge.h
@@ -30,6 +30,17 @@ static const uint8_t RF_CODE_BEEP = 0xC0;
 static const uint8_t RF_CODE_STOP = 0x55;
 static const uint8_t RF_DEBOUNCE = 200;
 static const size_t MAX_RX_BUFFER_SIZE = 512;
+// ~10 byte times at 19200 baud: long enough to prove the UART went quiet
+// after a possible bucket-frame terminator, short enough to finish well
+// before the next radio capture can be delivered.
+static const uint32_t BUCKET_CANDIDATE_QUIET_MS = 5;
+// Portisch drains a B1 frame's header, bucket table, and pulse data as
+// separate UART writes, so an in-progress bucket frame tolerates a longer
+// inter-region gap than the generic 50 ms inter-byte timeout.
+static const uint32_t BUCKET_FRAME_TIMEOUT_MS = 250;
+// Portisch's uart_put_RF_buckets sends at most 7 buckets plus the sync
+// bucket, so a B1 count byte above 8 (or 0) is malformed for any protocol.
+static const uint8_t B1_MAX_BUCKET_COUNT = 8;
 
 struct RFBridgeData {
   uint16_t sync;
@@ -67,10 +78,12 @@ class RFBridgeComponent final : public uart::UARTDevice, public Component {
   void ack_();
   void decode_();
   bool parse_bridge_byte_(uint8_t byte);
+  void finish_bucket_frame_();
   void write_byte_str_(const std::string &codes);
 
   std::vector<uint8_t> rx_buffer_;
   uint32_t last_bridge_byte_{0};
+  bool bucket_frame_candidate_{false};
 
   CallbackManager<void(RFBridgeData)> data_callback_;
   CallbackManager<void(RFBridgeAdvancedData)> advanced_data_callback_;


### PR DESCRIPTION
# What does this implement/fix?

Fixes two `rf_bridge` receive-path bugs that break continuous bucket sniffing with the widely used [Portisch firmware](https://github.com/Portisch/RF-Bridge-EFM8BB1) on Sonoff RF Bridge R2 hardware (EFM8BB1). Both were root-caused against the Portisch sources and verified live on hardware; the same logic has been running in production on a 7-bridge fleet via a vendored fork.

1. **B1 bucket deliveries are no longer ACKed.** Portisch's `0xB1` command handler leaves `last_sniffing_command` at the previous mode (`RF_CODE_RFIN`) — `PCA0_DoSniffing()` returns the *previous* command, and the handler assigns that return value back (`RF_Bridge_main.c` line 201). Its host-ACK handler then re-arms sniffing from that stale value (line 221), so the component's automatic ACK of the **first delivered capture** (any ambient burst) silently reverted the radio to standard sniffing and ended bucket capture. This is why Tasmota's `RfRaw 177` streams continuously (Tasmota never ACKs sniffed frames) while ESPHome bucket sniffing "works once, then dies." Portisch's delivery path is fire-and-forget (it clears `RF_DATA_STATUS` and re-enables the capture interrupt immediately), and stock Itead firmware never emits B1 frames — so suppressing this one ACK cannot change stock-firmware behavior. The A4/A6/learn ACK paths are untouched (Portisch's `SNIFFING_ON` handler assigns the literal, so advanced sniffing is not affected by ACKs).

2. **B1 frames no longer terminate at the first interior `0x55`.** `0x55` is legal data inside a B1 frame: `uart_put_RF_buckets` masks only the *high* byte of each 16-bit bucket duration (`& 0x7F`), so a duration like `0x0155` µs puts a raw `0x55` low byte inside the bucket table — real captures containing it were truncated into malformed frames. The header declares the bucket-table length (`raw[2]` pairs), so a `0x55` inside the table is always data; a trailing `0x55` at or past the first pulse index is treated as a terminator *candidate* and confirmed once the UART goes quiet (`BUCKET_CANDIDATE_QUIET_MS = 5` ms ≈ 10 byte times at 19200 baud). Two scheduling hazards are handled deterministically: a queued `0xAA` start-byte while a candidate is pending finalizes the previous frame immediately (Portisch builds pulse entries from alternating signal edges, so the two level bits inside one pulse byte are always opposite — `0xAA` cannot occur in pulse data), and an in-progress B1 frame is never discarded while its continuation bytes are already queued (Portisch drains a B1 frame's header, bucket table, and pulse regions as separate UART writes, so B1 gets a 250 ms bound instead of the generic 50 ms inter-byte timeout; non-B1 timeout behavior is unchanged). A B1 count byte of `0` or above `8` is rejected outright — `uart_put_RF_buckets` sends at most 7 buckets plus the sync bucket, so larger claims are malformed for any protocol and would otherwise occupy the buffer for a full frame timeout.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome#17682

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing configuration or API change; log output for bucket frames is now complete instead of truncated)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Hardware: Sonoff RF Bridge R2 V1.0 (ESP8285 + EFM8BB1 flashed with Portisch), `uart` at 19200 on GPIO1/GPIO3, `logger: baud_rate: 0`.

## Example entry for `config.yaml`:

```yaml
uart:
  tx_pin: GPIO01
  rx_pin: GPIO03
  baud_rate: 19200

logger:
  baud_rate: 0

rf_bridge:

esphome:
  on_boot:
    - rf_bridge.start_bucket_sniffing:
```

Repro for (1): with `start_bucket_sniffing` armed, the stock component logs one `Received RFBridge Bucket` (any ambient burst) and then never again — pressing any 433 MHz remote produces nothing. With this fix, captures continue indefinitely.

Repro for (2): any remote whose capture contains an interior `0x55` (bucket durations around 341 µs, or matching pulse nibbles) — previously truncated, now logged complete.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The existing `tests/components/rf_bridge/` compile tests cover the change; the parser has no host-side unit-test harness. The identical logic (plus project-specific validation not included here) is hardware-validated and running in production on a 7-bridge fleet: <https://github.com/joyfulhouse/esphome-rf433-mqtt-bridge>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
