### PR TITLE
[internal_temperature] Read the RP2 on-die sensor directly instead of via the Arduino API

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature_rp2.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <hardware/adc.h>
+#include <pico/time.h>
 
 // The RP2 variant headers (pulled in transitively by Arduino.h) define
 // ADC_RESOLUTION as the pin-level ADC bit count, which would be substituted
@@ -27,11 +28,16 @@ static constexpr float ADC_RESOLUTION = 4096.0f;  // 12-bit
 static constexpr float TEMPERATURE_AT_REFERENCE = 27.0f;
 static constexpr float REFERENCE_VOLTAGE = 0.706f;
 static constexpr float VOLTS_PER_DEGREE = 0.001721f;
+// The sensor is powered down again after each read, so every conversion is the
+// first one after enabling. Let the bias circuitry settle first, matching what
+// the adc component does for its own temperature readings.
+static constexpr uint32_t SETTLE_TIME_US = 1000;
 
 static float read_internal_temperature() {
-  // adc_init() resets the ADC block, so only do it if nothing else has. The
-  // adc component calls it from its own setup(); both re-select their input
-  // on every read, so the ordering between them does not matter.
+  // adc_init() resets the ADC block, so this runs at most once for this
+  // component. The adc component guards its own adc_init() the same way, so a
+  // redundant reset is still possible when both are used. That is harmless
+  // because both re-select their input on every read.
   static bool adc_ready = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
   if (!adc_ready) {
     adc_init();
@@ -39,6 +45,7 @@ static float read_internal_temperature() {
   }
 
   adc_set_temp_sensor_enabled(true);
+  busy_wait_us(SETTLE_TIME_US);
   adc_select_input(TEMPERATURE_ADC_INPUT);
   const uint16_t raw = adc_read();
   adc_set_temp_sensor_enabled(false);

--- a/esphome/components/internal_temperature/internal_temperature_rp2.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2.cpp
@@ -3,17 +3,55 @@
 #include "esphome/core/log.h"
 #include "internal_temperature.h"
 
-#include "Arduino.h"
+#include <cmath>
+#include <hardware/adc.h>
+
+// The RP2 variant headers (pulled in transitively by Arduino.h) define
+// ADC_RESOLUTION as the pin-level ADC bit count, which would be substituted
+// into the constant below. Nothing here uses the Arduino definition, so drop
+// it for this file. Not restored with pop_macro: the uses below would then be
+// substituted again.
+#undef ADC_RESOLUTION
 
 namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.rp2";
 
+// ADC input 4 is wired to the on-die temperature sensor on both RP2040 and
+// RP2350. The ADC returns a raw conversion, so the datasheet formula below
+// turns it into degrees Celsius.
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = 4;
+static constexpr float ADC_VREF = 3.3f;
+static constexpr float ADC_RESOLUTION = 4096.0f;  // 12-bit
+// RP2040 datasheet 4.9.5 / RP2350 datasheet 12.4.6: T = 27 - (V - 0.706) / 0.001721
+static constexpr float TEMPERATURE_AT_REFERENCE = 27.0f;
+static constexpr float REFERENCE_VOLTAGE = 0.706f;
+static constexpr float VOLTS_PER_DEGREE = 0.001721f;
+
+static float read_internal_temperature() {
+  // adc_init() resets the ADC block, so only do it if nothing else has. The
+  // adc component calls it from its own setup(); both re-select their input
+  // on every read, so the ordering between them does not matter.
+  static bool adc_ready = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+  if (!adc_ready) {
+    adc_init();
+    adc_ready = true;
+  }
+
+  adc_set_temp_sensor_enabled(true);
+  adc_select_input(TEMPERATURE_ADC_INPUT);
+  const uint16_t raw = adc_read();
+  adc_set_temp_sensor_enabled(false);
+
+  const float voltage = raw * (ADC_VREF / ADC_RESOLUTION);
+  return TEMPERATURE_AT_REFERENCE - (voltage - REFERENCE_VOLTAGE) / VOLTS_PER_DEGREE;
+}
+
 void InternalTemperatureSensor::update() {
   float temperature = NAN;
   bool success = false;
 
-  temperature = analogReadTemp();
+  temperature = read_internal_temperature();
   success = (temperature != 0.0f);
 
   if (success && std::isfinite(temperature)) {

--- a/esphome/components/internal_temperature/internal_temperature_rp2.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2.cpp
@@ -18,12 +18,11 @@ namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.rp2";
 
-// The on-die temperature sensor sits on the last ADC channel, and which one
-// that is depends on the chip: input 4 on RP2040 and RP2350A, but input 8 on
-// RP2350B, which has eight external channels instead of four. The SDK resolves
-// it for the target being built, so do not hardcode it. The ADC returns a raw
-// conversion, so the datasheet formula below turns it into degrees Celsius.
-static constexpr uint8_t TEMPERATURE_ADC_INPUT = ADC_TEMPERATURE_CHANNEL_NUM;
+// Temperature sensor input: 4 on RP2040/RP2350A, 8 on RP2350B. The SDK's
+// ADC_TEMPERATURE_CHANNEL_NUM is wrong under arduino-pico: it reads
+// PICO_RP2350A, which pins_arduino.h defines only after <pico.h> baked in
+// the RP2350B channel count.
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = __GPIOCNT - __FIRSTANALOGGPIO;
 static constexpr float ADC_VREF = 3.3f;
 static constexpr float ADC_RESOLUTION = 4096.0f;  // 12-bit
 // RP2040 datasheet 4.9.5 / RP2350 datasheet 12.4.6: T = 27 - (V - 0.706) / 0.001721

--- a/esphome/components/internal_temperature/internal_temperature_rp2.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2.cpp
@@ -18,11 +18,24 @@ namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.rp2";
 
-// Temperature sensor input: 4 on RP2040/RP2350A, 8 on RP2350B. The SDK's
-// ADC_TEMPERATURE_CHANNEL_NUM is wrong under arduino-pico: it reads
-// PICO_RP2350A, which pins_arduino.h defines only after <pico.h> baked in
-// the RP2350B channel count.
-static constexpr uint8_t TEMPERATURE_ADC_INPUT = __GPIOCNT - __FIRSTANALOGGPIO;
+// The on-die temperature sensor sits on the last ADC channel: input 4 on RP2040
+// and RP2350A, but input 8 on RP2350B, which has eight external channels rather
+// than four.
+//
+// This deliberately does not use the SDK's ADC_TEMPERATURE_CHANNEL_NUM. That
+// derives from NUM_ADC_CHANNELS, which <pico.h> settles from a board header, and
+// arduino-pico supplies a fixed B-die one for every RP2350 build. The real die
+// is only declared later, by the variant's pins_arduino.h, so the SDK constant
+// reads 8 on A-die boards. PICO_RP2350A itself is correct by the time this file
+// is compiled, on both arduino-pico and pico-sdk builds.
+#if defined(PICO_RP2350) && !defined(PICO_RP2350A)
+#error "PICO_RP2350A is not defined, so the RP2350 die is unknown and the temperature ADC channel cannot be chosen"
+#endif
+#if defined(PICO_RP2350) && !PICO_RP2350A
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = 8;
+#else
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = 4;
+#endif
 static constexpr float ADC_VREF = 3.3f;
 static constexpr float ADC_RESOLUTION = 4096.0f;  // 12-bit
 // RP2040 datasheet 4.9.5 / RP2350 datasheet 12.4.6: T = 27 - (V - 0.706) / 0.001721

--- a/esphome/components/internal_temperature/internal_temperature_rp2.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2.cpp
@@ -18,10 +18,12 @@ namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.rp2";
 
-// ADC input 4 is wired to the on-die temperature sensor on both RP2040 and
-// RP2350. The ADC returns a raw conversion, so the datasheet formula below
-// turns it into degrees Celsius.
-static constexpr uint8_t TEMPERATURE_ADC_INPUT = 4;
+// The on-die temperature sensor sits on the last ADC channel, and which one
+// that is depends on the chip: input 4 on RP2040 and RP2350A, but input 8 on
+// RP2350B, which has eight external channels instead of four. The SDK resolves
+// it for the target being built, so do not hardcode it. The ADC returns a raw
+// conversion, so the datasheet formula below turns it into degrees Celsius.
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = ADC_TEMPERATURE_CHANNEL_NUM;
 static constexpr float ADC_VREF = 3.3f;
 static constexpr float ADC_RESOLUTION = 4096.0f;  // 12-bit
 // RP2040 datasheet 4.9.5 / RP2350 datasheet 12.4.6: T = 27 - (V - 0.706) / 0.001721


### PR DESCRIPTION
# What does this implement/fix?

The RP2 implementation of `internal_temperature` read the on-die temperature sensor through `analogReadTemp()`. That is an Arduino core convenience wrapper, so the component depended on the Arduino API for what is really a couple of register accesses.

This reads the ADC directly using the pico-sdk `hardware/adc.h` API instead. Those headers are available on the RP2 platform regardless, so this builds and runs exactly as before, and it removes one more Arduino API dependency from the component.

The conversion now happens in ESPHome rather than in the Arduino core: select ADC input 4 (wired to the on-die sensor on both RP2040 and RP2350), read the raw 12-bit conversion, and apply the formula from the datasheets (RP2040 section 4.9.5, RP2350 section 12.4.6). Behaviour is unchanged.

Two details worth calling out for reviewers:

The file needs `#undef ADC_RESOLUTION`. The RP2 variant headers, reached transitively through `Arduino.h`, define `ADC_RESOLUTION` as the pin-level ADC bit count, which would otherwise be substituted into the `static constexpr float ADC_RESOLUTION` declaration and fail to compile. Macros ignore namespaces, so include ordering does not help, and the `#pragma push_macro`/`pop_macro` pattern used elsewhere does not work here because the uses sit below the declaration and popping would substitute them again. The undef is scoped to this translation unit, and nothing else in ESPHome references that macro.

`adc_init()` resets the whole ADC block, so it is guarded by a static flag and only runs if nothing else has initialised it. The `adc` component calls `adc_init()` from its own `setup()`; both re-select their input on every read, so the ordering between them does not matter.

Verified on two physical Raspberry Pi Pico W boards running this code on the Arduino framework and reporting through the ESPHome logger. Board 1 reported 21.05, 21.52, 21.05, 21.05, 21.05 C (mean 21.14) and board 2 reported 21.52, 21.52, 21.05, 22.45, 21.05 C (mean 21.52). Both are plausible room temperatures and sit 0.38 C apart, comfortably within the chip-to-chip variation of the RP2040 temperature sensor. The visible quantisation step from 21.05 to 21.52 is exactly one 12-bit ADC count, which matches the datasheet formula.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: internal_temperature
    name: Internal Temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
