### PR TITLE
[logger] Fix garbled stack traces

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -5,6 +5,7 @@
 #include <esp_log.h>
 
 #include <driver/uart.h>
+#include <soc/soc_caps.h>
 
 #ifdef USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG
 #include <driver/usb_serial_jtag.h>
@@ -76,7 +77,11 @@ void init_uart(uart_port_t uart_num, uint32_t baud_rate, int tx_buffer_size) {
   uart_config.parity = UART_PARITY_DISABLE;
   uart_config.stop_bits = UART_STOP_BITS_1;
   uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+#if SOC_UART_SUPPORT_XTAL_CLK
+  uart_config.source_clk = UART_SCLK_XTAL;
+#else
   uart_config.source_clk = UART_SCLK_DEFAULT;
+#endif
   uart_param_config(uart_num, &uart_config);
   // The logger only writes to UART, never reads, so use the minimum RX buffer.
   // ESP-IDF requires rx_buffer_size > UART_HW_FIFO_LEN (128 bytes).


### PR DESCRIPTION
# What does this implement/fix?

There is a hardware or ESP-IDF issue on ESP32-S3 that when the UART clock is configured to APB, the backtraces printed of serial are garbled:

```
abort() was called at PC 0x42006984 on core 1
 
 
Backtrace: 0x4037a2b1:0x3fcea7f0 0x4037a279:0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

They're garbled because the baud rate drops from 115200 to 28800 in the middle of the output:

<img width="1553" height="138" alt="image" src="https://github.com/user-attachments/assets/5a3c7e67-f578-4838-9192-e5d7c9e1bbb7" />

I have reported this to the ESP-IDF team in https://github.com/espressif/esp-idf/issues/18901, but as a simple workaround for ESPHome we can just use the XTAL clock for UART.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: uart-clock-test
  friendly_name: "UART Clock Test"

esp32:
  variant: esp32s3
  framework:
    type: esp-idf

logger:
  hardware_uart: UART0
  baud_rate: 115200

ota:
  - platform: esphome
    password: !secret ota_password

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

web_server:
  port: 80

button:
  - platform: template
    id: abort_test
    name: "Trigger abort()"
    entity_category: diagnostic
    on_press:
      then:
        - lambda: |-
            ESP_LOGW("abort_test", "Calling abort() - expect an immediate crash");
            abort();

  - platform: template
    id: wdt_test
    name: "Trigger watchdog"
    entity_category: diagnostic
    on_press:
      then:
        - lambda: |-
            ESP_LOGW("wdt_test", "Blocking loop to trigger WDT - expect crash in ~5s");
            uint32_t start = millis();
            while (millis() - start < 15000) {}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

