### PR TITLE
[daikin] Add presets with working comfort mode

### DIFF
--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -6,10 +6,11 @@ namespace esphome::daikin {
 static const char *const TAG = "daikin.climate";
 
 void DaikinClimate::transmit_state() {
-  uint8_t remote_state[35] = {0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7, 0x11, 0xDA, 0x27, 0x00,
+  uint8_t remote_state[35] = {0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0x00, 0x11, 0xDA, 0x27, 0x00,
                               0x42, 0x49, 0x05, 0xA2, 0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x00, 0x00,
                               0x00, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00};
 
+  remote_state[6] |= this->preset == climate::CLIMATE_PRESET_COMFORT ? DAIKIN_PRESET_COMFORT_ON : 0;
   remote_state[21] = this->operation_mode_();
   remote_state[22] = this->temperature_();
   uint16_t fan_speed = this->fan_speed_();
@@ -18,7 +19,10 @@ void DaikinClimate::transmit_state() {
   remote_state[29] = this->powerful_quiet_preset_();
   remote_state[32] = this->eco_preset_();
 
-  // Calculate checksum
+  // Calculate checksums
+  for (int i = 0; i < 7; i++) {
+    remote_state[7] += remote_state[i];
+  }
   for (int i = 16; i < 34; i++) {
     remote_state[34] += remote_state[i];
   }
@@ -258,7 +262,6 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
       break;
   }
 
-  this->preset = climate::CLIMATE_PRESET_NONE;
   uint8_t powerful_quiet_preset = frame[13];
   uint8_t eco_preset = frame[16];
 
@@ -271,9 +274,6 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
       break;
   }
   switch (eco_preset) {
-    case DAIKIN_PRESET_COMFORT_ON:
-      this->preset = climate::CLIMATE_PRESET_COMFORT;
-      break;
     case DAIKIN_PRESET_ECONO_ON:
       this->preset = climate::CLIMATE_PRESET_ECO;
       break;
@@ -286,12 +286,32 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
   return true;
 }
 
+bool DaikinClimate::parse_comfort_frame_(const uint8_t frame[]) {
+  uint8_t checksum = 0;
+  for (int i = 0; i < (DAIKIN_COMFORT_FRAME_SIZE - 1); i++) {
+    checksum += frame[i];
+  }
+  if (frame[DAIKIN_COMFORT_FRAME_SIZE - 1] != checksum)
+    return false;
+
+  uint8_t comfort_preset = frame[6];
+
+  this->preset = climate::CLIMATE_PRESET_NONE;
+  if (comfort_preset & DAIKIN_PRESET_COMFORT_ON) {
+    this->preset = climate::CLIMATE_PRESET_COMFORT;
+  }
+
+  return true;
+}
+
 bool DaikinClimate::on_receive(remote_base::RemoteReceiveData data) {
-  uint8_t state_frame[DAIKIN_STATE_FRAME_SIZE] = {};
+  uint8_t frame[DAIKIN_STATE_FRAME_SIZE] = {};
   if (!data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
     return false;
   }
-  for (uint8_t pos = 0; pos < DAIKIN_STATE_FRAME_SIZE; pos++) {
+
+  uint8_t frame_size = DAIKIN_STATE_FRAME_SIZE;
+  for (uint8_t pos = 0; pos < frame_size; pos++) {
     uint8_t byte = 0;
     for (int8_t bit = 0; bit < 8; bit++) {
       if (data.expect_item(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE)) {
@@ -300,7 +320,7 @@ bool DaikinClimate::on_receive(remote_base::RemoteReceiveData data) {
         return false;
       }
     }
-    state_frame[pos] = byte;
+    frame[pos] = byte;
     if (pos == 0) {
       // frame header
       if (byte != 0x11)
@@ -319,11 +339,22 @@ bool DaikinClimate::on_receive(remote_base::RemoteReceiveData data) {
         return false;
     } else if (pos == 4) {
       // frame type
-      if (byte != 0x00)
+      if (byte == 0xC5)
+        frame_size = DAIKIN_COMFORT_FRAME_SIZE;
+      else if (byte != 0x00)
         return false;
     }
   }
-  return this->parse_state_frame_(state_frame);
+
+  switch (frame[4]) {
+    case 0:
+      return this->parse_state_frame_(frame);
+    case 0xC5:
+      return this->parse_comfort_frame_(frame);
+    default:
+      return false;
+  }
+  return false;
 }
 
 }  // namespace esphome::daikin

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -15,6 +15,8 @@ void DaikinClimate::transmit_state() {
   uint16_t fan_speed = this->fan_speed_();
   remote_state[24] = fan_speed >> 8;
   remote_state[25] = fan_speed & 0xff;
+  remote_state[29] = this->powerful_quiet_preset_();
+  remote_state[32] = this->eco_preset_();
 
   // Calculate checksum
   for (int i = 16; i < 34; i++) {
@@ -141,6 +143,55 @@ uint8_t DaikinClimate::temperature_() const {
   }
 }
 
+void DaikinClimate::cancel_boost_mode_() {
+  if (this->preset == climate::CLIMATE_PRESET_BOOST) {
+    ESP_LOGD(TAG, "Turning off boost mode after timeout");
+    this->preset = climate::CLIMATE_PRESET_NONE;
+    this->publish_state();
+  }
+}
+
+uint8_t DaikinClimate::powerful_quiet_preset_() {
+  uint8_t powerful_quiet_preset = DAIKIN_PRESET_OFF;
+  if (this->preset.has_value()) {
+    if (this->preset == climate::CLIMATE_PRESET_BOOST) {
+      powerful_quiet_preset = DAIKIN_PRESET_POWERFUL_ON;
+      // Only set the timer if this is a new boost mode activation
+      if (this->boost_mode_start_ == 0) {
+        this->boost_mode_start_ = millis();
+        ESP_LOGD(TAG, "Starting boost mode timer");
+        this->set_timeout("boost_timeout", 15 * 60 * 1000, [this]() {
+          this->cancel_boost_mode_();
+          this->boost_mode_start_ = 0;
+        });
+      }
+    } else if (this->preset == climate::CLIMATE_PRESET_SLEEP) {
+      powerful_quiet_preset = DAIKIN_PRESET_QUIET_ON;
+    }
+
+    // If changing away from boost mode, clear the timer
+    if (this->preset != climate::CLIMATE_PRESET_BOOST && this->boost_mode_start_ != 0) {
+      this->boost_mode_start_ = 0;
+      this->cancel_timeout("boost_timeout");
+    }
+  }
+  return powerful_quiet_preset;
+}
+
+uint8_t DaikinClimate::eco_preset_() const {
+  uint8_t eco_preset = DAIKIN_PRESET_OFF;
+  if (this->preset.has_value()) {
+    if (this->preset == climate::CLIMATE_PRESET_ECO) {
+      eco_preset = DAIKIN_PRESET_ECONO_ON;
+    } else if (this->preset == climate::CLIMATE_PRESET_COMFORT) {
+      eco_preset = DAIKIN_PRESET_COMFORT_ON;
+    } else if (this->preset == climate::CLIMATE_PRESET_ACTIVITY) {
+      eco_preset = DAIKIN_PRESET_SENSOR_ON;
+    }
+  }
+  return eco_preset;
+}
+
 bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
   uint8_t checksum = 0;
   for (int i = 0; i < (DAIKIN_STATE_FRAME_SIZE - 1); i++) {
@@ -206,6 +257,31 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
       this->fan_mode = climate::CLIMATE_FAN_QUIET;
       break;
   }
+
+  this->preset = climate::CLIMATE_PRESET_NONE;
+  uint8_t powerful_quiet_preset = frame[13];
+  uint8_t eco_preset = frame[16];
+
+  switch (powerful_quiet_preset) {
+    case DAIKIN_PRESET_POWERFUL_ON:
+      this->preset = climate::CLIMATE_PRESET_BOOST;
+      break;
+    case DAIKIN_PRESET_QUIET_ON:
+      this->preset = climate::CLIMATE_PRESET_SLEEP;
+      break;
+  }
+  switch (eco_preset) {
+    case DAIKIN_PRESET_COMFORT_ON:
+      this->preset = climate::CLIMATE_PRESET_COMFORT;
+      break;
+    case DAIKIN_PRESET_ECONO_ON:
+      this->preset = climate::CLIMATE_PRESET_ECO;
+      break;
+    case DAIKIN_PRESET_SENSOR_ON:
+      this->preset = climate::CLIMATE_PRESET_ACTIVITY;
+      break;
+  }
+
   this->publish_state();
   return true;
 }

--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -138,8 +138,8 @@ uint8_t DaikinClimate::temperature_() const {
     case climate::CLIMATE_MODE_DRY:
       return 0xc0;
     default:
-      uint8_t temperature = (uint8_t) roundf(clamp<float>(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX));
-      return temperature << 1;
+      // Temperature is encoded as degrees * 2, supporting 0.5°C increments
+      return (uint8_t) roundf(clamp<float>(this->target_temperature, DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX) * 2.0f);
   }
 }
 

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "esphome/components/climate_ir/climate_ir.h"
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
 
 namespace esphome::daikin {
 
@@ -27,6 +29,14 @@ const uint8_t DAIKIN_FAN_3 = 0x50;
 const uint8_t DAIKIN_FAN_4 = 0x60;
 const uint8_t DAIKIN_FAN_5 = 0x70;
 
+// Presets
+const uint8_t DAIKIN_PRESET_OFF = 0x00;
+const uint8_t DAIKIN_PRESET_POWERFUL_ON = 0x01;
+const uint8_t DAIKIN_PRESET_QUIET_ON = 0x20;
+const uint8_t DAIKIN_PRESET_COMFORT_ON = 0x02;
+const uint8_t DAIKIN_PRESET_ECONO_ON = 0x04;
+const uint8_t DAIKIN_PRESET_SENSOR_ON = 0x08;
+
 // IR Transmission
 const uint32_t DAIKIN_IR_FREQUENCY = 38000;
 const uint32_t DAIKIN_HEADER_MARK = 3360;
@@ -42,11 +52,14 @@ const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
 class DaikinClimate final : public climate_ir::ClimateIR {
  public:
   DaikinClimate()
-      : climate_ir::ClimateIR(DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
-                              {climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
-                               climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
-                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
-                               climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH}) {}
+      : climate_ir::ClimateIR(
+            DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
+            {climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
+             climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL,
+             climate::CLIMATE_SWING_BOTH},
+            {climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_COMFORT,
+             climate::CLIMATE_PRESET_SLEEP, climate::CLIMATE_PRESET_ACTIVITY, climate::CLIMATE_PRESET_NONE}) {}
 
  protected:
   // Transmit via IR the state of this climate controller.
@@ -54,6 +67,10 @@ class DaikinClimate final : public climate_ir::ClimateIR {
   uint8_t operation_mode_() const;
   uint16_t fan_speed_() const;
   uint8_t temperature_() const;
+  uint8_t powerful_quiet_preset_();
+  uint8_t eco_preset_() const;
+  void cancel_boost_mode_();
+  uint32_t boost_mode_start_{0};
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_state_frame_(const uint8_t frame[]);

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -31,11 +31,11 @@ const uint8_t DAIKIN_FAN_5 = 0x70;
 
 // Presets
 const uint8_t DAIKIN_PRESET_OFF = 0x00;
+const uint8_t DAIKIN_PRESET_COMFORT_ON = 0x10;
 const uint8_t DAIKIN_PRESET_POWERFUL_ON = 0x01;
 const uint8_t DAIKIN_PRESET_QUIET_ON = 0x20;
-const uint8_t DAIKIN_PRESET_COMFORT_ON = 0x02;
 const uint8_t DAIKIN_PRESET_ECONO_ON = 0x04;
-const uint8_t DAIKIN_PRESET_SENSOR_ON = 0x08;
+const uint8_t DAIKIN_PRESET_SENSOR_ON = 0x02;
 
 // IR Transmission
 const uint32_t DAIKIN_IR_FREQUENCY = 38000;
@@ -48,6 +48,7 @@ const uint32_t DAIKIN_MESSAGE_SPACE = 32300;
 
 // State Frame size
 const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
+const uint8_t DAIKIN_COMFORT_FRAME_SIZE = 8;
 
 class DaikinClimate final : public climate_ir::ClimateIR {
  public:
@@ -74,6 +75,7 @@ class DaikinClimate final : public climate_ir::ClimateIR {
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_state_frame_(const uint8_t frame[]);
+  bool parse_comfort_frame_(const uint8_t frame[]);
 };
 
 }  // namespace esphome::daikin

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -53,7 +53,7 @@ class DaikinClimate final : public climate_ir::ClimateIR {
  public:
   DaikinClimate()
       : climate_ir::ClimateIR(
-            DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 1.0f, true, true,
+            DAIKIN_TEMP_MIN, DAIKIN_TEMP_MAX, 0.5f, true, true,
             {climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
              climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
             {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL,


### PR DESCRIPTION
# What does this implement/fix?

Adds support for 0.5 degree steps for temperature, as supported by Daikin air conditioners.
    Adds support for Daikin preset modes, previously discussed in https://github.com/esphome/esphome/pull/3606 but closed and created a new PR just for the preset modes.
Builds off of #10073 but fixes handling of comfort preset

Quiet (Sleep)
Powerful (Boost)
Comfort
Sensor (Activity)
Eco

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/1248
- fixes https://github.com/esphome/feature-requests/issues/859

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
