### PR TITLE
[hitachi_ac344] Add quiet and vertical swing mode

### DIFF
--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -110,21 +110,19 @@ void HitachiClimate::set_fan_(uint8_t speed) {
 }
 
 void HitachiClimate::set_swing_v_toggle_(bool on) {
-  uint8_t button = get_button_();  // Get the current button value.
-  if (on) {
-    button = HITACHI_AC344_BUTTON_SWINGV;              // Set the button to SwingV.
-  } else if (button == HITACHI_AC344_BUTTON_SWINGV) {  // Asked to unset it
-    // It was set previous, so use Power as a default
-    button = HITACHI_AC344_BUTTON_POWER;
+  if (on != prev_swingv_on_) {  // Only initiate a swing v change if the state is different than the previous state.
+    set_button_(HITACHI_AC344_BUTTON_SWINGV);  // Set the button to SwingV.
+  } else {
+    // Set to default button
+    set_button_(HITACHI_AC344_BUTTON_POWER);
   }
-  set_button_(button);
+  prev_swingv_on_ = on;  // Remember the state for next time.
 }
 
-bool HitachiClimate::get_swing_v_toggle_() { return get_button_() == HITACHI_AC344_BUTTON_SWINGV; }
-
 void HitachiClimate::set_swing_v_(bool on) {
-  set_swing_v_toggle_(on);  // Set the button value.
-  set_bit(&remote_state_[HITACHI_AC344_SWINGV_BYTE], HITACHI_AC344_SWINGV_OFFSET, on);
+  set_swing_v_toggle_(on);  // The toggle relied on the previous state.
+  set_bit(&remote_state_[HITACHI_AC344_SWINGV_BYTE], HITACHI_AC344_SWINGV_OFFSET,
+          on);  // The remote state may be inconsistent with the air conditioner state
 }
 
 bool HitachiClimate::get_swing_v_() {
@@ -136,6 +134,8 @@ void HitachiClimate::set_swing_h_(uint8_t position) {
     set_swing_h_(HITACHI_AC344_SWINGH_MIDDLE);
     return;
   }
+  if (position == get_swing_h_())
+    return;
   set_bits(&remote_state_[HITACHI_AC344_SWINGH_BYTE], HITACHI_AC344_SWINGH_OFFSET, HITACHI_AC344_SWINGH_SIZE, position);
   set_button_(HITACHI_AC344_BUTTON_SWINGH);
 }
@@ -175,6 +175,9 @@ void HitachiClimate::transmit_state() {
   set_temp_(static_cast<uint8_t>(this->target_temperature));
 
   switch (this->fan_mode.value_or(climate::CLIMATE_FAN_ON)) {
+    case climate::CLIMATE_FAN_QUIET:
+      set_fan_(HITACHI_AC344_FAN_MIN);
+      break;
     case climate::CLIMATE_FAN_LOW:
       set_fan_(HITACHI_AC344_FAN_LOW);
       break;
@@ -191,26 +194,24 @@ void HitachiClimate::transmit_state() {
   }
 
   switch (this->swing_mode) {
+    // set_swing_v has to be the last call in all state settings as it relies on the button type to initiate an action.
     case climate::CLIMATE_SWING_BOTH:
-      set_swing_v_(true);
       set_swing_h_(HITACHI_AC344_SWINGH_AUTO);
+      set_swing_v_(true);
       break;
     case climate::CLIMATE_SWING_VERTICAL:
-      set_swing_v_(true);
       set_swing_h_(HITACHI_AC344_SWINGH_MIDDLE);
+      set_swing_v_(true);
       break;
     case climate::CLIMATE_SWING_HORIZONTAL:
-      set_swing_v_(false);
       set_swing_h_(HITACHI_AC344_SWINGH_AUTO);
+      set_swing_v_(false);
       break;
     case climate::CLIMATE_SWING_OFF:
-      set_swing_v_(false);
       set_swing_h_(HITACHI_AC344_SWINGH_MIDDLE);
+      set_swing_v_(false);
       break;
   }
-
-  // TODO: find change value to set button, now always set to power button
-  set_button_(HITACHI_AC344_BUTTON_POWER);
 
   invert_byte_pairs(remote_state_ + 3, HITACHI_AC344_STATE_LENGTH - 3);
 
@@ -281,6 +282,8 @@ bool HitachiClimate::parse_fan_(const uint8_t remote_state[]) {
   ESP_LOGV(TAG, "Fan: %02X %02X", remote_state[HITACHI_AC344_FAN_BYTE], fan_mode);
   switch (fan_mode) {
     case HITACHI_AC344_FAN_MIN:
+      this->fan_mode = climate::CLIMATE_FAN_QUIET;
+      break;
     case HITACHI_AC344_FAN_LOW:
       this->fan_mode = climate::CLIMATE_FAN_LOW;
       break;
@@ -302,12 +305,16 @@ bool HitachiClimate::parse_swing_(const uint8_t remote_state[]) {
   uint8_t swing_modeh =
       GETBITS8(remote_state[HITACHI_AC344_SWINGH_BYTE], HITACHI_AC344_SWINGH_OFFSET, HITACHI_AC344_SWINGH_SIZE);
   ESP_LOGV(TAG, "SwingH: %02X %02X", remote_state[HITACHI_AC344_SWINGH_BYTE], swing_modeh);
+  bool swing_v = GETBIT8(remote_state[HITACHI_AC344_SWINGV_BYTE], HITACHI_AC344_SWINGV_OFFSET);
+  ESP_LOGV(TAG, "SwingV: %02X %s", remote_state[HITACHI_AC344_SWINGV_BYTE], ONOFF(swing_v));
 
-  if ((swing_modeh & 0x3) == 0x3) {
-    this->swing_mode = climate::CLIMATE_SWING_OFF;
+  if (swing_modeh != HITACHI_AC344_SWINGH_AUTO) {
+    this->swing_mode = swing_v ? climate::CLIMATE_SWING_VERTICAL : climate::CLIMATE_SWING_OFF;
   } else {
-    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+    this->swing_mode = swing_v ? climate::CLIMATE_SWING_BOTH : climate::CLIMATE_SWING_HORIZONTAL;
   }
+
+  prev_swingv_on_ = swing_v;  // Save the previous state of the swing v for future reference.
 
   return true;
 }

--- a/esphome/components/hitachi_ac344/hitachi_ac344.h
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.h
@@ -65,6 +65,7 @@ const uint8_t HITACHI_AC344_SWINGH_LEFT_MAX = 5;   // 0b101
 
 const uint8_t HITACHI_AC344_SWINGV_BYTE = 37;
 const uint8_t HITACHI_AC344_SWINGV_OFFSET = 5;  // Mask 0b00x00000
+const uint8_t HITACHI_AC344_SWINGV_SIZE = 1;    // Mask 0b00x00000
 
 const uint8_t HITACHI_AC344_MILDEWPROOF_BYTE = HITACHI_AC344_SWINGV_BYTE;
 const uint8_t HITACHI_AC344_MILDEWPROOF_OFFSET = 2;  // Mask 0b00000x00
@@ -79,9 +80,10 @@ class HitachiClimate final : public climate_ir::ClimateIR {
  public:
   HitachiClimate()
       : climate_ir::ClimateIR(HITACHI_AC344_TEMP_MIN, HITACHI_AC344_TEMP_MAX, 1.0F, true, true,
-                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM,
-                               climate::CLIMATE_FAN_HIGH},
-                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL}) {}
+                              {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW,
+                               climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+                              {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                               climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH}) {}
 
  protected:
   uint8_t remote_state_[HITACHI_AC344_STATE_LENGTH]{0x01, 0x10, 0x00, 0x40, 0x00, 0xFF, 0x00, 0xCC, 0x00, 0x00, 0x00,
@@ -89,6 +91,7 @@ class HitachiClimate final : public climate_ir::ClimateIR {
                                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
                                                     0x80, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   uint8_t previous_temp_{27};
+  bool prev_swingv_on_{false};
   // Transmit via IR the state of this climate controller.
   void transmit_state() override;
   bool get_power_();
@@ -99,7 +102,6 @@ class HitachiClimate final : public climate_ir::ClimateIR {
   uint8_t get_fan_();
   void set_fan_(uint8_t speed);
   void set_swing_v_toggle_(bool on);
-  bool get_swing_v_toggle_();
   void set_swing_v_(bool on);
   bool get_swing_v_();
   void set_swing_h_(uint8_t position);


### PR DESCRIPTION
# What does this implement/fix?

Adds quiet fan support to the Hitachi AC344 climate component by mapping the protocol's minimum fan speed to ESPHome's quiet fan mode.

It also adds vertical and combined swing modes, decodes the vertical swing state from received IR messages, and tracks the previous vertical swing state when generating toggle commands.

*Note that the vertical swing state can become out of sync even when using the physical remote if the air conditioner does not receive a command. The air conditioner ignores HITACHI_AC344_SWINGV_BYTE when changing this setting. Instead, it toggles vertical swing only when HITACHI_AC344_BUTTON_BYTE is set to HITACHI_AC344_BUTTON_SWINGV, so the component must track the previous state.

Users sometimes need to recalibrate the vertical swing state by sending a command from the physical remote without reaching the air conditioner and the IR receiver to sync the actual state among "air conditioner", "physical remote", and "home assistant".

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

Somehow there is no detailed hitachi_ac344-related document in the first place; it is only briefly mentioned in esphome IR Remote Climate. Therefore, no document is added for now, but it can be added if requested.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

None

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  id: xmitr
  pin: GPIO2
  carrier_duty_percent: 50%

climate:
  - platform: hitachi_ac344
    id: hitachi_climate
    name: Hitachi Climate
    transmitter_id: xmitr

# The climate entity exposes QUIET fan mode and
# VERTICAL, HORIZONTAL, and BOTH swing modes.

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
