### PR TITLE
[ble_device_base] Migrate BLE sensor platforms to the neutral layer (batch 1: ble_presence, ble_rssi, ble_scanner)

### DIFF
--- a/esphome/components/ble_presence/binary_sensor.py
+++ b/esphome/components/ble_presence/binary_sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import binary_sensor, esp32_ble_tracker
+from esphome.components import binary_sensor, ble_device_base
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_IBEACON_MAJOR,
@@ -13,14 +13,14 @@ from esphome.const import (
 
 CONF_IRK = "irk"
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 ble_presence_ns = cg.esphome_ns.namespace("ble_presence")
 BLEPresenceDevice = ble_presence_ns.class_(
     "BLEPresenceDevice",
     binary_sensor.BinarySensor,
     cg.Component,
-    esp32_ble_tracker.ESPBTDeviceListener,
+    ble_device_base.ESPBTDeviceListener,
 )
 
 
@@ -33,23 +33,24 @@ def _validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("ble_presence"),
     binary_sensor.binary_sensor_schema(BLEPresenceDevice)
     .extend(
         {
             cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_IRK): cv.uuid,
-            cv.Optional(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
+            cv.Optional(CONF_SERVICE_UUID): ble_device_base.bt_uuid,
             cv.Optional(CONF_IBEACON_MAJOR): cv.uint16_t,
             cv.Optional(CONF_IBEACON_MINOR): cv.uint16_t,
-            cv.Optional(CONF_IBEACON_UUID): esp32_ble_tracker.bt_uuid,
+            cv.Optional(CONF_IBEACON_UUID): ble_device_base.bt_uuid,
             cv.Optional(CONF_TIMEOUT, default="5min"): cv.positive_time_period,
             cv.Optional(CONF_MIN_RSSI): cv.All(
                 cv.decibel, cv.int_range(min=-100, max=-30)
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA),
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
     cv.has_exactly_one_key(
         CONF_MAC_ADDRESS, CONF_IRK, CONF_SERVICE_UUID, CONF_IBEACON_UUID
     ),
@@ -60,7 +61,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_timeout(config[CONF_TIMEOUT].total_milliseconds))
     if min_rssi := config.get(CONF_MIN_RSSI):
@@ -70,20 +71,15 @@ async def to_code(config):
         cg.add(var.set_address(mac_address.as_hex))
 
     if irk := config.get(CONF_IRK):
-        irk = esp32_ble_tracker.as_hex_array(str(irk))
+        ble_device_base.request_irk_support()
+        irk = ble_device_base.as_hex_array(str(irk))
         cg.add(var.set_irk(irk))
 
     if service_uuid := config.get(CONF_SERVICE_UUID):
-        if len(service_uuid) == len(esp32_ble_tracker.bt_uuid16_format):
-            cg.add(var.set_service_uuid16(esp32_ble_tracker.as_hex(service_uuid)))
-        elif len(service_uuid) == len(esp32_ble_tracker.bt_uuid32_format):
-            cg.add(var.set_service_uuid32(esp32_ble_tracker.as_hex(service_uuid)))
-        elif len(service_uuid) == len(esp32_ble_tracker.bt_uuid128_format):
-            uuid128 = esp32_ble_tracker.as_reversed_hex_array(service_uuid)
-            cg.add(var.set_service_uuid128(uuid128))
+        ble_device_base.add_service_uuid(var, service_uuid)
 
     if ibeacon_uuid := config.get(CONF_IBEACON_UUID):
-        ibeacon_uuid = esp32_ble_tracker.as_reversed_hex_array(ibeacon_uuid)
+        ibeacon_uuid = ble_device_base.as_reversed_hex_array(ibeacon_uuid)
         cg.add(var.set_ibeacon_uuid(ibeacon_uuid))
 
         if (ibeacon_major := config.get(CONF_IBEACON_MAJOR)) is not None:

--- a/esphome/components/ble_presence/ble_presence_device.cpp
+++ b/esphome/components/ble_presence/ble_presence_device.cpp
@@ -1,8 +1,6 @@
 #include "ble_presence_device.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::ble_presence {
 
 static const char *const TAG = "ble_presence";
@@ -10,5 +8,3 @@ static const char *const TAG = "ble_presence";
 void BLEPresenceDevice::dump_config() { LOG_BINARY_SENSOR("", "BLE Presence", this); }
 
 }  // namespace esphome::ble_presence
-
-#endif

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -1,15 +1,17 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-#ifdef USE_ESP32
-
+// No platform #ifdef: ble_device_base provides the BLE types on every platform,
+// and this component is only compiled when configured — which requires a BLE
+// hub — so it builds on any platform with a BLEHub tracker without a per-chip
+// guard.
 namespace esphome::ble_presence {
 
 class BLEPresenceDevice final : public binary_sensor::BinarySensorInitiallyOff,
-                                public esp32_ble_tracker::ESPBTDeviceListener,
+                                public ble_device_base::ESPBTDeviceListener,
                                 public Component {
  public:
   void set_address(uint64_t address) {
@@ -22,19 +24,19 @@ class BLEPresenceDevice final : public binary_sensor::BinarySensorInitiallyOff,
   }
   void set_service_uuid16(uint16_t uuid) {
     this->match_by_ = MATCH_BY_SERVICE_UUID;
-    this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_uint16(uuid);
+    this->uuid_ = ble_device_base::ESPBTUUID::from_uint16(uuid);
   }
   void set_service_uuid32(uint32_t uuid) {
     this->match_by_ = MATCH_BY_SERVICE_UUID;
-    this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_uint32(uuid);
+    this->uuid_ = ble_device_base::ESPBTUUID::from_uint32(uuid);
   }
   void set_service_uuid128(uint8_t *uuid) {
     this->match_by_ = MATCH_BY_SERVICE_UUID;
-    this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(uuid);
+    this->uuid_ = ble_device_base::ESPBTUUID::from_raw(uuid);
   }
   void set_ibeacon_uuid(uint8_t *uuid) {
     this->match_by_ = MATCH_BY_IBEACON_UUID;
-    this->ibeacon_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(uuid);
+    this->ibeacon_uuid_ = ble_device_base::ESPBTUUID::from_raw(uuid);
   }
   void set_ibeacon_major(uint16_t major) {
     this->check_ibeacon_major_ = true;
@@ -49,7 +51,7 @@ class BLEPresenceDevice final : public binary_sensor::BinarySensorInitiallyOff,
     this->minimum_rssi_ = rssi;
   }
   void set_timeout(uint32_t timeout) { this->timeout_ = timeout; }
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override {
     if (this->check_minimum_rssi_ && this->minimum_rssi_ > device.get_rssi()) {
       return false;
     }
@@ -119,9 +121,9 @@ class BLEPresenceDevice final : public binary_sensor::BinarySensorInitiallyOff,
   uint64_t address_;
   uint8_t *irk_;
 
-  esp32_ble_tracker::ESPBTUUID uuid_;
+  ble_device_base::ESPBTUUID uuid_;
 
-  esp32_ble_tracker::ESPBTUUID ibeacon_uuid_;
+  ble_device_base::ESPBTUUID ibeacon_uuid_;
   uint16_t ibeacon_major_{0};
   uint16_t ibeacon_minor_{0};
 
@@ -137,5 +139,3 @@ class BLEPresenceDevice final : public binary_sensor::BinarySensorInitiallyOff,
 };
 
 }  // namespace esphome::ble_presence
-
-#endif

--- a/esphome/components/ble_rssi/ble_rssi_sensor.cpp
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.cpp
@@ -1,8 +1,6 @@
 #include "ble_rssi_sensor.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::ble_rssi {
 
 static const char *const TAG = "ble_rssi";
@@ -10,5 +8,3 @@ static const char *const TAG = "ble_rssi";
 void BLERSSISensor::dump_config() { LOG_SENSOR("", "BLE RSSI Sensor", this); }
 
 }  // namespace esphome::ble_rssi
-
-#endif

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -1,14 +1,16 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/components/sensor/sensor.h"
 
-#ifdef USE_ESP32
-
+// No platform #ifdef: ble_device_base provides the BLE types on every platform,
+// and this component is only compiled when configured — which requires a BLE
+// hub — so it builds on any platform with a BLEHub tracker without a per-chip
+// guard.
 namespace esphome::ble_rssi {
 
-class BLERSSISensor final : public sensor::Sensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
+class BLERSSISensor final : public sensor::Sensor, public ble_device_base::ESPBTDeviceListener, public Component {
  public:
   void set_address(uint64_t address) {
     this->match_by_ = MATCH_BY_MAC_ADDRESS;
@@ -20,19 +22,19 @@ class BLERSSISensor final : public sensor::Sensor, public esp32_ble_tracker::ESP
   }
   void set_service_uuid16(uint16_t uuid) {
     this->match_by_ = MATCH_BY_SERVICE_UUID;
-    this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_uint16(uuid);
+    this->uuid_ = ble_device_base::ESPBTUUID::from_uint16(uuid);
   }
   void set_service_uuid32(uint32_t uuid) {
     this->match_by_ = MATCH_BY_SERVICE_UUID;
-    this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_uint32(uuid);
+    this->uuid_ = ble_device_base::ESPBTUUID::from_uint32(uuid);
   }
   void set_service_uuid128(uint8_t *uuid) {
     this->match_by_ = MATCH_BY_SERVICE_UUID;
-    this->uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(uuid);
+    this->uuid_ = ble_device_base::ESPBTUUID::from_raw(uuid);
   }
   void set_ibeacon_uuid(uint8_t *uuid) {
     this->match_by_ = MATCH_BY_IBEACON_UUID;
-    this->ibeacon_uuid_ = esp32_ble_tracker::ESPBTUUID::from_raw(uuid);
+    this->ibeacon_uuid_ = ble_device_base::ESPBTUUID::from_raw(uuid);
   }
   void set_ibeacon_major(uint16_t major) {
     this->check_ibeacon_major_ = true;
@@ -47,7 +49,7 @@ class BLERSSISensor final : public sensor::Sensor, public esp32_ble_tracker::ESP
       this->publish_state(NAN);
     this->found_ = false;
   }
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override {
     switch (this->match_by_) {
       case MATCH_BY_MAC_ADDRESS:
         if (device.address_uint64() == this->address_) {
@@ -109,9 +111,9 @@ class BLERSSISensor final : public sensor::Sensor, public esp32_ble_tracker::ESP
   uint64_t address_;
   uint8_t *irk_;
 
-  esp32_ble_tracker::ESPBTUUID uuid_;
+  ble_device_base::ESPBTUUID uuid_;
 
-  esp32_ble_tracker::ESPBTUUID ibeacon_uuid_;
+  ble_device_base::ESPBTUUID ibeacon_uuid_;
   uint16_t ibeacon_major_;
   uint16_t ibeacon_minor_;
 
@@ -120,5 +122,3 @@ class BLERSSISensor final : public sensor::Sensor, public esp32_ble_tracker::ESP
 };
 
 }  // namespace esphome::ble_rssi
-
-#endif

--- a/esphome/components/ble_rssi/sensor.py
+++ b/esphome/components/ble_rssi/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, sensor
+from esphome.components import ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_IBEACON_MAJOR,
@@ -14,11 +14,11 @@ from esphome.const import (
 
 CONF_IRK = "irk"
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 ble_rssi_ns = cg.esphome_ns.namespace("ble_rssi")
 BLERSSISensor = ble_rssi_ns.class_(
-    "BLERSSISensor", sensor.Sensor, cg.Component, esp32_ble_tracker.ESPBTDeviceListener
+    "BLERSSISensor", sensor.Sensor, cg.Component, ble_device_base.ESPBTDeviceListener
 )
 
 
@@ -31,6 +31,7 @@ def _validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("ble_rssi"),
     sensor.sensor_schema(
         BLERSSISensor,
         unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
@@ -42,14 +43,14 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_IRK): cv.uuid,
-            cv.Optional(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
+            cv.Optional(CONF_SERVICE_UUID): ble_device_base.bt_uuid,
             cv.Optional(CONF_IBEACON_MAJOR): cv.uint16_t,
             cv.Optional(CONF_IBEACON_MINOR): cv.uint16_t,
-            cv.Optional(CONF_IBEACON_UUID): esp32_ble_tracker.bt_uuid,
+            cv.Optional(CONF_IBEACON_UUID): ble_device_base.bt_uuid,
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA),
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
     cv.has_exactly_one_key(
         CONF_MAC_ADDRESS, CONF_IRK, CONF_SERVICE_UUID, CONF_IBEACON_UUID
     ),
@@ -60,26 +61,21 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     if mac_address := config.get(CONF_MAC_ADDRESS):
         cg.add(var.set_address(mac_address.as_hex))
 
     if irk := config.get(CONF_IRK):
-        irk = esp32_ble_tracker.as_hex_array(str(irk))
+        ble_device_base.request_irk_support()
+        irk = ble_device_base.as_hex_array(str(irk))
         cg.add(var.set_irk(irk))
 
     if service_uuid := config.get(CONF_SERVICE_UUID):
-        if len(service_uuid) == len(esp32_ble_tracker.bt_uuid16_format):
-            cg.add(var.set_service_uuid16(esp32_ble_tracker.as_hex(service_uuid)))
-        elif len(service_uuid) == len(esp32_ble_tracker.bt_uuid32_format):
-            cg.add(var.set_service_uuid32(esp32_ble_tracker.as_hex(service_uuid)))
-        elif len(service_uuid) == len(esp32_ble_tracker.bt_uuid128_format):
-            uuid128 = esp32_ble_tracker.as_reversed_hex_array(service_uuid)
-            cg.add(var.set_service_uuid128(uuid128))
+        ble_device_base.add_service_uuid(var, service_uuid)
 
     if ibeacon_uuid := config.get(CONF_IBEACON_UUID):
-        ibeacon_uuid = esp32_ble_tracker.as_reversed_hex_array(ibeacon_uuid)
+        ibeacon_uuid = ble_device_base.as_reversed_hex_array(ibeacon_uuid)
         cg.add(var.set_ibeacon_uuid(ibeacon_uuid))
 
         if (ibeacon_major := config.get(CONF_IBEACON_MAJOR)) is not None:

--- a/esphome/components/ble_scanner/ble_scanner.cpp
+++ b/esphome/components/ble_scanner/ble_scanner.cpp
@@ -1,8 +1,6 @@
 #include "ble_scanner.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::ble_scanner {
 
 static const char *const TAG = "ble_scanner";
@@ -10,5 +8,3 @@ static const char *const TAG = "ble_scanner";
 void BLEScanner::dump_config() { LOG_TEXT_SENSOR("", "BLE Scanner", this); }
 
 }  // namespace esphome::ble_scanner
-
-#endif

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -7,18 +7,18 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/string_ref.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-#ifdef USE_ESP32
-
+// No platform #ifdef: ble_device_base provides the BLE types on every platform,
+// and this component is only compiled when configured — which requires a BLE
+// hub — so it builds on any platform with a BLEHub tracker without a per-chip
+// guard.
 namespace esphome::ble_scanner {
 
-class BLEScanner final : public text_sensor::TextSensor,
-                         public esp32_ble_tracker::ESPBTDeviceListener,
-                         public Component {
+class BLEScanner final : public text_sensor::TextSensor, public ble_device_base::ESPBTDeviceListener, public Component {
  public:
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override {
     char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
     // Escape special characters in the device name for valid JSON. Control characters stay in the \u00XX form this
     // sensor has always published.
@@ -35,5 +35,3 @@ class BLEScanner final : public text_sensor::TextSensor,
 };
 
 }  // namespace esphome::ble_scanner
-
-#endif

--- a/esphome/components/ble_scanner/text_sensor.py
+++ b/esphome/components/ble_scanner/text_sensor.py
@@ -1,25 +1,26 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, text_sensor
+from esphome.components import ble_device_base, text_sensor
 import esphome.config_validation as cv
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 ble_scanner_ns = cg.esphome_ns.namespace("ble_scanner")
 BLEScanner = ble_scanner_ns.class_(
     "BLEScanner",
     text_sensor.TextSensor,
     cg.Component,
-    esp32_ble_tracker.ESPBTDeviceListener,
+    ble_device_base.ESPBTDeviceListener,
 )
 
 CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("ble_scanner"),
     text_sensor.text_sensor_schema(BLEScanner)
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = await text_sensor.new_text_sensor(config)
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)

--- a/tests/components/ble_presence/common-ln.yaml
+++ b/tests/components/ble_presence/common-ln.yaml
@@ -1,0 +1,4 @@
+binary_sensor:
+  - platform: ble_presence
+    mac_address: 11:22:33:44:55:66
+    name: BLE Test Presence

--- a/tests/components/ble_presence/common.yaml
+++ b/tests/components/ble_presence/common.yaml
@@ -1,7 +1,10 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
 binary_sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: ble_presence
+    ble_hub_id: ble_tracker_hub
     mac_address: AC:37:43:77:5F:4C
     name: ESP32 BLE Tracker Google Home Mini
   - platform: ble_presence

--- a/tests/components/ble_presence/test.ln882x-ard.yaml
+++ b/tests/components/ble_presence/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  ble_presence: !include common-ln.yaml

--- a/tests/components/ble_presence/validate.bk72xx-ard.yaml
+++ b/tests/components/ble_presence/validate.bk72xx-ard.yaml
@@ -1,0 +1,14 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_hub
+
+binary_sensor:
+  - platform: ble_presence
+    ble_hub_id: ble_hub
+    mac_address: AC:37:43:77:5F:4C
+    name: BK BLE Presence
+  - platform: ble_presence
+    irk: 1234567890abcdef1234567890abcdef
+    name: BK BLE Presence IRK

--- a/tests/components/ble_rssi/common-ln.yaml
+++ b/tests/components/ble_rssi/common-ln.yaml
@@ -1,0 +1,5 @@
+sensor:
+  - platform: ble_rssi
+    # irk: is the only thing that emits USE_BLE_DEVICE_IRK off ESP32
+    irk: 1234567890abcdef1234567890abcdef
+    name: BLE Test RSSI

--- a/tests/components/ble_rssi/common.yaml
+++ b/tests/components/ble_rssi/common.yaml
@@ -17,7 +17,9 @@ sensor:
     service_uuid: 11223344-5566-7788-99aa-bbccddeeff00
     name: BLE Test Service 128
   - platform: ble_rssi
-    service_uuid: 11223344-5566-7788-99aa-bbccddeeff00
+    ibeacon_uuid: 11223344-5566-7788-99aa-bbccddeeff00
+    ibeacon_major: 100
+    ibeacon_minor: 1
     name: BLE Test iBeacon UUID
   - platform: ble_rssi
     irk: 1234567890abcdef1234567890abcdef

--- a/tests/components/ble_rssi/common.yaml
+++ b/tests/components/ble_rssi/common.yaml
@@ -1,7 +1,10 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
 sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: ble_rssi
+    ble_hub_id: ble_tracker_hub
     mac_address: AC:37:43:77:5F:4C
     name: BLE Google Home Mini RSSI value
   - platform: ble_rssi

--- a/tests/components/ble_rssi/test.ln882x-ard.yaml
+++ b/tests/components/ble_rssi/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  ble_rssi: !include common-ln.yaml

--- a/tests/components/ble_rssi/validate-legacy-key.esp32-idf.yaml
+++ b/tests/components/ble_rssi/validate-legacy-key.esp32-idf.yaml
@@ -1,0 +1,11 @@
+# Config-only: pins the esp32_ble_id: -> ble_hub_id: deprecation alias — the
+# legacy key must keep validating (with a rename warning) until its removal
+# release (2027.2.0).
+esp32_ble_tracker:
+  id: legacy_tracker
+
+sensor:
+  - platform: ble_rssi
+    esp32_ble_id: legacy_tracker
+    mac_address: AC:37:43:77:5F:4C
+    name: Legacy Key RSSI

--- a/tests/components/ble_rssi/validate.bk72xx-ard.yaml
+++ b/tests/components/ble_rssi/validate.bk72xx-ard.yaml
@@ -1,0 +1,14 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_hub
+
+sensor:
+  - platform: ble_rssi
+    ble_hub_id: ble_hub
+    mac_address: AC:37:43:77:5F:4C
+    name: BK BLE RSSI
+  - platform: ble_rssi
+    irk: 1234567890abcdef1234567890abcdef
+    name: BK BLE RSSI IRK

--- a/tests/components/ble_scanner/common-ln.yaml
+++ b/tests/components/ble_scanner/common-ln.yaml
@@ -1,0 +1,3 @@
+text_sensor:
+  - platform: ble_scanner
+    name: BLE Test Scanner

--- a/tests/components/ble_scanner/common.yaml
+++ b/tests/components/ble_scanner/common.yaml
@@ -1,5 +1,8 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
 text_sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: ble_scanner
+    ble_hub_id: ble_tracker_hub
     name: Scanner

--- a/tests/components/ble_scanner/common.yaml
+++ b/tests/components/ble_scanner/common.yaml
@@ -6,3 +6,6 @@ text_sensor:
   - platform: ble_scanner
     ble_hub_id: ble_tracker_hub
     name: Scanner
+  # No ble_hub_id: exercises the generated binding _require_hub guards.
+  - platform: ble_scanner
+    name: Scanner Implicit

--- a/tests/components/ble_scanner/common.yaml
+++ b/tests/components/ble_scanner/common.yaml
@@ -6,6 +6,3 @@ text_sensor:
   - platform: ble_scanner
     ble_hub_id: ble_tracker_hub
     name: Scanner
-  # No ble_hub_id: exercises the generated binding _require_hub guards.
-  - platform: ble_scanner
-    name: Scanner Implicit

--- a/tests/components/ble_scanner/test.ln882x-ard.yaml
+++ b/tests/components/ble_scanner/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  ble_scanner: !include common-ln.yaml

--- a/tests/components/ble_scanner/validate.bk72xx-ard.yaml
+++ b/tests/components/ble_scanner/validate.bk72xx-ard.yaml
@@ -1,0 +1,10 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_hub
+
+text_sensor:
+  - platform: ble_scanner
+    ble_hub_id: ble_hub
+    name: BK Scanner

--- a/tests/components/ble_scanner/validate.bk72xx-ard.yaml
+++ b/tests/components/ble_scanner/validate.bk72xx-ard.yaml
@@ -8,3 +8,6 @@ text_sensor:
   - platform: ble_scanner
     ble_hub_id: ble_hub
     name: BK Scanner
+  # No ble_hub_id: exercises the generated binding _require_hub guards.
+  - platform: ble_scanner
+    name: BK Scanner Implicit

--- a/tests/components/ln882h_ble_tracker/common.yaml
+++ b/tests/components/ln882h_ble_tracker/common.yaml
@@ -14,10 +14,3 @@ wifi:
 
 ota:
   - platform: esphome
-
-# A migrated BLE sensor so CI compiles the tracker's listener dispatch path
-# (ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT sized to a real listener).
-sensor:
-  - platform: ble_rssi
-    mac_address: 11:22:33:44:55:66
-    name: BLE Test RSSI

--- a/tests/components/ln882h_ble_tracker/common.yaml
+++ b/tests/components/ln882h_ble_tracker/common.yaml
@@ -14,3 +14,10 @@ wifi:
 
 ota:
   - platform: esphome
+
+# A migrated BLE sensor so CI compiles the tracker's listener dispatch path
+# (ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT sized to a real listener).
+sensor:
+  - platform: ble_rssi
+    mac_address: 11:22:33:44:55:66
+    name: BLE Test RSSI


### PR DESCRIPTION
# What does this implement/fix?

Migrates advertisement-based BLE consumers onto the platform-neutral `ble_device_base` layer introduced in #17150 — the follow-up jesserockz pre-blessed in https://github.com/orgs/esphome/discussions/3758 ("it's fine to touch all of the sensors in follow-up PRs to allow them to use the generic base").

Per review direction, the migration is split into batches of up to 3 similar platforms, submitted serially — **one PR open at a time**. This PR is **batch 1 of 13**.

## What migrates in this batch

The three generic listener platforms (no per-vendor parsing): **`ble_presence`**, **`ble_rssi`**, **`ble_scanner`** and their fixtures. The shared enablers (hub provider registry, `BLE_DEVICE_SCHEMA`, `rename_legacy_hub_id`, `add_service_uuid`, deprecation markers, iBeacon prefix check) were lifted into #18081 per review, now merged — this PR carries only the platform migrations and its diff is against dev.

Uniform per-component recipe (identical in every batch):

- python: `DEPENDENCIES ["esp32_ble_tracker"]` → `AUTO_LOAD ["ble_device_base"]`; schema extends the neutral binding (`ble_device_base.BLE_DEVICE_SCHEMA`, so an explicit `ble_hub_id:` is a declared key even on strict schemas); registration via `ble_device_base.register_ble_device`; helpers (`bt_uuid`, `as_hex*`, format constants) from `ble_device_base`
- C++: `esp32_ble_tracker::` types → `ble_device_base::`; include the neutral header; `USE_ESP32` guards dropped (the components are now platform-neutral)
- sensors with `irk:` call `request_irk_support()` so IRK resolution is compiled only when used

After each batch, its platforms work on **any chip with a `BLEHub` tracker** — esp32 today, the LibreTiny trackers (#16691 LN882H, the merged #17135 BK72xx) as they land.

## Batch roadmap (next opens when this merges)

| Batch | Where | Platforms |
|---|---|---|
| 1 | #17716 (open for review) | `ble_presence`, `ble_rssi`, `ble_scanner` + shared `ble_device_base` enablers |
| 2 | #17950 (draft, queued) | `atc_mithermometer`, `pvvx_mithermometer`, `bthome_mithermometer` |
| 3 | #17951 (draft, queued) | `mopeka_ble`, `mopeka_pro_check`, `mopeka_std_check` |
| 4 | branch [`ble-sensors-batch4`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch4) | `ruuvi_ble`, `ruuvitag`, `b_parasite` |
| 5 | branch [`ble-sensors-batch5`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch5) | `airthings_ble`, `inkbird_ibsth1_mini`, `radon_eye_ble` |
| 6 | branch [`ble-sensors-batch6`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch6) | `thermopro_ble`, `exposure_notifications`, `xiaomi_ble` (shared hub; portable AES-CCM) |
| 7 | branch [`ble-sensors-batch7`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch7) | `xiaomi_cgd1`, `xiaomi_cgdk2`, `xiaomi_cgg1` |
| 8 | branch [`ble-sensors-batch8`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch8) | `xiaomi_cgpr1`, `xiaomi_gcls002`, `xiaomi_hhccjcy01` |
| 9 | branch [`ble-sensors-batch9`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch9) | `xiaomi_hhccjcy10`, `xiaomi_hhccpot002`, `xiaomi_jqjcy01ym` |
| 10 | branch [`ble-sensors-batch10`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch10) | `xiaomi_lywsd02`, `xiaomi_lywsd02mmc`, `xiaomi_lywsd03mmc` |
| 11 | branch [`ble-sensors-batch11`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch11) | `xiaomi_lywsdcgq`, `xiaomi_mhoc303`, `xiaomi_mhoc401` |
| 12 | branch [`ble-sensors-batch12`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch12) | `xiaomi_miscale`, `xiaomi_mjyd02yla`, `xiaomi_mue4094rt` |
| 13 | branch [`ble-sensors-batch13`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch13) | `xiaomi_rtcgq02lm`, `xiaomi_wx08zm`, `xiaomi_xmwsdj04mmc` |

Batches 2+ extend `ble_device_base.BLE_DEVICE_SCHEMA`, introduced here — their queued drafts show red CI until this PR merges and they rebase, which is expected for a serial series. Each batch is a single commit cut from the same validated full-migration tree, so the series is complete by construction (batch 1 + batches 2–13 = all 39 platforms). A batch PR flips from draft to ready only when the previous one merges — one PR open for review at a time per the direction on #17716.


## Breaking changes and migration

The auto-generated per-sensor tracker reference `esp32_ble_id:` becomes `ble_hub_id:` on the migrated platforms. An esp32-named key cannot survive on platform-neutral sensors (#3758: "non esp32 platforms should not be adding an esp32 component, even if it is just by name").

Most configurations are unaffected: the key is auto-generated and only written explicitly to disambiguate multiple trackers. Configurations that do set it rename the key:

```yaml
# before
sensor:
  - platform: ble_rssi
    esp32_ble_id: my_tracker
    mac_address: AC:37:43:77:5F:4C
    name: "BLE Google Home Mini RSSI value"

# after
sensor:
  - platform: ble_rssi
    ble_hub_id: my_tracker
    mac_address: AC:37:43:77:5F:4C
    name: "BLE Google Home Mini RSSI value"
```

A transitional alias (`ble_device_base.rename_legacy_hub_id`, built on `cv.rename_key`) warns and auto-migrates an explicit `esp32_ble_id:` until 2027.2.0, so existing configurations keep validating through the rename window.

## Tests

- The esp32 component tests now set an explicit `ble_hub_id:` on one entry per platform, pinning the neutral binding as a declared key (the binding defect fixed earlier in this PR existed precisely because no fixture set it). All other entries are unchanged and validate the no-YAML-change claim.
- New config-only `validate.bk72xx-ard.yaml` fixtures run all three platforms against `bk72xx_ble_tracker`, locking the cross-platform claim into CI (config-only because the CI base board generic-bk7252 is BLE 4.2 and cannot compile the BLE 5.x tracker).
- The missing-tracker diagnostics (actionable error naming the current platform's tracker, provider registry, enforcement test) live in #18081 (merged).
- #16691 landed first, so this PR adds a `ble_rssi` sensor to `tests/components/ln882h_ble_tracker/common.yaml` — the LN hub's listener dispatch path is compiled in CI with a real bound listener.
- **Hardware-validated in production**: this migration ran for weeks on ESP32 (tracker + proxy + presence/RSSI/scanner), and on LN882H + BK72xx devices via the tracker PRs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Design discussion: https://github.com/esphome/esphome/discussions/3758

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6859
- esphome/esphome.io#7024

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#164

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: ble_rssi
    mac_address: AC:37:43:77:5F:4C
    name: "BLE Google Home Mini RSSI value"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).







