### PR TITLE
[spi] Add nRF52 (Zephyr) hardware SPI support

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -64,6 +64,10 @@ PLATFORM_SPI_CLOCKS = {
     PLATFORM_RP2: 62.5e6,
 }
 
+# SPIM2 only implements these discrete clock steps - unlike the other platforms
+# it does not derive an arbitrary rate from a divisor of its max clock.
+PLATFORM_NRF52_SPI_RATES = (125e3, 250e3, 500e3, 1e6, 2e6, 4e6, 8e6)
+
 MAX_DATA_RATE_ERROR = 0.05  # Max allowable actual data rate difference from requested
 
 
@@ -100,8 +104,11 @@ def _frequency_validator(value):
         )
     if value < 1000:
         raise cv.Invalid("The configured SPI data rate must be at least 1000Hz")
-    divisor = round(frequency / value)
-    actual = frequency / divisor
+    if platform == PLATFORM_NRF52:
+        actual = min(PLATFORM_NRF52_SPI_RATES, key=lambda rate: abs(rate - value))
+    else:
+        divisor = round(frequency / value)
+        actual = frequency / divisor
     error = abs(actual - value) / value
     if error > MAX_DATA_RATE_ERROR:
         raise cv.Invalid(
@@ -410,9 +417,10 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config):
+def _final_validate(config: ConfigType) -> None:
     full_config = fv.full_config.get().get(CONF_SPI, [])
-    if CORE.using_zephyr and len(full_config) > 1:
+    hardware_buses = sum(CONF_INTERFACE_INDEX in spi for spi in full_config)
+    if CORE.using_zephyr and hardware_buses > 1:
         raise cv.Invalid("Second spi is not implemented on Zephyr yet")
 
 
@@ -436,51 +444,58 @@ async def to_code(configs):
             cg.add(var.set_mosi(await cg.gpio_pin_expression(mosi)))
         if data_pins := spi.get(CONF_DATA_PINS):
             cg.add(var.set_data_pins(data_pins))
-        if CORE.using_zephyr:
-            zephyr_add_prj_conf("SPI", True)
-            clk_pin = spi[CONF_CLK_PIN][CONF_NUMBER]
-            mosi_pin = mosi[CONF_NUMBER] if mosi else None
-            miso_pin = miso[CONF_NUMBER] if miso else None
-            psels = f"<NRF_PSEL(SPIM_SCK, {clk_pin // 32}, {clk_pin % 32})>"
-            if mosi_pin is not None:
-                psels += f", <NRF_PSEL(SPIM_MOSI, {mosi_pin // 32}, {mosi_pin % 32})>"
-            if miso_pin is not None:
-                psels += f", <NRF_PSEL(SPIM_MISO, {miso_pin // 32}, {miso_pin % 32})>"
-            zephyr_add_overlay(
-                f"""
-                    &pinctrl {{
-                        spi2_default: spi2_default {{
-                            group1 {{
-                                psels = {psels};
+        if (index := spi.get(CONF_INTERFACE_INDEX)) is not None:
+            if CORE.using_zephyr:
+                zephyr_add_prj_conf("SPI", True)
+                clk_pin = spi[CONF_CLK_PIN][CONF_NUMBER]
+                mosi_pin = mosi[CONF_NUMBER] if mosi else None
+                miso_pin = miso[CONF_NUMBER] if miso else None
+                psels = f"<NRF_PSEL(SPIM_SCK, {clk_pin // 32}, {clk_pin % 32})>"
+                if mosi_pin is not None:
+                    psels += (
+                        f", <NRF_PSEL(SPIM_MOSI, {mosi_pin // 32}, {mosi_pin % 32})>"
+                    )
+                if miso_pin is not None:
+                    psels += (
+                        f", <NRF_PSEL(SPIM_MISO, {miso_pin // 32}, {miso_pin % 32})>"
+                    )
+                zephyr_add_overlay(
+                    f"""
+                        &pinctrl {{
+                            spi2_default: spi2_default {{
+                                group1 {{
+                                    psels = {psels};
+                                }};
+                            }};
+                            spi2_sleep: spi2_sleep {{
+                                group1 {{
+                                    psels = {psels};
+                                    low-power-enable;
+                                }};
                             }};
                         }};
-                        spi2_sleep: spi2_sleep {{
-                            group1 {{
-                                psels = {psels};
-                                low-power-enable;
-                            }};
+                        &spi2 {{
+                            status = "okay";
+                            pinctrl-0 = <&spi2_default>;
+                            pinctrl-1 = <&spi2_sleep>;
+                            pinctrl-names = "default", "sleep";
                         }};
-                    }};
-                    &spi2 {{
-                        status = "okay";
-                        pinctrl-0 = <&spi2_default>;
-                        pinctrl-1 = <&spi2_sleep>;
-                        pinctrl-names = "default", "sleep";
-                    }};
-                """
-            )
-            cg.add(
-                var.set_interface(cg.RawExpression("DEVICE_DT_GET(DT_NODELABEL(spi2))"))
-            )
-            cg.add(var.set_interface_name("spi2"))
-        elif (index := spi.get(CONF_INTERFACE_INDEX)) is not None:
-            interface = get_spi_interface(index)
-            cg.add(var.set_interface(cg.RawExpression(interface)))
-            cg.add(
-                var.set_interface_name(
-                    re.sub(r"\W", "", interface.replace("new SPIClass", ""))
+                    """
                 )
