### PR TITLE
[epaper_spi] Resume the partial refresh cycle after deep sleep

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -45,6 +45,7 @@ from . import models
 AUTO_LOAD = ["split_buffer"]
 DEPENDENCIES = ["spi"]
 
+CONF_FULL_REFRESH_AFTER_DEEP_SLEEP = "full_refresh_after_deep_sleep"
 CONF_INIT_SEQUENCE_ID = "init_sequence_id"
 CONF_MINIMUM_UPDATE_INTERVAL = "minimum_update_interval"
 
@@ -97,6 +98,7 @@ def model_schema(config):
                 }
             ),
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=1): cv.int_range(1, 255),
+            cv.Optional(CONF_FULL_REFRESH_AFTER_DEEP_SLEEP, default=True): cv.boolean,
             model.option(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
             model.option(CONF_CS_PIN): pins.gpio_output_pin_schema,
             model.option(CONF_DC_PIN, fallback=None): pins.gpio_output_pin_schema,
@@ -220,6 +222,11 @@ async def to_code(config):
         enable = [await cg.gpio_pin_expression(pin) for pin in enable_pin]
         cg.add(var.set_enable_pins(enable))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
+    cg.add(
+        var.set_full_refresh_after_deep_sleep(
+            config[CONF_FULL_REFRESH_AFTER_DEEP_SLEEP]
+        )
+    )
     if CONF_RESET_DURATION in config:
         cg.add(var.set_reset_duration(config[CONF_RESET_DURATION]))
     if transform := config.get(CONF_TRANSFORM):

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -4,6 +4,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_ESP32
+#include <esp_system.h>
+#endif
+
 namespace esphome::epaper_spi {
 
 static const char *const TAG = "epaper_spi";
@@ -27,6 +31,34 @@ void EPaperBase::setup() {
   }
   this->setup_pins_();
   this->spi_setup();
+  this->restore_update_count_();
+}
+
+void EPaperBase::restore_update_count_() {
+  if (!this->is_using_partial_update_() || this->full_refresh_after_deep_sleep_)
+    return;
+  // update_count_ decides whether the next refresh is partial. It lives in RAM,
+  // so a device that deep sleeps between refreshes restarts the cycle on every
+  // wake and never takes the partial path, making full_update_every ineffective
+  // exactly where it matters most for battery life.
+  //
+  // Resuming the cycle is only sound when the panel kept the base image a
+  // partial refresh differences against, which needs both its RAM-retaining
+  // sleep mode and uninterrupted supply. The latter is a board property the
+  // driver cannot observe, hence the opt-in; the former rules out a power cycle,
+  // so only a deep sleep wake resumes, and any other reset refreshes fully.
+  char pin_summary[64];
+  this->dc_pin_->dump_summary(pin_summary, sizeof(pin_summary));
+  const uint32_t hash = fnv1_hash(std::string("epaper_spi_update_count_") + pin_summary);
+  this->update_count_pref_ = global_preferences->make_preference<uint8_t>(hash);
+  this->persist_update_count_ = true;
+#ifdef USE_ESP32
+  if (esp_reset_reason() != ESP_RST_DEEPSLEEP)
+    return;
+  uint8_t update_count = 0;
+  if (this->update_count_pref_.load(&update_count) && update_count < this->full_update_every_)
+    this->update_count_ = update_count;
+#endif
 }
 
 bool EPaperBase::init_buffer_(size_t buffer_length) {
@@ -225,6 +257,8 @@ void EPaperBase::process_state_() {
     case EPaperState::REFRESH_SCREEN:
       this->refresh_screen(this->update_count_ != 0);
       this->update_count_ = (this->update_count_ + 1) % this->full_update_every_;
+      if (this->persist_update_count_)
+        this->update_count_pref_.save(&this->update_count_);
       this->set_state_(EPaperState::POWER_OFF);
       break;
     case EPaperState::POWER_OFF:
@@ -342,12 +376,13 @@ void EPaperBase::dump_config() {
                 "  Model: %s\n"
                 "  SPI Data Rate: %uMHz\n"
                 "  Full update every: %d\n"
+                "  Full refresh after deep sleep: %s\n"
                 "  Swap X/Y: %s\n"
                 "  Mirror X: %s\n"
                 "  Mirror Y: %s",
                 this->name_, (unsigned) (this->data_rate_ / 1000000), this->full_update_every_,
-                YESNO(this->transform_ & SWAP_XY), YESNO(this->transform_ & MIRROR_X),
-                YESNO(this->transform_ & MIRROR_Y));
+                YESNO(this->full_refresh_after_deep_sleep_), YESNO(this->transform_ & SWAP_XY),
+                YESNO(this->transform_ & MIRROR_X), YESNO(this->transform_ & MIRROR_Y));
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -4,6 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/split_buffer/split_buffer.h"
 #include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
 
 namespace esphome::epaper_spi {
 using namespace display;
@@ -61,6 +62,7 @@ class EPaperBase : public Display,
     this->update_effective_transform_();
   }
   void set_full_update_every(uint8_t full_update_every) { this->full_update_every_ = full_update_every; }
+  void set_full_refresh_after_deep_sleep(bool full_refresh) { this->full_refresh_after_deep_sleep_ = full_refresh; }
   void dump_config() override;
 
   void command(uint8_t value);
@@ -124,6 +126,7 @@ class EPaperBase : public Display,
   const char *epaper_state_to_string_();
   bool is_idle_() const;
   void setup_pins_() const;
+  void restore_update_count_();
   virtual bool reset();
   virtual bool initialise(bool partial);
   void send_init_sequence_(const uint8_t *sequence, size_t length);
@@ -185,6 +188,9 @@ class EPaperBase : public Display,
   uint8_t transform_{};
   uint8_t effective_transform_{};
   uint8_t update_count_{};
+  bool full_refresh_after_deep_sleep_{true};
+  bool persist_update_count_{false};
+  ESPPreferenceObject update_count_pref_{};
   // these values represent the bounds of the updated buffer. Note that x_high and y_high
   // point to the pixel past the last one updated, i.e. may range up to width/height.
   uint16_t x_low_{}, y_low_{}, x_high_{}, y_high_{};

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -87,6 +87,7 @@ display:
   - platform: epaper_spi
     model: seeed-ee04-mono-4.26
     full_update_every: 10
+    full_refresh_after_deep_sleep: false
     # Override pins to avoid conflict with other display configs
     busy_pin: 43
     dc_pin: 42


### PR DESCRIPTION
# What does this implement/fix?

Adds `full_refresh_after_deep_sleep` (default `true`), letting a board that keeps its panel powered through deep sleep continue the partial refresh cycle across wakes.

`update_count_` decides whether the next refresh is partial, but it lives in RAM, so a device that deep sleeps between refreshes restarts the cycle on every wake and never takes the partial path. `full_update_every` is then ineffective exactly where it matters most for battery life: every wake pays for a full refresh and its flicker, however high the setting.

Resuming the cycle is only correct when the panel kept the base image a partial refresh differences against, which needs uninterrupted supply to the panel while the ESP32 sleeps. That is a board property the driver cannot observe, and cannot reliably detect. Hence an opt-in rather than a fix. On a board that gates the panel rail, resuming would difference against RAM the panel had lost and render speckle.

With the default `true` nothing is stored or restored at all, so behaviour is byte-identical to today for every existing configuration. When set to `false`, the counter is persisted and restored but only a deep sleep wake resumes the cycle; any other reset refreshes fully, since a power cycle clears panel RAM regardless of the rail.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/7274

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Hardware-tested on a Waveshare ESP32-S3-ePaper-1.54 (esp-idf) on a five minute deep sleep cycle, with the panel rail held on through sleep: with `full_refresh_after_deep_sleep: false` the partial cycle continues across wakes and only every 30th refresh is full, where before every wake forced a full refresh. The default was checked to leave behaviour unchanged.

The restore is guarded by `#ifdef USE_ESP32`, since `esp_reset_reason()` is ESP-IDF specific; other platforms are unaffected and untested here.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: epaper_spi
    model: goodisplay-gdey042t81-4.2
    cs_pin: GPIO11
    dc_pin: GPIO10
    reset_pin: GPIO9
    busy_pin: GPIO8
    full_update_every: 30
    # Only correct because this board keeps the panel powered while the ESP32
    # sleeps; the default (true) refreshes fully on each wake.
    full_refresh_after_deep_sleep: false
    update_interval: never

deep_sleep:
  run_duration: 30s
  sleep_duration: 5min
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The existing component tests cover the build. The behaviour itself is a deep sleep wake path, which the component test harness does not exercise; it was verified on hardware.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).