### PR TITLE
[ble_device_base] Migrate BLE sensor platforms to the neutral layer (batch 6: thermopro_ble, exposure_notifications, xiaomi_ble)

### DIFF
--- a/esphome/components/exposure_notifications/__init__.py
+++ b/esphome/components/exposure_notifications/__init__.py
@@ -1,33 +1,59 @@
+from typing import Any
+
 from esphome import automation
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker
+from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_TRIGGER_ID
+from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@OttoWinter"]
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 exposure_notifications_ns = cg.esphome_ns.namespace("exposure_notifications")
 ExposureNotification = exposure_notifications_ns.struct("ExposureNotification")
 ExposureNotificationTrigger = exposure_notifications_ns.class_(
     "ExposureNotificationTrigger",
-    esp32_ble_tracker.ESPBTDeviceListener,
+    ble_device_base.ESPBTDeviceListener,
     automation.Trigger.template(ExposureNotification),
 )
 
 CONF_ON_EXPOSURE_NOTIFICATION = "on_exposure_notification"
 
+_RENAME_HUB_ID = ble_device_base.rename_legacy_hub_id("exposure_notifications")
+
+_VALIDATE_AUTOMATION = automation.validate_automation(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ExposureNotificationTrigger),
+        }
+        # The trigger is the BLE listener, so the hub id lives on it.
+    ).extend(ble_device_base.BLE_DEVICE_SCHEMA)
+)
+
+
+# validate_automation() needs a dict-based schema, so the rename cannot go
+# inside it and has to run on the option value first. That value may also be a
+# list of automations or malformed, and rename_legacy_hub_id() is dict-only, so
+# map over lists and let validate_automation() report anything else.
+# schema_extractor keeps the key typed as a trigger in the generated editor
+# schema; build_language_schema.py recurses into cv.All but not into a plain
+# function.
+@schema_extractor("automation")
+def _validate_on_exposure_notification(value: Any) -> list[ConfigType]:
+    if value is SCHEMA_EXTRACT:
+        return _VALIDATE_AUTOMATION(value)
+    if isinstance(value, dict):
+        value = _RENAME_HUB_ID(value)
+    elif isinstance(value, list):
+        value = [_RENAME_HUB_ID(v) if isinstance(v, dict) else v for v in value]
+    return _VALIDATE_AUTOMATION(value)
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_ON_EXPOSURE_NOTIFICATION): automation.validate_automation(
-            cv.Schema(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                        ExposureNotificationTrigger
-                    ),
-                }
-            ).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
-        ),
+        cv.Required(CONF_ON_EXPOSURE_NOTIFICATION): _validate_on_exposure_notification,
     }
 )
 