-            )
+                cg.add(
+                    var.set_interface(
+                        cg.RawExpression("DEVICE_DT_GET(DT_NODELABEL(spi2))")
+                    )
+                )
+                cg.add(var.set_interface_name("spi2"))
+            else:
+                interface = get_spi_interface(index)
+                cg.add(var.set_interface(cg.RawExpression(interface)))
+                cg.add(
+                    var.set_interface_name(
+                        re.sub(r"\W", "", interface.replace("new SPIClass", ""))
+                    )
+                )
 
 
 def spi_device_schema(

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -17,6 +17,7 @@ from esphome.components.esp32 import (
     VARIANT_ESP32S3,
     only_on_variant,
 )
+from esphome.components.zephyr import zephyr_add_overlay, zephyr_add_prj_conf
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -29,12 +30,14 @@ from esphome.const import (
     CONF_MISO_PIN,
     CONF_MOSI_PIN,
     CONF_NUMBER,
+    CONF_SPI,
     CONF_SPI_ID,
     KEY_CORE,
     KEY_TARGET_PLATFORM,
     KEY_VARIANT,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
+    PLATFORM_NRF52,
     PLATFORM_RP2,
     PlatformFramework,
 )
@@ -54,6 +57,10 @@ SPIMode = spi_ns.enum("SPIMode")
 PLATFORM_SPI_CLOCKS = {
     PLATFORM_ESP8266: 40e6,
     PLATFORM_ESP32: 80e6,
+    # nRF52 exposes spi2 (SPIM2), whose documented max data rate is 8 MHz;
+    # the 16/32 MHz "fast" rates are only available on the separate SPIM3
+    # peripheral, which isn't used here.
+    PLATFORM_NRF52: 8e6,
     PLATFORM_RP2: 62.5e6,
 }
 
@@ -181,6 +188,8 @@ def get_hw_interface_list():
         return [["spi", "spi2"], ["spi3"]]
     if target_platform == PLATFORM_RP2:
         return [["spi"], ["spi1"]]
+    if target_platform == PLATFORM_NRF52:
+        return [["spi", "spi2"]]
     return []
 
 
@@ -262,6 +271,8 @@ def validate_hw_pins(spi, index=-1):
         if sdo_pin_no not in pin_set[CONF_MOSI_PIN]:
             return False
         return sdi_pin_no in pin_set[CONF_MISO_PIN]
+    if target_platform == PLATFORM_NRF52:
+        return clk_pin_no >= 0
     return False
 
 
@@ -349,7 +360,7 @@ SPI_SINGLE_SCHEMA = cv.All(
         }
     ),
     cv.has_at_least_one_key(CONF_MISO_PIN, CONF_MOSI_PIN),
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_NRF52, PLATFORM_RP2]),
 )
 
 
