### PR TITLE
[mistral_ir] Add climate component for Mistral MHFE1126A IR AC units

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -341,6 +341,7 @@ esphome/components/midea_ir/* @dudanov
 esphome/components/mipi_dsi/* @clydebarrow
 esphome/components/mipi_rgb/* @clydebarrow
 esphome/components/mipi_spi/* @clydebarrow
+esphome/components/mistral_ir/* @lerhum
 esphome/components/mitsubishi/* @RubyBailey
 esphome/components/mitsubishi_cn105/* @crnjan
 esphome/components/mixer/speaker/* @kahrendt

--- a/esphome/components/mistral_ir/climate.py
+++ b/esphome/components/mistral_ir/climate.py
@@ -1,0 +1,14 @@
+import esphome.codegen as cg
+from esphome.components import climate_ir
+
+AUTO_LOAD = ["climate_ir"]
+CODEOWNERS = ["@lerhum"]
+
+mistral_ir_ns = cg.esphome_ns.namespace("mistral_ir")
+MistralIR = mistral_ir_ns.class_("MistralIR", climate_ir.ClimateIR)
+
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MistralIR)
+
+
+async def to_code(config):
+    await climate_ir.new_climate_ir(config)

--- a/esphome/components/mistral_ir/mistral_ir.cpp
+++ b/esphome/components/mistral_ir/mistral_ir.cpp
@@ -6,8 +6,6 @@ namespace esphome::mistral_ir {
 
 static const char *const TAG = "mistral_ir.climate";
 
-constexpr uint16_t MISTRAL_ADDRESS = 0x322C;
-
 constexpr uint8_t MISTRAL_MODE_COOL = 0xC0;
 constexpr uint8_t MISTRAL_MODE_DRY = 0x40;
 constexpr uint8_t MISTRAL_MODE_FAN_ONLY = 0x80;
@@ -48,11 +46,19 @@ static uint8_t temperature_to_byte(uint8_t temp_celsius) {
 
 static uint8_t byte_to_temperature(uint8_t byte5) { return static_cast<uint8_t>(0x9F - bit_reverse(byte5)); }
 
-static uint8_t compute_checksum(const std::array<uint8_t, 12> &frame) {
+static uint8_t compute_checksum(const std::vector<uint8_t> &frame) {
   uint8_t sum = 0;
   for (uint8_t idx : {1, 3, 4, 5, 6, 8})
     sum += bit_reverse(frame[idx]);
   return bit_reverse(sum);
+}
+
+// Validates the fixed bytes and checksum of a received frame, to reject corrupted or unrelated
+// AEHA frames that happen to share the Mistral address and length before acting on their contents.
+static bool is_valid_frame(const std::vector<uint8_t> &frame) {
+  return frame[0] == MISTRAL_HEADER && frame[2] == MISTRAL_BYTE2 && frame[7] == MISTRAL_BYTE7 &&
+         frame[8] == MISTRAL_BYTE8 && frame[9] == MISTRAL_BYTE9 && frame[10] == MISTRAL_BYTE10 &&
+         frame[11] == compute_checksum(frame);
 }
 
 void MistralIR::transmit_state() {
@@ -99,14 +105,22 @@ void MistralIR::transmit_state() {
   const uint8_t power_byte = this->mode == climate::CLIMATE_MODE_OFF ? MISTRAL_POWER_OFF : MISTRAL_POWER_ON;
   const uint8_t temp = static_cast<uint8_t>(clamp<float>(this->target_temperature, MISTRAL_TEMP_MIN, MISTRAL_TEMP_MAX));
 
-  std::array<uint8_t, 12> frame = {
-      MISTRAL_HEADER, fan_byte1,     MISTRAL_BYTE2, power_byte,    mode_byte,      temperature_to_byte(temp),
-      fan_byte6,      MISTRAL_BYTE7, MISTRAL_BYTE8, MISTRAL_BYTE9, MISTRAL_BYTE10, 0x00};
+  std::vector<uint8_t> &frame = this->frame_.data;
+  frame[0] = MISTRAL_HEADER;
+  frame[1] = fan_byte1;
+  frame[2] = MISTRAL_BYTE2;
+  frame[3] = power_byte;
+  frame[4] = mode_byte;
+  frame[5] = temperature_to_byte(temp);
+  frame[6] = fan_byte6;
+  frame[7] = MISTRAL_BYTE7;
+  frame[8] = MISTRAL_BYTE8;
+  frame[9] = MISTRAL_BYTE9;
+  frame[10] = MISTRAL_BYTE10;
   frame[11] = compute_checksum(frame);
 
   auto transmit = this->transmitter_->transmit();
-  remote_base::AEHAProtocol().encode(transmit.get_data(),
-                                     {MISTRAL_ADDRESS, std::vector<uint8_t>(frame.begin(), frame.end())});
+  remote_base::AEHAProtocol().encode(transmit.get_data(), this->frame_);
   transmit.perform();
 }
 
@@ -116,6 +130,9 @@ bool MistralIR::on_receive(remote_base::RemoteReceiveData data) {
     return false;
 
   const std::vector<uint8_t> &frame = aeha->data;
+  if (!is_valid_frame(frame))
+    return false;
+
   if (frame[3] == MISTRAL_POWER_OFF) {
     this->mode = climate::CLIMATE_MODE_OFF;
     this->publish_state();
@@ -135,12 +152,14 @@ bool MistralIR::on_receive(remote_base::RemoteReceiveData data) {
     case MISTRAL_MODE_HEAT:
       this->mode = climate::CLIMATE_MODE_HEAT;
       break;
-    default:
+    case MISTRAL_MODE_AUTO:
       this->mode = climate::CLIMATE_MODE_HEAT_COOL;
       break;
+    default:
+      return false;
   }
 
-  this->target_temperature = byte_to_temperature(frame[5]);
+  this->target_temperature = clamp<float>(byte_to_temperature(frame[5]), MISTRAL_TEMP_MIN, MISTRAL_TEMP_MAX);
 
   switch (frame[6]) {
     case MISTRAL_FAN_LOW_B6:
@@ -152,9 +171,11 @@ bool MistralIR::on_receive(remote_base::RemoteReceiveData data) {
     case MISTRAL_FAN_HIGH_B6:
       this->fan_mode = climate::CLIMATE_FAN_HIGH;
       break;
-    default:
+    case MISTRAL_FAN_AUTO_B6:
       this->fan_mode = climate::CLIMATE_FAN_AUTO;
       break;
+    default:
+      return false;
   }
 
   ESP_LOGV(TAG, "Received Mistral frame: mode=%d temp=%.0f fan=%d", static_cast<int>(this->mode),

--- a/esphome/components/mistral_ir/mistral_ir.cpp
+++ b/esphome/components/mistral_ir/mistral_ir.cpp
@@ -1,0 +1,166 @@
+#include "mistral_ir.h"
+#include "esphome/components/remote_base/aeha_protocol.h"
+#include "esphome/core/log.h"
+
+namespace esphome::mistral_ir {
+
+static const char *const TAG = "mistral_ir.climate";
+
+constexpr uint16_t MISTRAL_ADDRESS = 0x322C;
+
+constexpr uint8_t MISTRAL_MODE_COOL = 0xC0;
+constexpr uint8_t MISTRAL_MODE_DRY = 0x40;
+constexpr uint8_t MISTRAL_MODE_FAN_ONLY = 0x80;
+constexpr uint8_t MISTRAL_MODE_HEAT = 0x60;
+constexpr uint8_t MISTRAL_MODE_AUTO = 0x10;
+
+constexpr uint8_t MISTRAL_POWER_ON = 0x20;
+constexpr uint8_t MISTRAL_POWER_OFF = 0x00;
+
+constexpr uint8_t MISTRAL_FAN_LOW_B1 = 0x44;
+constexpr uint8_t MISTRAL_FAN_LOW_B6 = 0x40;
+constexpr uint8_t MISTRAL_FAN_MEDIUM_B1 = 0x24;
+constexpr uint8_t MISTRAL_FAN_MEDIUM_B6 = 0xC0;
+constexpr uint8_t MISTRAL_FAN_HIGH_B1 = 0xA4;
+constexpr uint8_t MISTRAL_FAN_HIGH_B6 = 0xA0;
+constexpr uint8_t MISTRAL_FAN_AUTO_B1 = 0xA4;
+constexpr uint8_t MISTRAL_FAN_AUTO_B6 = 0x00;
+
+// Fixed bytes present in every frame regardless of state.
+constexpr uint8_t MISTRAL_HEADER = 0x56;
+constexpr uint8_t MISTRAL_BYTE2 = 0x08;
+constexpr uint8_t MISTRAL_BYTE7 = 0x00;
+constexpr uint8_t MISTRAL_BYTE8 = 0xE8;
+constexpr uint8_t MISTRAL_BYTE9 = 0x00;
+constexpr uint8_t MISTRAL_BYTE10 = 0x60;
+
+// The checksum (and the temperature encoding) operate on bit-reversed byte values.
+static uint8_t bit_reverse(uint8_t b) {
+  uint8_t result = 0;
+  for (uint8_t i = 0; i < 8; i++)
+    result |= ((b >> i) & 1) << (7 - i);
+  return result;
+}
+
+static uint8_t temperature_to_byte(uint8_t temp_celsius) {
+  return bit_reverse(static_cast<uint8_t>(0x9F - temp_celsius));
+}
+
+static uint8_t byte_to_temperature(uint8_t byte5) { return static_cast<uint8_t>(0x9F - bit_reverse(byte5)); }
+
+static uint8_t compute_checksum(const std::array<uint8_t, 12> &frame) {
+  uint8_t sum = 0;
+  for (uint8_t idx : {1, 3, 4, 5, 6, 8})
+    sum += bit_reverse(frame[idx]);
+  return bit_reverse(sum);
+}
+
+void MistralIR::transmit_state() {
+  uint8_t mode_byte;
+  switch (this->mode) {
+    case climate::CLIMATE_MODE_COOL:
+      mode_byte = MISTRAL_MODE_COOL;
+      break;
+    case climate::CLIMATE_MODE_DRY:
+      mode_byte = MISTRAL_MODE_DRY;
+      break;
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      mode_byte = MISTRAL_MODE_FAN_ONLY;
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      mode_byte = MISTRAL_MODE_HEAT;
+      break;
+    default:
+      mode_byte = MISTRAL_MODE_AUTO;
+      break;
+  }
+
+  uint8_t fan_byte1;
+  uint8_t fan_byte6;
+  switch (this->fan_mode.value_or(climate::CLIMATE_FAN_AUTO)) {
+    case climate::CLIMATE_FAN_LOW:
+      fan_byte1 = MISTRAL_FAN_LOW_B1;
+      fan_byte6 = MISTRAL_FAN_LOW_B6;
+      break;
+    case climate::CLIMATE_FAN_MEDIUM:
+      fan_byte1 = MISTRAL_FAN_MEDIUM_B1;
+      fan_byte6 = MISTRAL_FAN_MEDIUM_B6;
+      break;
+    case climate::CLIMATE_FAN_HIGH:
+      fan_byte1 = MISTRAL_FAN_HIGH_B1;
+      fan_byte6 = MISTRAL_FAN_HIGH_B6;
+      break;
+    default:
+      fan_byte1 = MISTRAL_FAN_AUTO_B1;
+      fan_byte6 = MISTRAL_FAN_AUTO_B6;
+      break;
+  }
+
+  const uint8_t power_byte = this->mode == climate::CLIMATE_MODE_OFF ? MISTRAL_POWER_OFF : MISTRAL_POWER_ON;
+  const uint8_t temp = static_cast<uint8_t>(clamp<float>(this->target_temperature, MISTRAL_TEMP_MIN, MISTRAL_TEMP_MAX));
+
+  std::array<uint8_t, 12> frame = {
+      MISTRAL_HEADER, fan_byte1,     MISTRAL_BYTE2, power_byte,    mode_byte,      temperature_to_byte(temp),
+      fan_byte6,      MISTRAL_BYTE7, MISTRAL_BYTE8, MISTRAL_BYTE9, MISTRAL_BYTE10, 0x00};
+  frame[11] = compute_checksum(frame);
+
+  auto transmit = this->transmitter_->transmit();
+  remote_base::AEHAProtocol().encode(transmit.get_data(),
+                                     {MISTRAL_ADDRESS, std::vector<uint8_t>(frame.begin(), frame.end())});
+  transmit.perform();
+}
+
+bool MistralIR::on_receive(remote_base::RemoteReceiveData data) {
+  auto aeha = remote_base::AEHAProtocol().decode(data);
+  if (!aeha.has_value() || aeha->address != MISTRAL_ADDRESS || aeha->data.size() != 12)
+    return false;
+
+  const std::vector<uint8_t> &frame = aeha->data;
+  if (frame[3] == MISTRAL_POWER_OFF) {
+    this->mode = climate::CLIMATE_MODE_OFF;
+    this->publish_state();
+    return true;
+  }
+
+  switch (frame[4]) {
+    case MISTRAL_MODE_COOL:
+      this->mode = climate::CLIMATE_MODE_COOL;
+      break;
+    case MISTRAL_MODE_DRY:
+      this->mode = climate::CLIMATE_MODE_DRY;
+      break;
+    case MISTRAL_MODE_FAN_ONLY:
+      this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+      break;
+    case MISTRAL_MODE_HEAT:
+      this->mode = climate::CLIMATE_MODE_HEAT;
+      break;
+    default:
+      this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+      break;
+  }
+
+  this->target_temperature = byte_to_temperature(frame[5]);
+
+  switch (frame[6]) {
+    case MISTRAL_FAN_LOW_B6:
+      this->fan_mode = climate::CLIMATE_FAN_LOW;
+      break;
+    case MISTRAL_FAN_MEDIUM_B6:
+      this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+      break;
+    case MISTRAL_FAN_HIGH_B6:
+      this->fan_mode = climate::CLIMATE_FAN_HIGH;
+      break;
+    default:
+      this->fan_mode = climate::CLIMATE_FAN_AUTO;
+      break;
+  }
+
+  ESP_LOGV(TAG, "Received Mistral frame: mode=%d temp=%.0f fan=%d", static_cast<int>(this->mode),
+           this->target_temperature, static_cast<int>(this->fan_mode.value_or(climate::CLIMATE_FAN_AUTO)));
+  this->publish_state();
+  return true;
+}
+
+}  // namespace esphome::mistral_ir

--- a/esphome/components/mistral_ir/mistral_ir.h
+++ b/esphome/components/mistral_ir/mistral_ir.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include "esphome/components/climate_ir/climate_ir.h"
+#include "esphome/components/remote_base/aeha_protocol.h"
 
 namespace esphome::mistral_ir {
 
 // Temperature range, Celsius
 constexpr uint8_t MISTRAL_TEMP_MIN = 16;
 constexpr uint8_t MISTRAL_TEMP_MAX = 30;
+
+constexpr uint16_t MISTRAL_ADDRESS = 0x322C;
 
 /* Reverse-engineered protocol for a "Mistral" (Belgian brand, model MHFE1126A / MR112C) split AC unit
    from the 2000-2010 era, likely a rebadged OEM design. It is carried over AEHA IR timing (address
@@ -30,6 +33,10 @@ class MistralIR : public climate_ir::ClimateIR {
  protected:
   void transmit_state() override;
   bool on_receive(remote_base::RemoteReceiveData data) override;
+
+  // Reused across transmit_state() calls to avoid a heap allocation on every send; the address and the
+  // 12-byte data buffer size never change, only the byte contents are overwritten in place.
+  remote_base::AEHAData frame_{MISTRAL_ADDRESS, std::vector<uint8_t>(12)};
 };
 
 }  // namespace esphome::mistral_ir

--- a/esphome/components/mistral_ir/mistral_ir.h
+++ b/esphome/components/mistral_ir/mistral_ir.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/components/climate_ir/climate_ir.h"
+
+namespace esphome::mistral_ir {
+
+// Temperature range, Celsius
+constexpr uint8_t MISTRAL_TEMP_MIN = 16;
+constexpr uint8_t MISTRAL_TEMP_MAX = 30;
+
+/* Reverse-engineered protocol for a "Mistral" (Belgian brand, model MHFE1126A / MR112C) split AC unit
+   from the 2000-2010 era, likely a rebadged OEM design. It is carried over AEHA IR timing (address
+   0x322C) but does not match any protocol already implemented in ESPHome, so it is decoded/encoded
+   directly here rather than through the generic AEHA helper.
+
+   Frame layout (12 bytes): 56 xx 08 xx xx xx xx 00 E8 00 60 xx
+     byte[1] / byte[6] -- fan speed (paired with byte[0]/byte[2]/byte[7]/byte[8]/byte[10], all fixed)
+     byte[3]           -- power: 0x20 on, 0x00 off
+     byte[4]           -- mode
+     byte[5]           -- target temperature (bit-reversed offset from 0x9F)
+     byte[11]          -- checksum: bit-reverse the sum of bit-reversed bytes 1, 3, 4, 5, 6, 8
+*/
+class MistralIR : public climate_ir::ClimateIR {
+ public:
+  MistralIR()
+      : climate_ir::ClimateIR(MISTRAL_TEMP_MIN, MISTRAL_TEMP_MAX, 1.0f, true, true,
+                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
+                               climate::CLIMATE_FAN_HIGH}) {}
+
+ protected:
+  void transmit_state() override;
+  bool on_receive(remote_base::RemoteReceiveData data) override;
+};
+
+}  // namespace esphome::mistral_ir

