### PR TITLE
[wifi] Support hidden option in single-network shorthand

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -388,9 +388,12 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-def _validate(config):
+def _validate(config: ConfigType) -> ConfigType:
     if CONF_PASSWORD in config and CONF_SSID not in config:
         raise cv.Invalid("Cannot have WiFi password without SSID!")
+
+    if CONF_HIDDEN in config and CONF_SSID not in config:
+        raise cv.Invalid("Cannot have 'hidden' without SSID!")
 
     if CONF_SSID in config:
         # Automatically move single network to 'networks' section
@@ -400,6 +403,8 @@ def _validate(config):
             network[CONF_PASSWORD] = config.pop(CONF_PASSWORD)
         if CONF_EAP in config:
             network[CONF_EAP] = config.pop(CONF_EAP)
+        if CONF_HIDDEN in config:
+            network[CONF_HIDDEN] = config.pop(CONF_HIDDEN)
         if CONF_NETWORKS in config:
             # In testing mode, merged component tests may have both ssid and networks
             # Just use the networks list and ignore the single ssid
@@ -479,6 +484,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_SSID): cv.sensitive(cv.ssid),
             cv.Optional(CONF_PASSWORD): cv.sensitive(validate_password),
+            cv.Optional(CONF_HIDDEN): cv.boolean,
             cv.Optional(CONF_MANUAL_IP): STA_MANUAL_IP_SCHEMA,
             cv.Optional(CONF_EAP): EAP_AUTH_SCHEMA,
             cv.Optional(CONF_AP): wifi_network_ap,

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -393,7 +393,10 @@ def _validate(config: ConfigType) -> ConfigType:
         raise cv.Invalid("Cannot have WiFi password without SSID!")
 
     if CONF_HIDDEN in config and CONF_SSID not in config:
-        raise cv.Invalid("Cannot have 'hidden' without SSID!")
+        raise cv.Invalid(
+            "Cannot have 'hidden' without 'ssid'. If you are using the 'networks' "
+            "list, put 'hidden' inside the network entry instead."
+        )
 
     if CONF_SSID in config:
         # Automatically move single network to 'networks' section

--- a/tests/component_tests/wifi/test_wifi.py
+++ b/tests/component_tests/wifi/test_wifi.py
@@ -1,0 +1,51 @@
+"""Config-validation tests for the wifi component."""
+
+import pytest
+from voluptuous import Invalid
+
+from esphome.components.wifi import _validate
+from esphome.const import (
+    CONF_HIDDEN,
+    CONF_NETWORKS,
+    CONF_PASSWORD,
+    CONF_SSID,
+    CONF_USE_ADDRESS,
+)
+
+
+def test_hidden_folded_into_networks() -> None:
+    """The shorthand 'hidden' option is moved into the generated networks entry."""
+    config = _validate(
+        {
+            CONF_SSID: "MyHomeNetwork",
+            CONF_PASSWORD: "password1",
+            CONF_HIDDEN: True,
+            CONF_USE_ADDRESS: "test.local",
+        }
+    )
+    assert CONF_SSID not in config
+    assert CONF_PASSWORD not in config
+    assert CONF_HIDDEN not in config
+    networks = config[CONF_NETWORKS]
+    assert len(networks) == 1
+    assert networks[0][CONF_SSID] == "MyHomeNetwork"
+    assert networks[0][CONF_PASSWORD] == "password1"
+    assert networks[0][CONF_HIDDEN] is True
+
+
+def test_shorthand_without_hidden_has_no_hidden_key() -> None:
+    """No 'hidden' key is set on the networks entry unless explicitly configured."""
+    config = _validate(
+        {
+            CONF_SSID: "MyHomeNetwork",
+            CONF_PASSWORD: "password1",
+            CONF_USE_ADDRESS: "test.local",
+        }
+    )
+    assert CONF_HIDDEN not in config[CONF_NETWORKS][0]
+
+
+def test_hidden_without_ssid_rejected() -> None:
+    """A 'hidden' option without an SSID has nothing to apply to and is rejected."""
+    with pytest.raises(Invalid, match="hidden"):
+        _validate({CONF_HIDDEN: True, CONF_USE_ADDRESS: "test.local"})

--- a/tests/components/wifi/validate-hidden-shorthand.esp32-idf.yaml
+++ b/tests/components/wifi/validate-hidden-shorthand.esp32-idf.yaml
@@ -1,0 +1,5 @@
+# Exercises the hidden option in the single-network ssid/password shorthand.
+wifi:
+  ssid: MyHiddenNetwork
+  password: password1
+  hidden: true


### PR DESCRIPTION
# What does this implement/fix?

`hidden:` is currently only accepted inside the `networks:` list, so a single hidden network forces the config out of the `ssid:`/`password:` shorthand into the `networks:` form. Since the shorthand is already folded into a one-entry `networks:` list during validation, this accepts `hidden:` at the top level and carries it into the generated entry, the same way `eap:` already is. `hidden:` without `ssid:` is rejected.

A hidden SSID is a property of the user's existing network rather than an advanced configuration choice like `bssid:`, `channel:` or `priority:`, and the users affected are typically the ones copying the getting-started shorthand.

Config-validation tests added under `tests/component_tests/wifi/`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7129

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  ssid: MyHiddenNetwork
  password: VerySafePassword
  hidden: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
