### PR TITLE
[core] StaticVector converting ctor

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -256,6 +256,11 @@ template<typename T, size_t N> class StaticVector {
     }
   }
 
+  // Converting constructor from a smaller StaticVector of the same element type
+  template<size_t M> StaticVector(const StaticVector<T, M> &other) : StaticVector(other.begin(), other.end()) {
+    static_assert(M <= N, "Source StaticVector cannot be larger than the destination");
+  }
+
   // Minimal vector-compatible interface - only what we actually use
   void push_back(const T &value) {
     if (count_ < N) {

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -55,4 +55,32 @@ TEST(HelpersTest, Ilog10RoundTripMatchesLog10) {
   }
 }
 
+TEST(StaticVectorTest, ConvertingConstructorFromSmaller) {
+  StaticVector<uint8_t, 5> small{0x03, 0x00, 0x10, 0x00, 0x01};
+  StaticVector<uint8_t, 253> big = small;
+  ASSERT_EQ(big.size(), small.size());
+  for (size_t i = 0; i < small.size(); i++) {
+    EXPECT_EQ(big[i], small[i]) << "mismatch at index " << i;
+  }
+}
+
+TEST(StaticVectorTest, ConvertingConstructorPartiallyFilledAndEmpty) {
+  StaticVector<uint8_t, 5> partial{0xAA, 0xBB};
+  StaticVector<uint8_t, 8> from_partial = partial;
+  ASSERT_EQ(from_partial.size(), 2u);
+  EXPECT_EQ(from_partial[0], 0xAA);
+  EXPECT_EQ(from_partial[1], 0xBB);
+
+  StaticVector<uint8_t, 5> empty;
+  StaticVector<uint8_t, 8> from_empty = empty;
+  EXPECT_TRUE(from_empty.empty());
+}
+
+TEST(StaticVectorTest, ConvertingConstructorSameSize) {
+  StaticVector<int, 3> src{1, 2, 3};
+  StaticVector<int, 3> dst = src;
+  ASSERT_EQ(dst.size(), 3u);
+  EXPECT_EQ(dst[2], 3);
+}
+
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Constructor to create a larger StaticVector from a smaller one of the same type.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