@@ -399,6 +410,15 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
+def _final_validate(config):
+    full_config = fv.full_config.get().get(CONF_SPI, [])
+    if CORE.using_zephyr and len(full_config) > 1:
+        raise cv.Invalid("Second spi is not implemented on Zephyr yet")
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
 @coroutine_with_priority(CoroPriority.BUS)
 async def to_code(configs):
     cg.add_define("USE_SPI")
@@ -416,7 +436,44 @@ async def to_code(configs):
             cg.add(var.set_mosi(await cg.gpio_pin_expression(mosi)))
         if data_pins := spi.get(CONF_DATA_PINS):
             cg.add(var.set_data_pins(data_pins))
-        if (index := spi.get(CONF_INTERFACE_INDEX)) is not None:
+        if CORE.using_zephyr:
+            zephyr_add_prj_conf("SPI", True)
+            clk_pin = spi[CONF_CLK_PIN][CONF_NUMBER]
+            mosi_pin = mosi[CONF_NUMBER] if mosi else None
+            miso_pin = miso[CONF_NUMBER] if miso else None
+            psels = f"<NRF_PSEL(SPIM_SCK, {clk_pin // 32}, {clk_pin % 32})>"
+            if mosi_pin is not None:
+                psels += f", <NRF_PSEL(SPIM_MOSI, {mosi_pin // 32}, {mosi_pin % 32})>"
+            if miso_pin is not None:
+                psels += f", <NRF_PSEL(SPIM_MISO, {miso_pin // 32}, {miso_pin % 32})>"
+            zephyr_add_overlay(
+                f"""
+                    &pinctrl {{
+                        spi2_default: spi2_default {{
+                            group1 {{
+                                psels = {psels};
+                            }};
+                        }};
+                        spi2_sleep: spi2_sleep {{
+                            group1 {{
+                                psels = {psels};
+                                low-power-enable;
+                            }};
+                        }};
+                    }};
+                    &spi2 {{
+                        status = "okay";
+                        pinctrl-0 = <&spi2_default>;
+                        pinctrl-1 = <&spi2_sleep>;
+                        pinctrl-names = "default", "sleep";
+                    }};
+                """
+            )
+            cg.add(
+                var.set_interface(cg.RawExpression("DEVICE_DT_GET(DT_NODELABEL(spi2))"))
+            )
+            cg.add(var.set_interface_name("spi2"))
+        elif (index := spi.get(CONF_INTERFACE_INDEX)) is not None:
             interface = get_spi_interface(index)
             cg.add(var.set_interface(cg.RawExpression(interface)))
             cg.add(
@@ -509,5 +566,6 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
             PlatformFramework.ESP32_ARDUINO,
             PlatformFramework.ESP32_IDF,
         },