@@ -36,4 +62,4 @@ async def to_code(config):
     for conf in config.get(CONF_ON_EXPOSURE_NOTIFICATION, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         await automation.build_automation(trigger, [(ExposureNotification, "x")], conf)
-        await esp32_ble_tracker.register_ble_device(trigger, conf)
+        await ble_device_base.register_ble_device(trigger, conf)

--- a/esphome/components/exposure_notifications/exposure_notifications.cpp
+++ b/esphome/components/exposure_notifications/exposure_notifications.cpp
@@ -2,11 +2,9 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::exposure_notifications {
 
-using namespace esp32_ble_tracker;
+using namespace ble_device_base;
 
 static const char *const TAG = "exposure_notifications";
 
@@ -43,5 +41,3 @@ bool ExposureNotificationTrigger::parse_device(const ESPBTDevice &device) {
 }
 
 }  // namespace esphome::exposure_notifications
-
-#endif

--- a/esphome/components/exposure_notifications/exposure_notifications.h
+++ b/esphome/components/exposure_notifications/exposure_notifications.h
@@ -2,10 +2,8 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include <array>
-
-#ifdef USE_ESP32
 
 namespace esphome::exposure_notifications {
 
@@ -17,11 +15,9 @@ struct ExposureNotification {
 };
 
 class ExposureNotificationTrigger final : public Trigger<ExposureNotification>,
-                                          public esp32_ble_tracker::ESPBTDeviceListener {
+                                          public ble_device_base::ESPBTDeviceListener {
  public:
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 };
 
 }  // namespace esphome::exposure_notifications
-
-#endif

--- a/esphome/components/thermopro_ble/sensor.py
+++ b/esphome/components/thermopro_ble/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, sensor
+from esphome.components import ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BATTERY_LEVEL,
@@ -22,14 +22,15 @@ from esphome.const import (
 
 CODEOWNERS = ["@sittner"]
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 thermopro_ble_ns = cg.esphome_ns.namespace("thermopro_ble")
 ThermoProBLE = thermopro_ble_ns.class_(
-    "ThermoProBLE", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+    "ThermoProBLE", ble_device_base.ESPBTDeviceListener, cg.Component
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("thermopro_ble"),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(ThermoProBLE),
@@ -68,15 +69,15 @@ CONFIG_SCHEMA = (
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
 

--- a/esphome/components/thermopro_ble/thermopro_ble.cpp
+++ b/esphome/components/thermopro_ble/thermopro_ble.cpp
@@ -2,8 +2,6 @@
 #include <cmath>
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::thermopro_ble {
 
 // this size must be large enough to hold the largest data frame
@@ -34,7 +32,7 @@ void ThermoProBLE::dump_config() {
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
 }
 
-bool ThermoProBLE::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool ThermoProBLE::parse_device(const ble_device_base::ESPBTDevice &device) {
   // check for matching mac address
   if (device.address_uint64() != this->address_) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
@@ -66,8 +64,8 @@ bool ThermoProBLE::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     }
 
     // reconstruct whole record from 2 byte uuid and data
-    esp_bt_uuid_t uuid = service_data.uuid.get_uuid();
-    uint8_t data[MAX_DATA_SIZE] = {static_cast<uint8_t>(uuid.uuid.uuid16), static_cast<uint8_t>(uuid.uuid.uuid16 >> 8)};
+    uint16_t svc_uuid16 = service_data.uuid.uuid16();
+    uint8_t data[MAX_DATA_SIZE] = {static_cast<uint8_t>(svc_uuid16), static_cast<uint8_t>(svc_uuid16 >> 8)};
     std::copy(service_data.data.begin(), service_data.data.end(), std::begin(data) + 2);
 
     // dispatch data to parser
@@ -202,5 +200,3 @@ static optional<ParseResult> parse_tp3(const uint8_t *data, std::size_t data_siz
 }
 
 }  // namespace esphome::thermopro_ble
-
-#endif

--- a/esphome/components/thermopro_ble/thermopro_ble.h
+++ b/esphome/components/thermopro_ble/thermopro_ble.h
@@ -2,9 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
-
-#ifdef USE_ESP32
+#include "esphome/components/ble_device_base/ble_device.h"
 
 namespace esphome::thermopro_ble {
 
@@ -17,11 +15,11 @@ struct ParseResult {
 
 using DeviceParser = optional<ParseResult> (*)(const uint8_t *data, std::size_t data_size);
 
-class ThermoProBLE final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class ThermoProBLE final : public Component, public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { this->address_ = address; };
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
   void dump_config() override;
   void set_signal_strength(sensor::Sensor *signal_strength) { this->signal_strength_ = signal_strength; }
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; }
@@ -45,5 +43,3 @@ class ThermoProBLE final : public Component, public esp32_ble_tracker::ESPBTDevi
 };
 
 }  // namespace esphome::thermopro_ble
-
-#endif

--- a/esphome/components/xiaomi_ble/__init__.py
+++ b/esphome/components/xiaomi_ble/__init__.py
@@ -1,22 +1,25 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker
+from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 xiaomi_ble_ns = cg.esphome_ns.namespace("xiaomi_ble")
 XiaomiListener = xiaomi_ble_ns.class_(
-    "XiaomiListener", esp32_ble_tracker.ESPBTDeviceListener
+    "XiaomiListener", ble_device_base.ESPBTDeviceListener
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(XiaomiListener),
-    }
-).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("xiaomi_ble"),
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(XiaomiListener),
+        }
+    ).extend(ble_device_base.BLE_DEVICE_SCHEMA),
+)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -2,14 +2,21 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 #include <vector>
+
+// AES-CCM backend for encrypted-payload (bindkey) decryption:
+//   - ESP32 + ESP-IDF >= 6.0 -> PSA crypto (psa_aead_decrypt), hardware-backed.
+//   - every other platform   -> the portable software AES-CCM in ble_device_base, so
+//     decryption never depends on the SDK exposing mbedtls/PSA to application code.
+#ifdef USE_ESP32
 #include <esp_idf_version.h>
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #include <psa/crypto.h>
-#else
-#include "mbedtls/ccm.h"
+#define XIAOMI_CRYPTO_PSA
+#endif
+#endif
+#ifndef XIAOMI_CRYPTO_PSA
+#include "esphome/components/ble_device_base/ble_aes_ccm.h"
 #endif
 
 namespace esphome::xiaomi_ble {
@@ -166,7 +173,7 @@ bool parse_xiaomi_message(const std::vector<uint8_t> &message, XiaomiParseResult
   return success;
 }
 
-optional<XiaomiParseResult> parse_xiaomi_header(const esp32_ble_tracker::ServiceData &service_data) {
+optional<XiaomiParseResult> parse_xiaomi_header(const ble_device_base::ServiceData &service_data) {
   XiaomiParseResult result;
   if (!service_data.uuid.contains(0x95, 0xFE)) {
     ESP_LOGVV(TAG, "parse_xiaomi_header(): no service data UUID magic bytes.");
@@ -318,7 +325,7 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   memcpy(vector.iv + 6, v + 2, 3);               // sensor type (2) + packet id (1)
   memcpy(vector.iv + 9, v + raw.size() - 7, 3);  // payload counter
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#ifdef XIAOMI_CRYPTO_PSA
   // PSA AEAD expects ciphertext + tag concatenated
   uint8_t ct_with_tag[sizeof(vector.ciphertext) + sizeof(vector.tag)];
   memcpy(ct_with_tag, vector.ciphertext, vector.datasize);
@@ -344,20 +351,10 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   psa_destroy_key(key_id);
   bool decrypt_ok = (status == PSA_SUCCESS && plaintext_length == vector.datasize);
 #else
-  mbedtls_ccm_context ctx;
-  mbedtls_ccm_init(&ctx);
-
-  int ret = mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, vector.key, vector.keysize * 8);
-  if (ret) {
-    ESP_LOGVV(TAG, "decrypt_xiaomi_payload(): mbedtls_ccm_setkey() failed.");
-    mbedtls_ccm_free(&ctx);
-    return false;
-  }
-
-  ret = mbedtls_ccm_auth_decrypt(&ctx, vector.datasize, vector.iv, vector.ivsize, vector.authdata, vector.authsize,
-                                 vector.ciphertext, vector.plaintext, vector.tag, vector.tagsize);
-  mbedtls_ccm_free(&ctx);
-  bool decrypt_ok = (ret == 0);
+  // Portable software AES-CCM (ble_device_base) — no SDK mbedtls/PSA dependency.
+  bool decrypt_ok = ble_device_base::aes_ccm_auth_decrypt(vector.key, vector.iv, vector.ivsize, vector.authdata,
+                                                          vector.authsize, vector.ciphertext, vector.datasize,
+                                                          vector.plaintext, vector.tag, vector.tagsize);
 #endif
 
   if (!decrypt_ok) {
@@ -448,7 +445,7 @@ bool report_xiaomi_results(const optional<XiaomiParseResult> &result, const char
   return true;
 }
 
-bool XiaomiListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool XiaomiListener::parse_device(const ble_device_base::ESPBTDevice &device) {
   // Previously the message was parsed twice per packet, once by XiaomiListener::parse_device()
   // and then again by the respective device class's parse_device() function. Parsing the header
   // here and then for each device seems to be unnecessary and complicates the duplicate packet filtering.
@@ -460,5 +457,3 @@ bool XiaomiListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 }
 
 }  // namespace esphome::xiaomi_ble
-
-#endif

--- a/esphome/components/xiaomi_ble/xiaomi_ble.h
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/core/component.h"
 
 #include <vector>
-
-#ifdef USE_ESP32
 
 namespace esphome::xiaomi_ble {
 
@@ -68,15 +66,13 @@ struct XiaomiAESVector {
 
 bool parse_xiaomi_value(uint16_t value_type, const uint8_t *data, uint8_t value_length, XiaomiParseResult &result);
 bool parse_xiaomi_message(const std::vector<uint8_t> &message, XiaomiParseResult &result);
-optional<XiaomiParseResult> parse_xiaomi_header(const esp32_ble_tracker::ServiceData &service_data);
+optional<XiaomiParseResult> parse_xiaomi_header(const ble_device_base::ServiceData &service_data);
 bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address);
 bool report_xiaomi_results(const optional<XiaomiParseResult> &result, const char *address);
 
-class XiaomiListener final : public esp32_ble_tracker::ESPBTDeviceListener {
+class XiaomiListener final : public ble_device_base::ESPBTDeviceListener {
  public:
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 };
 
 }  // namespace esphome::xiaomi_ble
-
-#endif

--- a/tests/components/ble_device_base/test_aes_ccm.cpp
+++ b/tests/components/ble_device_base/test_aes_ccm.cpp
@@ -19,6 +19,33 @@ const uint8_t TAG[4] = {0x48, 0x4d, 0xaa, 0x56};
 const uint8_t PLAINTEXT[7] = {0x02, 0x01, 0x64, 0x03, 0x10, 0x8a, 0x01};
 }  // namespace
 
+// Xiaomi's parameters differ from BTHome's: a 12-byte nonce and a 1-byte AAD
+// (0x11). Both the AAD block and the l = 3 length encoding are only reachable
+// through this shape, so they need their own vector. Generated the same way.
+namespace {
+const uint8_t NONCE_XIAOMI[12] = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b};
+const uint8_t AAD_XIAOMI[1] = {0x11};
+const uint8_t CIPHERTEXT_XIAOMI[5] = {0xc3, 0x7e, 0x0a, 0x1d, 0x23};
+const uint8_t TAG_XIAOMI[4] = {0x98, 0x79, 0x87, 0xc6};
+const uint8_t PLAINTEXT_XIAOMI[5] = {0x04, 0x10, 0x02, 0xd4, 0x00};
+}  // namespace
+
+TEST(BleAesCcm, DecryptsXiaomiShapedVector) {
+  uint8_t out[sizeof(PLAINTEXT_XIAOMI)] = {};
+  EXPECT_TRUE(aes_ccm_auth_decrypt(KEY, NONCE_XIAOMI, sizeof(NONCE_XIAOMI), AAD_XIAOMI, sizeof(AAD_XIAOMI),
+                                   CIPHERTEXT_XIAOMI, sizeof(CIPHERTEXT_XIAOMI), out, TAG_XIAOMI, sizeof(TAG_XIAOMI)));
+  EXPECT_EQ(0, memcmp(out, PLAINTEXT_XIAOMI, sizeof(PLAINTEXT_XIAOMI)));
+}
+
+TEST(BleAesCcm, RejectsWrongAssociatedData) {
+  uint8_t bad_aad[sizeof(AAD_XIAOMI)];
+  memcpy(bad_aad, AAD_XIAOMI, sizeof(AAD_XIAOMI));
+  bad_aad[0] ^= 0x01;
+  uint8_t out[sizeof(PLAINTEXT_XIAOMI)] = {};
+  EXPECT_FALSE(aes_ccm_auth_decrypt(KEY, NONCE_XIAOMI, sizeof(NONCE_XIAOMI), bad_aad, sizeof(bad_aad),
+                                    CIPHERTEXT_XIAOMI, sizeof(CIPHERTEXT_XIAOMI), out, TAG_XIAOMI, sizeof(TAG_XIAOMI)));
+}
+
 TEST(BleAesCcm, DecryptsAndAuthenticatesKnownVector) {
   uint8_t out[sizeof(PLAINTEXT)] = {};
   EXPECT_TRUE(aes_ccm_auth_decrypt(KEY, NONCE, sizeof(NONCE), nullptr, 0, CIPHERTEXT, sizeof(CIPHERTEXT), out, TAG,

--- a/tests/components/exposure_notifications/common-ln.yaml
+++ b/tests/components/exposure_notifications/common-ln.yaml
@@ -1,0 +1,5 @@
+exposure_notifications:
+  on_exposure_notification:
+    then:
+      - lambda: |
+          ESP_LOGD("main", "RSSI: %d", x.rssi);

--- a/tests/components/exposure_notifications/test.ln882x-ard.yaml
+++ b/tests/components/exposure_notifications/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  exposure_notifications: !include common-ln.yaml

--- a/tests/components/exposure_notifications/validate.bk72xx-ard.yaml
+++ b/tests/components/exposure_notifications/validate.bk72xx-ard.yaml
@@ -1,4 +1,7 @@
-esp32_ble_tracker:
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
   id: ble_tracker_hub
 
 exposure_notifications:

--- a/tests/components/thermopro_ble/common-ln.yaml
+++ b/tests/components/thermopro_ble/common-ln.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: thermopro_ble
+    mac_address: FE:74:B8:6A:97:B7
+    temperature:
+      name: ThermoPro Temperature
+    humidity:
+      name: ThermoPro Humidity

--- a/tests/components/thermopro_ble/common.yaml
+++ b/tests/components/thermopro_ble/common.yaml
@@ -1,7 +1,10 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
 sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: thermopro_ble
+    ble_hub_id: ble_tracker_hub
     mac_address: FE:74:B8:6A:97:B7
     temperature:
       name: "ThermoPro Temperature"

--- a/tests/components/thermopro_ble/test.ln882x-ard.yaml
+++ b/tests/components/thermopro_ble/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  thermopro_ble: !include common-ln.yaml

--- a/tests/components/thermopro_ble/validate.bk72xx-ard.yaml
+++ b/tests/components/thermopro_ble/validate.bk72xx-ard.yaml
@@ -1,0 +1,24 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
+  - platform: thermopro_ble
+    ble_hub_id: ble_tracker_hub
+    mac_address: FE:74:B8:6A:97:B7
+    temperature:
+      name: "ThermoPro Temperature"
+    humidity:
+      name: "ThermoPro Humidity"
+    battery_level:
+      name: "ThermoPro Battery Level"
+    signal_strength:
+      name: "ThermoPro Signal Strength"
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: thermopro_ble
+    mac_address: FE:74:B8:6A:97:B8
+    temperature:
+      name: BK ThermoPro Implicit Temperature

--- a/tests/components/xiaomi_ble/common-ln.yaml
+++ b/tests/components/xiaomi_ble/common-ln.yaml
@@ -1,0 +1,1 @@
+xiaomi_ble:

--- a/tests/components/xiaomi_ble/common.yaml
+++ b/tests/components/xiaomi_ble/common.yaml
@@ -1,3 +1,6 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
+# Explicit ble_hub_id: pins the neutral binding as a declared key.
 xiaomi_ble:
+  ble_hub_id: ble_tracker_hub

--- a/tests/components/xiaomi_ble/test.ln882x-ard.yaml
+++ b/tests/components/xiaomi_ble/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  xiaomi_ble: !include common-ln.yaml

--- a/tests/components/xiaomi_ble/validate.bk72xx-ard.yaml
+++ b/tests/components/xiaomi_ble/validate.bk72xx-ard.yaml
@@ -1,0 +1,9 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+# Explicit ble_hub_id: pins the neutral binding as a declared key.
+xiaomi_ble:
+  ble_hub_id: ble_tracker_hub


### PR DESCRIPTION
# What does this implement/fix?

**Batch 6 of 13** of the neutral-layer BLE sensor migration — the series is defined and reviewed in #17716 (batch 1, merged). The shared `ble_device_base` enablers landed in #18081. This branch is cut against merged dev and carries only the three platform migrations. Per review direction: batches of up to 3 similar platforms, **one PR open for review at a time** — 

## What migrates in this batch

**`thermopro_ble`**, **`exposure_notifications`** and **`xiaomi_ble`** — the last is the shared parser for the whole Xiaomi family and carries the portable AES-CCM path.

The AES-CCM switch is not only a new-platform enabler: on ESP32 with IDF < 6.0 `xiaomi_ble` moves from `mbedtls_ccm_auth_decrypt` to the in-tree software implementation, which is the configuration most existing Xiaomi users are on. IDF >= 6.0 keeps the PSA path unchanged. The memory-impact job selected `ln882x-ard` for this PR, so it did not measure the ESP32 flash delta from that swap.

Same uniform recipe as #17716: python `DEPENDENCIES` → `AUTO_LOAD ["ble_device_base"]`, schema extends `ble_device_base.BLE_DEVICE_SCHEMA` with `rename_legacy_hub_id` prepended, registration via `ble_device_base.register_ble_device`, C++ `esp32_ble_tracker::` → `ble_device_base::`, `USE_ESP32` guards dropped.

`exposure_notifications` keeps the `esp32_ble_id` alias like every other platform in the series: `validate_automation()` needs a dict-based schema, so the rename is applied to the option value instead of inside the automation schema. Verified — a config with `esp32_ble_id:` validates and warns.

`tests/components/ble_device_base/test_aes_ccm.cpp` gains a Xiaomi-shaped known-answer vector (12-byte nonce, 1-byte AAD `0x11`, 4-byte tag) plus a wrong-AAD rejection case, so the AAD block and the `l = 3` length encoding that `xiaomi_ble` newly depends on are covered.

Fixtures: all three `common.yaml` files gain `id: ble_tracker_hub` and pin `ble_hub_id:` on one entry; new per-platform `common-ln.yaml` + `test.ln882x-ard.yaml` compile the guard-free C++ on LN882H (`xiaomi_ble` build verified, exit 0); new config-only `validate.bk72xx-ard.yaml` fixtures, with `thermopro_ble` also covering the generated binding.

## Batch roadmap

| Batch | Where | Platforms |
|---|---|---|
| 1 | #17716 (merged) | `ble_presence`, `ble_rssi`, `ble_scanner` + shared `ble_device_base` enablers |
| 2 | #17950 (merged) | `atc_mithermometer`, `pvvx_mithermometer`, `bthome_mithermometer` |
| 3 | #17951 (merged) | `mopeka_ble`, `mopeka_pro_check`, `mopeka_std_check` |
| 4 | #18161 (merged) | `ruuvi_ble`, `ruuvitag`, `b_parasite` |
| 5 | #18165 (merged) | `airthings_ble`, `inkbird_ibsth1_mini`, `radon_eye_ble` |
| 6 | this PR | `thermopro_ble`, `exposure_notifications`, `xiaomi_ble` (shared hub; portable AES-CCM) |
| 7 | branch [`ble-sensors-batch7`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch7) | `xiaomi_cgd1`, `xiaomi_cgdk2`, `xiaomi_cgg1` |
| 8 | branch [`ble-sensors-batch8`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch8) | `xiaomi_cgpr1`, `xiaomi_gcls002`, `xiaomi_hhccjcy01` |
| 9 | branch [`ble-sensors-batch9`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch9) | `xiaomi_hhccjcy10`, `xiaomi_hhccpot002`, `xiaomi_jqjcy01ym` |
| 10 | branch [`ble-sensors-batch10`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch10) | `xiaomi_lywsd02`, `xiaomi_lywsd02mmc`, `xiaomi_lywsd03mmc` |
| 11 | branch [`ble-sensors-batch11`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch11) | `xiaomi_lywsdcgq`, `xiaomi_mhoc303`, `xiaomi_mhoc401` |
| 12 | branch [`ble-sensors-batch12`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch12) | `xiaomi_miscale`, `xiaomi_mjyd02yla`, `xiaomi_mue4094rt` |
| 13 | branch [`ble-sensors-batch13`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch13) | `xiaomi_rtcgq02lm`, `xiaomi_wx08zm`, `xiaomi_xmwsdj04mmc` |

Each batch is a single commit cut from the same validated full-migration tree, so the series is complete by construction (batch 1 + batches 2–13 = all 39 platforms). A batch PR flips from draft to ready only when the previous one merges — one PR open for review at a time per the direction on #17716.

## Breaking changes and migration

Same as the rest of the series: the auto-generated per-sensor tracker reference `esp32_ble_id:` becomes `ble_hub_id:` on the migrated platforms. Most configurations are unaffected: the key is auto-generated and only written explicitly to disambiguate multiple trackers. Configurations that do set it rename the key:

```yaml
# before
sensor:
  - platform: thermopro_ble
    esp32_ble_id: my_tracker
    mac_address: "FE:74:B8:6A:97:B7"
    temperature:
      name: "ThermoPro Temperature"

# after
sensor:
  - platform: thermopro_ble
    ble_hub_id: my_tracker
    mac_address: "FE:74:B8:6A:97:B7"
    temperature:
      name: "ThermoPro Temperature"
```

The transitional alias (`ble_device_base.rename_legacy_hub_id`) warns and auto-migrates an explicit `esp32_ble_id:` until 2027.2.0, so existing configurations keep validating through the rename window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Design discussion: https://github.com/esphome/esphome/discussions/3758
- Series: #17716

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7128
- esphome/esphome.io#7024

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#164

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: thermopro_ble
    mac_address: "FE:74:B8:6A:97:B7"
    temperature:
      name: "ThermoPro Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).








