### PR TITLE
Implemented initial support for WiFi DPP

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -158,6 +158,7 @@ CONF_SAVE = "save"
 CONF_BAND_MODE = "band_mode"
 CONF_DPP = "dpp"
 CONF_MIN_AUTH_MODE = "min_auth_mode"
+CONF_ON_DPP_URI = "on_dpp_uri"
 CONF_PHY_MODE = "phy_mode"
 CONF_POST_CONNECT_ROAMING = "post_connect_roaming"
 
@@ -556,6 +557,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(
                 single=True
             ),
+            cv.Optional(CONF_ON_DPP_URI): automation.validate_automation(single=True),
             cv.Optional(CONF_USE_PSRAM): cv.All(
                 cv.only_on_esp32, cv.requires_component("psram"), cv.boolean
             ),
@@ -824,6 +826,12 @@ async def to_code(config):
         cg.add_define("USE_WIFI_DISCONNECT_TRIGGER")
         await automation.build_automation(
             var.get_disconnect_trigger(), [], on_disconnect_config
+        )
+
+    if on_dpp_uri_config := config.get(CONF_ON_DPP_URI):
+        cg.add_define("USE_WIFI_DPP_URI_TRIGGER")
+        await automation.build_automation(
+            var.get_dpp_uri_trigger(), [(cg.std_string, "uri")], on_dpp_uri_config
         )
 
     CORE.add_job(final_step)

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -297,7 +297,9 @@ DPP_SCHEMA = cv.Schema(
         cv.Optional(CONF_PRIVATE_KEY): cv.string_strict,
         cv.Optional(CONF_DEVICE_INFO): cv.string_strict,
         cv.Optional(CONF_CHANNELS, default="6"): cv.string_strict,
-        cv.Optional(CONF_TIMEOUT, default=DEFAULT_AP_TIMEOUT): cv.positive_time_period_milliseconds,
+        cv.Optional(
+            CONF_TIMEOUT, default=DEFAULT_AP_TIMEOUT
+        ): cv.positive_time_period_milliseconds,
     }
 )
 

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -676,6 +676,7 @@ async def to_code(config):
 
     if CONF_DPP in config:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DPP_SUPPORT", True)
+        add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_ENABLE_DPP", True)
         conf = config[CONF_DPP]
         cg.add(var.set_dpp_mode(conf[CONF_MODE]))
         if CONF_PRIVATE_KEY in conf:

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -28,6 +28,7 @@ from esphome.const import (
     CONF_CERTIFICATE,
     CONF_CERTIFICATE_AUTHORITY,
     CONF_CHANNEL,
+    CONF_CHANNELS,
     CONF_DNS1,
     CONF_DNS2,
     CONF_DOMAIN,
@@ -42,6 +43,7 @@ from esphome.const import (
     CONF_IDENTITY,
     CONF_KEY,
     CONF_MANUAL_IP,
+    CONF_MODE,
     CONF_NETWORKS,
     CONF_ON_CONNECT,
     CONF_ON_DISCONNECT,
@@ -154,6 +156,7 @@ def has_native_wifi(
 
 CONF_SAVE = "save"
 CONF_BAND_MODE = "band_mode"
+CONF_DPP = "dpp"
 CONF_MIN_AUTH_MODE = "min_auth_mode"
 CONF_PHY_MODE = "phy_mode"
 CONF_POST_CONNECT_ROAMING = "post_connect_roaming"
@@ -279,6 +282,25 @@ EAP_AUTH_SCHEMA = cv.All(
     cv.has_at_least_one_key(CONF_IDENTITY, CONF_CERTIFICATE),
 )
 
+esp_supp_dpp_bootstrap_t = cg.global_ns.enum("esp_supp_dpp_bootstrap_t")
+ESP_SUPP_DPP_BOOTSTRAP = {
+    "QR_CODE": esp_supp_dpp_bootstrap_t.DPP_BOOTSTRAP_QR_CODE,
+    "PKEX": esp_supp_dpp_bootstrap_t.DPP_BOOTSTRAP_PKEX,
+    "NFC_URI": esp_supp_dpp_bootstrap_t.DPP_BOOTSTRAP_NFC_URI,
+}
+
+CONF_PRIVATE_KEY = "private_key"
+CONF_DEVICE_INFO = "device_info"
+DPP_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_MODE): cv.enum(ESP_SUPP_DPP_BOOTSTRAP, upper=True),
+        cv.Optional(CONF_PRIVATE_KEY): cv.string_strict,
+        cv.Optional(CONF_DEVICE_INFO): cv.string_strict,
+        cv.Optional(CONF_CHANNELS, default="6"): cv.string_strict,
+        cv.Optional(CONF_TIMEOUT, default=DEFAULT_AP_TIMEOUT): cv.positive_time_period_milliseconds,
+    }
+)
+
 WIFI_NETWORK_BASE = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(WiFiAP),