+        "spi_zephyr.cpp": {PlatformFramework.NRF52_ZEPHYR},
     }
 )

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -2,6 +2,10 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
+#ifdef USE_ZEPHYR
+#include "spi_zephyr.h"
+#endif
+
 namespace esphome::spi {
 
 const char *const TAG = "spi";
@@ -118,8 +122,19 @@ uint16_t SPIDelegateBitBash::transfer_(uint16_t data, size_t num_bits) {
   return out_data;
 }
 
-#if !defined(USE_ESP32) && !defined(USE_ARDUINO)
-// Stub for unsupported platforms (host, Zephyr, etc.) - hardware SPI is unavailable
+#if defined(USE_ZEPHYR)
+
+SPIBus *SPIComponent::get_bus(SPIInterface interface, GPIOPin *clk, GPIOPin *sdo, GPIOPin *sdi,
+                              const std::vector<uint8_t> &data_pins) {
+  if (interface == nullptr || !device_is_ready(interface)) {
+    ESP_LOGE(TAG, "SPI device is not ready");
+    return nullptr;
+  }
+  return new ZephyrSPIBus(interface);  // NOLINT
+}
+
+#elif !defined(USE_ESP32) && !defined(USE_ARDUINO)
+// Stub for unsupported platforms (host, etc.) - hardware SPI is unavailable
 SPIBus *SPIComponent::get_bus(SPIInterface interface, GPIOPin *clk, GPIOPin *sdo, GPIOPin *sdi,
                               const std::vector<uint8_t> &data_pins) {
   return nullptr;

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -23,9 +23,14 @@ using SPIInterface = SPIClassRP2040 *;
 using SPIInterface = SPIClass *;
 #endif
 
+#elif defined(USE_ZEPHYR)
+
+struct device;
+using SPIInterface = const device *;
+
 #elif defined(USE_HOST) || defined(CLANG_TIDY)
 
-using SPIInterface = void *;  // Stub for platforms without SPI (e.g., host, Zephyr)
+using SPIInterface = void *;  // Stub for platforms without SPI (e.g., host)
 
 #endif  // USE_ESP32 / USE_ARDUINO
 

--- a/esphome/components/spi/spi_zephyr.cpp
+++ b/esphome/components/spi/spi_zephyr.cpp
@@ -1,0 +1,110 @@
+#ifdef USE_ZEPHYR
+
+#include "spi_zephyr.h"
+#include <cstdint>
+#include <cstring>
+#include "esphome/core/log.h"
+
+namespace esphome::spi {
+
+static const char *const TAG = "spi.zephyr";
+
+// nRF52's SPIM peripheral uses EasyDMA, which can only access RAM -- flash reads silently fail
+// (garbage or nothing is transferred, with no error reported). ESPHome epaper drivers commonly
+// pass `static const` command tables, which live in flash. RAM starts at 0x20000000 on every
+// nRF52 part, so anything below that needs to be staged through a RAM buffer first.
+static bool is_ram_address(const void *ptr) { return reinterpret_cast<uintptr_t>(ptr) >= 0x20000000UL; }
+
+static constexpr size_t FLASH_STAGING_SIZE = 64;
+
+static spi_operation_t build_operation(SPIBitOrder bit_order, SPIMode mode) {
+  spi_operation_t op = SPI_OP_MODE_MASTER | SPI_WORD_SET(8);
+  op |= (bit_order == BIT_ORDER_LSB_FIRST) ? SPI_TRANSFER_LSB : SPI_TRANSFER_MSB;
+  if (Utility::get_polarity(mode) == CLOCK_POLARITY_HIGH)
+    op |= SPI_MODE_CPOL;
+  if (Utility::get_phase(mode) == CLOCK_PHASE_TRAILING)
+    op |= SPI_MODE_CPHA;
+  return op;
+}
+
+SPIDelegate *ZephyrSPIBus::get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
+                                        bool release_device, bool write_only) {
+  return new ZephyrSPIDelegate(this->dev_, data_rate, bit_order, mode, cs_pin);  // NOLINT
+}
+
+ZephyrSPIDelegate::ZephyrSPIDelegate(const device *dev, uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode,
+                                     GPIOPin *cs_pin)
+    : SPIDelegate(data_rate, bit_order, mode, cs_pin), dev_(dev) {
+  this->cfg_.frequency = data_rate;
+  this->cfg_.operation = build_operation(bit_order, mode);
+}
+
+void ZephyrSPIDelegate::do_transceive_(const uint8_t *tx, uint8_t *rx, size_t length) {
+  if (length == 0)
+    return;
+
+  if (tx != nullptr && !is_ram_address(tx)) {
+    uint8_t chunk[FLASH_STAGING_SIZE];
+    size_t remaining = length;
+    const uint8_t *src = tx;
+    uint8_t *dst_rx = rx;
+    while (remaining > 0) {
+      size_t n = remaining < FLASH_STAGING_SIZE ? remaining : FLASH_STAGING_SIZE;
+      memcpy(chunk, src, n);
+      this->transceive_chunk_(chunk, dst_rx, n);
+      src += n;
+      if (dst_rx != nullptr)
+        dst_rx += n;
+      remaining -= n;
+    }
+    return;
+  }
+
+  this->transceive_chunk_(tx, rx, length);
+}
+
+void ZephyrSPIDelegate::transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t length) {
+  spi_buf tx_buf{};
+  spi_buf rx_buf{};
+  spi_buf_set tx_set{};
+  spi_buf_set rx_set{};
+
+  if (tx != nullptr) {
+    tx_buf.buf = const_cast<uint8_t *>(tx);
+    tx_buf.len = length;
+    tx_set.buffers = &tx_buf;
+    tx_set.count = 1;
+  }
+  if (rx != nullptr) {
+    rx_buf.buf = rx;
+    rx_buf.len = length;
+    rx_set.buffers = &rx_buf;
+    rx_set.count = 1;
+  }
+
+  int err =
+      spi_transceive(this->dev_, &this->cfg_, tx != nullptr ? &tx_set : nullptr, rx != nullptr ? &rx_set : nullptr);
+  if (err != 0) {
+    ESP_LOGE(TAG, "spi_transceive failed: %d", err);
+  }
+}
+
+uint8_t ZephyrSPIDelegate::transfer(uint8_t data) {
+  uint8_t rx = 0;
+  this->do_transceive_(&data, &rx, 1);
+  return rx;
+}
+
+void ZephyrSPIDelegate::transfer(uint8_t *ptr, size_t length) { this->do_transceive_(ptr, ptr, length); }
+
+void ZephyrSPIDelegate::transfer(const uint8_t *txbuf, uint8_t *rxbuf, size_t length) {
+  this->do_transceive_(txbuf, rxbuf, length);
+}
+
+void ZephyrSPIDelegate::write_array(const uint8_t *ptr, size_t length) { this->do_transceive_(ptr, nullptr, length); }
+
+void ZephyrSPIDelegate::read_array(uint8_t *ptr, size_t length) { this->do_transceive_(nullptr, ptr, length); }
+
+}  // namespace esphome::spi
+
+#endif  // USE_ZEPHYR

