### PR TITLE
[nrf52] Add power_enable option for boards with a GPIO-gated peripheral rail

### DIFF
--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -257,12 +257,20 @@ def _validate_power_enable_pin(value: ConfigType) -> ConfigType:
 
 _POWER_ENABLE_SCHEMA = cv.Schema(
     {
+        # internal_gpio_output_pin_schema (not gpio_output_pin_schema) scopes pin
+        # validation to CORE.target_platform, so a GPIO-expander pin (e.g. a
+        # pcf8574 pin) is rejected outright instead of silently validating and
+        # then getting rendered as an on-chip nRF52 pin number in the overlay.
         cv.Required(CONF_PIN): cv.All(
-            pins.gpio_output_pin_schema, _validate_power_enable_pin
+            pins.internal_gpio_output_pin_schema, _validate_power_enable_pin
         ),
-        cv.Optional(
-            CONF_STARTUP_DELAY, default="0us"
-        ): cv.positive_time_period_microseconds,
+        cv.Optional(CONF_STARTUP_DELAY, default="0us"): cv.All(
+            cv.positive_time_period_microseconds,
+            # startup-delay-us is a single 32-bit devicetree cell; catch an
+            # overflow here with a clear config error instead of a dtc failure
+            # ("value out of range") that doesn't point back at this key.
+            cv.Range(max=cv.TimePeriod(microseconds=(1 << 32) - 1)),
+        ),
     }
 )
 
@@ -451,9 +459,7 @@ async def to_code(config: ConfigType) -> None:
         if mode.get(CONF_PULLDOWN):
             flags.append("GPIO_PULL_DOWN")
         flags_expr = flags[0] if len(flags) == 1 else "(" + " | ".join(flags) + ")"