@@ -346,14 +368,15 @@ def _apply_min_auth_mode_default(config):
 def final_validate(config):
     has_sta = bool(config.get(CONF_NETWORKS, True))
     has_ap = CONF_AP in config
+    has_dpp = CONF_DPP in config
     full_config = fv.full_config.get()
     has_improv = "esp32_improv" in full_config
     has_improv_serial = "improv_serial" in full_config
     has_captive_portal = "captive_portal" in full_config
     has_web_server = "web_server" in full_config
-    if not (has_sta or has_ap or has_improv or has_improv_serial):
+    if not (has_sta or has_ap or has_dpp or has_improv or has_improv_serial):
         raise cv.Invalid(
-            "Please specify at least an SSID or an Access Point to create."
+            "Please specify at least an SSID or an Access Point to create, or configure DPP (Easy Connect)."
         )
     if has_ap and not has_captive_portal and not has_web_server:
         _LOGGER.warning(
@@ -482,6 +505,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MANUAL_IP): STA_MANUAL_IP_SCHEMA,
             cv.Optional(CONF_EAP): EAP_AUTH_SCHEMA,
             cv.Optional(CONF_AP): wifi_network_ap,
+            cv.Optional(CONF_DPP): DPP_SCHEMA,
             cv.Optional(CONF_DOMAIN, default=".local"): cv.domain_name,
             cv.Optional(
                 CONF_REBOOT_TIMEOUT, default="15min"
@@ -647,6 +671,18 @@ async def to_code(config):
     # drops SoftAP support / the LWIP DHCP server when AP mode is unused.
     if CORE.is_esp32:
         request_wifi(ap=CONF_AP in config)
+
+    if CONF_DPP in config:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DPP_SUPPORT", True)
+        conf = config[CONF_DPP]
+        cg.add(var.set_dpp_mode(conf[CONF_MODE]))
+        if CONF_PRIVATE_KEY in conf:
+            cg.add(var.set_dpp_key(conf[CONF_PRIVATE_KEY]))
+        if CONF_DEVICE_INFO in conf:
+            cg.add(var.set_dpp_device_info(conf[CONF_DEVICE_INFO]))
+        cg.add(var.set_dpp_channels(conf[CONF_CHANNELS]))
+        cg.add(var.set_dpp_timeout(conf[CONF_TIMEOUT]))
+        cg.add_define("USE_WIFI_DPP")
 
     # Disable Enterprise WiFi support if no EAP is configured
     if CORE.is_esp32:

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -171,6 +171,10 @@ MAX_WIFI_NETWORKS = 127
 # before falling back to AP mode. Aligned with improv wifi_timeout default.
 DEFAULT_AP_TIMEOUT = "90s"
 
+# Similar to AP timeout, but reduced to allow repetitive enrollment attempts
+# in the case of failure. Does not affect AP or scanning.
+DEFAULT_DPP_TIMEOUT = "20s"
+
 wifi_ns = cg.esphome_ns.namespace("wifi")
 EAPAuth = wifi_ns.struct("EAPAuth")
 ManualIP = wifi_ns.struct("ManualIP")
@@ -298,7 +302,7 @@ DPP_SCHEMA = cv.Schema(
         cv.Optional(CONF_DEVICE_INFO): cv.string_strict,
         cv.Optional(CONF_CHANNELS, default="6"): cv.string_strict,
         cv.Optional(
-            CONF_TIMEOUT, default=DEFAULT_AP_TIMEOUT
+            CONF_TIMEOUT, default=DEFAULT_DPP_TIMEOUT
         ): cv.positive_time_period_milliseconds,
     }
 )

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -738,11 +738,12 @@ void WiFiComponent::start() {
   }
 #ifdef USE_WIFI_DPP
   if (!this->has_sta()) {
-    if (this->wifi_mode_(true, {})) {
-      esp_err_t err = esp_supp_dpp_start_listen();
-      if (err == ERR_OK)
-        this->dpp_listening_ = true;
-    }
+    this->wifi_mode_(true, {});
+    esp_err_t err = esp_supp_dpp_start_listen();
+    if (err != ERR_OK)
+      ESP_LOGW(TAG, "esp_supp_dpp_start_listen failed: %s", esp_err_to_name(err));
+    else
+      this->dpp_listening_ = true;
   }
 #endif
 #ifdef USE_IMPROV