--- a/esphome/components/spi/spi_zephyr.cpp
+++ b/esphome/components/spi/spi_zephyr.cpp
@@ -51,7 +51,13 @@ void ZephyrSPIDelegate::do_transceive_(const uint8_t *tx, uint8_t *rx, size_t le
     while (remaining > 0) {
       size_t n = remaining < FLASH_STAGING_SIZE ? remaining : FLASH_STAGING_SIZE;
       memcpy(chunk, src, n);
-      this->transceive_chunk_(chunk, dst_rx, n);
+      if (!this->transceive_chunk_(chunk, dst_rx, n)) {
+        // The rest of rx wasn't touched by this or any prior chunk; zero it too so the
+        // whole buffer is deterministic rather than part-result, part-stale data.
+        if (dst_rx != nullptr)
+          memset(dst_rx + n, 0, remaining - n);
+        return;
+      }
       src += n;
       if (dst_rx != nullptr)
         dst_rx += n;
@@ -63,7 +69,7 @@ void ZephyrSPIDelegate::do_transceive_(const uint8_t *tx, uint8_t *rx, size_t le
   this->transceive_chunk_(tx, rx, length);
 }
 
-void ZephyrSPIDelegate::transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t length) {
+bool ZephyrSPIDelegate::transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t length) {
   spi_buf tx_buf{};
   spi_buf rx_buf{};
   spi_buf_set tx_set{};
@@ -86,7 +92,11 @@ void ZephyrSPIDelegate::transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t
       spi_transceive(this->dev_, &this->cfg_, tx != nullptr ? &tx_set : nullptr, rx != nullptr ? &rx_set : nullptr);
   if (err != 0) {
     ESP_LOGE(TAG, "spi_transceive failed: %d", err);
+    if (rx != nullptr)
+      memset(rx, 0, length);
+    return false;
   }
+  return true;
 }
 
 uint8_t ZephyrSPIDelegate::transfer(uint8_t data) {
@@ -102,6 +112,25 @@ void ZephyrSPIDelegate::transfer(const uint8_t *txbuf, uint8_t *rxbuf, size_t le
 }
 
 void ZephyrSPIDelegate::write_array(const uint8_t *ptr, size_t length) { this->do_transceive_(ptr, nullptr, length); }
+
+void ZephyrSPIDelegate::write_array16(const uint16_t *data, size_t length) {
+  if (this->bit_order_ == BIT_ORDER_LSB_FIRST) {
+    this->write_array(reinterpret_cast<const uint8_t *>(data), length * 2);
+    return;
+  }
+  // MSB-first needs each 16-bit word byte-swapped before it goes out; stage the swap
+  // through a small stack buffer instead of one write16() (and one transceive) per pixel.
+  static constexpr size_t SWAP_BUFFER_WORDS = FLASH_STAGING_SIZE / 2;
+  uint16_t buffer[SWAP_BUFFER_WORDS];
+  while (length != 0) {
+    size_t partial = length < SWAP_BUFFER_WORDS ? length : SWAP_BUFFER_WORDS;
+    for (size_t i = 0; i != partial; i++)
+      buffer[i] = (data[i] >> 8) | (data[i] << 8);
+    this->write_array(reinterpret_cast<const uint8_t *>(buffer), partial * 2);
+    data += partial;
+    length -= partial;
+  }
+}
 
 void ZephyrSPIDelegate::read_array(uint8_t *ptr, size_t length) { this->do_transceive_(nullptr, ptr, length); }
 

--- a/esphome/components/spi/spi_zephyr.h
+++ b/esphome/components/spi/spi_zephyr.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifdef USE_ZEPHYR
+
+#include "spi.h"
+#include <zephyr/drivers/spi.h>
+
+namespace esphome::spi {
+
+class ZephyrSPIBus : public SPIBus {
+ public:
+  explicit ZephyrSPIBus(const device *dev) : dev_(dev) {}
+
+  bool is_hw() override { return true; }
+
+  SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
+                            bool release_device, bool write_only) override;
+
+ protected:
+  const device *dev_;
+};
+
+class ZephyrSPIDelegate : public SPIDelegate {
+ public:
+  ZephyrSPIDelegate(const device *dev, uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin);
+
+  uint8_t transfer(uint8_t data) override;
+  void transfer(uint8_t *ptr, size_t length) override;
+  void transfer(const uint8_t *txbuf, uint8_t *rxbuf, size_t length) override;
+  void write_array(const uint8_t *ptr, size_t length) override;
+  void read_array(uint8_t *ptr, size_t length) override;
+
+ protected:
+  void do_transceive_(const uint8_t *tx, uint8_t *rx, size_t length);
+  void transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t length);
+
+  const device *dev_;
+  // CS is driven by ESPHome via SPIDelegate::cs_pin_; cfg_.cs stays unset so
+  // the Zephyr driver never touches a devicetree cs-gpios pin itself.
+  spi_config cfg_{};
+};
+
+}  // namespace esphome::spi
+
+#endif  // USE_ZEPHYR