-        startup_delay_us = int(
-            power_enable_config[CONF_STARTUP_DELAY].total_microseconds
-        )
+        startup_delay_us = power_enable_config[CONF_STARTUP_DELAY].total_microseconds
         zephyr_add_prj_conf("REGULATOR", True)
         zephyr_add_overlay(
             f"""

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -37,9 +37,13 @@ from esphome.const import (
     CONF_FRAMEWORK,
     CONF_ID,
     CONF_INVERTED,
+    CONF_MODE,
     CONF_NUMBER,
+    CONF_OPEN_DRAIN,
     CONF_OTA,
     CONF_PIN,
+    CONF_PULLDOWN,
+    CONF_PULLUP,
     CONF_RESET_PIN,
     CONF_SAFE_MODE,
     CONF_STARTUP_DELAY,
@@ -234,14 +238,28 @@ def _dfu_schema(value: bool | ConfigType) -> ConfigType:
 
 
 # Some nRF52 boards (mostly cheap hobby clones, e.g. "SuperMini nRF52840"/nRFMicro)
-# gate their external peripheral header behind a GPIO-controlled power rail that
-# Arduino's board-support code enables invisibly on boot. Zephyr has no board port
-# for these clones, so nothing does that for them. Modelling the pin as a Zephyr
-# `regulator-fixed` devicetree node (rather than app-level C++) means the rail is
-# enabled by Zephyr's own device init, before any ESPHome component's setup() runs.
+# have no pull-up on their external-peripheral-rail enable pin, so it floats at an
+# indeterminate level instead of the rail reliably being on by default (confirmed on
+# real hardware with a multimeter: 1.9V floating vs. 3.3V driven). Modelling the pin
+# as a Zephyr `regulator-fixed` devicetree node (rather than app-level C++) means the
+# rail is driven deterministically during Zephyr's own device init, before any
+# ESPHome component's setup() runs.
+def _validate_power_enable_pin(value: ConfigType) -> ConfigType:
+    # nRF52's EXTRA_ADC pin names (e.g. "VDD", "VDDHDIV5") validate as non-numeric
+    # strings under an output pin schema -- reject them here with a clear config
+    # error instead of crashing later on `pin_no // 32` in to_code().
+    if not isinstance(value[CONF_NUMBER], int):
+        raise cv.Invalid(
+            f"power_enable pin must be a numeric GPIO pin (e.g. P0.13), not '{value[CONF_NUMBER]}'"
+        )
+    return value
+
+
 _POWER_ENABLE_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_PIN): cv.All(
+            pins.gpio_output_pin_schema, _validate_power_enable_pin
+        ),
         cv.Optional(
             CONF_STARTUP_DELAY, default="0us"
         ): cv.positive_time_period_microseconds,
@@ -424,7 +442,15 @@ async def to_code(config: ConfigType) -> None:
     if power_enable_config := config.get(CONF_POWER_ENABLE):
         pin = power_enable_config[CONF_PIN]
         pin_no = pin[CONF_NUMBER]
-        active = "GPIO_ACTIVE_LOW" if pin[CONF_INVERTED] else "GPIO_ACTIVE_HIGH"
+        flags = ["GPIO_ACTIVE_LOW" if pin[CONF_INVERTED] else "GPIO_ACTIVE_HIGH"]
+        mode = pin[CONF_MODE]
+        if mode.get(CONF_OPEN_DRAIN):
+            flags.append("GPIO_OPEN_DRAIN")
+        if mode.get(CONF_PULLUP):
+            flags.append("GPIO_PULL_UP")
+        if mode.get(CONF_PULLDOWN):
+            flags.append("GPIO_PULL_DOWN")
+        flags_expr = flags[0] if len(flags) == 1 else "(" + " | ".join(flags) + ")"
         startup_delay_us = int(
             power_enable_config[CONF_STARTUP_DELAY].total_microseconds
         )
@@ -435,7 +461,7 @@ async def to_code(config: ConfigType) -> None:
                     esphome_power_enable: esphome_power_enable {{
                         compatible = "regulator-fixed";
                         regulator-name = "esphome_power_enable";
-                        enable-gpios = <&gpio{pin_no // 32} {pin_no % 32} {active}>;
+                        enable-gpios = <&gpio{pin_no // 32} {pin_no % 32} {flags_expr}>;
                         regulator-boot-on;
                         startup-delay-us = <{startup_delay_us}>;
                     }};

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -36,9 +36,13 @@ from esphome.const import (
     CONF_ENABLE_OTA_ROLLBACK,
     CONF_FRAMEWORK,
     CONF_ID,
+    CONF_INVERTED,
+    CONF_NUMBER,
     CONF_OTA,
+    CONF_PIN,
     CONF_RESET_PIN,
     CONF_SAFE_MODE,
+    CONF_STARTUP_DELAY,
     CONF_TOOLCHAIN,
     CONF_VERSION,
     CONF_VOLTAGE,
@@ -206,6 +210,7 @@ DeviceFirmwareUpdate = nrf52_ns.class_("DeviceFirmwareUpdate", cg.Component)
 CONF_DFU = "dfu"
 CONF_DCDC = "dcdc"
 CONF_LIBC_NANO = "libc_nano"
+CONF_POWER_ENABLE = "power_enable"
 CONF_REG0 = "reg0"
 CONF_UICR_ERASE = "uicr_erase"
 
@@ -228,6 +233,22 @@ def _dfu_schema(value: bool | ConfigType) -> ConfigType:
     return _DFU_SCHEMA(value)
 
 
+# Some nRF52 boards (mostly cheap hobby clones, e.g. "SuperMini nRF52840"/nRFMicro)
+# gate their external peripheral header behind a GPIO-controlled power rail that
+# Arduino's board-support code enables invisibly on boot. Zephyr has no board port
+# for these clones, so nothing does that for them. Modelling the pin as a Zephyr
+# `regulator-fixed` devicetree node (rather than app-level C++) means the rail is
+# enabled by Zephyr's own device init, before any ESPHome component's setup() runs.
+_POWER_ENABLE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(
+            CONF_STARTUP_DELAY, default="0us"
+        ): cv.positive_time_period_microseconds,
+    }
+)
+
+
 CONFIG_SCHEMA = cv.All(
     _detect_bootloader,
     set_core_data,
@@ -239,6 +260,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(KEY_BOOTLOADER): cv.one_of(*BOOTLOADERS, lower=True),
             cv.Optional(CONF_DFU): _dfu_schema,
             cv.Optional(CONF_DCDC): cv.boolean,
+            cv.Optional(CONF_POWER_ENABLE): _POWER_ENABLE_SCHEMA,
             cv.Optional(CONF_REG0): cv.Schema(
                 {
                     cv.Required(CONF_VOLTAGE): cv.All(
@@ -398,6 +420,28 @@ async def to_code(config: ConfigType) -> None:
         cg.add_define("USE_NRF52_REG0_VOUT", value)
         if reg0_config[CONF_UICR_ERASE]:
             cg.add_define("USE_NRF52_UICR_ERASE")
+
+    if power_enable_config := config.get(CONF_POWER_ENABLE):
+        pin = power_enable_config[CONF_PIN]
+        pin_no = pin[CONF_NUMBER]
+        active = "GPIO_ACTIVE_LOW" if pin[CONF_INVERTED] else "GPIO_ACTIVE_HIGH"
+        startup_delay_us = int(
+            power_enable_config[CONF_STARTUP_DELAY].total_microseconds
+        )
+        zephyr_add_prj_conf("REGULATOR", True)
+        zephyr_add_overlay(
+            f"""
+                / {{
+                    esphome_power_enable: esphome_power_enable {{
+                        compatible = "regulator-fixed";
+                        regulator-name = "esphome_power_enable";
+                        enable-gpios = <&gpio{pin_no // 32} {pin_no % 32} {active}>;
+                        regulator-boot-on;
+                        startup-delay-us = <{startup_delay_us}>;
+                    }};
+                }};
+            """
+        )
 
     conf = config[CONF_FRAMEWORK]
     advanced = conf[CONF_ADVANCED]

--- a/tests/components/nrf52/test.nrf52-adafruit.yaml
+++ b/tests/components/nrf52/test.nrf52-adafruit.yaml
@@ -19,9 +19,14 @@ nrf52:
   reg0:
     voltage: 2.1V
     uicr_erase: true
-  # P1.x (port-1 math) + inverted + omitted startup_delay (defaults to 0us) --
-  # the mcumgr target's power_enable test only covers P0.x/non-inverted/explicit.
+  # P1.x (port-1 math) + inverted + open_drain + omitted startup_delay (defaults
+  # to 0us) -- the mcumgr target's power_enable test only covers P0.x/non-inverted/
+  # explicit delay/pullup. inverted + open_drain together also exercise the
+  # multi-flag `(GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)` parenthesized-join path.
   power_enable:
     pin:
       number: P1.02
       inverted: true
+      mode:
+        output: true
+        open_drain: true

--- a/tests/components/nrf52/test.nrf52-adafruit.yaml
+++ b/tests/components/nrf52/test.nrf52-adafruit.yaml
@@ -19,3 +19,9 @@ nrf52:
   reg0:
     voltage: 2.1V
     uicr_erase: true
+  # P1.x (port-1 math) + inverted + omitted startup_delay (defaults to 0us) --
+  # the mcumgr target's power_enable test only covers P0.x/non-inverted/explicit.
+  power_enable:
+    pin:
+      number: P1.02
+      inverted: true

--- a/tests/components/nrf52/test.nrf52-mcumgr.yaml
+++ b/tests/components/nrf52/test.nrf52-mcumgr.yaml
@@ -2,6 +2,12 @@ nrf52:
   reg0:
     voltage: 3.3V
     uicr_erase: true
+  # P0.x/non-inverted/explicit delay + pullup -- the adafruit target's
+  # power_enable test covers P1.x/inverted/open_drain instead.
   power_enable:
-    pin: P0.13
+    pin:
+      number: P0.13
+      mode:
+        output: true
+        pullup: true
     startup_delay: 500ms

--- a/tests/components/nrf52/test.nrf52-mcumgr.yaml
+++ b/tests/components/nrf52/test.nrf52-mcumgr.yaml
@@ -2,3 +2,6 @@ nrf52:
   reg0:
     voltage: 3.3V
     uicr_erase: true
+  power_enable:
+    pin: P0.13
+    startup_delay: 500ms


### PR DESCRIPTION
# What does this implement/fix?

Some nRF52 boards -- mostly cheap hobby clones such as the "SuperMini nRF52840" (nRFMicro-style) -- gate their external peripheral header (the pin header used for sensors, displays, etc.) behind a GPIO that must be driven high before those peripherals will power up. On my board this pin is off by default and needs to be driven; genuine nice!nano-schematic boards may have a passive pull-up that keeps it on by default instead, so this mainly matters for clones/variants without that pull-up. Zephyr has no board port for these unofficial clone boards, so nothing handles it there, and until now ESPHome had no way to express it either -- the only option was a hand-written, board-specific C++ component.

This adds `nrf52: power_enable:`, which models the pin as a Zephyr `regulator-fixed` devicetree node rather than app-level C++:

```yaml
nrf52:
  power_enable:
    pin: P0.13
    startup_delay: 500ms
```

Zephyr's own `regulator_fixed` driver (`drivers/regulator/regulator_fixed.c`) configures the GPIO as output and drives it high during its own `POST_KERNEL` device-init phase -- before any ESPHome component's `setup()` runs -- and `startup_delay` maps directly to the driver's native `startup-delay-us` devicetree property, so the boot sequence blocks for exactly that long before any later-initialized peripheral driver (e.g. SPI) starts. This is earlier and more robust than anything achievable from ESPHome's own component `setup_priority`, and needs no custom C++ at all.

I originally solved this exact problem for my own SuperMini nRF52840 + WeAct e-paper display setup with a small hand-written `ExtVccEnable : public Component` doing the equivalent `pinMode`/`digitalWrite`/`delay` at `setup_priority::POWER`. This PR replaces that with a two-line YAML option that works the same way for anyone hitting this pattern, not just my specific board.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7200

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
nrf52:
  board: adafruit_feather_nrf52840
  power_enable:
    pin: P0.13
    startup_delay: 500ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