@@ -876,18 +877,6 @@ void WiFiComponent::loop() {
     }
 #endif  // USE_WIFI_AP
 
-#ifdef USE_WIFI_DPP
-    if (!this->is_dpp_active_()) {
-      if (now - this->last_connected_ > this->dpp_timeout_) {
-        if (this->wifi_mode_(true, {})) {
-          esp_err_t err = esp_supp_dpp_start_listen();
-          if (err == ERR_OK)
-            this->dpp_listening_ = true;
-        }
-      }
-    }
-#endif
-
 #ifdef USE_IMPROV
     if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active() &&
         !esp32_improv::global_improv_component->should_start()) {
@@ -917,6 +906,19 @@ void WiFiComponent::loop() {
       }
     }
   }
+
+#ifdef USE_WIFI_DPP
+  if (!this->is_dpp_active_()) {
+    if (now - this->last_connected_ > this->dpp_timeout_) {
+      this->wifi_mode_(true, {});
+      esp_err_t err = esp_supp_dpp_start_listen();
+      if (err != ERR_OK)
+        ESP_LOGW(TAG, "esp_supp_dpp_start_listen failed: %s", esp_err_to_name(err));
+      else
+        this->dpp_listening_ = true;
+    }
+  }
+#endif
 
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   // Check if power save mode needs to be updated based on high-performance requests

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -804,7 +804,8 @@ void WiFiComponent::loop() {
           break;
         }
         // Use longer cooldown when DPP/captive portal/improv is active to avoid disrupting user config