--- a/esphome/components/spi/spi_zephyr.h
+++ b/esphome/components/spi/spi_zephyr.h
@@ -28,11 +28,13 @@ class ZephyrSPIDelegate : public SPIDelegate {
   void transfer(uint8_t *ptr, size_t length) override;
   void transfer(const uint8_t *txbuf, uint8_t *rxbuf, size_t length) override;
   void write_array(const uint8_t *ptr, size_t length) override;
+  void write_array16(const uint16_t *data, size_t length) override;
   void read_array(uint8_t *ptr, size_t length) override;
 
  protected:
   void do_transceive_(const uint8_t *tx, uint8_t *rx, size_t length);
-  void transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t length);
+  // Returns false if the transfer failed; rx (if given) is zeroed in that case.
+  bool transceive_chunk_(const uint8_t *tx, uint8_t *rx, size_t length);
 
   const device *dev_;
   // CS is driven by ESPHome via SPIDelegate::cs_pin_; cfg_.cs stays unset so

--- a/tests/components/spi/test.nrf52-adafruit.yaml
+++ b/tests/components/spi/test.nrf52-adafruit.yaml
@@ -1,0 +1,4 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/nrf52.yaml
+
+<<: !include common.yaml

--- a/tests/components/spi/test.nrf52-mcumgr.yaml
+++ b/tests/components/spi/test.nrf52-mcumgr.yaml
@@ -1,0 +1,4 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/nrf52.yaml
+
+<<: !include common.yaml