--- a/tests/components/mistral_ir/common.yaml
+++ b/tests/components/mistral_ir/common.yaml
@@ -1,0 +1,4 @@
+climate:
+  - platform: mistral_ir
+    name: Mistral IR
+    transmitter_id: xmitr

--- a/tests/components/mistral_ir/test.esp32-idf.yaml
+++ b/tests/components/mistral_ir/test.esp32-idf.yaml
@@ -1,0 +1,3 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+  mistral_ir: !include common.yaml

--- a/tests/components/mistral_ir/test.esp8266-ard.yaml
+++ b/tests/components/mistral_ir/test.esp8266-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+  mistral_ir: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `mistral_ir` climate component for a "Mistral" brand split AC unit (model MHFE1126A / MR112C, ~2000-2010 era, likely a rebadged OEM design) that isn't supported by any existing ESPHome climate platform.

The protocol was reverse-engineered from captured IR signals of the original remote: it uses AEHA-style timing (address `0x322C`) with a 12-byte data frame and its own checksum algorithm, distinct from the protocols already handled by the generic AEHA/Panasonic decoders in `remote_base`. Every field (mode, temperature, fan speed, power, checksum) was derived and cross-verified against a set of captured frames covering all supported modes/fan speeds and several temperatures, plus a validated checksum formula that reproduces all 12 reference samples exactly.

Supports:
- Power on/off
- Modes: cool, dry, fan-only, heat, auto
- Target temperature: 16-30°C (1° steps)
- Fan speed: low/medium/high/auto
- Optional state sync via `on_receive` when the original remote is used alongside ESPHome

Swing/vane control is not implemented — only one sample was captured for it, not enough to derive a reliable bit-level encoding.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  id: ir_transmitter
  pin: GPIO3
  carrier_duty_percent: 50%

climate:
  - platform: mistral_ir
    name: "Living Room AC"
    transmitter_id: ir_transmitter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).