### PR TITLE
[dallas_temp] filter 85 temp from sensor reset

### DIFF
--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -6,6 +6,7 @@ namespace esphome::dallas_temp {
 static const char *const TAG = "dallas.temp.sensor";
 
 static const uint8_t DALLAS_MODEL_DS18S20 = 0x10;
+static const uint8_t DALLAS_MODEL_DS18B20 = 0x28;
 static const uint8_t DALLAS_COMMAND_START_CONVERSION = 0x44;
 static const uint8_t DALLAS_COMMAND_READ_SCRATCH_PAD = 0xBE;
 static const uint8_t DALLAS_COMMAND_WRITE_SCRATCH_PAD = 0x4E;
@@ -154,7 +155,11 @@ float DallasTemperatureSensor::get_temp_c_() {
     default:
       break;
   }
-
+  // undocumented test for powerup measurement of 85
+  if ((this->address_ & 0xff) == DALLAS_MODEL_DS18B20) {
+    if ((temp == 85 * 16) && (this->scratch_pad_[6] == 0xc))
+      return NAN;
+  }
   return temp / 16.0f;
 }
 

--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -156,9 +156,12 @@ float DallasTemperatureSensor::get_temp_c_() {
       break;
   }
   // undocumented test for powerup measurement of 85
+  // https://github.com/cpetrich/counterfeit_DS18B20#solution-to-the-85-c-problem
   if ((this->address_ & 0xff) == DALLAS_MODEL_DS18B20) {
-    if ((temp == 85 * 16) && (this->scratch_pad_[6] == 0xc))
+    if ((temp == 85 * 16) && (this->scratch_pad_[6] == 0xc)) {
+      ESP_LOGD(TAG, "dropping reading caused by sensor reset");
       return NAN;
+    }
   }
   return temp / 16.0f;
 }


### PR DESCRIPTION
# What does this implement/fix?

There's an undocumented check for a temperature of 85 caused by a reboot on DS18B20.
https://github.com/cpetrich/counterfeit_DS18B20#solution-to-the-85-c-problem

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6207

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