--- a/tests/components/spi/test.nrf52-xiao-ble.yaml
+++ b/tests/components/spi/test.nrf52-xiao-ble.yaml
@@ -1,0 +1,4 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/nrf52.yaml
+
+<<: !include common.yaml

--- a/tests/test_build_components/common/spi/nrf52.yaml
+++ b/tests/test_build_components/common/spi/nrf52.yaml
@@ -1,0 +1,12 @@
+# Common SPI configuration for NRF52 tests
+
+substitutions:
+  clk_pin: P0.14
+  mosi_pin: P0.13
+  miso_pin: P0.15
+
+spi:
+  - id: spi_bus
+    clk_pin: ${clk_pin}
+    mosi_pin: ${mosi_pin}
+    miso_pin: ${miso_pin}


### PR DESCRIPTION
# What does this implement/fix?

Adds hardware SPI support for nRF52 (Zephyr) boards, following the same pattern already used for nRF52 I2C (`i2c_bus_zephyr.cpp/h`). This wires SPI into the existing `SPIBus`/`SPIDelegate` architecture with a new `ZephyrSPIBus`/`ZephyrSPIDelegate` backend that drives the nRF52840's SPIM2 peripheral via Zephyr's `spi_transceive()` API. A devicetree pinctrl overlay for `spi2` is generated at build time from the configured clk/mosi/miso pins, mirroring how the I2C backend generates its TWIM pinctrl overlay.

Only standard 4-wire single SPI is supported (no quad/octal), matching the scope of the existing ESP32-only quad/octal support and the capabilities of Zephyr's SPIM driver.

While implementing this, I ran into and fixed a real hardware bug: the nRF52840's EasyDMA engine cannot read directly from flash memory, so `spi_buf` entries pointing at `static const` command tables get silently corrupted mid-transfer. `spi_zephyr.cpp` works around this by staging any non-RAM-resident buffer through a fixed 64-byte on-stack chunk before handing it to `spi_transceive()`.

This has been extensively tested on real nRF52840 hardware (SuperMini nRF52840 board) driving a WeAct 2.9" 3-color e-paper display (SSD1683) through the official upstream `epaper_spi` component, including full 3-color rendering, at up to 8 MHz.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7335

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
spi:
  clk_pin: P0.14
  mosi_pin: P0.13
  miso_pin: P0.15

display:
  - platform: epaper_spi
    model: weact-2.9in-3c
    cs_pin: P0.08
    dc_pin: P0.11
    busy_pin: P0.02
    reset_pin: P0.31
    data_rate: 8MHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