-        bool portal_active = this->is_dpp_active_() || this->is_captive_portal_active_() || this->is_esp32_improv_active_();
+        bool portal_active =
+            this->is_dpp_active_() || this->is_captive_portal_active_() || this->is_esp32_improv_active_();
         uint32_t cooldown_duration = portal_active ? WIFI_COOLDOWN_WITH_AP_ACTIVE_MS : WIFI_COOLDOWN_DURATION_MS;
         if (now - this->action_started_ > cooldown_duration) {
           // After cooldown we either restarted the adapter because of
@@ -2227,10 +2228,18 @@ void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
 void WiFiComponent::set_passive_scan(bool passive) { this->passive_scan_ = passive; }
 
 #ifdef USE_WIFI_DPP
-void WiFiComponent::set_dpp_device_info(const std::string &dpp_device_info) { this->dpp_device_info_ = CompactString(dpp_device_info.c_str(), dpp_device_info.size()); }
-void WiFiComponent::set_dpp_device_info(const char *dpp_device_info) { this->dpp_device_info_ = CompactString(dpp_device_info, strlen(dpp_device_info)); }
-void WiFiComponent::set_dpp_channels(const std::string &dpp_channels) { this->dpp_channels_ = CompactString(dpp_channels.c_str(), dpp_channels.size()); }
-void WiFiComponent::set_dpp_channels(const char *dpp_channels) { this->dpp_channels_ = CompactString(dpp_channels, strlen(dpp_channels)); }
+void WiFiComponent::set_dpp_device_info(const std::string &dpp_device_info) {
+  this->dpp_device_info_ = CompactString(dpp_device_info.c_str(), dpp_device_info.size());
+}
+void WiFiComponent::set_dpp_device_info(const char *dpp_device_info) {
+  this->dpp_device_info_ = CompactString(dpp_device_info, strlen(dpp_device_info));
+}
+void WiFiComponent::set_dpp_channels(const std::string &dpp_channels) {
+  this->dpp_channels_ = CompactString(dpp_channels.c_str(), dpp_channels.size());
+}
+void WiFiComponent::set_dpp_channels(const char *dpp_channels) {
+  this->dpp_channels_ = CompactString(dpp_channels, strlen(dpp_channels));
+}
 #endif
 
 bool WiFiComponent::is_dpp_active_() {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -15,6 +15,9 @@
 
 #if defined(USE_ESP32)
 #include <esp_wifi.h>
+#ifdef USE_WIFI_DPP
+#include <esp_dpp.h>
+#endif
 #endif
 #ifdef USE_ESP8266
 #include <user_interface.h>
@@ -184,11 +187,11 @@ bool CompactString::operator==(const StringRef &other) const {
 /// │                          ↓                                           │
 /// │  5. FAILED → RESTARTING_ADAPTER                                      │
 /// │     - Normal: restart adapter, clear state                           │
-/// │     - AP/improv active: skip restart, just disconnect                │
+/// │     - AP/DPP/improv active: skip restart, just disconnect            │
 /// │                          ↓                                           │
 /// │  6. Loop back to start:                                              │
 /// │     - If first network is hidden → EXPLICIT_HIDDEN (retry cycle)     │
-/// │     - If AP/improv active → RETRY_HIDDEN (blind retry, see below)    │
+/// │     - If AP/DPP/improv active → RETRY_HIDDEN (blind retry, see below)│
 /// │     - Otherwise → SCAN_CONNECTING (rescan)                           │
 /// │                          ↓                                           │
 /// │  7. RESCAN → Apply stored priorities, sort again                     │
@@ -733,6 +736,15 @@ void WiFiComponent::start() {
 #endif
 #endif  // USE_WIFI_AP
   }
+#ifdef USE_WIFI_DPP
+  if (!this->has_sta()) {
+    if (this->wifi_mode_(true, {})) {
+      esp_err_t err = esp_supp_dpp_start_listen();
+      if (err == ERR_OK)
+        this->dpp_listening_ = true;
+    }
+  }
+#endif
 #ifdef USE_IMPROV
   if (!this->has_sta() && esp32_improv::global_improv_component != nullptr) {
     if (this->wifi_mode_(true, {}))
@@ -791,8 +803,8 @@ void WiFiComponent::loop() {
           this->check_connecting_finished(now);
           break;
         }
-        // Use longer cooldown when captive portal/improv is active to avoid disrupting user config
-        bool portal_active = this->is_captive_portal_active_() || this->is_esp32_improv_active_();
+        // Use longer cooldown when DPP/captive portal/improv is active to avoid disrupting user config
+        bool portal_active = this->is_dpp_active_() || this->is_captive_portal_active_() || this->is_esp32_improv_active_();
         uint32_t cooldown_duration = portal_active ? WIFI_COOLDOWN_WITH_AP_ACTIVE_MS : WIFI_COOLDOWN_DURATION_MS;
         if (now - this->action_started_ > cooldown_duration) {
           // After cooldown we either restarted the adapter because of
@@ -863,6 +875,18 @@ void WiFiComponent::loop() {
     }
 #endif  // USE_WIFI_AP
 
+#ifdef USE_WIFI_DPP
+    if (!this->is_dpp_active_()) {
+      if (now - this->last_connected_ > this->dpp_timeout_) {
+        if (this->wifi_mode_(true, {})) {
+          esp_err_t err = esp_supp_dpp_start_listen();
+          if (err == ERR_OK)
+            this->dpp_listening_ = true;
+        }
+      }
+    }
+#endif
+
 #ifdef USE_IMPROV
     if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active() &&
         !esp32_improv::global_improv_component->should_start()) {
@@ -871,7 +895,6 @@ void WiFiComponent::loop() {
           esp32_improv::global_improv_component->start();
       }
     }
-
 #endif
 
     if (!this->has_ap() && this->reboot_timeout_ != 0) {
@@ -1617,6 +1640,12 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
       ESP_LOGD(TAG, "Disabling AP");
       this->wifi_mode_({}, false);
     }
+#ifdef USE_WIFI_DPP
+    if (this->is_dpp_active_()) {
+      esp_supp_dpp_stop_listen();
+      this->dpp_listening_ = false;
+    }
+#endif
 #ifdef USE_IMPROV
     if (this->is_esp32_improv_active_()) {
       esp32_improv::global_improv_component->stop();
@@ -1792,7 +1821,7 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       }
       // No hidden networks - always go through RESTARTING_ADAPTER phase
       // This ensures num_retried_ gets reset and a fresh scan is triggered
-      // The actual adapter restart will be skipped if captive portal/improv is active
+      // The actual adapter restart will be skipped if DPP/captive portal/improv is active
       return WiFiRetryPhase::RESTARTING_ADAPTER;
 
     case WiFiRetryPhase::RETRY_HIDDEN:
@@ -1815,7 +1844,7 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       }
       // Exhausted all potentially hidden SSIDs - always go through RESTARTING_ADAPTER
       // This ensures num_retried_ gets reset and a fresh scan is triggered
-      // The actual adapter restart will be skipped if captive portal/improv is active
+      // The actual adapter restart will be skipped if DPP/captive portal/improv is active
       return WiFiRetryPhase::RESTARTING_ADAPTER;
 
     case WiFiRetryPhase::RESTARTING_ADAPTER:
@@ -1845,14 +1874,14 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       // attempting to connect to all configured networks in sequence.
       // Captive portal needs scan results to show available networks.
       // If captive portal is active, only skip scanning if we've done a scan after it started.
-      // If only improv is active (no captive portal), skip scanning since improv doesn't need results.
+      // If only DPP or improv is active (no captive portal), skip scanning since neither needs results.
       if (this->is_captive_portal_active_()) {
         if (this->has_completed_scan_after_captive_portal_start_) {
           return WiFiRetryPhase::RETRY_HIDDEN;
         }
         // Need to scan for captive portal
-      } else if (this->is_esp32_improv_active_()) {
-        // Improv doesn't need scan results
+      } else if (this->is_dpp_active_() || this->is_esp32_improv_active_()) {
+        // DPP/Improv doesn't need scan results
         return WiFiRetryPhase::RETRY_HIDDEN;
       }
       return WiFiRetryPhase::SCAN_CONNECTING;
@@ -1939,10 +1968,10 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
       break;
 
     case WiFiRetryPhase::RESTARTING_ADAPTER:
-      // Skip actual adapter restart if captive portal/improv is active
+      // Skip actual adapter restart if DPP/captive portal/improv is active
       // This allows state machine to reset num_retried_ and trigger fresh scan
       // without disrupting the captive portal/improv connection
-      if (!this->is_captive_portal_active_() && !this->is_esp32_improv_active_()) {
+      if (!this->is_dpp_active_() && !this->is_captive_portal_active_() && !this->is_esp32_improv_active_()) {
         this->restart_adapter();
       } else {
         // Even when skipping full restart, disconnect to clear driver state
@@ -1950,7 +1979,7 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
         this->wifi_disconnect_();
       }
       // Clear scan flag - we're starting a new retry cycle
-      // This is critical for captive portal/improv flow: when determine_next_phase_()
+      // This is critical for DPP/captive portal/improv flow: when determine_next_phase_()
       // returns RETRY_HIDDEN (because scanning is skipped), find_next_hidden_sta_()
       // will see BLIND_RETRY mode and treat ALL networks as candidates,
       // effectively cycling through all configured networks without scan results.
@@ -2197,6 +2226,20 @@ void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
 
 void WiFiComponent::set_passive_scan(bool passive) { this->passive_scan_ = passive; }
 
+#ifdef USE_WIFI_DPP
+void WiFiComponent::set_dpp_device_info(const std::string &dpp_device_info) { this->dpp_device_info_ = CompactString(dpp_device_info.c_str(), dpp_device_info.size()); }
+void WiFiComponent::set_dpp_device_info(const char *dpp_device_info) { this->dpp_device_info_ = CompactString(dpp_device_info, strlen(dpp_device_info)); }
+void WiFiComponent::set_dpp_channels(const std::string &dpp_channels) { this->dpp_channels_ = CompactString(dpp_channels.c_str(), dpp_channels.size()); }
+void WiFiComponent::set_dpp_channels(const char *dpp_channels) { this->dpp_channels_ = CompactString(dpp_channels, strlen(dpp_channels)); }
+#endif
+
+bool WiFiComponent::is_dpp_active_() {
+#ifdef USE_WIFI_DPP
+  return this->dpp_listening_;
+#else
+  return false;
+#endif
+}
 bool WiFiComponent::is_captive_portal_active_() {
 #ifdef USE_CAPTIVE_PORTAL
   return captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -577,6 +577,9 @@ class WiFiComponent final : public Component {
 #ifdef USE_WIFI_DISCONNECT_TRIGGER
   Trigger<> *get_disconnect_trigger() { return &this->disconnect_trigger_; }
 #endif
+#ifdef USE_WIFI_DPP_URI_TRIGGER
+  Trigger<std::string> *get_dpp_uri_trigger() { return &this->dpp_uri_trigger_; }
+#endif
 
   int32_t get_wifi_channel();
 
@@ -899,6 +902,9 @@ class WiFiComponent final : public Component {
 #endif
 #ifdef USE_WIFI_DISCONNECT_TRIGGER
   Trigger<> disconnect_trigger_;
+#endif
+#ifdef USE_WIFI_DPP_URI_TRIGGER
+  Trigger<std::string> dpp_uri_trigger_;
 #endif
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   SemaphoreHandle_t high_performance_semaphore_{nullptr};

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -35,6 +35,10 @@
 #endif
 #endif
 
+#ifdef USE_WIFI_DPP
+#include <esp_dpp.h>
+#endif
+
 #ifdef USE_ESP8266
 #include <ESP8266WiFi.h>
 #include <ESP8266WiFiType.h>
@@ -452,6 +456,18 @@ class WiFiComponent final : public Component {
   void set_ap_timeout(uint32_t ap_timeout) { ap_timeout_ = ap_timeout; }
 #endif  // USE_WIFI_AP
 
+#ifdef USE_WIFI_DPP
+  void set_dpp_mode(esp_supp_dpp_bootstrap_t dpp_mode) { dpp_mode_ = dpp_mode; }
+  void set_dpp_key(const std::string &dpp_key) { dpp_key_ = dpp_key; }
+  void set_dpp_device_info(const std::string &dpp_device_info);
+  void set_dpp_device_info(const char *dpp_device_info);
+  void set_dpp_device_info(StringRef dpp_device_info) { dpp_device_info_ = CompactString(dpp_device_info.c_str(), dpp_device_info.size()); }
+  void set_dpp_channels(const std::string &dpp_channels);
+  void set_dpp_channels(const char *dpp_channels);
+  void set_dpp_channels(StringRef dpp_channels) { dpp_channels_ = CompactString(dpp_channels.c_str(), dpp_channels.size()); }
+  void set_dpp_timeout(uint32_t dpp_timeout) { dpp_timeout_ = dpp_timeout; }
+#endif
+
   void enable();
   void disable();
   bool is_disabled();
@@ -776,6 +792,7 @@ class WiFiComponent final : public Component {
   network::IPAddress wifi_gateway_ip_();
   network::IPAddress wifi_dns_ip_(int num);
 
+  bool is_dpp_active_();
   bool is_captive_portal_active_();
   bool is_esp32_improv_active_();
 
@@ -851,6 +868,12 @@ class WiFiComponent final : public Component {
 #ifdef USE_WIFI_AP
   WiFiAP ap_;
 #endif
+#ifdef USE_WIFI_DPP
+  std::string dpp_key_;
+  CompactString dpp_device_info_;
+  CompactString dpp_channels_;
+#endif
+
 #ifdef USE_WIFI_IP_STATE_LISTENERS
   StaticVector<WiFiIPStateListener *, ESPHOME_WIFI_IP_STATE_LISTENERS> ip_state_listeners_;
 #endif
@@ -899,6 +922,9 @@ class WiFiComponent final : public Component {
 #ifdef USE_WIFI_AP
   uint32_t ap_timeout_{};
 #endif
+#ifdef USE_WIFI_DPP
+  uint32_t dpp_timeout_{};
+#endif
 
   // 1-byte enums and integers
   WiFiComponentState state_{WIFI_COMPONENT_STATE_OFF};
@@ -910,6 +936,9 @@ class WiFiComponent final : public Component {
   WiFi8266PhyMode phy_mode_{WIFI_8266_PHY_MODE_AUTO};
 #endif
   WifiMinAuthMode min_auth_mode_{WIFI_MIN_AUTH_MODE_WPA2};
+#ifdef USE_WIFI_DPP
+  esp_supp_dpp_bootstrap_t dpp_mode_;
+#endif
   WiFiRetryPhase retry_phase_{WiFiRetryPhase::INITIAL_CONNECT};
   uint8_t num_retried_{0};
   // Index into sta_ array for the currently selected AP configuration (-1 = none selected)
@@ -967,6 +996,9 @@ class WiFiComponent final : public Component {
   bool scan_done_{false};
   bool ap_setup_{false};
   bool ap_started_{false};
+#ifdef USE_WIFI_DPP
+  bool dpp_listening_{false};
+#endif
   bool passive_scan_{false};
   bool has_saved_wifi_settings_{false};
 #ifdef USE_WIFI_11KV_SUPPORT

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -461,10 +461,14 @@ class WiFiComponent final : public Component {
   void set_dpp_key(const std::string &dpp_key) { dpp_key_ = dpp_key; }
   void set_dpp_device_info(const std::string &dpp_device_info);
   void set_dpp_device_info(const char *dpp_device_info);
-  void set_dpp_device_info(StringRef dpp_device_info) { dpp_device_info_ = CompactString(dpp_device_info.c_str(), dpp_device_info.size()); }
+  void set_dpp_device_info(StringRef dpp_device_info) {
+    dpp_device_info_ = CompactString(dpp_device_info.c_str(), dpp_device_info.size());
+  }
   void set_dpp_channels(const std::string &dpp_channels);
   void set_dpp_channels(const char *dpp_channels);
-  void set_dpp_channels(StringRef dpp_channels) { dpp_channels_ = CompactString(dpp_channels.c_str(), dpp_channels.size()); }
+  void set_dpp_channels(StringRef dpp_channels) {
+    dpp_channels_ = CompactString(dpp_channels.c_str(), dpp_channels.size());
+  }
   void set_dpp_timeout(uint32_t dpp_timeout) { dpp_timeout_ = dpp_timeout; }
 #endif
 

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -1032,9 +1032,10 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
 #ifdef USE_WIFI_DPP
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_URI_READY) {
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
     const auto &it = data->data.dpp_uri_ready;
     ESP_LOGV(TAG, "DPP URI: %s", it.uri);
+#ifdef USE_WIFI_DPP_URI_TRIGGER
+    this->dpp_uri_trigger_.trigger(std::string(it.uri, it.uri_data_len));
 #endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_CFG_RECVD) {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -1038,13 +1038,15 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 #endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_CFG_RECVD) {
+    this->dpp_listening_ = false;
+
     ESP_LOGV(TAG, "DPP config received");
     const auto &it = data->data.dpp_config_received;
 
     wifi_config_t conf;
     memcpy(&conf, &it.wifi_cfg, sizeof(conf));
 
-    esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &conf);
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &conf);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "esp_wifi_set_config failed: %d", err);
       return;
@@ -1070,6 +1072,8 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     }
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_FAILED) {
+    this->dpp_listening_ = false;
+
     const auto &it = data->data.dpp_failed;
     ESP_LOGE(TAG, "DPP failed: %s", esp_err_to_name(it.failure_reason));
 #endif /* USE_WIFI_DPP */

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -24,6 +24,10 @@
 #endif
 #endif
 
+#ifdef USE_WIFI_DPP
+#include <esp_dpp.h>
+#endif
+
 #ifdef USE_WIFI_AP
 #include "dhcpserver/dhcpserver.h"
 #endif  // USE_WIFI_AP
@@ -70,6 +74,17 @@ struct IDFWiFiEvent {
     wifi_event_ap_stadisconnected_t ap_stadisconnected;
     wifi_event_ap_probe_req_rx_t ap_probe_req_rx;
     wifi_event_bss_rssi_low_t bss_rssi_low;
+#ifdef USE_WIFI_DPP
+    union {
+      wifi_event_dpp_uri_ready_t dpp_uri_ready;
+      struct {
+        uint32_t uri_data_len;
+        char uri[256];
+      };
+    };
+    wifi_event_dpp_config_received_t dpp_config_received;
+    wifi_event_dpp_failed_t dpp_failed;
+#endif
     ip_event_got_ip_t ip_got_ip;
 #if USE_NETWORK_IPV6
     ip_event_got_ip6_t ip_got_ip6;
@@ -119,6 +134,14 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
     memcpy(&event.data.ap_staconnected, event_data, sizeof(wifi_event_ap_staconnected_t));
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_STADISCONNECTED) {
     memcpy(&event.data.ap_stadisconnected, event_data, sizeof(wifi_event_ap_stadisconnected_t));
+#ifdef USE_WIFI_DPP
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_DPP_URI_READY) {
+    memcpy(&event.data.dpp_uri_ready, event_data, sizeof(wifi_event_dpp_uri_ready_t) + ((wifi_event_dpp_uri_ready_t*)event_data)->uri_data_len);
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_DPP_CFG_RECVD) {
+    memcpy(&event.data.dpp_config_received, event_data, sizeof(wifi_event_dpp_config_received_t));  // configs[] gets dropped (unused)
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_DPP_FAILED) {
+    memcpy(&event.data.dpp_failed, event_data, sizeof(wifi_event_dpp_failed_t));
+#endif
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_ASSIGNED_IP_TO_CLIENT) {
     memcpy(&event.data.ip_assigned_ip_to_client, event_data, sizeof(ip_event_assigned_ip_to_client_t));
@@ -241,6 +264,19 @@ void WiFiComponent::wifi_lazy_init_() {
     ESP_LOGE(TAG, "esp_wifi_set_storage failed: %s", esp_err_to_name(err));
     return;
   }
+
+#ifdef USE_WIFI_DPP
+  err = esp_supp_dpp_init(NULL);
+  if (err != ERR_OK) {
+    ESP_LOGW(TAG, "esp_supp_dpp_init failed: %s", esp_err_to_name(err));
+  } else {
+    err = esp_supp_dpp_bootstrap_gen(this->dpp_channels_.c_str(), this->dpp_mode_, !this->dpp_key_.empty()?this->dpp_key_.c_str():NULL, !this->dpp_device_info_.empty()?this->dpp_device_info_.c_str():NULL);
+    if (err != ERR_OK) {
+      ESP_LOGW(TAG, "esp_supp_dpp_bootstrap_gen failed: %s", esp_err_to_name(err));
+    }
+  }
+#endif
+
   this->wifi_initialized_ = true;
 }
 
@@ -989,6 +1025,50 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     format_mac_addr_upper(it.mac, mac_buf);
     ESP_LOGV(TAG, "AP client disconnected MAC=%s", mac_buf);
 #endif
+
+#ifdef USE_WIFI_DPP
+  } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_URI_READY) {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+    const auto &it = data->data.dpp_uri_ready;
+    ESP_LOGV(TAG, "DPP URI: %s", it.uri);
+#endif
+
+  } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_CFG_RECVD) {
+    ESP_LOGV(TAG, "DPP config received");
+    const auto &it = data->data.dpp_config_received;
+
+    wifi_config_t conf;
+    memcpy(&conf, &it.wifi_cfg, sizeof(conf));
+
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &conf);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_wifi_set_config failed: %d", err);
+      return;
+    }
+
+    // Reset flags, do this _before_ wifi_station_connect as the callback method
+    // may be called from wifi_station_connect
+    s_sta_connecting = true;
+    s_sta_connected = false;
+    s_sta_connect_error = false;
+    s_sta_connect_not_found = false;
+    // Reset IP address flags - ensures we don't report connected before DHCP completes
+    // (IP_EVENT_STA_LOST_IP doesn't always fire on disconnect)
+    this->got_ipv4_address_ = false;
+#if USE_NETWORK_IPV6
+    this->num_ipv6_addresses_ = 0;
+#endif
+
+    err = esp_wifi_connect();
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "esp_wifi_connect failed: %s", esp_err_to_name(err));
+      return;
+    }
+
+  } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_DPP_FAILED) {
+    const auto &it = data->data.dpp_failed;
+    ESP_LOGE(TAG, "DPP failed: %s", esp_err_to_name(it.failure_reason));
+#endif /* USE_WIFI_DPP */
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_ASSIGNED_IP_TO_CLIENT) {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -136,9 +136,11 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
     memcpy(&event.data.ap_stadisconnected, event_data, sizeof(wifi_event_ap_stadisconnected_t));
 #ifdef USE_WIFI_DPP
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_DPP_URI_READY) {
-    memcpy(&event.data.dpp_uri_ready, event_data, sizeof(wifi_event_dpp_uri_ready_t) + ((wifi_event_dpp_uri_ready_t*)event_data)->uri_data_len);
+    memcpy(&event.data.dpp_uri_ready, event_data,
+           sizeof(wifi_event_dpp_uri_ready_t) + ((wifi_event_dpp_uri_ready_t *) event_data)->uri_data_len);
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_DPP_CFG_RECVD) {
-    memcpy(&event.data.dpp_config_received, event_data, sizeof(wifi_event_dpp_config_received_t));  // configs[] gets dropped (unused)
+    memcpy(&event.data.dpp_config_received, event_data,
+           sizeof(wifi_event_dpp_config_received_t));  // configs[] gets dropped (unused)
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_DPP_FAILED) {
     memcpy(&event.data.dpp_failed, event_data, sizeof(wifi_event_dpp_failed_t));
 #endif
@@ -270,7 +272,9 @@ void WiFiComponent::wifi_lazy_init_() {
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "esp_supp_dpp_init failed: %s", esp_err_to_name(err));
   } else {
-    err = esp_supp_dpp_bootstrap_gen(this->dpp_channels_.c_str(), this->dpp_mode_, !this->dpp_key_.empty()?this->dpp_key_.c_str():NULL, !this->dpp_device_info_.empty()?this->dpp_device_info_.c_str():NULL);
+    err = esp_supp_dpp_bootstrap_gen(this->dpp_channels_.c_str(), this->dpp_mode_,
+                                     !this->dpp_key_.empty() ? this->dpp_key_.c_str() : NULL,
+                                     !this->dpp_device_info_.empty() ? this->dpp_device_info_.c_str() : NULL);
     if (err != ERR_OK) {
       ESP_LOGW(TAG, "esp_supp_dpp_bootstrap_gen failed: %s", esp_err_to_name(err));
     }

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -225,6 +225,7 @@
 #define USE_TIME_TIMEZONE
 #define USE_WIFI
 #define USE_WIFI_AP
+#define USE_WIFI_DPP
 #define USE_WIFI_MANUAL_IP
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

### [WiFi Easy Connect](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_dpp.html).

~Note: I wasn't yet able to verify that the provisioning actually happens since I only have a Samsung phone at hand, and those famously don't implement DPP for some reason (silly me!).~
QR code provisioning verified to work with a Sony phone.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  dpp:
    mode: qr_code
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).