### PR TITLE
[gree] Add sleep preset support for GREE YAC1FB9

### DIFF
--- a/esphome/components/gree/gree.cpp
+++ b/esphome/components/gree/gree.cpp
@@ -100,13 +100,11 @@ void GreeClimate::transmit_state() {
     }
   }
 
-  if (this->model_ == GREE_YX1FF || this->model_ == GREE_YAC1FB9) {
-    if (this->preset_() == GREE_PRESET_SLEEP) {
-      remote_state[0] |= GREE_PRESET_SLEEP_BIT;
-      // Sleep is encoded as bit 7 of byte 0.
-    }
+  if (this->preset_() == GREE_PRESET_SLEEP) {
+    remote_state[0] |= GREE_PRESET_SLEEP_BIT;
+    // Sleep is encoded as bit 7 of byte 0.
   }
-
+  
   // Calculate the checksum
   if (this->model_ == GREE_YAN || this->model_ == GREE_YX1FF) {
     remote_state[7] = ((remote_state[0] << 4) + (remote_state[1] << 4) + 0xC0);

--- a/esphome/components/gree/gree.cpp
+++ b/esphome/components/gree/gree.cpp
@@ -104,7 +104,7 @@ void GreeClimate::transmit_state() {
     remote_state[0] |= GREE_PRESET_SLEEP_BIT;
     // Sleep is encoded as bit 7 of byte 0.
   }
-  
+
   // Calculate the checksum
   if (this->model_ == GREE_YAN || this->model_ == GREE_YX1FF) {
     remote_state[7] = ((remote_state[0] << 4) + (remote_state[1] << 4) + 0xC0);

--- a/esphome/components/gree/gree.cpp
+++ b/esphome/components/gree/gree.cpp
@@ -28,6 +28,11 @@ void GreeClimate::set_model(Model model) {
     this->presets_.insert(climate::CLIMATE_PRESET_SLEEP);  // YX1FF sleep mode
   }
 
+  if (model == GREE_YAC1FB9) {
+    this->presets_.insert(climate::CLIMATE_PRESET_NONE);   // YAC1FB9 sleep mode
+    this->presets_.insert(climate::CLIMATE_PRESET_SLEEP);  // YAC1FB9 sleep mode
+  }
+
   this->model_ = model;
 }
 
@@ -93,9 +98,12 @@ void GreeClimate::transmit_state() {
     if (this->fan_speed_() == GREE_FAN_TURBO) {
       remote_state[2] |= GREE_FAN_TURBO_BIT;
     }
+  }
 
+  if (this->model_ == GREE_YX1FF || this->model_ == GREE_YAC1FB9) {
     if (this->preset_() == GREE_PRESET_SLEEP) {
       remote_state[0] |= GREE_PRESET_SLEEP_BIT;
+      // Sleep is encoded as bit 7 of byte 0.
     }
   }
 
@@ -241,8 +249,8 @@ uint8_t GreeClimate::temperature_() {
 }
 
 uint8_t GreeClimate::preset_() {
-  // YX1FF has sleep preset
-  if (this->model_ == GREE_YX1FF) {
+  // YX1FF and YAC1FB9 have sleep preset
+  if (this->model_ == GREE_YX1FF || this->model_ == GREE_YAC1FB9) {
     switch (this->preset.value_or(climate::CLIMATE_PRESET_NONE)) {
       case climate::CLIMATE_PRESET_NONE:
         return GREE_PRESET_NONE;


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for the Sleep preset for the GREE YAC1FB9 protocol.

The protocol already supports Light, Health and X-Fan, but Sleep was not implemented.

The implementation exposes the Sleep preset in Home Assistant and sets the corresponding bit when transmitting.

## Types of changes

- Added the sleep preset to the climate component for the GREE YAC1FB9 protocol.

- Added the sleep bit for the GREE YAC1FB9 protocol. This follows the GREE_YX1FF behavior.

## Test Environment

The implementation was verified against an original GREE remote.

IR captures show that enabling Sleep changes only:

Frame 1
Byte 0
Bit 7

The second frame is unchanged.

This behavior was reverse engineered from IR captures because no public documentation describing the YAC1FB9 Sleep bit could be found.

Sleep OFF

Byte 0 = 0x09

Sleep ON

Byte 0 = 0x89

Difference:
Bit 7 = 0 → 1

Frame 2:
No differences.

## Example entry for `config.yaml`:
- YAML is unaffected.

# Example config.yaml

- YAML config is unaffected.


## Checklist:
  - [x] The code change is tested and works locally.

