### PR TITLE
[bluetooth_proxy] Only advance the scanner-state detector when the frame was sent

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -59,7 +59,6 @@ void BluetoothProxy::setup() {
 
   // Capture the configured scan mode from YAML before any API changes
   this->configured_scan_active_ = this->hub_->scan_active();
-  this->last_scan_running_ = this->hub_->scan_running();
 
   // The hub delivers raw advertisements on the ESPHome main loop:
   // mac is least-significant octet first (BLE controller convention).
@@ -93,19 +92,21 @@ void BluetoothProxy::on_raw_advertisement_(const ble_device_base::RawAdvertiseme
 }
 
 void BluetoothProxy::send_bluetooth_scanner_state_() {
-  // Records what goes on the wire so loop()'s change detector cannot report the
-  // same transition twice; every caller relies on this instead of updating
-  // last_scan_running_ itself.
-  this->last_scan_running_ = this->hub_->scan_running();
+  // One read feeds both the frame and the change detector; the detector only
+  // advances if the frame was accepted, so a dropped send (WOULD_BLOCK on a
+  // full TX buffer) is retried from loop() instead of leaving a stale state.
+  const bool running = this->hub_->scan_running();
   api::BluetoothScannerStateResponse resp;
-  resp.state = this->last_scan_running_ ? api::enums::BluetoothScannerState::BLUETOOTH_SCANNER_STATE_RUNNING
-                                        : api::enums::BluetoothScannerState::BLUETOOTH_SCANNER_STATE_IDLE;
+  resp.state = running ? api::enums::BluetoothScannerState::BLUETOOTH_SCANNER_STATE_RUNNING
+                       : api::enums::BluetoothScannerState::BLUETOOTH_SCANNER_STATE_IDLE;
   resp.mode = this->hub_->scan_active() ? api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_ACTIVE
                                         : api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_PASSIVE;
   resp.configured_mode = this->configured_scan_active_
                              ? api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_ACTIVE
                              : api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_PASSIVE;
-  this->api_connection_->send_message(resp);
+  if (this->api_connection_->send_message(resp)) {
+    this->last_scan_running_ = running;
+  }
 }
 
 #endif  // USE_ESP32

--- a/tests/component_tests/bluetooth_proxy/test_platform_gates.py
+++ b/tests/component_tests/bluetooth_proxy/test_platform_gates.py
@@ -23,6 +23,13 @@ HUB_PLATFORM_FRAMEWORKS = [
 ]
 
 
+def test_hub_platform_list_covers_every_hub_platform() -> None:
+    # A platform added to _HUB_PLATFORMS (bk72xx is planned) would otherwise
+    # get no gate coverage at all.
+    covered = {pf.value[0] for pf in HUB_PLATFORM_FRAMEWORKS}
+    assert covered == set(bluetooth_proxy._HUB_PLATFORMS)
+
+
 def _set_platform(platform: str | None) -> None:
     # For arms set_core_config cannot express (bare platform, no framework).
     CORE.data.setdefault(KEY_CORE, {})[KEY_TARGET_PLATFORM] = platform


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #18150, carrying the three items from its review.

**`last_scan_running_` only advances when the frame was accepted.** `send_message()` returns false on `WOULD_BLOCK` (full TX buffer, connection stays alive) — the frame is dropped, but the detector used to move anyway, so `loop()` never retried and the subscriber kept a stale RUNNING/IDLE until the next real transition. For a proxy that just stopped scanning, that transition may never come. One `scan_running()` read now feeds both the frame and the detector.

**`setup()` no longer seeds `last_scan_running_`.** The write is unobservable: `loop()` returns early while `api_connection_` is null, and `subscribe_api_connection()` sends (and therefore seeds) before anything reads it. The header already zero-initialises the field. The sender is now the only writer.

**`HUB_PLATFORM_FRAMEWORKS` is pinned to `_HUB_PLATFORMS`.** The list caught a platform being removed but not one being added — bk72xx is planned, and would have landed with no gate coverage.

18 component tests pass.

## Verification

- `pytest tests/component_tests/bluetooth_proxy/` — 18/18
- Built for esp32 (config validation), BK72xx and LN882H (full compiles)
- Flashed both LN882H and BK72xx test devices; clean boot, zero errors, proxy streaming scanner state

BK/LN components are not compiled in CI because `build_components_base.bk72xx-ard.yaml` pins board `generic-bk7252` (BLE 4.2); both were compiled and flashed locally.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
