### PR TITLE
[epaper_spi] Add SSD1681 and the Waveshare 1.54in V2 panel

### DIFF
--- a/esphome/components/epaper_spi/models/ssd1683.py
+++ b/esphome/components/epaper_spi/models/ssd1683.py
@@ -25,3 +25,15 @@ goodisplay_gdey042t81 = ssd1683.extend(
     width=400,
     height=300,
 )
+
+# The SSD1681 shares the SSD1683 command set for everything this driver uses:
+# the same 0x01/0x11/0x18 initialisation, the same 0x44/0x45 window and
+# 0x4E/0x4F cursor registers with a byte-addressed X and a 16-bit Y, and the
+# same 0x22/0x20 update. It only differs in the panel sizes it drives.
+ssd1681 = SSD1683("ssd1681")
+
+waveshare_1_54in_v2 = ssd1681.extend(
+    "waveshare-1.54in-v2",
+    width=200,
+    height=200,
+)

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -170,6 +170,24 @@ display:
       allow_other_uses: true
       number: GPIO4
 
+  # Waveshare 1.54" V2 mono e-paper (200x200, SSD1681)
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-1.54in-v2
+    full_update_every: 30
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+
   # Waveshare 2.13" V4 B series 3-color e-paper (122x250, BWR, SSD1680)
   - platform: epaper_spi
     spi_id: spi_bus


### PR DESCRIPTION
# What does this implement/fix?

Adds the SSD1681 controller and the 200x200 Waveshare 1.54in V2 panel to `epaper_spi`.

The SSD1681 shares the SSD1683 command set for everything this driver uses: the same `0x01`/`0x11`/`0x18` initialisation, the same `0x44`/`0x45` window and `0x4E`/`0x4F` cursor registers with a byte-addressed X and a 16-bit Y, and the same `0x22`/`0x20` update. Waveshare's own driver for this panel issues exactly these, so the existing `EPaperSSD1683` class drives it without any C++ changes but only the model definition was missing.

The panel is already supported by `waveshare_epaper` as `1.54inv2`, but only with full refreshes on a device that deep sleeps: that driver resets the panel in `setup()` on every wake, which clears the base image partial refreshes difference against. Under `epaper_spi` the partial path works, including across a deep sleep when the panel keeps its own supply.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

https://github.com/esphome/esphome.io/pull/7273

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Hardware-tested on a Waveshare ESP32-S3-ePaper-1.54 (esp-idf): full and partial refreshes both render correctly, and partial refreshes survive a deep sleep wake.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: epaper_spi
    model: waveshare-1.54in-v2
    cs_pin: GPIO11
    dc_pin: GPIO10
    reset_pin: GPIO9
    busy_pin: GPIO8
    full_update_every: 30
    update_interval: 60s
    lambda: |-
      it.strftime(5, 5, id(my_font), "%H:%M", id(my_time).now());
```

`reset_pin` is required rather than optional on this panel: between updates the driver parks it in deep sleep mode 1, which retains RAM but holds BUSY high and can only be exited by a reset pulse.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).