### PR TITLE
[ble_device_base] Migrate BLE sensor platforms to the neutral layer (batch 12: xiaomi_miscale, xiaomi_mjyd02yla, xiaomi_mue4094rt)

### DIFF
--- a/esphome/components/xiaomi_miscale/sensor.py
+++ b/esphome/components/xiaomi_miscale/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import esp32_ble_tracker, sensor
+from esphome.components import ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CLEAR_IMPEDANCE,
@@ -15,14 +15,15 @@ from esphome.const import (
     UNIT_OHM,
 )
 
-DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["ble_device_base"]
 
 xiaomi_miscale_ns = cg.esphome_ns.namespace("xiaomi_miscale")
 XiaomiMiscale = xiaomi_miscale_ns.class_(
-    "XiaomiMiscale", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
+    "XiaomiMiscale", ble_device_base.ESPBTDeviceListener, cg.Component
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("xiaomi_miscale"),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(XiaomiMiscale),
@@ -43,15 +44,15 @@ CONFIG_SCHEMA = (
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
     cg.add(var.set_clear_impedance(config[CONF_CLEAR_IMPEDANCE]))

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
@@ -1,8 +1,6 @@
 #include "xiaomi_miscale.h"
-#include "esphome/components/esp32_ble/ble_uuid.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/core/log.h"
-
-#ifdef USE_ESP32
 
 namespace esphome::xiaomi_miscale {
 
@@ -14,7 +12,7 @@ void XiaomiMiscale::dump_config() {
   LOG_SENSOR("  ", "Impedance", this->impedance_);
 }
 
-bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool XiaomiMiscale::parse_device(const ble_device_base::ESPBTDevice &device) {
   if (device.address_uint64() != this->address_) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
@@ -56,14 +54,14 @@ bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-optional<ParseResult> XiaomiMiscale::parse_header_(const esp32_ble_tracker::ServiceData &service_data) {
+optional<ParseResult> XiaomiMiscale::parse_header_(const ble_device_base::ServiceData &service_data) {
   ParseResult result;
-  if (service_data.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x181D) && service_data.data.size() == 10) {
+  if (service_data.uuid == ble_device_base::ESPBTUUID::from_uint16(0x181D) && service_data.data.size() == 10) {
     result.version = 1;
-  } else if (service_data.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x181B) && service_data.data.size() == 13) {
+  } else if (service_data.uuid == ble_device_base::ESPBTUUID::from_uint16(0x181B) && service_data.data.size() == 13) {
     result.version = 2;
   } else {
-    char uuid_buf[esp32_ble::UUID_STR_LEN];
+    char uuid_buf[ble_device_base::UUID_STR_LEN];
     ESP_LOGVV(TAG,
               "parse_header(): Couldn't identify scale version or data size was not correct. UUID: %s, data_size: %d",
               service_data.uuid.to_str(uuid_buf), service_data.data.size());
@@ -167,5 +165,3 @@ bool XiaomiMiscale::report_results_(const optional<ParseResult> &result, const c
 }
 
 }  // namespace esphome::xiaomi_miscale
-
-#endif

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.h
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.h
@@ -2,11 +2,9 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 
 #include <vector>
-
-#ifdef USE_ESP32
 
 namespace esphome::xiaomi_miscale {
 
@@ -16,11 +14,11 @@ struct ParseResult {
   optional<float> impedance;
 };
 
-class XiaomiMiscale final : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+class XiaomiMiscale final : public Component, public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
   void dump_config() override;
   void set_weight(sensor::Sensor *weight) { weight_ = weight; }
   void set_impedance(sensor::Sensor *impedance) { impedance_ = impedance; }
@@ -32,7 +30,7 @@ class XiaomiMiscale final : public Component, public esp32_ble_tracker::ESPBTDev
   sensor::Sensor *impedance_{nullptr};
   bool clear_impedance_{false};
 
-  optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
+  optional<ParseResult> parse_header_(const ble_device_base::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
   bool parse_message_v1_(const std::vector<uint8_t> &message, ParseResult &result);
   bool parse_message_v2_(const std::vector<uint8_t> &message, ParseResult &result);
@@ -40,5 +38,3 @@ class XiaomiMiscale final : public Component, public esp32_ble_tracker::ESPBTDev
 };
 
 }  // namespace esphome::xiaomi_miscale
-
-#endif

--- a/esphome/components/xiaomi_mjyd02yla/binary_sensor.py
+++ b/esphome/components/xiaomi_mjyd02yla/binary_sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import binary_sensor, esp32_ble_tracker, sensor
+from esphome.components import binary_sensor, ble_device_base, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BATTERY_LEVEL,
@@ -20,18 +20,18 @@ from esphome.const import (
     UNIT_PERCENT,
 )
 
-DEPENDENCIES = ["esp32_ble_tracker"]
-AUTO_LOAD = ["xiaomi_ble", "sensor"]
+AUTO_LOAD = ["ble_device_base", "xiaomi_ble", "sensor"]
 
 xiaomi_mjyd02yla_ns = cg.esphome_ns.namespace("xiaomi_mjyd02yla")
 XiaomiMJYD02YLA = xiaomi_mjyd02yla_ns.class_(
     "XiaomiMJYD02YLA",
     binary_sensor.BinarySensor,
     cg.Component,
-    esp32_ble_tracker.ESPBTDeviceListener,
+    ble_device_base.ESPBTDeviceListener,
 )
 
 CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("xiaomi_mjyd02yla"),
     binary_sensor.binary_sensor_schema(
         XiaomiMJYD02YLA, device_class=DEVICE_CLASS_MOTION
     )
@@ -63,15 +63,15 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
     cg.add(var.set_bindkey(config[CONF_BINDKEY]))

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
@@ -2,8 +2,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::xiaomi_mjyd02yla {
 
 static const char *const TAG = "xiaomi_mjyd02yla";
@@ -17,7 +15,7 @@ void XiaomiMJYD02YLA::dump_config() {
   LOG_SENSOR("  ", "Illuminance", this->illuminance_);
 }
 
-bool XiaomiMJYD02YLA::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool XiaomiMJYD02YLA::parse_device(const ble_device_base::ESPBTDevice &device) {
   if (device.address_uint64() != this->address_) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
@@ -65,5 +63,3 @@ bool XiaomiMJYD02YLA::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
 void XiaomiMJYD02YLA::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace esphome::xiaomi_mjyd02yla
-
-#endif

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
@@ -3,21 +3,19 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/components/xiaomi_ble/xiaomi_ble.h"
-
-#ifdef USE_ESP32
 
 namespace esphome::xiaomi_mjyd02yla {
 
 class XiaomiMJYD02YLA final : public Component,
                               public binary_sensor::BinarySensorInitiallyOff,
-                              public esp32_ble_tracker::ESPBTDeviceListener {
+                              public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
   void set_bindkey(const char *bindkey);
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 
   void dump_config() override;
   void set_idle_time(sensor::Sensor *idle_time) { idle_time_ = idle_time; }
@@ -35,5 +33,3 @@ class XiaomiMJYD02YLA final : public Component,
 };
 
 }  // namespace esphome::xiaomi_mjyd02yla
-
-#endif

--- a/esphome/components/xiaomi_mue4094rt/binary_sensor.py
+++ b/esphome/components/xiaomi_mue4094rt/binary_sensor.py
@@ -1,21 +1,21 @@
 from esphome import core
 import esphome.codegen as cg
-from esphome.components import binary_sensor, esp32_ble_tracker
+from esphome.components import binary_sensor, ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_MAC_ADDRESS, CONF_TIMEOUT, DEVICE_CLASS_MOTION
 
-DEPENDENCIES = ["esp32_ble_tracker"]
-AUTO_LOAD = ["xiaomi_ble"]
+AUTO_LOAD = ["ble_device_base", "xiaomi_ble"]
 
 xiaomi_mue4094rt_ns = cg.esphome_ns.namespace("xiaomi_mue4094rt")
 XiaomiMUE4094RT = xiaomi_mue4094rt_ns.class_(
     "XiaomiMUE4094RT",
     binary_sensor.BinarySensor,
     cg.Component,
-    esp32_ble_tracker.ESPBTDeviceListener,
+    ble_device_base.ESPBTDeviceListener,
 )
 
 CONFIG_SCHEMA = cv.All(
+    ble_device_base.rename_legacy_hub_id("xiaomi_mue4094rt"),
     binary_sensor.binary_sensor_schema(
         XiaomiMUE4094RT, device_class=DEVICE_CLASS_MOTION
     )
@@ -28,15 +28,15 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
-    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_device_base.BLE_DEVICE_SCHEMA),
 )
 
 
 async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
-    await esp32_ble_tracker.register_ble_device(var, config)
+    await ble_device_base.register_ble_device(var, config)
 
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
     cg.add(var.set_time(config[CONF_TIMEOUT]))

--- a/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.cpp
+++ b/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.cpp
@@ -1,8 +1,6 @@
 #include "xiaomi_mue4094rt.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
 namespace esphome::xiaomi_mue4094rt {
 
 static const char *const TAG = "xiaomi_mue4094rt";
@@ -12,7 +10,7 @@ void XiaomiMUE4094RT::dump_config() {
   LOG_BINARY_SENSOR("  ", "Motion", this);
 }
 
-bool XiaomiMUE4094RT::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool XiaomiMUE4094RT::parse_device(const ble_device_base::ESPBTDevice &device) {
   if (device.address_uint64() != this->address_) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
@@ -51,5 +49,3 @@ bool XiaomiMUE4094RT::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
 }
 
 }  // namespace esphome::xiaomi_mue4094rt
-
-#endif

--- a/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.h
+++ b/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.h
@@ -2,20 +2,18 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/ble_device_base/ble_device.h"
 #include "esphome/components/xiaomi_ble/xiaomi_ble.h"
-
-#ifdef USE_ESP32
 
 namespace esphome::xiaomi_mue4094rt {
 
 class XiaomiMUE4094RT final : public Component,
                               public binary_sensor::BinarySensorInitiallyOff,
-                              public esp32_ble_tracker::ESPBTDeviceListener {
+                              public ble_device_base::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
 
-  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
 
   void dump_config() override;
   void set_time(uint16_t timeout) { timeout_ = timeout; }
@@ -26,5 +24,3 @@ class XiaomiMUE4094RT final : public Component,
 };
 
 }  // namespace esphome::xiaomi_mue4094rt
-
-#endif

--- a/tests/components/xiaomi_miscale/common-ln.yaml
+++ b/tests/components/xiaomi_miscale/common-ln.yaml
@@ -1,10 +1,5 @@
-esp32_ble_tracker:
-  id: ble_tracker_hub
-
 sensor:
-  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: xiaomi_miscale
-    ble_hub_id: ble_tracker_hub
     mac_address: '5C:CA:D3:70:D4:A2'
     weight:
       name: "Xiaomi Mi Scale Weight"

--- a/tests/components/xiaomi_miscale/test.ln882x-ard.yaml
+++ b/tests/components/xiaomi_miscale/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  xiaomi_miscale: !include common-ln.yaml

--- a/tests/components/xiaomi_miscale/validate.bk72xx-ard.yaml
+++ b/tests/components/xiaomi_miscale/validate.bk72xx-ard.yaml
@@ -1,0 +1,20 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
+  - platform: xiaomi_miscale
+    ble_hub_id: ble_tracker_hub
+    mac_address: '5C:CA:D3:70:D4:A2'
+    weight:
+      name: "Xiaomi Mi Scale Weight"
+    impedance:
+      name: "Xiaomi Mi Scale Impedance"
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: xiaomi_miscale
+    mac_address: '5C:CA:D3:70:D4:A3'
+    weight:
+      name: "BK Xiaomi Mi Scale Implicit Weight"

--- a/tests/components/xiaomi_mjyd02yla/common-ln.yaml
+++ b/tests/components/xiaomi_mjyd02yla/common-ln.yaml
@@ -1,10 +1,5 @@
-esp32_ble_tracker:
-  id: ble_tracker_hub
-
 binary_sensor:
-  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: xiaomi_mjyd02yla
-    ble_hub_id: ble_tracker_hub
     name: MJYD02YL-A Motion
     mac_address: 50:EC:50:CD:32:02
     bindkey: 48403ebe2d385db8d0c187f81e62cb64

--- a/tests/components/xiaomi_mjyd02yla/test.ln882x-ard.yaml
+++ b/tests/components/xiaomi_mjyd02yla/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  xiaomi_mjyd02yla: !include common-ln.yaml

--- a/tests/components/xiaomi_mjyd02yla/validate.bk72xx-ard.yaml
+++ b/tests/components/xiaomi_mjyd02yla/validate.bk72xx-ard.yaml
@@ -1,0 +1,24 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+binary_sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
+  - platform: xiaomi_mjyd02yla
+    ble_hub_id: ble_tracker_hub
+    name: MJYD02YL-A Motion
+    mac_address: 50:EC:50:CD:32:02
+    bindkey: 48403ebe2d385db8d0c187f81e62cb64
+    idle_time:
+      name: MJYD02YL-A Idle Time
+    light:
+      name: MJYD02YL-A Light Status
+    battery_level:
+      name: MJYD02YL-A Battery Level
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: xiaomi_mjyd02yla
+    name: BK MJYD02YL-A Implicit Motion
+    mac_address: 50:EC:50:CD:32:03
+    bindkey: 48403ebe2d385db8d0c187f81e62cb64

--- a/tests/components/xiaomi_mue4094rt/common-ln.yaml
+++ b/tests/components/xiaomi_mue4094rt/common-ln.yaml
@@ -1,0 +1,5 @@
+binary_sensor:
+  - platform: xiaomi_mue4094rt
+    name: MUE4094RT Motion
+    mac_address: 7A:80:8E:19:36:BA
+    timeout: 5s

--- a/tests/components/xiaomi_mue4094rt/common.yaml
+++ b/tests/components/xiaomi_mue4094rt/common.yaml
@@ -1,7 +1,10 @@
 esp32_ble_tracker:
+  id: ble_tracker_hub
 
 binary_sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
   - platform: xiaomi_mue4094rt
+    ble_hub_id: ble_tracker_hub
     name: MUE4094RT Motion
     mac_address: 7A:80:8E:19:36:BA
     timeout: 5s

--- a/tests/components/xiaomi_mue4094rt/test.ln882x-ard.yaml
+++ b/tests/components/xiaomi_mue4094rt/test.ln882x-ard.yaml
@@ -1,0 +1,3 @@
+packages:
+  ln882h_ble_tracker: !include ../ln882h_ble_tracker/common.yaml
+  xiaomi_mue4094rt: !include common-ln.yaml

--- a/tests/components/xiaomi_mue4094rt/validate.bk72xx-ard.yaml
+++ b/tests/components/xiaomi_mue4094rt/validate.bk72xx-ard.yaml
@@ -1,0 +1,18 @@
+# Config-only: the CI base board (generic-bk7252, BLE 4.2) cannot compile the
+# BLE 5.x tracker, so this fixture proves validation (schema + neutral binding)
+# on a non-esp32 platform; codegen and compilation are not exercised here.
+bk72xx_ble_tracker:
+  id: ble_tracker_hub
+
+binary_sensor:
+  # Explicit ble_hub_id: pins the neutral binding as a declared key.
+  - platform: xiaomi_mue4094rt
+    ble_hub_id: ble_tracker_hub
+    name: MUE4094RT Motion
+    mac_address: 7A:80:8E:19:36:BA
+    timeout: 5s
+  # No ble_hub_id: exercises the generated binding real configs use.
+  - platform: xiaomi_mue4094rt
+    name: BK MUE4094RT Implicit Motion
+    mac_address: 7A:80:8E:19:36:BB
+    timeout: 5s


### PR DESCRIPTION
# What does this implement/fix?

**Batch 12 of 13** of the neutral-layer BLE sensor migration — the series is defined and reviewed in #17716 (batch 1, merged). The shared `ble_device_base` enablers landed in #18081. This branch is cut against merged dev and carries only the three platform migrations. Per review direction: batches of up to 3 similar platforms, **one PR open for review at a time**.

## What migrates in this batch

**`xiaomi_miscale`**, **`xiaomi_mjyd02yla`** and **`xiaomi_mue4094rt`** — the Mi body scale plus two motion sensors (the first two platforms in the series with binary_sensor fixtures beyond `cgpr1`). `mjyd02yla` and `mue4094rt` decode through the shared `xiaomi_ble` parser migrated in #18168; `miscale` carries its own parser and does not auto-load `xiaomi_ble`.

Same uniform recipe as #17716: python `DEPENDENCIES` → `AUTO_LOAD ["ble_device_base"]`, schema extends `ble_device_base.BLE_DEVICE_SCHEMA` with `rename_legacy_hub_id` prepended, registration via `ble_device_base.register_ble_device`, C++ `esp32_ble_tracker::` → `ble_device_base::`, `USE_ESP32` guards dropped.

No crypto or parser changes in this batch — `xiaomi_ble` already carries the portable AES-CCM path from #18168, and these three are consumers of it.

Fixtures: all three `common.yaml` files gain `id: ble_tracker_hub` and pin `ble_hub_id:` on the platform entry; new per-platform `common-ln.yaml` + `test.ln882x-ard.yaml` compile the guard-free C++ on LN882H and exercise the generated binding (no explicit hub id); the config-only `validate.bk72xx-ard.yaml` fixtures pair the pinned entry with a second `ble_hub_id`-less entry, matching the merged batches. `xiaomi_mjyd02yla` and `xiaomi_mue4094rt` are `binary_sensor` platforms, so their fixtures use that domain (implicit entries carry the required `name:` and, for mjyd02yla, `bindkey:`). All nine fixture combinations validate.

Docs: esphome/esphome.io#7132 (opened for batch 7) documents the `ble_hub_id` tracker binding on the shared Xiaomi BLE page and is worded to cover both migrated and not-yet-migrated platforms, so this batch needs no further docs change.

## Batch roadmap

| Batch | Where | Platforms |
|---|---|---|
| 1 | #17716 (merged) | `ble_presence`, `ble_rssi`, `ble_scanner` + shared `ble_device_base` enablers |
| 2 | #17950 (merged) | `atc_mithermometer`, `pvvx_mithermometer`, `bthome_mithermometer` |
| 3 | #17951 (merged) | `mopeka_ble`, `mopeka_pro_check`, `mopeka_std_check` |
| 4 | #18161 (merged) | `ruuvi_ble`, `ruuvitag`, `b_parasite` |
| 5 | #18165 (merged) | `airthings_ble`, `inkbird_ibsth1_mini`, `radon_eye_ble` |
| 6 | #18168 (merged) | `thermopro_ble`, `exposure_notifications`, `xiaomi_ble` (shared hub; portable AES-CCM) |
| 7 | #18170 (merged) | `xiaomi_cgd1`, `xiaomi_cgdk2`, `xiaomi_cgg1` |
| 8 | #18171 (merged) | `xiaomi_cgpr1`, `xiaomi_gcls002`, `xiaomi_hhccjcy01` |
| 9 | #18172 (merged) | `xiaomi_hhccjcy10`, `xiaomi_hhccpot002`, `xiaomi_jqjcy01ym` |
| 10 | #18174 (merged) | `xiaomi_lywsd02`, `xiaomi_lywsd02mmc`, `xiaomi_lywsd03mmc` |
| 11 | #18178 (merged) | `xiaomi_lywsdcgq`, `xiaomi_mhoc303`, `xiaomi_mhoc401` |
| 12 | this PR | `xiaomi_miscale`, `xiaomi_mjyd02yla`, `xiaomi_mue4094rt` |
| 13 | branch [`ble-sensors-batch13`](https://github.com/Bl00d-B0b/esphome/tree/ble-sensors-batch13) | `xiaomi_rtcgq02lm`, `xiaomi_wx08zm`, `xiaomi_xmwsdj04mmc` |

Each batch is a single commit cut from the same validated full-migration tree, so the series is complete by construction (batch 1 + batches 2–13 = all 39 platforms). A batch PR opens only when the previous one merges — one PR open for review at a time per the direction on #17716.

## Breaking changes and migration

Same as the rest of the series: the auto-generated per-sensor tracker reference `esp32_ble_id:` becomes `ble_hub_id:` on the migrated platforms. Most configurations are unaffected: the key is auto-generated and only written explicitly to disambiguate multiple trackers. Configurations that do set it rename the key:

```yaml
# before
sensor:
  - platform: xiaomi_miscale
    esp32_ble_id: my_tracker
    mac_address: "5C:CA:D3:70:D4:A2"
    weight:
      name: "Xiaomi Mi Scale Weight"

# after
sensor:
  - platform: xiaomi_miscale
    ble_hub_id: my_tracker
    mac_address: "5C:CA:D3:70:D4:A2"
    weight:
      name: "Xiaomi Mi Scale Weight"
```

The transitional alias (`ble_device_base.rename_legacy_hub_id`) warns and auto-migrates an explicit `esp32_ble_id:` until 2027.2.0, so existing configurations keep validating through the rename window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: xiaomi_miscale
    mac_address: "5C:CA:D3:70:D4:A2"
    weight:
      name: "Xiaomi Mi Scale Weight"
    impedance:
      name: "Xiaomi Mi Scale Impedance"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
