### PR TITLE
[bluetooth_proxy] Latch the connection replies and tighten the send paths

### DIFF
--- a/esphome/components/bluetooth_connection/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.cpp
@@ -50,8 +50,7 @@ BatchClose close_service_batch(api::BluetoothGATTGetServicesResponse &resp, size
 namespace esphome::bluetooth_connection {
 
 // Address-scoped Bluedroid maintenance. Gated with the connection surface:
-// the advertisement-only arm answers these requests with a canned error and
-// no longer compiles any caller.
+// the advertisement-only arm no longer dispatches these requests at all.
 
 conn_err_t unpair_device(uint64_t address) {
   esp_bd_addr_t bda;

--- a/esphome/components/bluetooth_connection/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.cpp
@@ -46,12 +46,12 @@ BatchClose close_service_batch(api::BluetoothGATTGetServicesResponse &resp, size
 
 #endif  // BLUETOOTH_CONNECTION_HAS_GATT
 
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && defined(USE_BLE_GATT_CLIENT)
 namespace esphome::bluetooth_connection {
 
-// Address-scoped Bluedroid maintenance shared by every esp32 proxy build,
-// including advertisement-only ones where no GATT backend (and none of the
-// gated surface above) is compiled - so this block sits outside that gate.
+// Address-scoped Bluedroid maintenance. Gated with the connection surface:
+// the advertisement-only arm answers these requests with a canned error and
+// no longer compiles any caller.
 
 conn_err_t unpair_device(uint64_t address) {
   esp_bd_addr_t bda;
@@ -66,4 +66,4 @@ conn_err_t clear_gatt_cache(uint64_t address) {
 }
 
 }  // namespace esphome::bluetooth_connection
-#endif  // USE_ESP32
+#endif  // USE_ESP32 && USE_BLE_GATT_CLIENT

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,9 +92,10 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
-// Owed-ack retries stop here (~25 s at the 100 ms drain cadence): just under
-// the client's 30 s GATT timeout, so a reply is abandoned before a re-ask.
-static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 250;
+// Owed-ack retries stop after ~25 s of subscribed drain time from the first
+// refusal, keeping most of the client's 30 s GATT window for congestion to
+// clear while still bounding how stale a delivered reply can be.
+static constexpr uint16_t PENDING_ACK_RETRY_LIMIT = 250;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -68,12 +68,12 @@ static constexpr bool SUPPORTS_CACHE_CLEARING = false;
 #endif
 
 // Address-scoped (not connection-scoped) maintenance requests.
-#if defined(USE_ESP32) || (defined(USE_RP2040_BLE) && defined(USE_BLE_GATT_CLIENT))
+#if (defined(USE_ESP32) || defined(USE_RP2040_BLE)) && defined(USE_BLE_GATT_CLIENT)
 conn_err_t unpair_device(uint64_t address);
 #else
 inline conn_err_t unpair_device(uint64_t) { return GATT_NOT_CONNECTED; }
 #endif
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && defined(USE_BLE_GATT_CLIENT)
 conn_err_t clear_gatt_cache(uint64_t address);
 #else
 inline conn_err_t clear_gatt_cache(uint64_t) { return GATT_NOT_CONNECTED; }

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,13 +92,8 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
-// Owed-ack retries stop here (~25 s at the 100 ms drain cadence). The bound
-// comes from the client, not the link: congestion can take tens of seconds to
-// clear, and bleak-esphome's GATT operation timeout is 30 s, so nothing can
-// re-ask before then. Stopping just under it keeps the whole window available
-// for delivery while still closing the stale-reply race that
-// supersede_pending_ack_() alone cannot (a drain that beats the re-request's
-// processing would answer the new request with the old reply).
+// Owed-ack retries stop here (~25 s at the 100 ms drain cadence): just under
+// the client's 30 s GATT timeout, so a reply is abandoned before a re-ask.
 static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 250;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,11 +92,14 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
-// Owed-ack retries stop on the same reasoning and cadence. supersede only
-// fires once the proxy processes the client's re-request, so a drain that
-// beats that processing could resolve the new request with the old reply;
-// an age bound is what closes that, not the supersede.
-static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 30;
+// Owed-ack retries stop here (~25 s at the 100 ms drain cadence). The bound
+// comes from the client, not the link: congestion can take tens of seconds to
+// clear, and bleak-esphome's GATT operation timeout is 30 s, so nothing can
+// re-ask before then. Stopping just under it keeps the whole window available
+// for delivery while still closing the stale-reply race that
+// supersede_pending_ack_() alone cannot (a drain that beats the re-request's
+// processing would answer the new request with the old reply).
+static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 250;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -92,6 +92,11 @@ static_assert(DONE_SENDING_SERVICES != GATT_NOT_CONNECTED && INIT_SENDING_SERVIC
 // delivered near the client's 30 s timeout could land on a fresh request's
 // empty accumulator and cache as an empty database.
 static constexpr uint8_t SERVICES_DONE_RETRY_LIMIT = 30;
+// Owed-ack retries stop on the same reasoning and cadence. supersede only
+// fires once the proxy processes the client's re-request, so a drain that
+// beats that processing could resolve the new request with the old reply;
+// an age bound is what closes that, not the supersede.
+static constexpr uint8_t PENDING_ACK_RETRY_LIMIT = 30;
 
 // ---- Service-streaming size budget, shared by every platform's streamer ----
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection.h
@@ -20,10 +20,9 @@
 // wired by codegen (one slot per connection). This is the single spelling of
 // that predicate - the hub wrapper and the API request handlers gate on it.
 // The wrapper serves the proxy's API surface, so it compiles only when a
-// backend AND the proxy are present; advertisement-only and backend-only
-// builds get the clean-error handlers instead. Address-scoped maintenance
-// (unpair, cache clear) still works there through the per-platform free
-// functions below.
+// backend AND the proxy are present. The address-scoped maintenance functions
+// below are only reached from that gated surface; their #else stubs just
+// keep this header parsing on arms without a backend.
 #if defined(USE_BLE_GATT_CLIENT) && defined(USE_BLUETOOTH_PROXY)
 #define BLUETOOTH_CONNECTION_HAS_GATT
 #endif

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -397,6 +397,8 @@ void BluedroidGattClient::deliver_pending_search_() {
 // which proxy builds compile without a materializer.
 static_assert(requires(BluedroidGattClient c, BluetoothConnection &conn) { c.stream_service_batch(conn); });
 
+// Bound by the SERVICE STREAMING HAZARD note at the top of
+// bluetooth_connection_hub.cpp: never skip a batch, never send done early.
 void BluedroidGattClient::stream_service_batch(BluetoothConnection &conn) {
   if (this->services_released_) {
     // Released under the stream: park without services-done so a partial

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -527,9 +527,11 @@ void BluedroidGattClient::stream_service_batch(BluetoothConnection &conn) {
   // On a failed send, rewind the cursor so the batch is retried instead of
   // silently skipped.
   if (!api_conn->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send service batch, retrying", conn.connection_index_, conn.address_str_);
+    conn.note_batch_stalled_();
     conn.send_service_ = batch_start;
+    return;
   }
+  conn.batch_stalled_ = false;
 }
 #endif  // USE_BLUETOOTH_PROXY
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -230,8 +230,15 @@ void BluetoothConnection::flush_pending_ack_() {
     return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
     this->clear_pending_ack_();
+    return;
   }
-  // Still refused: stays owed for the next paced drain.
+  if (++this->pending_ack_retries_ >= PENDING_ACK_RETRY_LIMIT) {
+    // Undeliverable: past here the client has given up and may have re-asked,
+    // and a late reply would answer the new request instead of this one.
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X undeliverable, abandoning", this->connection_index_,
+             this->address_str_, this->pending_ack_handle_);
+    this->clear_pending_ack_();
+  }
 }
 
 void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, uint16_t len, int error) {

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -77,9 +77,7 @@ void BluetoothConnection::reset_connection_(conn_err_t reason) {
   this->services_discovered_ = false;
   this->paired_ = false;
   // Link gone: the slot may hold a different device before the drain runs.
-  this->clear_pending_ack_();
-  this->batch_stalled_ = false;
-  this->connected_reply_owed_ = false;
+  this->clear_owed_flags_();
   this->backend_->release_services();
   this->proxy_->reset_connection_slot_(this, reason);
 }
@@ -123,7 +121,6 @@ void BluetoothConnection::on_connection_state(bool connected, uint16_t mtu, int 
         ESP_LOGW(TAG, "[%d] [%s] conn param update failed, err=%d", this->connection_index_, this->address_str_,
                  param_err);
       }
-      this->mtu_ = mtu;
       this->send_connected_reply_();
       this->proxy_->send_connections_free();
       return;
@@ -164,6 +161,18 @@ void BluetoothConnection::on_service_discovery_done(int error) {
   this->services_discovered_ = true;
   this->send_connected_reply_();
   this->proxy_->send_connections_free();
+}
+
+void BluetoothConnection::flush_owed_replies_() {
+  if (this->send_service_ == SERVICES_DONE_PENDING) {
+    this->send_services_done_();
+  }
+  if (this->connected_reply_owed_) {
+    this->send_connected_reply_();
+  }
+  if (this->has_pending_ack_()) {
+    this->flush_pending_ack_();
+  }
 }
 
 void BluetoothConnection::send_connected_reply_() {
@@ -238,7 +247,6 @@ void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t
 }
 
 void BluetoothConnection::flush_pending_ack_() {
-  // No-op on its own rather than relying on the proxy drain's pre-check.
   if (!this->has_pending_ack_())
     return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -16,9 +16,8 @@ static const char *const TAG = "bluetooth_connection";
 void BluetoothConnection::set_address(uint64_t address) {
   // Keep the proxy's pre-allocated connections-free message in step
   this->proxy_->update_address_slot_(this->address_, address);
-  // The slot is changing hands, so anything owed belonged to the old address.
-  // reset_connection_() already clears on the ordinary teardown path; this is
-  // the choke point that covers every other way a slot is reassigned or freed.
+  // Slot changing hands: anything owed belonged to the old address. The
+  // choke point for every reassignment, not just reset_connection_()'s path.
   this->clear_pending_ack_();
   this->address_ = address;
   if (address == 0) {
@@ -77,9 +76,7 @@ void BluetoothConnection::reset_connection_(conn_err_t reason) {
   this->state_ = ClientState::IDLE;
   this->services_discovered_ = false;
   this->paired_ = false;
-  // The link is gone: an owed reply for it would arrive addressed to a
-  // connection the client has already been told about, and the slot may be
-  // reserved for a different device by the time the drain runs.
+  // Link gone: the slot may hold a different device before the drain runs.
   this->clear_pending_ack_();
   this->batch_stalled_ = false;
   this->backend_->release_services();
@@ -180,61 +177,56 @@ void BluetoothConnection::note_batch_stalled_() {
            this->address_str_);
 }
 
-/// Build and send one payload-free GATT reply. The only construction site
-/// for these messages: first attempt and retry both come through here, so a
-/// re-offer cannot drift from the original.
+/// Both payload-free acks are just (address, handle); only the type differs.
+template<typename Response>
+static bool send_handle_reply_(api::APIConnection *api_connection, uint64_t address, uint16_t handle) {
+  Response resp;
+  resp.address = address;
+  resp.handle = handle;
+  return api_connection->send_message(resp);
+}
+
+/// Sole construction site, so a re-offer cannot drift from the original.
 bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (kind == PendingAck::PENDING_ACK_ERROR) {
-    // The proxy owns the error reply; it reports a refusal the same way.
+    // Proxy owns the error reply and reports a refusal the same way.
     return this->proxy_->send_gatt_error(this->address_, handle, error);
   }
   auto *api_connection = this->proxy_->get_api_connection();
   if (api_connection == nullptr)
     return true;  // Nobody subscribed: nothing is owed
   switch (kind) {
-    case PendingAck::PENDING_ACK_WRITE: {
-      api::BluetoothGATTWriteResponse resp;
-      resp.address = this->address_;
-      resp.handle = handle;
-      return api_connection->send_message(resp);
-    }
-    case PendingAck::PENDING_ACK_NOTIFY: {
-      api::BluetoothGATTNotifyResponse resp;
-      resp.address = this->address_;
-      resp.handle = handle;
-      return api_connection->send_message(resp);
-    }
+    case PendingAck::PENDING_ACK_WRITE:
+      return send_handle_reply_<api::BluetoothGATTWriteResponse>(api_connection, this->address_, handle);
+    case PendingAck::PENDING_ACK_NOTIFY:
+      return send_handle_reply_<api::BluetoothGATTNotifyResponse>(api_connection, this->address_, handle);
     case PendingAck::PENDING_ACK_NONE:
     case PendingAck::PENDING_ACK_ERROR:  // returned above
       return true;
   }
-  // Every enumerator is listed and there is no default label, so adding one
-  // without a branch is a -Wswitch warning rather than a silent notify reply.
-  // This return only satisfies -Wreturn-type.
+  // No default label above, so a new enumerator is a -Wswitch warning rather
+  // than a silent notify reply. This return only satisfies -Wreturn-type.
   return true;
 }
 
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // V, not W: the reply is owed rather than lost, and a warning here would
-  // ride the same connection that just refused a frame. Matches how the
-  // proxy logs a deferred connections-free update.
+  // V, not W: the reply is owed rather than lost, and a warning would ride
+  // the connection that just refused it (as for connections-free).
   ESP_LOGV(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
            this->address_str_, handle);
   this->latch_pending_ack_(kind, handle, error);
 }
 
 void BluetoothConnection::flush_pending_ack_() {
-  // Local guard: the proxy drain pre-checks, but this must be a no-op on its
-  // own rather than relying on a caller in another file.
+  // No-op on its own rather than relying on the proxy drain's pre-check.
   if (!this->has_pending_ack_())
     return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
     this->clear_pending_ack_();
   }
-  // Still refused: stays owed, re-offered on the next paced drain. The
-  // client's operation timeout remains the outer bound.
+  // Still refused: stays owed for the next paced drain.
 }
 
 void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, uint16_t len, int error) {
@@ -254,8 +246,8 @@ void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
-    // Not latched: the payload would have to be held on the heap through the
-    // congestion that refused it. The client's read timeout arbitrates.
+    // Not latched: would mean holding the payload through the congestion
+    // that refused it. The client's read timeout arbitrates.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send read response", this->connection_index_, this->address_str_);
   }
 }
@@ -295,9 +287,8 @@ void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
-    // Not latched, same reason as the read reply: the payload cannot be held
-    // through congestion. Notify data is genuinely lossy; the peripheral will
-    // not resend it.
+    // Not latched, same reason as the read reply. Notify data is lossy: the
+    // peripheral will not resend it.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
   }
 }

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -212,10 +212,13 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // V, not W: the reply is owed rather than lost, and a warning would ride
-  // the connection that just refused it (as for connections-free).
-  ESP_LOGV(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
-           this->address_str_, handle);
+  // Warn on the leading edge only, like a stalled service batch: a refused
+  // reply must not be silent, but repeating it every attempt would add traffic
+  // to the connection that just refused one.
+  if (!this->has_pending_ack_()) {
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
+             this->address_str_, handle);
+  }
   this->latch_pending_ack_(kind, handle, error);
 }
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -79,6 +79,7 @@ void BluetoothConnection::reset_connection_(conn_err_t reason) {
   // Link gone: the slot may hold a different device before the drain runs.
   this->clear_pending_ack_();
   this->batch_stalled_ = false;
+  this->connected_reply_owed_ = false;
   this->backend_->release_services();
   this->proxy_->reset_connection_slot_(this, reason);
 }
@@ -122,7 +123,8 @@ void BluetoothConnection::on_connection_state(bool connected, uint16_t mtu, int 
         ESP_LOGW(TAG, "[%d] [%s] conn param update failed, err=%d", this->connection_index_, this->address_str_,
                  param_err);
       }
-      this->proxy_->send_device_connection(this->address_, true, mtu);
+      this->mtu_ = mtu;
+      this->send_connected_reply_();
       this->proxy_->send_connections_free();
       return;
     }
@@ -160,8 +162,21 @@ void BluetoothConnection::on_service_discovery_done(int error) {
            this->mtu_);
   this->state_ = ClientState::ESTABLISHED;
   this->services_discovered_ = true;
-  this->proxy_->send_device_connection(this->address_, true, this->mtu_);
+  this->send_connected_reply_();
   this->proxy_->send_connections_free();
+}
+
+void BluetoothConnection::send_connected_reply_() {
+  if (this->proxy_->send_device_connection(this->address_, true, this->mtu_)) {
+    this->connected_reply_owed_ = false;
+    return;
+  }
+  // Warn on the leading edge only, as elsewhere: the drop must be visible but
+  // must not add traffic to the connection that just refused a frame.
+  if (!this->connected_reply_owed_) {
+    ESP_LOGW(TAG, "[%d] [%s] Connected reply deferred, TCP buffer full", this->connection_index_, this->address_str_);
+    this->connected_reply_owed_ = true;
+  }
 }
 
 void BluetoothConnection::log_gatt_operation_error_(const char *operation, uint16_t handle, int status) {

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -215,10 +215,10 @@ void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t
   // Report a newly owed reply and a displaced one; displacing is the case
   // that loses a reply. Re-refusing the same one stays quiet.
   if (!this->has_pending_ack_()) {
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X deferred, TCP buffer full", this->connection_index_,
              this->address_str_, handle);
   } else if (this->pending_ack_handle_ != handle || this->pending_ack_ != kind) {
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X dropped for handle 0x%2X", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X dropped for handle 0x%04X", this->connection_index_,
              this->address_str_, this->pending_ack_handle_, handle);
   }
   this->latch_pending_ack_(kind, handle, error);
@@ -235,7 +235,7 @@ void BluetoothConnection::flush_pending_ack_() {
   if (++this->pending_ack_retries_ >= PENDING_ACK_RETRY_LIMIT) {
     // Undeliverable: past here the client has given up and may have re-asked,
     // and a late reply would answer the new request instead of this one.
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X undeliverable, abandoning", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X undeliverable, abandoning", this->connection_index_,
              this->address_str_, this->pending_ack_handle_);
     this->clear_pending_ack_();
   }
@@ -317,7 +317,7 @@ conn_err_t BluetoothConnection::check_connected_op_(const char *action, const ch
 }
 
 conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_NONE);
   if (conn_err_t err = this->check_connected_op_("read", "characteristic"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
@@ -326,7 +326,7 @@ conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
 
 conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint8_t *data, size_t length,
                                                      bool response) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_WRITE);
   if (conn_err_t err = this->check_connected_op_("write", "characteristic"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
@@ -334,7 +334,7 @@ conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint
 }
 
 conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_NONE);
   if (conn_err_t err = this->check_connected_op_("read", "descriptor"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
@@ -345,7 +345,7 @@ conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 // the response flag is intentionally ignored (esp32 maps it to RSP/NO_RSP).
 conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t *data, size_t length,
                                                  bool /*response*/) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_WRITE);
   if (conn_err_t err = this->check_connected_op_("write", "descriptor"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
@@ -353,7 +353,7 @@ conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t 
 }
 
 conn_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
-  this->supersede_pending_ack_(handle);
+  this->supersede_pending_ack_(handle, PendingAck::PENDING_ACK_NOTIFY);
   if (conn_err_t err = this->check_connected_op_("notify", "characteristic"); err != CONN_OK)
     return err;
   ESP_LOGV(TAG, "[%d] [%s] %s GATT characteristic notifications handle %d", this->connection_index_, this->address_str_,

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -235,7 +235,7 @@ void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, u
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("reading char/descriptor", handle, error);
-    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+    this->send_gatt_error_(handle, error);
     return;
   }
   auto *api_connection = this->proxy_->get_api_connection();
@@ -257,7 +257,7 @@ void BluetoothConnection::on_write_result(uint16_t handle, int error) {
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("writing char/descriptor", handle, error);
-    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+    this->send_gatt_error_(handle, error);
     return;
   }
   this->send_ack_(PendingAck::PENDING_ACK_WRITE, handle);
@@ -269,7 +269,7 @@ void BluetoothConnection::on_notify_state(uint16_t handle, bool enabled, int err
   if (error != 0) {
     this->log_gatt_operation_error_(enabled ? "registering notifications" : "unregistering notifications", handle,
                                     error);
-    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+    this->send_gatt_error_(handle, error);
     return;
   }
   this->send_ack_(PendingAck::PENDING_ACK_NOTIFY, handle);
@@ -305,26 +305,26 @@ conn_err_t BluetoothConnection::check_connected_op_(const char *action, const ch
 }
 
 conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("read", "characteristic"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_characteristic(handle);
 }
 
 conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint8_t *data, size_t length,
                                                      bool response) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("write", "characteristic"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_characteristic(handle, data, static_cast<uint16_t>(length), response);
 }
 
 conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("read", "descriptor"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_descriptor(handle);
 }
@@ -333,17 +333,17 @@ conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 // the response flag is intentionally ignored (esp32 maps it to RSP/NO_RSP).
 conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t *data, size_t length,
                                                  bool /*response*/) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("write", "descriptor"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_descriptor(handle, data, static_cast<uint16_t>(length));
 }
 
 conn_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
+  this->supersede_pending_ack_(handle);
   if (conn_err_t err = this->check_connected_op_("notify", "characteristic"); err != CONN_OK)
     return err;
-  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] %s GATT characteristic notifications handle %d", this->connection_index_, this->address_str_,
            enable ? "Registering for" : "Unregistering for", handle);
   return this->backend_->notify_characteristic(handle, enable);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -281,6 +281,10 @@ void BluetoothConnection::flush_pending_ack_() {
     this->clear_pending_ack_();
     return;
   }
+  this->age_pending_ack_();
+}
+
+void BluetoothConnection::age_pending_ack_() {
   if (++this->pending_ack_retries_ >= PENDING_ACK_RETRY_LIMIT) {
     // Undeliverable: past here the client has given up and may have re-asked,
     // and a late reply would answer the new request instead of this one.
@@ -430,7 +434,13 @@ void BluetoothConnection::send_services_done_() {
     ESP_LOGW(TAG, "[%d] [%s] Failed to send services done, retrying", this->connection_index_, this->address_str_);
     this->services_done_retries_ = 0;
     this->send_service_ = SERVICES_DONE_PENDING;
-  } else if (++this->services_done_retries_ >= SERVICES_DONE_RETRY_LIMIT) {
+  } else {
+    this->age_services_done_();
+  }
+}
+
+void BluetoothConnection::age_services_done_() {
+  if (++this->services_done_retries_ >= SERVICES_DONE_RETRY_LIMIT) {
     // Undeliverable (see SERVICES_DONE_RETRY_LIMIT); silence arbitrates.
     ESP_LOGW(TAG, "[%d] [%s] Services done undeliverable, abandoning", this->connection_index_, this->address_str_);
     this->send_service_ = DONE_SENDING_SERVICES;

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -1,4 +1,24 @@
 // The proxy's per-slot connection wrapper, shared by every platform.
+//
+// SERVICE STREAMING HAZARD - read before touching the streaming code here or
+// in the platform streamers (bluetooth_connection_bluedroid.cpp).
+//
+// A V3 client caches the service list it receives as the device's complete,
+// permanent database. Nothing on the wire marks a list as partial, so a
+// stream that is truncated, has a skipped batch, or is terminated early
+// would be cached whole and poison every later session with the device.
+//
+// The rule: it is always better to send nothing and let the client time out
+// than to let services-done follow an incomplete stream. Concretely:
+//   - a refused batch rewinds the cursor and is retried, never skipped;
+//   - services-done is sent only after every batch was accepted;
+//   - every interruption (subscriber lost or swapped, backend abort,
+//     bounds-check failure) parks or aborts WITHOUT services-done and drops
+//     any owed done;
+//   - a new GetServices supersedes an owed done, so a stale done can never
+//     land on a fresh request's empty accumulator and cache it as empty.
+// The client only caches a list terminated by services-done within the same
+// request; timeouts, disconnects and errors raise instead of caching.
 #include "bluetooth_connection_hub.h"
 
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -73,6 +73,11 @@ void BluetoothConnection::reset_connection_(conn_err_t reason) {
   this->state_ = ClientState::IDLE;
   this->services_discovered_ = false;
   this->paired_ = false;
+  // The link is gone: an owed reply for it would arrive addressed to a
+  // connection the client has already been told about, and the slot may be
+  // reserved for a different device by the time the drain runs.
+  this->clear_pending_ack_();
+  this->batch_stalled_ = false;
   this->backend_->release_services();
   this->proxy_->reset_connection_slot_(this, reason);
 }
@@ -163,13 +168,63 @@ void BluetoothConnection::log_gatt_operation_error_(const char *operation, uint1
            operation, handle, status);
 }
 
+void BluetoothConnection::note_batch_stalled_() {
+  if (this->batch_stalled_)
+    return;
+  this->batch_stalled_ = true;
+  ESP_LOGW(TAG, "[%d] [%s] Service batch deferred, TCP buffer full; retrying", this->connection_index_,
+           this->address_str_);
+}
+
+/// Build and send one payload-free GATT reply. The only construction site
+/// for these messages: first attempt and retry both come through here, so a
+/// re-offer cannot drift from the original.
+bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
+  if (kind == PendingAck::PENDING_ACK_ERROR) {
+    // The proxy owns the error reply; it reports a refusal the same way.
+    return this->proxy_->send_gatt_error(this->address_, handle, error);
+  }
+  auto *api_connection = this->proxy_->get_api_connection();
+  if (api_connection == nullptr)
+    return true;  // Nobody subscribed: nothing is owed
+  if (kind == PendingAck::PENDING_ACK_WRITE) {
+    api::BluetoothGATTWriteResponse resp;
+    resp.address = this->address_;
+    resp.handle = handle;
+    return api_connection->send_message(resp);
+  }
+  api::BluetoothGATTNotifyResponse resp;
+  resp.address = this->address_;
+  resp.handle = handle;
+  return api_connection->send_message(resp);
+}
+
+void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
+  if (this->try_send_ack_(kind, handle, error))
+    return;
+  // V, not W: the reply is owed rather than lost, and a warning here would
+  // ride the same connection that just refused a frame. Matches how the
+  // proxy logs a deferred connections-free update.
+  ESP_LOGV(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
+           this->address_str_, handle);
+  this->latch_pending_ack_(kind, handle, error);
+}
+
+void BluetoothConnection::flush_pending_ack_() {
+  if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
+    this->clear_pending_ack_();
+  }
+  // Still refused: stays owed, re-offered on the next paced drain. The
+  // client's operation timeout remains the outer bound.
+}
+
 void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, uint16_t len, int error) {
   // Late completion for a freed slot; nothing to report.
   if (this->address_ == 0)
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("reading char/descriptor", handle, error);
-    this->proxy_->send_gatt_error(this->address_, handle, error);
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
     return;
   }
   auto *api_connection = this->proxy_->get_api_connection();
@@ -180,6 +235,8 @@ void BluetoothConnection::on_read_result(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
+    // Not latched: the payload would have to be held on the heap through the
+    // congestion that refused it. The client's read timeout arbitrates.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send read response", this->connection_index_, this->address_str_);
   }
 }
@@ -189,18 +246,10 @@ void BluetoothConnection::on_write_result(uint16_t handle, int error) {
     return;
   if (error != 0) {
     this->log_gatt_operation_error_("writing char/descriptor", handle, error);
-    this->proxy_->send_gatt_error(this->address_, handle, error);
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
     return;
   }
-  auto *api_connection = this->proxy_->get_api_connection();
-  if (api_connection == nullptr)
-    return;
-  api::BluetoothGATTWriteResponse resp;
-  resp.address = this->address_;
-  resp.handle = handle;
-  if (!api_connection->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send write response", this->connection_index_, this->address_str_);
-  }
+  this->send_ack_(PendingAck::PENDING_ACK_WRITE, handle);
 }
 
 void BluetoothConnection::on_notify_state(uint16_t handle, bool enabled, int error) {
@@ -209,18 +258,10 @@ void BluetoothConnection::on_notify_state(uint16_t handle, bool enabled, int err
   if (error != 0) {
     this->log_gatt_operation_error_(enabled ? "registering notifications" : "unregistering notifications", handle,
                                     error);
-    this->proxy_->send_gatt_error(this->address_, handle, error);
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
     return;
   }
-  auto *api_connection = this->proxy_->get_api_connection();
-  if (api_connection == nullptr)
-    return;
-  api::BluetoothGATTNotifyResponse resp;
-  resp.address = this->address_;
-  resp.handle = handle;
-  if (!api_connection->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send notify state response", this->connection_index_, this->address_str_);
-  }
+  this->send_ack_(PendingAck::PENDING_ACK_NOTIFY, handle);
 }
 
 void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, uint16_t len) {
@@ -235,6 +276,9 @@ void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, u
   resp.handle = handle;
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
+    // Not latched, same reason as the read reply: the payload cannot be held
+    // through congestion. Notify data is genuinely lossy; the peripheral will
+    // not resend it.
     ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
   }
 }
@@ -413,9 +457,11 @@ void BluetoothConnection::send_service_for_discovery_() {
   // (bounded: a subscriber that stays gone ends streaming via the api-lost
   // rewind above).
   if (!api_conn->send_message(resp)) {
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send service batch, retrying", this->connection_index_, this->address_str_);
+    this->note_batch_stalled_();
     this->send_service_ = batch_start;
+    return;
   }
+  this->batch_stalled_ = false;
 }
 
 }  // namespace esphome::bluetooth_connection

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -18,7 +18,7 @@ void BluetoothConnection::set_address(uint64_t address) {
   this->proxy_->update_address_slot_(this->address_, address);
   // Slot changing hands: anything owed belonged to the old address. The
   // choke point for every reassignment, not just reset_connection_()'s path.
-  this->clear_pending_ack_();
+  this->clear_owed_flags_();
   this->address_ = address;
   if (address == 0) {
     this->address_str_[0] = '\0';

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -190,6 +190,14 @@ void BluetoothConnection::flush_owed_replies_() {
   if (this->connected_reply_owed_) {
     this->send_connected_reply_();
     if (this->connected_reply_owed_) {
+      // The retry limits are wall-clock windows: age the deferred budgets so
+      // a reply cannot outlive the window it was sized for.
+      if (this->send_service_ == SERVICES_DONE_PENDING) {
+        this->age_services_done_();
+      }
+      if (this->has_pending_ack_()) {
+        this->age_pending_ack_();
+      }
       return;
     }
   }

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -212,12 +212,16 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // Warn on the leading edge only, like a stalled service batch: a refused
-  // reply must not be silent, but repeating it every attempt would add traffic
-  // to the connection that just refused one.
+  // Report anything the client will not otherwise learn about: a newly owed
+  // reply, or one being displaced, which is the case that actually loses a
+  // reply for good. Re-refusing the same reply is the only quiet path, since
+  // it is already owed and the drain keeps trying.
   if (!this->has_pending_ack_()) {
     ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
              this->address_str_, handle);
+  } else if (this->pending_ack_handle_ != handle || this->pending_ack_ != kind) {
+    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X dropped for handle 0x%2X", this->connection_index_,
+             this->address_str_, this->pending_ack_handle_, handle);
   }
   this->latch_pending_ack_(kind, handle, error);
 }

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -212,10 +212,8 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
   if (this->try_send_ack_(kind, handle, error))
     return;
-  // Report anything the client will not otherwise learn about: a newly owed
-  // reply, or one being displaced, which is the case that actually loses a
-  // reply for good. Re-refusing the same reply is the only quiet path, since
-  // it is already owed and the drain keeps trying.
+  // Report a newly owed reply and a displaced one; displacing is the case
+  // that loses a reply. Re-refusing the same one stays quiet.
   if (!this->has_pending_ack_()) {
     ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%2X deferred, TCP buffer full", this->connection_index_,
              this->address_str_, handle);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -179,7 +179,7 @@ void BluetoothConnection::note_batch_stalled_() {
 
 /// Both payload-free acks are just (address, handle); only the type differs.
 template<typename Response>
-static bool send_handle_reply_(api::APIConnection *api_connection, uint64_t address, uint16_t handle) {
+static bool send_handle_reply(api::APIConnection *api_connection, uint64_t address, uint16_t handle) {
   Response resp;
   resp.address = address;
   resp.handle = handle;
@@ -197,9 +197,9 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
     return true;  // Nobody subscribed: nothing is owed
   switch (kind) {
     case PendingAck::PENDING_ACK_WRITE:
-      return send_handle_reply_<api::BluetoothGATTWriteResponse>(api_connection, this->address_, handle);
+      return send_handle_reply<api::BluetoothGATTWriteResponse>(api_connection, this->address_, handle);
     case PendingAck::PENDING_ACK_NOTIFY:
-      return send_handle_reply_<api::BluetoothGATTNotifyResponse>(api_connection, this->address_, handle);
+      return send_handle_reply<api::BluetoothGATTNotifyResponse>(api_connection, this->address_, handle);
     case PendingAck::PENDING_ACK_NONE:
     case PendingAck::PENDING_ACK_ERROR:  // returned above
       return true;

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -185,9 +185,13 @@ void BluetoothConnection::on_service_discovery_done(int error) {
 
 void BluetoothConnection::flush_owed_replies_() {
   // Connected first: the client should never see services-done or an ack for
-  // a link it has not been told is up.
+  // a link it has not been told is up. Structural, not size-dependent: a
+  // still-owed connected reply defers the smaller sends to the next tick.
   if (this->connected_reply_owed_) {
     this->send_connected_reply_();
+    if (this->connected_reply_owed_) {
+      return;
+    }
   }
   if (this->send_service_ == SERVICES_DONE_PENDING) {
     this->send_services_done_();

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -16,6 +16,10 @@ static const char *const TAG = "bluetooth_connection";
 void BluetoothConnection::set_address(uint64_t address) {
   // Keep the proxy's pre-allocated connections-free message in step
   this->proxy_->update_address_slot_(this->address_, address);
+  // The slot is changing hands, so anything owed belonged to the old address.
+  // reset_connection_() already clears on the ordinary teardown path; this is
+  // the choke point that covers every other way a slot is reassigned or freed.
+  this->clear_pending_ack_();
   this->address_ = address;
   if (address == 0) {
     this->address_str_[0] = '\0';
@@ -187,16 +191,27 @@ bool BluetoothConnection::try_send_ack_(PendingAck kind, uint16_t handle, conn_e
   auto *api_connection = this->proxy_->get_api_connection();
   if (api_connection == nullptr)
     return true;  // Nobody subscribed: nothing is owed
-  if (kind == PendingAck::PENDING_ACK_WRITE) {
-    api::BluetoothGATTWriteResponse resp;
-    resp.address = this->address_;
-    resp.handle = handle;
-    return api_connection->send_message(resp);
+  switch (kind) {
+    case PendingAck::PENDING_ACK_WRITE: {
+      api::BluetoothGATTWriteResponse resp;
+      resp.address = this->address_;
+      resp.handle = handle;
+      return api_connection->send_message(resp);
+    }
+    case PendingAck::PENDING_ACK_NOTIFY: {
+      api::BluetoothGATTNotifyResponse resp;
+      resp.address = this->address_;
+      resp.handle = handle;
+      return api_connection->send_message(resp);
+    }
+    case PendingAck::PENDING_ACK_NONE:
+    case PendingAck::PENDING_ACK_ERROR:  // returned above
+      return true;
   }
-  api::BluetoothGATTNotifyResponse resp;
-  resp.address = this->address_;
-  resp.handle = handle;
-  return api_connection->send_message(resp);
+  // Every enumerator is listed and there is no default label, so adding one
+  // without a branch is a -Wswitch warning rather than a silent notify reply.
+  // This return only satisfies -Wreturn-type.
+  return true;
 }
 
 void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t error) {
@@ -211,6 +226,10 @@ void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t
 }
 
 void BluetoothConnection::flush_pending_ack_() {
+  // Local guard: the proxy drain pre-checks, but this must be a no-op on its
+  // own rather than relying on a caller in another file.
+  if (!this->has_pending_ack_())
+    return;
   if (this->try_send_ack_(this->pending_ack_, this->pending_ack_handle_, this->pending_ack_error_)) {
     this->clear_pending_ack_();
   }
@@ -297,6 +316,7 @@ conn_err_t BluetoothConnection::check_connected_op_(const char *action, const ch
 conn_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   if (conn_err_t err = this->check_connected_op_("read", "characteristic"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_characteristic(handle);
 }
@@ -305,6 +325,7 @@ conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint
                                                      bool response) {
   if (conn_err_t err = this->check_connected_op_("write", "characteristic"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_characteristic(handle, data, static_cast<uint16_t>(length), response);
 }
@@ -312,6 +333,7 @@ conn_err_t BluetoothConnection::write_characteristic(uint16_t handle, const uint
 conn_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   if (conn_err_t err = this->check_connected_op_("read", "descriptor"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->read_descriptor(handle);
 }
@@ -322,6 +344,7 @@ conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t 
                                                  bool /*response*/) {
   if (conn_err_t err = this->check_connected_op_("write", "descriptor"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_, handle);
   return this->backend_->write_descriptor(handle, data, static_cast<uint16_t>(length));
 }
@@ -329,6 +352,7 @@ conn_err_t BluetoothConnection::write_descriptor(uint16_t handle, const uint8_t 
 conn_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
   if (conn_err_t err = this->check_connected_op_("notify", "characteristic"); err != CONN_OK)
     return err;
+  this->supersede_pending_ack_(handle);
   ESP_LOGV(TAG, "[%d] [%s] %s GATT characteristic notifications handle %d", this->connection_index_, this->address_str_,
            enable ? "Registering for" : "Unregistering for", handle);
   return this->backend_->notify_characteristic(handle, enable);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -164,11 +164,13 @@ void BluetoothConnection::on_service_discovery_done(int error) {
 }
 
 void BluetoothConnection::flush_owed_replies_() {
-  if (this->send_service_ == SERVICES_DONE_PENDING) {
-    this->send_services_done_();
-  }
+  // Connected first: the client should never see services-done or an ack for
+  // a link it has not been told is up.
   if (this->connected_reply_owed_) {
     this->send_connected_reply_();
+  }
+  if (this->send_service_ == SERVICES_DONE_PENDING) {
+    this->send_services_done_();
   }
   if (this->has_pending_ack_()) {
     this->flush_pending_ack_();

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -236,9 +236,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
-  // Plain byte, ordered after the bitfields: an 8-bit field cannot share
-  // pending_ack_'s storage unit, so anywhere earlier it would straddle and
-  // push the tail into a new 8-byte row. Here it takes the one padding byte.
+  // Plain byte after the bitfields: takes the padding byte instead of
+  // straddling pending_ack_'s storage unit and growing the object.
   uint8_t pending_ack_retries_{0};
 };
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -137,10 +137,12 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply when the client re-asks about that handle: clients
-  /// match on (address, handle), so a stale one would resolve the new request.
-  void supersede_pending_ack_(uint16_t handle) {
-    if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
+  /// Drop an owed reply this re-ask makes stale. Clients match futures on
+  /// response type as well as handle, so an owed error (which resolves any op
+  /// on the handle) is cleared by any re-ask, other kinds only by their own.
+  void supersede_pending_ack_(uint16_t handle, PendingAck kind) {
+    if (this->has_pending_ack_() && this->pending_ack_handle_ == handle &&
+        (this->pending_ack_ == PendingAck::PENDING_ACK_ERROR || this->pending_ack_ == kind)) {
       this->clear_pending_ack_();
     }
   }
@@ -238,6 +240,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool batch_stalled_ : 1 {false};
   // Plain byte after the bitfields: takes the padding byte instead of
   // straddling pending_ack_'s storage unit and growing the object.
+  static_assert(PENDING_ACK_RETRY_LIMIT <= 0xFF, "retry counter too narrow");
   uint8_t pending_ack_retries_{0};
 };
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -234,8 +234,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
 
   // Group 5: bit-packed tail. The first two bytes were already full, so the
   // first added bit forced a third and took the 8-aligned object 48 -> 56;
-  // the handle and error ride in that padding. One byte and four bits left,
-  // so another flag is free but another member costs 8 per slot.
+  // the handle, error and retry counter ride in that padding. Four bitfield
+  // bits left; another byte-sized member costs 8 per slot.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
                 "connection_type_ bitfield too narrow");

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -131,6 +131,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// newest wins: a GATT client works one request at a time, and a discarded
   /// reply falls back to the timeout it would have hit anyway.
   void latch_pending_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0) {
+    this->pending_ack_retries_ = 0;
     this->pending_ack_ = kind;
     this->pending_ack_handle_ = handle;
     this->pending_ack_error_ = error;
@@ -233,6 +234,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool services_discovered_ : 1 {false};
   static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
+  static_assert(PENDING_ACK_RETRY_LIMIT < (1 << 5), "ack retry counter too narrow");
+  uint8_t pending_ack_retries_ : 5 {0};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
 };

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -153,7 +153,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   void note_batch_stalled_();
   /// Send the connected=true reply, latching it if the API refuses. Rebuilt
   /// from address_ and mtu_, so the latch is one bit; a dropped confirmation
-  /// leaves the client timing out while this slot holds a live link.
+  /// leaves the client timing out while this slot holds a live link. No retry
+  /// bound: the slot's lifetime is the bound (teardown clears the flag).
   void send_connected_reply_();
   /// Re-offer everything this slot owes. One entry point so the proxy drain
   /// does not have to know which latches exist.

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -177,6 +177,9 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// interrupted stream must never be declared complete (the client's
   /// timeout arbitrates), and an owed done is dropped with it.
   void park_service_stream_() {
+    // Agree with reset_connection_(): a stall flag left set would swallow the
+    // next session's leading-edge warning.
+    this->batch_stalled_ = false;
     if (this->send_service_ >= 0) {
       this->backend_->release_services();
       this->send_service_ = DONE_SENDING_SERVICES;
@@ -199,10 +202,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bluetooth_proxy::BluetoothProxy *proxy_{nullptr};
   ble_device_base::BLEGattConnection *backend_{nullptr};
 
-  // Group 2: 2-byte types (pending_ack_handle_ lands in existing padding)
+  // Group 2: 2-byte types. Exactly 4 bytes, so address_ below stays
+  // 8-aligned with no padding (the vptr makes Group 1 12 bytes, not 8).
   int16_t send_service_{INIT_SENDING_SERVICES};
   uint16_t mtu_{ble_device_base::DEFAULT_ATT_MTU};
-  uint16_t pending_ack_handle_{0};
 
   // Group 3: 8-byte and 4-byte types
   uint64_t address_{0};
@@ -213,8 +216,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
 
   // Group 4: Arrays
   char address_str_[MAC_ADDRESS_PRETTY_BUFFER_SIZE]{};
+  // Parked here rather than in Group 2: address_str_ ends 2-aligned, so this
+  // uses tail slack instead of pushing address_ out by 6 bytes of padding.
+  uint16_t pending_ack_handle_{0};
 
-  // Group 5: bit-packed tail. pending_ack_error_ already took the object
+  // Group 5: bit-packed tail. pending_ack_error_ takes the 8-aligned object
   // from 48 to 56, so the third tail byte is free; first two stay packed.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
@@ -233,6 +239,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
 };
+
+// Pins the layout the field grouping above is arranged for: putting
+// pending_ack_handle_ in Group 2 instead pushes address_ out by 6 bytes of
+// padding and takes this to 64 (the vptr makes Group 1 12 bytes, not 8).
+static_assert(sizeof(BluetoothConnection) <= 56, "BluetoothConnection layout regressed");
 
 }  // namespace esphome::bluetooth_connection
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -136,12 +136,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply when the client re-asks about that handle. Clients
-  /// match replies by (address, handle), so a stale one would otherwise
-  /// resolve the retried request before the peripheral has answered. Called
-  /// before the connected check, so a request rejected on a dead link still
-  /// invalidates it, and matched on handle alone: a read superseding an owed
-  /// write reply costs a timeout, which is the safe direction.
+  /// Drop an owed reply when the client re-asks about that handle: clients
+  /// match on (address, handle), so a stale one would resolve the new request.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -25,12 +25,9 @@ namespace esphome::bluetooth_connection {
 using ClientState = ble_device_base::ClientState;
 using ConnectionType = ble_device_base::ConnectionType;
 
-/// A GATT acknowledgement the API refused, owed to the current subscriber.
-/// Only payload-free replies appear here: each one is rebuilt from the
-/// address plus the fields below, so a retry is idempotent and costs no
-/// buffered data. Read and notify-data replies carry payloads and are
-/// deliberately absent - retrying those would mean holding data on the heap
-/// through exactly the congestion that refused them.
+/// A refused GATT reply owed to the current subscriber. Payload-free only:
+/// these rebuild from address + handle + error, so a retry costs no buffered
+/// data. Read and notify-data carry payloads and are deliberately absent.
 enum class PendingAck : uint8_t {
   PENDING_ACK_NONE = 0,
   PENDING_ACK_WRITE,
@@ -129,47 +126,33 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     }
   }
 
-  /// Remember a refused acknowledgement so the proxy drain can re-offer it.
-  /// Newest wins: one slot per connection, sized for the sequential
-  /// request/reply pattern a GATT client uses. If a second reply is refused
-  /// while one is owed, the older one is discarded and that operation falls
-  /// back to the client's timeout, which is what happened to both before
-  /// this latch existed.
+  /// Latch a refused reply for the proxy drain. One slot per connection,
+  /// newest wins: a GATT client works one request at a time, and a discarded
+  /// reply falls back to the timeout it would have hit anyway.
   void latch_pending_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0) {
     this->pending_ack_ = kind;
     this->pending_ack_handle_ = handle;
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply once the client asks again about the same handle.
-  ///
-  /// Without this the retry is unbounded in a way that can do real harm: a
-  /// client whose write times out re-issues it, and the drain could then
-  /// deliver the *old* reply against the *new* request. API clients match a
-  /// reply by (address, handle), so the retried operation would be reported
-  /// as complete before the peripheral has answered it. Dropping the stale
-  /// reply restores the pre-latch outcome for that case, a timeout, which is
-  /// wrong but honest.
+  /// Drop an owed reply when the client re-asks about that handle. Clients
+  /// match replies by (address, handle), so a stale one would otherwise
+  /// resolve the retried request before the peripheral has answered.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();
     }
   }
   bool has_pending_ack_() const { return this->pending_ack_ != PendingAck::PENDING_ACK_NONE; }
-  /// Report a refused service batch on the stall's leading edge only. The
-  /// batch itself is never lost - the caller rewinds the cursor and the next
-  /// loop iteration re-sends it - so warning on every attempt says nothing
-  /// new while adding traffic to the connection that is already refusing
-  /// frames. Both streamers route their refusal here, so both report it
-  /// identically.
+  /// Warn on the stall's leading edge only. The batch is never lost (the
+  /// caller rewinds the cursor), and a warning per attempt would add traffic
+  /// to the connection already refusing frames. Both streamers route here.
   void note_batch_stalled_();
-  /// Build and send one payload-free GATT reply. The single construction
-  /// site for these messages, shared by the first attempt and the retry.
+  /// Sole construction site for these replies, shared by send and retry.
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
   /// First attempt: send, and latch it for the drain if the API refuses.
   void send_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0);
-  /// Re-send the owed acknowledgement, rebuilt from the latch. Clears on
-  /// success or when nobody is subscribed; keeps it owed on a refusal.
+  /// Re-offer the owed reply; clears on success, stays owed on a refusal.
   void flush_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the
   // response in place from its stack cache; the rest use the table streamer.
@@ -208,8 +191,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bluetooth_proxy::BluetoothProxy *proxy_{nullptr};
   ble_device_base::BLEGattConnection *backend_{nullptr};
 
-  // Group 2: 2-byte types (pending_ack_handle_ lands in padding that was
-  // already there, so it is free)
+  // Group 2: 2-byte types (pending_ack_handle_ lands in existing padding)
   int16_t send_service_{INIT_SENDING_SERVICES};
   uint16_t mtu_{ble_device_base::DEFAULT_ATT_MTU};
   uint16_t pending_ack_handle_{0};
@@ -217,17 +199,15 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   // Group 3: 8-byte and 4-byte types
   uint64_t address_{0};
   conn_err_t pending_error_{0};
-  // Full width on purpose: the GATT error domain is open-ended (see
-  // ble_gatt_client.h) and the value is forwarded to the API untranslated,
-  // so narrowing it here would corrupt platform status codes.
+  // Full width: the GATT error domain is open-ended (ble_gatt_client.h) and
+  // forwarded untranslated, so narrowing would corrupt platform codes.
   conn_err_t pending_ack_error_{0};
 
   // Group 4: Arrays
   char address_str_[MAC_ADDRESS_PRETTY_BUFFER_SIZE]{};
 
-  // Group 5: bit-packed tail. pending_ack_error_ already pushed the
-  // 8-aligned object from 48 to 56, so the third tail byte the ack fields
-  // need is free; keep the first two packed exactly as before.
+  // Group 5: bit-packed tail. pending_ack_error_ already took the object
+  // from 48 to 56, so the third tail byte is free; first two stay packed.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
                 "connection_type_ bitfield too narrow");
@@ -242,9 +222,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool services_discovered_ : 1 {false};
   static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
-  /// True while a refused service batch is being retried. Exists only so the
-  /// warning fires on the stall's leading edge: the retry itself is silent,
-  /// because the log rides the same connection that refused the batch.
+  /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
 };
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -152,6 +152,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// caller rewinds the cursor), and a warning per attempt would add traffic
   /// to the connection already refusing frames. Both streamers route here.
   void note_batch_stalled_();
+  /// Send the connected=true reply, latching it if the API refuses. The
+  /// message rebuilds from address_ and mtu_, so the latch is one bit; a
+  /// dropped confirmation otherwise leaves the client timing out while this
+  /// slot holds a live link.
+  void send_connected_reply_();
   /// Sole construction site for these replies, shared by send and retry.
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
   /// First attempt: send, and latch it for the drain if the API refuses.
@@ -239,6 +244,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
+  /// An owed connected=true reply; the proxy's paced drain re-offers it.
+  bool connected_reply_owed_ : 1 {false};
 };
 
 // Pins the layout the field grouping above is arranged for: putting

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -241,11 +241,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool batch_stalled_ : 1 {false};
 };
 
-// Pins the layout the field grouping above is arranged for: putting
-// pending_ack_handle_ in Group 2 instead pushes address_ out by 6 bytes of
-// padding and takes this to 64 (the vptr makes Group 1 12 bytes, not 8).
-// Only meaningful on the 32-bit targets that grouping is for; the host unit
-// tests build 64-bit, where every pointer and the vptr double.
+// Pins the grouping above: pending_ack_handle_ in Group 2 instead would pad
+// address_ out and reach 64. 32-bit only; the host unit tests build 64-bit.
 static_assert(sizeof(void *) != 4 || sizeof(BluetoothConnection) <= 56,
               "BluetoothConnection layout regressed on a 32-bit target");
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -136,12 +136,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
-  /// Drop an owed reply when the client re-asks about that handle. Clients
-  /// match replies by (address, handle), so a stale one would otherwise
-  /// resolve the retried request before the peripheral has answered. Called
-  /// before the connected check, so a request rejected on a dead link still
-  /// invalidates it, and matched on handle alone: a read superseding an owed
-  /// write reply costs a timeout, which is the safe direction.
+  /// Drop an owed reply when the client re-asks about that handle: clients
+  /// match on (address, handle), so a stale one would resolve the retried
+  /// request before the peripheral answered. Handle alone, so a read can
+  /// supersede an owed write reply; that costs a timeout, the safe direction.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();
@@ -152,11 +150,19 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// caller rewinds the cursor), and a warning per attempt would add traffic
   /// to the connection already refusing frames. Both streamers route here.
   void note_batch_stalled_();
-  /// Send the connected=true reply, latching it if the API refuses. The
-  /// message rebuilds from address_ and mtu_, so the latch is one bit; a
-  /// dropped confirmation otherwise leaves the client timing out while this
-  /// slot holds a live link.
+  /// Send the connected=true reply, latching it if the API refuses. Rebuilt
+  /// from address_ and mtu_, so the latch is one bit; a dropped confirmation
+  /// leaves the client timing out while this slot holds a live link.
   void send_connected_reply_();
+  /// Re-offer everything this slot owes. One entry point so the proxy drain
+  /// does not have to know which latches exist.
+  void flush_owed_replies_();
+  /// Drop everything this slot owes, in one write to the shared tail byte.
+  void clear_owed_flags_() {
+    this->pending_ack_ = PendingAck::PENDING_ACK_NONE;
+    this->batch_stalled_ = false;
+    this->connected_reply_owed_ = false;
+  }
   /// Sole construction site for these replies, shared by send and retry.
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
   /// First attempt: send, and latch it for the drain if the API refuses.
@@ -183,8 +189,6 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// interrupted stream must never be declared complete (the client's
   /// timeout arbitrates), and an owed done is dropped with it.
   void park_service_stream_() {
-    // Agree with reset_connection_(): a stall flag left set would swallow the
-    // next session's leading-edge warning.
     this->batch_stalled_ = false;
     if (this->send_service_ >= 0) {
       this->backend_->release_services();
@@ -226,8 +230,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   // uses tail slack instead of pushing address_ out by 6 bytes of padding.
   uint16_t pending_ack_handle_{0};
 
-  // Group 5: bit-packed tail. pending_ack_error_ takes the 8-aligned object
-  // from 48 to 56, so the third tail byte is free; first two stay packed.
+  // Group 5: bit-packed tail. The first two bytes were already exactly full
+  // (3+5, 4+2+1+1), so the first added bit forces a third and the 8-aligned
+  // object goes 48 -> 56; the handle and error then ride in that padding for
+  // free. One byte and four bits remain: another flag is free, another
+  // byte-sized member costs 8 per slot and trips the assert below.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
                 "connection_type_ bitfield too narrow");

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -176,6 +176,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   }
   /// Re-offer the owed reply; clears on success, stays owed on a refusal.
   void flush_pending_ack_();
+  /// Advance the retry budget and abandon at the limit, without sending.
+  void age_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the
   // response in place from its stack cache; the rest use the table streamer.
   // Template so the discarded branch is not odr-checked against backends
@@ -205,6 +207,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   /// retries). Callers release the table first; the message needs only the
   /// address.
   void send_services_done_();
+  /// Advance the retry budget and abandon at the limit, without sending.
+  void age_services_done_();
   void reset_connection_(conn_err_t reason);
   conn_err_t check_connected_op_(const char *action, const char *type) const;
   void log_gatt_operation_error_(const char *operation, uint16_t handle, int status);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -141,6 +141,20 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_error_ = error;
   }
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
+  /// Drop an owed reply once the client asks again about the same handle.
+  ///
+  /// Without this the retry is unbounded in a way that can do real harm: a
+  /// client whose write times out re-issues it, and the drain could then
+  /// deliver the *old* reply against the *new* request. API clients match a
+  /// reply by (address, handle), so the retried operation would be reported
+  /// as complete before the peripheral has answered it. Dropping the stale
+  /// reply restores the pre-latch outcome for that case, a timeout, which is
+  /// wrong but honest.
+  void supersede_pending_ack_(uint16_t handle) {
+    if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
+      this->clear_pending_ack_();
+    }
+  }
   bool has_pending_ack_() const { return this->pending_ack_ != PendingAck::PENDING_ACK_NONE; }
   /// Report a refused service batch on the stall's leading edge only. The
   /// batch itself is never lost - the caller rewinds the cursor and the next

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -137,7 +137,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
   /// Drop an owed reply when the client re-asks about that handle. Clients
   /// match replies by (address, handle), so a stale one would otherwise
-  /// resolve the retried request before the peripheral has answered.
+  /// resolve the retried request before the peripheral has answered. Called
+  /// before the connected check, so a request rejected on a dead link still
+  /// invalidates it, and matched on handle alone: a read superseding an owed
+  /// write reply costs a timeout, which is the safe direction.
   void supersede_pending_ack_(uint16_t handle) {
     if (this->has_pending_ack_() && this->pending_ack_handle_ == handle) {
       this->clear_pending_ack_();
@@ -152,6 +155,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
   /// First attempt: send, and latch it for the drain if the API refuses.
   void send_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0);
+  /// Report a rejected request. Latched like a completion reply, so a
+  /// refused frame does not strand the client for its whole timeout.
+  void send_gatt_error_(uint16_t handle, conn_err_t error) {
+    this->send_ack_(PendingAck::PENDING_ACK_ERROR, handle, error);
+  }
   /// Re-offer the owed reply; clears on success, stays owed on a refusal.
   void flush_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -234,10 +234,12 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool services_discovered_ : 1 {false};
   static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
   PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
-  static_assert(PENDING_ACK_RETRY_LIMIT < (1 << 5), "ack retry counter too narrow");
-  uint8_t pending_ack_retries_ : 5 {0};
   /// Set while a refused batch is retrying, so only the first one warns.
   bool batch_stalled_ : 1 {false};
+  // Plain byte, ordered after the bitfields: an 8-bit field cannot share
+  // pending_ack_'s storage unit, so anywhere earlier it would straddle and
+  // push the tail into a new 8-byte row. Here it takes the one padding byte.
+  uint8_t pending_ack_retries_{0};
 };
 
 // Pins the grouping above: pending_ack_handle_ in Group 2 instead would pad

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -25,6 +25,19 @@ namespace esphome::bluetooth_connection {
 using ClientState = ble_device_base::ClientState;
 using ConnectionType = ble_device_base::ConnectionType;
 
+/// A GATT acknowledgement the API refused, owed to the current subscriber.
+/// Only payload-free replies appear here: each one is rebuilt from the
+/// address plus the fields below, so a retry is idempotent and costs no
+/// buffered data. Read and notify-data replies carry payloads and are
+/// deliberately absent - retrying those would mean holding data on the heap
+/// through exactly the congestion that refused them.
+enum class PendingAck : uint8_t {
+  PENDING_ACK_NONE = 0,
+  PENDING_ACK_WRITE,
+  PENDING_ACK_NOTIFY,
+  PENDING_ACK_ERROR,
+};
+
 class BluetoothConnection final : public ble_device_base::GattClientListener {
  public:
   /// Wire the platform backend. Called from codegen before setup.
@@ -115,6 +128,35 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
       this->pending_error_ = err;
     }
   }
+
+  /// Remember a refused acknowledgement so the proxy drain can re-offer it.
+  /// Newest wins: one slot per connection, sized for the sequential
+  /// request/reply pattern a GATT client uses. If a second reply is refused
+  /// while one is owed, the older one is discarded and that operation falls
+  /// back to the client's timeout, which is what happened to both before
+  /// this latch existed.
+  void latch_pending_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0) {
+    this->pending_ack_ = kind;
+    this->pending_ack_handle_ = handle;
+    this->pending_ack_error_ = error;
+  }
+  void clear_pending_ack_() { this->pending_ack_ = PendingAck::PENDING_ACK_NONE; }
+  bool has_pending_ack_() const { return this->pending_ack_ != PendingAck::PENDING_ACK_NONE; }
+  /// Report a refused service batch on the stall's leading edge only. The
+  /// batch itself is never lost - the caller rewinds the cursor and the next
+  /// loop iteration re-sends it - so warning on every attempt says nothing
+  /// new while adding traffic to the connection that is already refusing
+  /// frames. Both streamers route their refusal here, so both report it
+  /// identically.
+  void note_batch_stalled_();
+  /// Build and send one payload-free GATT reply. The single construction
+  /// site for these messages, shared by the first attempt and the retry.
+  bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
+  /// First attempt: send, and latch it for the drain if the API refuses.
+  void send_ack_(PendingAck kind, uint16_t handle, conn_err_t error = 0);
+  /// Re-send the owed acknowledgement, rebuilt from the latch. Clears on
+  /// success or when nobody is subscribed; keeps it owed on a refusal.
+  void flush_pending_ack_();
   // A backend providing its own streamer (see the contract doc) builds the
   // response in place from its stack cache; the rest use the table streamer.
   // Template so the discarded branch is not odr-checked against backends
@@ -152,23 +194,31 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bluetooth_proxy::BluetoothProxy *proxy_{nullptr};
   ble_device_base::BLEGattConnection *backend_{nullptr};
 
-  // Group 2: 2-byte types
+  // Group 2: 2-byte types (pending_ack_handle_ lands in padding that was
+  // already there, so it is free)
   int16_t send_service_{INIT_SENDING_SERVICES};
   uint16_t mtu_{ble_device_base::DEFAULT_ATT_MTU};
+  uint16_t pending_ack_handle_{0};
 
   // Group 3: 8-byte and 4-byte types
   uint64_t address_{0};
   conn_err_t pending_error_{0};
+  // Full width on purpose: the GATT error domain is open-ended (see
+  // ble_gatt_client.h) and the value is forwarded to the API untranslated,
+  // so narrowing it here would corrupt platform status codes.
+  conn_err_t pending_ack_error_{0};
 
   // Group 4: Arrays
   char address_str_[MAC_ADDRESS_PRETTY_BUFFER_SIZE]{};
 
-  // Group 5: bit-packed tail; within 2 bytes the 8-aligned object stays 48.
+  // Group 5: bit-packed tail. pending_ack_error_ already pushed the
+  // 8-aligned object from 48 to 56, so the third tail byte the ack fields
+  // need is free; keep the first two packed exactly as before.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
                 "connection_type_ bitfield too narrow");
   // Ordered so neither byte's fields straddle a storage unit: 3+5 and
-  // 4+2+1+1 fill the two tail bytes exactly.
+  // 4+2+1+1 fill the first two tail bytes exactly.
   ClientState state_ : 3 {ClientState::IDLE};
   static_assert(SERVICES_DONE_RETRY_LIMIT < (1 << 5), "counter bitfield too narrow");
   uint8_t services_done_retries_ : 5 {0};
@@ -176,6 +226,12 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   ConnectionType connection_type_ : 2 {ConnectionType::V1};
   bool paired_ : 1 {false};
   bool services_discovered_ : 1 {false};
+  static_assert(static_cast<uint8_t>(PendingAck::PENDING_ACK_ERROR) < (1 << 2), "pending_ack_ bitfield too narrow");
+  PendingAck pending_ack_ : 2 {PendingAck::PENDING_ACK_NONE};
+  /// True while a refused service batch is being retried. Exists only so the
+  /// warning fires on the stall's leading edge: the retry itself is silent,
+  /// because the log rides the same connection that refused the batch.
+  bool batch_stalled_ : 1 {false};
 };
 
 }  // namespace esphome::bluetooth_connection

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -243,7 +243,10 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
 // Pins the layout the field grouping above is arranged for: putting
 // pending_ack_handle_ in Group 2 instead pushes address_ out by 6 bytes of
 // padding and takes this to 64 (the vptr makes Group 1 12 bytes, not 8).
-static_assert(sizeof(BluetoothConnection) <= 56, "BluetoothConnection layout regressed");
+// Only meaningful on the 32-bit targets that grouping is for; the host unit
+// tests build 64-bit, where every pointer and the vptr double.
+static_assert(sizeof(void *) != 4 || sizeof(BluetoothConnection) <= 56,
+              "BluetoothConnection layout regressed on a 32-bit target");
 
 }  // namespace esphome::bluetooth_connection
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -596,9 +596,9 @@ void BluetoothProxy::loop() {
 
   if (this->connections_free_pending_ && this->api_connection_ != nullptr) {
     // Resend a dropped slot-state update, paced by the 100 ms gate so the
-    // retry does not hammer the congestion it exists to survive; the
-    // advertisement-only arm answers DISCONNECT requests with this message
-    // too, so the drain compiles on every proxy build.
+    // retry does not hammer the congestion it exists to survive. Every build
+    // sends this at subscribe time (api_connection.cpp), so the drain
+    // compiles on every proxy build.
     this->connections_free_pending_ = false;
     this->send_connections_free(this->api_connection_);
   }
@@ -830,8 +830,8 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   this->pending_unpairing_.set(address, error);
 }
 
-// Shared by both platform paths: the neutral bluetooth_device_request() uses it to
-// answer a clear-cache request with a clean error, so it must not be esp32-guarded.
+// GATT arm only: the advertisement-only arm no longer dispatches CLEAR_CACHE,
+// so its response encoder would be dead weight there.
 void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -597,6 +597,9 @@ void BluetoothProxy::loop() {
     if (connection->send_service_ == SERVICES_DONE_PENDING) {
       connection->send_services_done_();
     }
+    if (connection->has_pending_ack_()) {
+      connection->flush_pending_ack_();
+    }
     auto &owed = this->pending_disconnections_[i];
     if (!owed.empty() && this->send_device_connection(owed.address(), false, 0, owed.error())) {
       owed.clear();
@@ -716,6 +719,8 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
       // Neither a partial stream's tail nor an owed done belongs to the new
       // session; silence (the client's timeout) arbitrates.
       this->connections_[i]->park_service_stream_();
+      // An ack owed to the previous subscriber means nothing to the new one.
+      this->connections_[i]->clear_pending_ack_();
     }
     this->pending_disconnections_.fill({});
 #endif
@@ -776,14 +781,14 @@ bool BluetoothProxy::send_gatt_services_done(uint64_t address) {
   return this->api_connection_->send_message(call);
 }
 
-void BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error) {
+bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error) {
   if (this->api_connection_ == nullptr)
-    return;
+    return true;  // Nobody subscribed: nothing is owed, only a refused frame reports false
   api::BluetoothGATTErrorResponse call;
   call.address = address;
   call.handle = handle;
   call.error = error;
-  this->api_connection_->send_message(call);
+  return this->api_connection_->send_message(call);
 }
 
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -808,7 +808,10 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     }
     return;
   }
-  this->log_reply_dropped_("Unpair");
+  // Leading edge only: the drain re-enters here every 100 ms while congested.
+  if (this->pending_unpairing_.empty()) {
+    this->log_reply_dropped_("Unpair");
+  }
   this->pending_unpairing_.set(address, error);
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -707,6 +707,25 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
 
 #endif  // !BLUETOOTH_CONNECTION_HAS_GATT
 
+void BluetoothProxy::reset_owed_replies_() {
+  this->connections_free_pending_ = false;
+#ifdef USE_BLE_SCANNER_STATE_CALLBACK
+  // subscribe_api_connection() re-drives this from the hub immediately after,
+  // so clearing it here costs nothing and keeps the list exhaustive.
+  this->scanner_state_pending_ = false;
+#endif
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  this->pending_unpairing_.clear();
+  this->pending_disconnections_.fill({});
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    // Neither a partial stream's tail nor an owed done belongs to the next
+    // session; silence (the client's timeout) arbitrates.
+    this->connections_[i]->park_service_stream_();
+    this->connections_[i]->clear_pending_ack_();
+  }
+#endif
+}
+
 void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection, uint32_t flags) {
   if (api_connection != this->api_connection_) {
     if (this->api_connection_ != nullptr) {
@@ -723,18 +742,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     }
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
-    this->connections_free_pending_ = false;
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-    this->pending_unpairing_.clear();
-    for (uint8_t i = 0; i < this->connection_count_; i++) {
-      // Neither a partial stream's tail nor an owed done belongs to the new
-      // session; silence (the client's timeout) arbitrates.
-      this->connections_[i]->park_service_stream_();
-      // An ack owed to the previous subscriber means nothing to the new one.
-      this->connections_[i]->clear_pending_ack_();
-    }
-    this->pending_disconnections_.fill({});
-#endif
+    this->reset_owed_replies_();
   }
   this->api_connection_ = api_connection;
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
@@ -751,13 +759,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
     return;
   }
   this->api_connection_ = nullptr;
-  this->connections_free_pending_ = false;
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  this->pending_unpairing_.clear();
-#endif
-#ifdef USE_BLE_SCANNER_STATE_CALLBACK
-  this->scanner_state_pending_ = false;
-#endif
+  this->reset_owed_replies_();
 }
 
 void BluetoothProxy::send_connections_free() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -828,7 +828,13 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   // retry state, so only the latch is conditional, not the send.
   [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (!sent) {
+  if (sent) {
+    // A later unpair landing for an address that still has one owed would
+    // otherwise have the drain repeat it.
+    if (this->pending_unpairing_.matches(address)) {
+      this->pending_unpairing_.clear();
+    }
+  } else {
     // Warn on the leading edge only: a refused reply must not be silent, but
     // repeating it would add traffic to the connection that just refused one.
     if (this->pending_unpairing_.empty()) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -606,14 +606,11 @@ void BluetoothProxy::loop() {
     }
   }
 
-  // An owed unpair reply. Cleared first, so another refusal re-latches through
-  // the sender; the success flag is recomputed as (error == 0), which is what
-  // every caller passed.
+  // An owed unpair reply. Not pre-cleared: the sender clears on success and
+  // re-latches on refusal, keeping its leading-edge warn guard honest.
   if (!this->pending_unpairing_.empty()) {
-    uint64_t address = this->pending_unpairing_.address();
     conn_err_t error = this->pending_unpairing_.error();
-    this->pending_unpairing_.clear();
-    this->send_device_unpairing(address, error == CONN_OK, error);
+    this->send_device_unpairing(this->pending_unpairing_.address(), error == CONN_OK, error);
   }
 #endif
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -122,6 +122,8 @@ void BluetoothProxy::log_connection_info_(BluetoothConnection *connection, const
 }
 #endif  // BLUETOOTH_CONNECTION_HAS_GATT
 
+void BluetoothProxy::log_reply_dropped_(const char *what) { ESP_LOGW(TAG, "%s reply dropped, TCP buffer full", what); }
+
 void BluetoothProxy::log_not_connected_gatt_(const char *action, const char *type) {
   ESP_LOGW(TAG, "Cannot %s GATT %s, not connected", action, type);
 }
@@ -131,7 +133,7 @@ void BluetoothProxy::handle_gatt_not_connected_(uint64_t address, uint16_t handl
   this->log_not_connected_gatt_(action, type);
   if (!this->send_gatt_error(address, handle, GATT_NOT_CONNECTED)) {
     // No connection, so nothing to latch against; the client's timeout arbitrates.
-    ESP_LOGW(TAG, "Not-connected reply dropped, TCP buffer full");
+    this->log_reply_dropped_("Not-connected");
   }
 }
 
@@ -230,6 +232,7 @@ void BluetoothProxy::clear_pending_disconnection_(uint64_t address) {
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     if (this->pending_disconnections_[i].matches(address)) {
       this->pending_disconnections_[i].clear();
+      return;  // latch_pending_disconnection_ keeps at most one entry per address
     }
   }
 }
@@ -510,7 +513,7 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
              connection ? connection->address_str() : "unknown");
     resp.error = GATT_NOT_CONNECTED;
     if (!this->api_connection_->send_message(resp)) {
-      ESP_LOGW(TAG, "Connection-params reply dropped, TCP buffer full");
+      this->log_reply_dropped_("Connection-params");
     }
     return;
   }
@@ -523,7 +526,7 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
                                                     static_cast<uint16_t>(std::min(msg.latency, max_val)),
                                                     static_cast<uint16_t>(std::min(msg.timeout, max_val)));
   if (!this->api_connection_->send_message(resp)) {
-    ESP_LOGW(TAG, "Connection-params reply dropped, TCP buffer full");
+    this->log_reply_dropped_("Connection-params");
   }
 }
 
@@ -611,20 +614,17 @@ void BluetoothProxy::loop() {
   // Paced retries of owed per-slot notifications; subscriber swaps clear
   // stale latches before this runs.
   for (uint8_t i = 0; i < this->connection_count_; i++) {
-    auto *connection = this->connections_[i];
-    if (connection->send_service_ == SERVICES_DONE_PENDING) {
-      connection->send_services_done_();
-    }
-    if (connection->connected_reply_owed_) {
-      connection->send_connected_reply_();
-    }
-    if (connection->has_pending_ack_()) {
-      connection->flush_pending_ack_();
-    }
-    auto &owed = this->pending_disconnections_[i];
-    if (!owed.empty() && this->send_device_connection(owed.address(), false, 0, owed.error())) {
-      owed.clear();
-    }
+    this->connections_[i]->flush_owed_replies_();
+  }
+  // Address-keyed, not slot-keyed, so it gets its own loop. Cleared first so
+  // another refusal re-latches through the sender, as the unpair drain does.
+  for (auto &owed : this->pending_disconnections_) {
+    if (owed.empty())
+      continue;
+    uint64_t address = owed.address();
+    conn_err_t error = owed.error();
+    owed.clear();
+    this->send_device_disconnected_(address, error);
   }
 
   // An owed unpair reply. Cleared first, so another refusal re-latches through
@@ -668,13 +668,13 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT:
       ESP_LOGW(TAG, "Active connections are not supported on this platform");
       if (!this->send_device_connection(msg.address, false, 0, GATT_NOT_CONNECTED)) {
-        ESP_LOGW(TAG, "Connection reply dropped, TCP buffer full");
+        this->log_reply_dropped_("Connection");
       }
       break;
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT:
       // Not an error: the device is already disconnected, which is the requested state.
       if (!this->send_device_connection(msg.address, false)) {
-        ESP_LOGW(TAG, "Connection reply dropped, TCP buffer full");
+        this->log_reply_dropped_("Connection");
       }
       this->send_connections_free();
       break;
@@ -729,7 +729,7 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
   resp.address = msg.address;
   resp.error = GATT_NOT_CONNECTED;
   if (!this->api_connection_->send_message(resp)) {
-    ESP_LOGW(TAG, "Connection-params reply dropped, TCP buffer full");
+    this->log_reply_dropped_("Connection-params");
   }
 }
 
@@ -748,9 +748,9 @@ void BluetoothProxy::reset_owed_replies_() {
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     // Neither a partial stream's tail nor an owed done belongs to the next
     // session; silence (the client's timeout) arbitrates.
-    this->connections_[i]->park_service_stream_();
-    this->connections_[i]->clear_pending_ack_();
-    this->connections_[i]->connected_reply_owed_ = false;
+    auto *connection = this->connections_[i];
+    connection->park_service_stream_();
+    connection->clear_owed_flags_();
   }
 #endif
 }
@@ -847,7 +847,7 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   if (!this->api_connection_->send_message(call)) {
     // Not latched: a retried PAIR is answered from is_paired(), so the client
     // recovers on its own. Still worth saying it happened.
-    ESP_LOGW(TAG, "Pairing reply dropped, TCP buffer full");
+    this->log_reply_dropped_("Pairing");
   }
 }
 
@@ -859,9 +859,12 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  // Advertisement-only builds answer this with a canned reply and keep no
-  // retry state, so only the latch is conditional, not the send.
-  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+  // Advertisement-only builds keep no retry state, so only the latch is
+  // conditional; the report is not.
+  bool sent = this->api_connection_->send_message(call);
+  if (!sent) {
+    this->log_reply_dropped_("Unpair");
+  }
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
   if (sent) {
     // A later unpair landing for an address that still has one owed would
@@ -870,11 +873,6 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
       this->pending_unpairing_.clear();
     }
   } else {
-    // Warn on the leading edge only: a refused reply must not be silent, but
-    // repeating it would add traffic to the connection that just refused one.
-    if (this->pending_unpairing_.empty()) {
-      ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
-    }
     this->pending_unpairing_.set(address, error);
   }
 #endif
@@ -892,7 +890,7 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
 
   if (!this->api_connection_->send_message(call)) {
     // Not latched: clear-cache is idempotent, so a retry gives the same answer.
-    ESP_LOGW(TAG, "Clear-cache reply dropped, TCP buffer full");
+    this->log_reply_dropped_("Clear-cache");
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -679,11 +679,7 @@ void BluetoothProxy::loop() {
 // unconditionally; answering would link response encoders this build has no
 // use for.
 
-void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {
-  // One diagnostic line without linking an encoder; the feature flags told
-  // the client not to send this.
-  ESP_LOGW(TAG, "Connection request for %012" PRIX64 " ignored, no connection support", msg.address);
-}
+void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {}
 void BluetoothProxy::bluetooth_gatt_read(const api::BluetoothGATTReadRequest &msg) {}
 void BluetoothProxy::bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &msg) {}
 void BluetoothProxy::bluetooth_gatt_read_descriptor(const api::BluetoothGATTReadDescriptorRequest &msg) {}

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -839,6 +839,10 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     } else if (!this->pending_unpairing_.matches(address)) {
       ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
                this->pending_unpairing_.address(), address);
+    } else if (this->pending_unpairing_.error() == CONN_OK) {
+      // A retry against the already-removed bond reports failure; the owed
+      // success is the answer the client needs, so keep it.
+      return;
     }
     this->pending_unpairing_.set(address, error);
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -129,7 +129,10 @@ void BluetoothProxy::log_not_connected_gatt_(const char *action, const char *typ
 void BluetoothProxy::handle_gatt_not_connected_(uint64_t address, uint16_t handle, const char *action,
                                                 const char *type) {
   this->log_not_connected_gatt_(action, type);
-  this->send_gatt_error(address, handle, GATT_NOT_CONNECTED);
+  if (!this->send_gatt_error(address, handle, GATT_NOT_CONNECTED)) {
+    // No connection, so nothing to latch against; the client's timeout arbitrates.
+    ESP_LOGW(TAG, "Not-connected reply dropped, TCP buffer full");
+  }
 }
 
 void BluetoothProxy::log_advertisement_flush_() {
@@ -209,6 +212,9 @@ void BluetoothProxy::latch_pending_disconnection_(uint64_t address, conn_err_t e
     }
   }
   if (free_entry != nullptr) {
+    // Leading edge for this address: the drop must be visible, but a repeat
+    // while it is already owed would ride the connection that refused it.
+    ESP_LOGW(TAG, "Disconnect notification for %012" PRIX64 " deferred, TCP buffer full", address);
     free_entry->set(address, error);
     return;
   }
@@ -228,15 +234,22 @@ void BluetoothProxy::clear_pending_disconnection_(uint64_t address) {
   }
 }
 
-void BluetoothProxy::reset_connection_slot_(BluetoothConnection *connection, conn_err_t reason) {
-  if (!this->send_device_connection(connection->get_address(), false, 0, reason)) {
-    // The client has no other way to learn of an unsolicited disconnect;
-    // latch and let loop()'s paced drain deliver it. V by design: a louder
-    // level would ride the same congested link this reports on.
-    ESP_LOGV(TAG, "[%d] [%s] Disconnect notification deferred, TCP buffer full", connection->get_connection_index(),
-             connection->address_str());
-    this->latch_pending_disconnection_(connection->get_address(), reason);
+void BluetoothProxy::send_device_disconnected_(uint64_t address, conn_err_t error) {
+  if (this->send_device_connection(address, false, 0, error)) {
+    // A later disconnect landing for an address that still has one owed would
+    // otherwise have the drain repeat it.
+    this->clear_pending_disconnection_(address);
+    return;
   }
+  // A dropped disconnect leaves the client believing the link is live, so
+  // every GATT operation on it times out until something else corrects it.
+  // latch_pending_disconnection_() reports the leading edge.
+  this->latch_pending_disconnection_(address, error);
+}
+
+void BluetoothProxy::reset_connection_slot_(BluetoothConnection *connection, conn_err_t reason) {
+  // The client has no other way to learn of an unsolicited disconnect.
+  this->send_device_disconnected_(connection->get_address(), reason);
   connection->set_address(0);
   connection->send_service_ = INIT_SENDING_SERVICES;
   this->send_connections_free();
@@ -282,18 +295,18 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       auto *connection = this->get_connection_(msg.address, true);
       if (connection == nullptr) {
         ESP_LOGW(TAG, "No free connections available");
-        this->send_device_connection(msg.address, false);
+        this->send_device_disconnected_(msg.address);
         return;
       }
       if (!msg.has_address_type) {
         ESP_LOGE(TAG, "[%d] [%s] Missing address type in connect request", connection->get_connection_index(),
                  connection->address_str());
-        this->send_device_connection(msg.address, false);
+        this->send_device_disconnected_(msg.address);
         return;
       }
       if (connection->state() == ClientState::CONNECTED || connection->state() == ClientState::ESTABLISHED) {
         this->log_connection_request_ignored_(connection, connection->state());
-        this->send_device_connection(msg.address, true);
+        connection->send_connected_reply_();
         this->send_connections_free();
         return;
       } else if (connection->state() == ClientState::DISCONNECTING && connection->cancel_teardown()) {
@@ -320,7 +333,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT: {
       auto *connection = this->get_connection_(msg.address, false);
       if (connection == nullptr) {
-        this->send_device_connection(msg.address, false);
+        this->send_device_disconnected_(msg.address);
         this->send_connections_free();
         return;
       }
@@ -328,7 +341,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
         connection->disconnect();
       } else {
         connection->set_address(0);
-        this->send_device_connection(msg.address, false);
+        this->send_device_disconnected_(msg.address);
         this->send_connections_free();
       }
       break;
@@ -372,7 +385,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     }
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT: {
       ESP_LOGE(TAG, "V1 connections removed");
-      this->send_device_connection(msg.address, false);
+      this->send_device_disconnected_(msg.address);
       break;
     }
   }
@@ -484,7 +497,8 @@ void BluetoothProxy::bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest
 void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConnectionParamsRequest &msg) {
   if (this->api_connection_ == nullptr)
     return;
-  // Send results unchecked (esp32 parity): a drop resolves via the client timeout.
+  // Not latched (esp32 parity): the request is idempotent, so a drop resolves
+  // via the client timeout and a retry gives the same answer. Still reported.
 
   auto *connection = this->get_connection_(msg.address, false);
   api::BluetoothSetConnectionParamsResponse resp;
@@ -495,7 +509,9 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
              connection ? static_cast<int>(connection->get_connection_index()) : -1,
              connection ? connection->address_str() : "unknown");
     resp.error = GATT_NOT_CONNECTED;
-    this->api_connection_->send_message(resp);
+    if (!this->api_connection_->send_message(resp)) {
+      ESP_LOGW(TAG, "Connection-params reply dropped, TCP buffer full");
+    }
     return;
   }
 
@@ -506,7 +522,9 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
                                                     static_cast<uint16_t>(std::min(msg.max_interval, max_val)),
                                                     static_cast<uint16_t>(std::min(msg.latency, max_val)),
                                                     static_cast<uint16_t>(std::min(msg.timeout, max_val)));
-  this->api_connection_->send_message(resp);
+  if (!this->api_connection_->send_message(resp)) {
+    ESP_LOGW(TAG, "Connection-params reply dropped, TCP buffer full");
+  }
 }
 
 #endif  // BLUETOOTH_CONNECTION_HAS_GATT
@@ -597,6 +615,9 @@ void BluetoothProxy::loop() {
     if (connection->send_service_ == SERVICES_DONE_PENDING) {
       connection->send_services_done_();
     }
+    if (connection->connected_reply_owed_) {
+      connection->send_connected_reply_();
+    }
     if (connection->has_pending_ack_()) {
       connection->flush_pending_ack_();
     }
@@ -646,11 +667,15 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE:
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT:
       ESP_LOGW(TAG, "Active connections are not supported on this platform");
-      this->send_device_connection(msg.address, false, 0, GATT_NOT_CONNECTED);
+      if (!this->send_device_connection(msg.address, false, 0, GATT_NOT_CONNECTED)) {
+        ESP_LOGW(TAG, "Connection reply dropped, TCP buffer full");
+      }
       break;
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT:
       // Not an error: the device is already disconnected, which is the requested state.
-      this->send_device_connection(msg.address, false);
+      if (!this->send_device_connection(msg.address, false)) {
+        ESP_LOGW(TAG, "Connection reply dropped, TCP buffer full");
+      }
       this->send_connections_free();
       break;
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR:
@@ -698,11 +723,14 @@ void BluetoothProxy::bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest
 void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConnectionParamsRequest &msg) {
   if (this->api_connection_ == nullptr)
     return;
-  // Send results unchecked (esp32 parity): a drop resolves via the client timeout.
+  // Not latched (esp32 parity): the request is idempotent, so a drop resolves
+  // via the client timeout and a retry gives the same answer. Still reported.
   api::BluetoothSetConnectionParamsResponse resp;
   resp.address = msg.address;
   resp.error = GATT_NOT_CONNECTED;
-  this->api_connection_->send_message(resp);
+  if (!this->api_connection_->send_message(resp)) {
+    ESP_LOGW(TAG, "Connection-params reply dropped, TCP buffer full");
+  }
 }
 
 #endif  // !BLUETOOTH_CONNECTION_HAS_GATT
@@ -722,6 +750,7 @@ void BluetoothProxy::reset_owed_replies_() {
     // session; silence (the client's timeout) arbitrates.
     this->connections_[i]->park_service_stream_();
     this->connections_[i]->clear_pending_ack_();
+    this->connections_[i]->connected_reply_owed_ = false;
   }
 #endif
 }
@@ -815,7 +844,11 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    // Not latched: a retried PAIR is answered from is_paired(), so the client
+    // recovers on its own. Still worth saying it happened.
+    ESP_LOGW(TAG, "Pairing reply dropped, TCP buffer full");
+  }
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -851,7 +884,10 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    // Not latched: clear-cache is idempotent, so a retry gives the same answer.
+    ESP_LOGW(TAG, "Clear-cache reply dropped, TCP buffer full");
+  }
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -606,19 +606,14 @@ void BluetoothProxy::loop() {
     }
   }
 
-  // Owed device-maintenance replies. take_owed_reply_() clears first, so a
-  // repeat refusal re-latches through the sender; the success flag is
-  // recomputed as (error == 0), which is what every caller passed.
-  uint64_t owed_address;
-  conn_err_t owed_error;
-  if (take_owed_reply_(this->pending_pairing_, owed_address, owed_error)) {
-    this->send_device_pairing(owed_address, owed_error == CONN_OK, owed_error);
-  }
-  if (take_owed_reply_(this->pending_unpairing_, owed_address, owed_error)) {
-    this->send_device_unpairing(owed_address, owed_error == CONN_OK, owed_error);
-  }
-  if (take_owed_reply_(this->pending_clear_cache_, owed_address, owed_error)) {
-    this->send_device_clear_cache(owed_address, owed_error == CONN_OK, owed_error);
+  // An owed unpair reply. Cleared first, so another refusal re-latches through
+  // the sender; the success flag is recomputed as (error == 0), which is what
+  // every caller passed.
+  if (!this->pending_unpairing_.empty()) {
+    uint64_t address = this->pending_unpairing_.address();
+    conn_err_t error = this->pending_unpairing_.error();
+    this->pending_unpairing_.clear();
+    this->send_device_unpairing(address, error == CONN_OK, error);
   }
 #endif
 
@@ -730,7 +725,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     // re-subscribe by the current one keeps what it is still owed.
     this->connections_free_pending_ = false;
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-    this->clear_pending_device_replies_();
+    this->pending_unpairing_.clear();
     for (uint8_t i = 0; i < this->connection_count_; i++) {
       // Neither a partial stream's tail nor an owed done belongs to the new
       // session; silence (the client's timeout) arbitrates.
@@ -758,7 +753,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   this->api_connection_ = nullptr;
   this->connections_free_pending_ = false;
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  this->clear_pending_device_replies_();
+  this->pending_unpairing_.clear();
 #endif
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   this->scanner_state_pending_ = false;
@@ -818,17 +813,7 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  // Advertisement-only builds answer these with a canned reply and keep no
-  // retry state, so only the latch is conditional, not the send.
-  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (!sent) {
-    // V, not W: the reply is owed rather than lost, and a warning would ride
-    // the connection that just refused it.
-    ESP_LOGV(TAG, "Pairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
-    this->pending_pairing_.set(address, error);
-  }
-#endif
+  this->api_connection_->send_message(call);
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -839,7 +824,7 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  // Advertisement-only builds answer these with a canned reply and keep no
+  // Advertisement-only builds answer this with a canned reply and keep no
   // retry state, so only the latch is conditional, not the send.
   [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
@@ -862,17 +847,7 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  // Advertisement-only builds answer these with a canned reply and keep no
-  // retry state, so only the latch is conditional, not the send.
-  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (!sent) {
-    // V, not W: the reply is owed rather than lost, and a warning would ride
-    // the connection that just refused it.
-    ESP_LOGV(TAG, "Clear-cache reply for %012" PRIX64 " deferred, TCP buffer full", address);
-    this->pending_clear_cache_.set(address, error);
-  }
-#endif
+  this->api_connection_->send_message(call);
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -656,74 +656,21 @@ void BluetoothProxy::loop() {
 
 #ifndef BLUETOOTH_CONNECTION_HAS_GATT
 
-// Advertisement-only proxy. GATT client connections are excluded at compile
-// time (no connection backend on this platform, or active: false), so every
-// connection-oriented request is answered with a clean error instead of
-// silence, and Home Assistant treats the proxy as passive.
+// Advertisement-only proxy: no connection backend on this platform, or
+// active: false. get_feature_flags() then omits FEATURE_ACTIVE_CONNECTIONS,
+// so a client treats the proxy as passive and never sends a connection or
+// GATT request. These exist only because the api layer dispatches them
+// unconditionally; answering would link response encoders this build has no
+// use for.
 
-void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {
-  switch (msg.request_type) {
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITH_CACHE:
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE:
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT:
-      ESP_LOGW(TAG, "Active connections are not supported on this platform");
-      if (!this->send_device_connection(msg.address, false, 0, GATT_NOT_CONNECTED)) {
-        this->log_reply_dropped_("Connection");
-      }
-      break;
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT:
-      // Not an error: the device is already disconnected, which is the requested state.
-      if (!this->send_device_connection(msg.address, false)) {
-        this->log_reply_dropped_("Connection");
-      }
-      this->send_connections_free();
-      break;
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR:
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR:
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE:
-      // Pairing needs a connection stack, so get_feature_flags() never
-      // advertises FEATURE_PAIRING or FEATURE_CACHE_CLEARING on this arm and
-      // a client does not send these. Listed so the switch stays total.
-      break;
-  }
-}
-
-void BluetoothProxy::bluetooth_gatt_read(const api::BluetoothGATTReadRequest &msg) {
-  this->handle_gatt_not_connected_(msg.address, msg.handle, "read", "characteristic");
-}
-
-void BluetoothProxy::bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &msg) {
-  this->handle_gatt_not_connected_(msg.address, msg.handle, "write", "characteristic");
-}
-
-void BluetoothProxy::bluetooth_gatt_read_descriptor(const api::BluetoothGATTReadDescriptorRequest &msg) {
-  this->handle_gatt_not_connected_(msg.address, msg.handle, "read", "descriptor");
-}
-
-void BluetoothProxy::bluetooth_gatt_write_descriptor(const api::BluetoothGATTWriteDescriptorRequest &msg) {
-  this->handle_gatt_not_connected_(msg.address, msg.handle, "write", "descriptor");
-}
-
-void BluetoothProxy::bluetooth_gatt_send_services(const api::BluetoothGATTGetServicesRequest &msg) {
-  this->handle_gatt_not_connected_(msg.address, 0, "get", "services");
-}
-
-void BluetoothProxy::bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest &msg) {
-  this->handle_gatt_not_connected_(msg.address, msg.handle, "notify", "characteristic");
-}
-
-void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConnectionParamsRequest &msg) {
-  if (this->api_connection_ == nullptr)
-    return;
-  // Not latched (esp32 parity): the request is idempotent, so a drop resolves
-  // via the client timeout and a retry gives the same answer. Still reported.
-  api::BluetoothSetConnectionParamsResponse resp;
-  resp.address = msg.address;
-  resp.error = GATT_NOT_CONNECTED;
-  if (!this->api_connection_->send_message(resp)) {
-    this->log_reply_dropped_("Connection-params");
-  }
-}
+void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {}
+void BluetoothProxy::bluetooth_gatt_read(const api::BluetoothGATTReadRequest &msg) {}
+void BluetoothProxy::bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &msg) {}
+void BluetoothProxy::bluetooth_gatt_read_descriptor(const api::BluetoothGATTReadDescriptorRequest &msg) {}
+void BluetoothProxy::bluetooth_gatt_write_descriptor(const api::BluetoothGATTWriteDescriptorRequest &msg) {}
+void BluetoothProxy::bluetooth_gatt_send_services(const api::BluetoothGATTGetServicesRequest &msg) {}
+void BluetoothProxy::bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest &msg) {}
+void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConnectionParamsRequest &msg) {}
 
 #endif  // !BLUETOOTH_CONNECTION_HAS_GATT
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -387,7 +387,7 @@ void BluetoothProxy::bluetooth_gatt_read(const api::BluetoothGATTReadRequest &ms
 
   auto err = connection->read_characteristic(msg.handle);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -400,7 +400,7 @@ void BluetoothProxy::bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &
 
   auto err = connection->write_characteristic(msg.handle, msg.data, msg.data_len, msg.response);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -413,7 +413,7 @@ void BluetoothProxy::bluetooth_gatt_read_descriptor(const api::BluetoothGATTRead
 
   auto err = connection->read_descriptor(msg.handle);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -426,7 +426,7 @@ void BluetoothProxy::bluetooth_gatt_write_descriptor(const api::BluetoothGATTWri
 
   auto err = connection->write_descriptor(msg.handle, msg.data, msg.data_len, true);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 
@@ -477,7 +477,7 @@ void BluetoothProxy::bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest
 
   auto err = connection->notify_characteristic(msg.handle, msg.enable);
   if (err != CONN_OK) {
-    this->send_gatt_error(msg.address, msg.handle, err);
+    connection->send_gatt_error_(msg.handle, err);
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -704,6 +704,25 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
 
 #endif  // !BLUETOOTH_CONNECTION_HAS_GATT
 
+void BluetoothProxy::reset_owed_replies_() {
+  this->connections_free_pending_ = false;
+#ifdef USE_BLE_SCANNER_STATE_CALLBACK
+  // subscribe_api_connection() re-drives this from the hub immediately after,
+  // so clearing it here costs nothing and keeps the list exhaustive.
+  this->scanner_state_pending_ = false;
+#endif
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  this->pending_unpairing_.clear();
+  this->pending_disconnections_.fill({});
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    // Neither a partial stream's tail nor an owed done belongs to the next
+    // session; silence (the client's timeout) arbitrates.
+    this->connections_[i]->park_service_stream_();
+    this->connections_[i]->clear_pending_ack_();
+  }
+#endif
+}
+
 void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection, uint32_t flags) {
   if (api_connection != this->api_connection_) {
     if (this->api_connection_ != nullptr) {
@@ -720,18 +739,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     }
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
-    this->connections_free_pending_ = false;
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-    this->pending_unpairing_.clear();
-    for (uint8_t i = 0; i < this->connection_count_; i++) {
-      // Neither a partial stream's tail nor an owed done belongs to the new
-      // session; silence (the client's timeout) arbitrates.
-      this->connections_[i]->park_service_stream_();
-      // An ack owed to the previous subscriber means nothing to the new one.
-      this->connections_[i]->clear_pending_ack_();
-    }
-    this->pending_disconnections_.fill({});
-#endif
+    this->reset_owed_replies_();
   }
   this->api_connection_ = api_connection;
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
@@ -748,13 +756,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
     return;
   }
   this->api_connection_ = nullptr;
-  this->connections_free_pending_ = false;
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  this->pending_unpairing_.clear();
-#endif
-#ifdef USE_BLE_SCANNER_STATE_CALLBACK
-  this->scanner_state_pending_ = false;
-#endif
+  this->reset_owed_replies_();
 }
 
 void BluetoothProxy::send_connections_free() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -707,9 +707,13 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
 void BluetoothProxy::reset_owed_replies_() {
   this->connections_free_pending_ = false;
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
-  // subscribe_api_connection() re-drives this from the hub immediately after,
-  // so clearing it here costs nothing and keeps the list exhaustive.
+  // Owed on unsubscribe; on subscribe the trailing send_scanner_state_()
+  // re-drives it from the hub, so clearing it there is free.
   this->scanner_state_pending_ = false;
+#else
+  // Force a poll-arm mismatch: a frame refused at subscribe time could
+  // otherwise match the stale detector and never be retried.
+  this->last_scan_running_ = !this->hub_->scan_running();
 #endif
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
   this->pending_unpairing_.clear();

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -829,9 +829,11 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
   if (!sent) {
-    // V, not W: the reply is owed rather than lost, and a warning would ride
-    // the connection that just refused it.
-    ESP_LOGV(TAG, "Unpairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    // Warn on the leading edge only: a refused reply must not be silent, but
+    // repeating it would add traffic to the connection that just refused one.
+    if (this->pending_unpairing_.empty()) {
+      ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    }
     this->pending_unpairing_.set(address, error);
   }
 #endif

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -122,7 +122,17 @@ void BluetoothProxy::log_connection_info_(BluetoothConnection *connection, const
 }
 #endif  // BLUETOOTH_CONNECTION_HAS_GATT
 
-void BluetoothProxy::log_reply_dropped_(const char *what) { ESP_LOGW(TAG, "%s reply dropped, TCP buffer full", what); }
+void BluetoothProxy::log_reply_dropped_(const char *what, uint64_t address) {
+  ESP_LOGW(TAG, "%s reply for %012" PRIX64 " dropped, TCP buffer full", what, address);
+}
+
+void BluetoothProxy::log_reply_deferred_(const char *what, uint64_t address) {
+  ESP_LOGW(TAG, "%s reply for %012" PRIX64 " deferred, TCP buffer full", what, address);
+}
+
+void BluetoothProxy::log_reply_displaced_(const char *what, uint64_t owed, uint64_t address) {
+  ESP_LOGW(TAG, "%s reply for %012" PRIX64 " dropped, displaced by %012" PRIX64, what, owed, address);
+}
 
 void BluetoothProxy::log_not_connected_gatt_(const char *action, const char *type) {
   ESP_LOGW(TAG, "Cannot %s GATT %s, not connected", action, type);
@@ -133,7 +143,7 @@ void BluetoothProxy::handle_gatt_not_connected_(uint64_t address, uint16_t handl
   this->log_not_connected_gatt_(action, type);
   if (!this->send_gatt_error(address, handle, GATT_NOT_CONNECTED)) {
     // No connection, so nothing to latch against; the client's timeout arbitrates.
-    this->log_reply_dropped_("Not-connected");
+    this->log_reply_dropped_("Not-connected", address);
   }
 }
 
@@ -214,15 +224,12 @@ void BluetoothProxy::latch_pending_disconnection_(uint64_t address, conn_err_t e
     }
   }
   if (free_entry != nullptr) {
-    // Leading edge for this address: the drop must be visible, but a repeat
-    // while it is already owed would ride the connection that refused it.
-    ESP_LOGW(TAG, "Disconnect notification for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->log_reply_deferred_("Disconnect", address);
     free_entry->set(address, error);
     return;
   }
   // Every entry is owed: evict the first so the newest loss is not silent too.
-  ESP_LOGW(TAG, "Owed disconnect dropped (0x%llx), retry pool full",
-           (unsigned long long) this->pending_disconnections_[0].address());
+  this->log_reply_displaced_("Disconnect", this->pending_disconnections_[0].address(), address);
   this->pending_disconnections_[0].set(address, error);
 }
 
@@ -513,7 +520,7 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
              connection ? connection->address_str() : "unknown");
     resp.error = GATT_NOT_CONNECTED;
     if (!this->api_connection_->send_message(resp)) {
-      this->log_reply_dropped_("Connection-params");
+      this->log_reply_dropped_("Connection-params", msg.address);
     }
     return;
   }
@@ -526,7 +533,7 @@ void BluetoothProxy::bluetooth_set_connection_params(const api::BluetoothSetConn
                                                     static_cast<uint16_t>(std::min(msg.latency, max_val)),
                                                     static_cast<uint16_t>(std::min(msg.timeout, max_val)));
   if (!this->api_connection_->send_message(resp)) {
-    this->log_reply_dropped_("Connection-params");
+    this->log_reply_dropped_("Connection-params", msg.address);
   }
 }
 
@@ -788,7 +795,7 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   if (!this->api_connection_->send_message(call)) {
     // Not latched: a retried PAIR is answered from is_paired(), so the client
     // recovers on its own. Still worth saying it happened.
-    this->log_reply_dropped_("Pairing");
+    this->log_reply_dropped_("Pairing", address);
   }
 }
 
@@ -808,14 +815,10 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     }
     return;
   }
-  // Warn on the leading edge and on displacement (that one loses a reply);
-  // the drain's re-refusals of the same reply stay quiet. Not
-  // log_reply_dropped_(): this reply is latched and retried, not dropped.
   if (this->pending_unpairing_.empty()) {
-    ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->log_reply_deferred_("Unpair", address);
   } else if (!this->pending_unpairing_.matches(address)) {
-    ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
-             this->pending_unpairing_.address(), address);
+    this->log_reply_displaced_("Unpair", this->pending_unpairing_.address(), address);
   }
   this->pending_unpairing_.set(address, error);
 }
@@ -832,7 +835,7 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
 
   if (!this->api_connection_->send_message(call)) {
     // Not latched: clear-cache is idempotent, so a retry gives the same answer.
-    this->log_reply_dropped_("Clear-cache");
+    this->log_reply_dropped_("Clear-cache", address);
   }
 }
 #endif

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -635,10 +635,12 @@ void BluetoothProxy::loop() {
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     this->connections_[i]->flush_owed_replies_();
   }
-  // Address-keyed, not slot-keyed, so it gets its own loop. Not pre-cleared:
+  // Address-keyed, not slot-keyed, so it gets its own loop; bounded by
+  // connection_count_ like the latch and clear helpers. Not pre-cleared:
   // the sender clears on success and re-latches on refusal, keeping the
   // latch's leading-edge warn honest (same shape as the unpair drain).
-  for (auto &owed : this->pending_disconnections_) {
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    auto &owed = this->pending_disconnections_[i];
     if (owed.empty())
       continue;
     this->send_device_disconnected_(owed.address(), owed.error());
@@ -677,7 +679,11 @@ void BluetoothProxy::loop() {
 // unconditionally; answering would link response encoders this build has no
 // use for.
 
-void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {}
+void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {
+  // One diagnostic line without linking an encoder; the feature flags told
+  // the client not to send this.
+  ESP_LOGW(TAG, "Connection request for %012" PRIX64 " ignored, no connection support", msg.address);
+}
 void BluetoothProxy::bluetooth_gatt_read(const api::BluetoothGATTReadRequest &msg) {}
 void BluetoothProxy::bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &msg) {}
 void BluetoothProxy::bluetooth_gatt_read_descriptor(const api::BluetoothGATTReadDescriptorRequest &msg) {}

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -244,6 +244,18 @@ void BluetoothProxy::clear_pending_disconnection_(uint64_t address) {
   }
 }
 
+void BluetoothProxy::answer_device_disconnected_(uint64_t address) {
+  if (this->send_device_connection(address, false)) {
+    // A landed answer satisfies any owed notification for the address; a
+    // drained duplicate would follow it otherwise.
+    this->clear_pending_disconnection_(address);
+    return;
+  }
+  // Not latched: the client's own request timeout arbitrates, and pooling
+  // these would let a request retry loop displace an unsolicited disconnect.
+  this->log_reply_dropped_("Disconnect", address);
+}
+
 void BluetoothProxy::send_device_disconnected_(uint64_t address, conn_err_t error) {
   if (this->send_device_connection(address, false, 0, error)) {
     // A later disconnect landing for an address that still has one owed would
@@ -305,13 +317,13 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       auto *connection = this->get_connection_(msg.address, true);
       if (connection == nullptr) {
         ESP_LOGW(TAG, "No free connections available");
-        this->send_device_disconnected_(msg.address);
+        this->answer_device_disconnected_(msg.address);
         return;
       }
       if (!msg.has_address_type) {
         ESP_LOGE(TAG, "[%d] [%s] Missing address type in connect request", connection->get_connection_index(),
                  connection->address_str());
-        this->send_device_disconnected_(msg.address);
+        this->answer_device_disconnected_(msg.address);
         return;
       }
       if (connection->state() == ClientState::CONNECTED || connection->state() == ClientState::ESTABLISHED) {
@@ -343,7 +355,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT: {
       auto *connection = this->get_connection_(msg.address, false);
       if (connection == nullptr) {
-        this->send_device_disconnected_(msg.address);
+        this->answer_device_disconnected_(msg.address);
         this->send_connections_free();
         return;
       }
@@ -351,7 +363,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
         connection->disconnect();
       } else {
         connection->set_address(0);
-        this->send_device_disconnected_(msg.address);
+        this->answer_device_disconnected_(msg.address);
         this->send_connections_free();
       }
       break;
@@ -395,7 +407,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
     }
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT: {
       ESP_LOGE(TAG, "V1 connections removed");
-      this->send_device_disconnected_(msg.address);
+      this->answer_device_disconnected_(msg.address);
       break;
     }
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -197,7 +197,7 @@ void BluetoothProxy::replace_allocated_slot_(uint64_t find_value, uint64_t set_v
 
 void BluetoothProxy::latch_pending_disconnection_(uint64_t address, conn_err_t error) {
   // Match before free entry so one address never occupies two pool slots.
-  PendingDisconnect *free_entry = nullptr;
+  PendingReply *free_entry = nullptr;
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     auto &owed = this->pending_disconnections_[i];
     if (owed.matches(address)) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -712,7 +712,9 @@ void BluetoothProxy::reset_owed_replies_() {
   this->scanner_state_pending_ = false;
 #else
   // Force a poll-arm mismatch: a frame refused at subscribe time could
-  // otherwise match the stale detector and never be retried.
+  // otherwise match the stale detector and never be retried. Inert on
+  // unsubscribe: loop() returns at the no-subscriber gate before the
+  // detector runs, and a re-subscribe re-arms this anyway.
   this->last_scan_running_ = !this->hub_->scan_running();
 #endif
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -832,10 +832,13 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
       this->pending_unpairing_.clear();
     }
   } else {
-    // Warn on the leading edge only: a refused reply must not be silent, but
-    // repeating it would add traffic to the connection that just refused one.
+    // Warn on the leading edge and on displacement (that one loses a reply);
+    // the drain's re-refusals of the same reply stay quiet.
     if (this->pending_unpairing_.empty()) {
       ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    } else if (!this->pending_unpairing_.matches(address)) {
+      ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
+               this->pending_unpairing_.address(), address);
     }
     this->pending_unpairing_.set(address, error);
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -799,23 +799,16 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  // Advertisement-only builds keep no retry state, so only the latch is
-  // conditional; the report is not.
-  bool sent = this->api_connection_->send_message(call);
-  if (!sent) {
-    this->log_reply_dropped_("Unpair");
-  }
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-  if (sent) {
+  if (this->api_connection_->send_message(call)) {
     // A later unpair landing for an address that still has one owed would
     // otherwise have the drain repeat it.
     if (this->pending_unpairing_.matches(address)) {
       this->pending_unpairing_.clear();
     }
-  } else {
-    this->pending_unpairing_.set(address, error);
+    return;
   }
-#endif
+  this->log_reply_dropped_("Unpair");
+  this->pending_unpairing_.set(address, error);
 }
 
 // Shared by both platform paths: the neutral bluetooth_device_request() uses it to

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -679,20 +679,12 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       this->send_connections_free();
       break;
     case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR:
-      this->send_device_pairing(msg.address, false, GATT_NOT_CONNECTED);
+    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR:
+    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE:
+      // Pairing needs a connection stack, so get_feature_flags() never
+      // advertises FEATURE_PAIRING or FEATURE_CACHE_CLEARING on this arm and
+      // a client does not send these. Listed so the switch stays total.
       break;
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR: {
-      // Address-scoped maintenance needs no connection slot: real on esp32
-      // (Bluedroid bond table), the stub elsewhere keeps the old error reply.
-      conn_err_t ret = bluetooth_connection::unpair_device(msg.address);
-      this->send_device_unpairing(msg.address, ret == CONN_OK, ret);
-      break;
-    }
-    case api::enums::BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE: {
-      conn_err_t ret = bluetooth_connection::clear_gatt_cache(msg.address);
-      this->send_device_clear_cache(msg.address, ret == CONN_OK, ret);
-      break;
-    }
   }
 }
 
@@ -836,6 +828,7 @@ bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err
   return this->api_connection_->send_message(call);
 }
 
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
@@ -893,6 +886,7 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
     this->log_reply_dropped_("Clear-cache");
   }
 }
+#endif
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -566,16 +566,6 @@ void BluetoothProxy::loop() {
     return;
   this->last_advertisement_flush_time_ = now;
 
-  // Owed device-maintenance replies. Cleared before re-sending so a refusal
-  // re-latches through the sender itself, as the connections-free drain does.
-  // The success flag is recomputed as (error == 0), which is what every
-  // caller passed in the first place.
-  if (this->api_connection_ != nullptr) {
-    this->drain_pending_device_reply_(this->pending_pairing_, &BluetoothProxy::send_device_pairing);
-    this->drain_pending_device_reply_(this->pending_unpairing_, &BluetoothProxy::send_device_unpairing);
-    this->drain_pending_device_reply_(this->pending_clear_cache_, &BluetoothProxy::send_device_clear_cache);
-  }
-
   if (this->connections_free_pending_ && this->api_connection_ != nullptr) {
     // Resend a dropped slot-state update, paced by the 100 ms gate so the
     // retry does not hammer the congestion it exists to survive; the
@@ -614,6 +604,21 @@ void BluetoothProxy::loop() {
     if (!owed.empty() && this->send_device_connection(owed.address(), false, 0, owed.error())) {
       owed.clear();
     }
+  }
+
+  // Owed device-maintenance replies. take_owed_reply_() clears first, so a
+  // repeat refusal re-latches through the sender; the success flag is
+  // recomputed as (error == 0), which is what every caller passed.
+  uint64_t owed_address;
+  conn_err_t owed_error;
+  if (take_owed_reply_(this->pending_pairing_, owed_address, owed_error)) {
+    this->send_device_pairing(owed_address, owed_error == CONN_OK, owed_error);
+  }
+  if (take_owed_reply_(this->pending_unpairing_, owed_address, owed_error)) {
+    this->send_device_unpairing(owed_address, owed_error == CONN_OK, owed_error);
+  }
+  if (take_owed_reply_(this->pending_clear_cache_, owed_address, owed_error)) {
+    this->send_device_clear_cache(owed_address, owed_error == CONN_OK, owed_error);
   }
 #endif
 
@@ -724,8 +729,8 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
     this->connections_free_pending_ = false;
-    this->clear_pending_device_replies_();
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
+    this->clear_pending_device_replies_();
     for (uint8_t i = 0; i < this->connection_count_; i++) {
       // Neither a partial stream's tail nor an owed done belongs to the new
       // session; silence (the client's timeout) arbitrates.
@@ -752,7 +757,9 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   }
   this->api_connection_ = nullptr;
   this->connections_free_pending_ = false;
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
   this->clear_pending_device_replies_();
+#endif
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   this->scanner_state_pending_ = false;
 #endif
@@ -803,23 +810,6 @@ bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err
   return this->api_connection_->send_message(call);
 }
 
-void BluetoothProxy::defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error) {
-  // V, not W: the reply is owed rather than lost, and a warning would ride the
-  // connection that just refused it.
-  ESP_LOGV(TAG, "Device reply for %012" PRIX64 " deferred, TCP buffer full", address);
-  owed.set(address, error);
-}
-
-void BluetoothProxy::drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender) {
-  if (owed.empty())
-    return;
-  uint64_t address = owed.address();
-  conn_err_t error = owed.error();
-  // Clear first: the sender re-latches if the API refuses it again.
-  owed.clear();
-  (this->*sender)(address, error == CONN_OK, error);
-}
-
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
@@ -828,9 +818,17 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  if (!this->api_connection_->send_message(call)) {
-    this->defer_device_reply_(this->pending_pairing_, address, error);
+  // Advertisement-only builds answer these with a canned reply and keep no
+  // retry state, so only the latch is conditional, not the send.
+  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  if (!sent) {
+    // V, not W: the reply is owed rather than lost, and a warning would ride
+    // the connection that just refused it.
+    ESP_LOGV(TAG, "Pairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->pending_pairing_.set(address, error);
   }
+#endif
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -841,9 +839,17 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  if (!this->api_connection_->send_message(call)) {
-    this->defer_device_reply_(this->pending_unpairing_, address, error);
+  // Advertisement-only builds answer these with a canned reply and keep no
+  // retry state, so only the latch is conditional, not the send.
+  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  if (!sent) {
+    // V, not W: the reply is owed rather than lost, and a warning would ride
+    // the connection that just refused it.
+    ESP_LOGV(TAG, "Unpairing reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->pending_unpairing_.set(address, error);
   }
+#endif
 }
 
 // Shared by both platform paths: the neutral bluetooth_device_request() uses it to
@@ -856,9 +862,17 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  if (!this->api_connection_->send_message(call)) {
-    this->defer_device_reply_(this->pending_clear_cache_, address, error);
+  // Advertisement-only builds answer these with a canned reply and keep no
+  // retry state, so only the latch is conditional, not the send.
+  [[maybe_unused]] bool sent = this->api_connection_->send_message(call);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  if (!sent) {
+    // V, not W: the reply is owed rather than lost, and a warning would ride
+    // the connection that just refused it.
+    ESP_LOGV(TAG, "Clear-cache reply for %012" PRIX64 " deferred, TCP buffer full", address);
+    this->pending_clear_cache_.set(address, error);
   }
+#endif
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -616,15 +616,13 @@ void BluetoothProxy::loop() {
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     this->connections_[i]->flush_owed_replies_();
   }
-  // Address-keyed, not slot-keyed, so it gets its own loop. Cleared first so
-  // another refusal re-latches through the sender, as the unpair drain does.
+  // Address-keyed, not slot-keyed, so it gets its own loop. Not pre-cleared:
+  // the sender clears on success and re-latches on refusal, keeping the
+  // latch's leading-edge warn honest (same shape as the unpair drain).
   for (auto &owed : this->pending_disconnections_) {
     if (owed.empty())
       continue;
-    uint64_t address = owed.address();
-    conn_err_t error = owed.error();
-    owed.clear();
-    this->send_device_disconnected_(address, error);
+    this->send_device_disconnected_(owed.address(), owed.error());
   }
 
   // An owed unpair reply. Not pre-cleared: the sender clears on success and
@@ -809,8 +807,9 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     return;
   }
   // Leading edge only: the drain re-enters here every 100 ms while congested.
+  // Not log_reply_dropped_(): this reply is latched and retried, not dropped.
   if (this->pending_unpairing_.empty()) {
-    this->log_reply_dropped_("Unpair");
+    ESP_LOGW(TAG, "Unpair reply for %012" PRIX64 " deferred, TCP buffer full", address);
   }
   this->pending_unpairing_.set(address, error);
 }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -566,6 +566,16 @@ void BluetoothProxy::loop() {
     return;
   this->last_advertisement_flush_time_ = now;
 
+  // Owed device-maintenance replies. Cleared before re-sending so a refusal
+  // re-latches through the sender itself, as the connections-free drain does.
+  // The success flag is recomputed as (error == 0), which is what every
+  // caller passed in the first place.
+  if (this->api_connection_ != nullptr) {
+    this->drain_pending_device_reply_(this->pending_pairing_, &BluetoothProxy::send_device_pairing);
+    this->drain_pending_device_reply_(this->pending_unpairing_, &BluetoothProxy::send_device_unpairing);
+    this->drain_pending_device_reply_(this->pending_clear_cache_, &BluetoothProxy::send_device_clear_cache);
+  }
+
   if (this->connections_free_pending_ && this->api_connection_ != nullptr) {
     // Resend a dropped slot-state update, paced by the 100 ms gate so the
     // retry does not hammer the congestion it exists to survive; the
@@ -714,6 +724,7 @@ void BluetoothProxy::subscribe_api_connection(api::APIConnection *api_connection
     // Stale retry latches belong to the previous subscriber's session; a
     // re-subscribe by the current one keeps what it is still owed.
     this->connections_free_pending_ = false;
+    this->clear_pending_device_replies_();
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
     for (uint8_t i = 0; i < this->connection_count_; i++) {
       // Neither a partial stream's tail nor an owed done belongs to the new
@@ -741,6 +752,7 @@ void BluetoothProxy::unsubscribe_api_connection(api::APIConnection *api_connecti
   }
   this->api_connection_ = nullptr;
   this->connections_free_pending_ = false;
+  this->clear_pending_device_replies_();
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   this->scanner_state_pending_ = false;
 #endif
@@ -791,6 +803,23 @@ bool BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, conn_err
   return this->api_connection_->send_message(call);
 }
 
+void BluetoothProxy::defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error) {
+  // V, not W: the reply is owed rather than lost, and a warning would ride the
+  // connection that just refused it.
+  ESP_LOGV(TAG, "Device reply for %012" PRIX64 " deferred, TCP buffer full", address);
+  owed.set(address, error);
+}
+
+void BluetoothProxy::drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender) {
+  if (owed.empty())
+    return;
+  uint64_t address = owed.address();
+  conn_err_t error = owed.error();
+  // Clear first: the sender re-latches if the API refuses it again.
+  owed.clear();
+  (this->*sender)(address, error == CONN_OK, error);
+}
+
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
@@ -799,7 +828,9 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
   call.paired = paired;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    this->defer_device_reply_(this->pending_pairing_, address, error);
+  }
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
@@ -810,7 +841,9 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
   call.success = success;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    this->defer_device_reply_(this->pending_unpairing_, address, error);
+  }
 }
 
 // Shared by both platform paths: the neutral bluetooth_device_request() uses it to
@@ -823,7 +856,9 @@ void BluetoothProxy::send_device_clear_cache(uint64_t address, bool success, con
   call.success = success;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  if (!this->api_connection_->send_message(call)) {
+    this->defer_device_reply_(this->pending_clear_cache_, address, error);
+  }
 }
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -816,6 +816,15 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, conn_err
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_err_t error) {
   if (this->api_connection_ == nullptr)
     return;
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+  // An owed success is the authoritative answer: a later attempt for the
+  // same address fails only because the first already removed the bond.
+  if (!this->pending_unpairing_.empty() && this->pending_unpairing_.matches(address) &&
+      this->pending_unpairing_.error() == CONN_OK) {
+    success = true;
+    error = CONN_OK;
+  }
+#endif
   api::BluetoothDeviceUnpairingResponse call;
   call.address = address;
   call.success = success;
@@ -839,10 +848,6 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, conn_
     } else if (!this->pending_unpairing_.matches(address)) {
       ESP_LOGW(TAG, "Owed unpair reply for %012" PRIX64 " dropped, displaced by %012" PRIX64,
                this->pending_unpairing_.address(), address);
-    } else if (this->pending_unpairing_.error() == CONN_OK) {
-      // A retry against the already-removed bond reports failure; the owed
-      // success is the answer the client needs, so keep it.
-      return;
     }
     this->pending_unpairing_.set(address, error);
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -149,7 +149,9 @@ class BluetoothProxy final : public Component {
   /// False only when the API refused the frame, so the reply is still owed.
   bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
-  void send_device_unpairing(uint64_t address, bool success, conn_err_t error = CONN_OK);
+  /// No default error: the drain rebuilds success as (error == CONN_OK), so a
+  /// caller that omitted it would have a reported failure resent as a success.
+  void send_device_unpairing(uint64_t address, bool success, conn_err_t error);
   void send_device_clear_cache(uint64_t address, bool success, conn_err_t error = CONN_OK);
 
   void bluetooth_scanner_set_mode(bool active);
@@ -303,7 +305,9 @@ class BluetoothProxy final : public Component {
   // needs no equivalent (a retried PAIR is answered from is_paired()) and
   // clear-cache is idempotent. Address-keyed, since unpair acts on an address
   // with no connection slot at all; the success flag is not stored because
-  // every caller passes exactly (error == 0).
+  // every caller passes exactly (error == 0). One slot: two unpairs refused in
+  // the same drain window displace the older reply, which is what happened to
+  // both before this existed. Home Assistant unpairs one device at a time.
   PendingDisconnect pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -289,8 +289,13 @@ class BluetoothProxy final : public Component {
   void clear_pending_disconnection_(uint64_t address);
   /// Send connected=false and pool it for the paced drain if refused. A
   /// dropped disconnect desynchronises the proxy: the client keeps a link it
-  /// believes is live and every operation on it times out.
+  /// believes is live and every operation on it times out. Unsolicited and
+  /// drained notifications only; request answers use the variant below.
   void send_device_disconnected_(uint64_t address, conn_err_t error = CONN_OK);
+  /// Answer a request with connected=false. Never pools: a refusal falls back
+  /// to the client's request timeout, keeping the pool for the unsolicited
+  /// notifications the client cannot recover on its own.
+  void answer_device_disconnected_(uint64_t address);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -63,7 +63,7 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
 /// One owed address-keyed reply in a single word: the 48-bit address in the
 /// low bits, the sign-extending 16-bit error on top. Backs the freed-slot
-/// notifications and the device-maintenance replies. Every error that reaches
+/// notifications and the owed unpair reply. Every error that reaches
 /// it (esp_gatt_status_t, esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits
 /// int16_t.
 class PendingDisconnect {
@@ -283,23 +283,6 @@ class BluetoothProxy final : public Component {
   void clear_pending_disconnection_(uint64_t address);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
-  /// Take an owed reply and clear the slot, so a repeat refusal re-latches
-  /// through the sender itself. False when nothing is owed. Inline so the
-  /// idle path is a load and a branch rather than a call.
-  static bool take_owed_reply_(PendingDisconnect &owed, uint64_t &address, conn_err_t &error) {
-    if (owed.empty())
-      return false;
-    address = owed.address();
-    error = owed.error();
-    owed.clear();
-    return true;
-  }
-  /// A reply owed to the previous subscriber means nothing to the next one.
-  void clear_pending_device_replies_() {
-    this->pending_pairing_.clear();
-    this->pending_unpairing_.clear();
-    this->pending_clear_cache_.clear();
-  }
 #endif
 
   // Memory optimized layout for 32-bit systems
@@ -313,13 +296,15 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-  // Owed device-maintenance replies, one slot per operation so a pair cannot
-  // evict an owed unpair. Address-keyed rather than slot-keyed: unpair and
-  // clear-cache act on an address with no connection at all. The success flag
-  // is not stored because every caller passes exactly (error == 0).
-  PendingDisconnect pending_pairing_{};
+  // An owed unpair reply. Unpair is the one device-maintenance reply worth
+  // retrying: the bond is already gone when the send is refused, so a client
+  // that times out and retries re-runs unpair_device() against a bond that no
+  // longer exists and is told the unpair failed when it succeeded. Pairing
+  // needs no equivalent (a retried PAIR is answered from is_paired()) and
+  // clear-cache is idempotent. Address-keyed, since unpair acts on an address
+  // with no connection slot at all; the success flag is not stored because
+  // every caller passes exactly (error == 0).
   PendingDisconnect pending_unpairing_{};
-  PendingDisconnect pending_clear_cache_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -145,8 +145,7 @@ class BluetoothProxy final : public Component {
   void send_connections_free(api::APIConnection *api_connection);
   /// Same convention as send_device_connection: false only on a refused frame.
   bool send_gatt_services_done(uint64_t address);
-  /// Returns false only when the API refused the frame, so a caller that
-  /// can re-offer it knows the reply is still owed.
+  /// False only when the API refused the frame, so the reply is still owed.
   bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
   void send_device_unpairing(uint64_t address, bool success, conn_err_t error = CONN_OK);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -288,6 +288,8 @@ class BluetoothProxy final : public Component {
 
   /// Drop everything the ending session was owed. One list, so a new latch is
   /// one edit rather than two call sites where an omission looks deliberate.
+  /// Drops state only, never sends: api_connection_ is the departing
+  /// subscriber on subscribe and nullptr on unsubscribe.
   void reset_owed_replies_();
 
   // Memory optimized layout for 32-bit systems

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -61,11 +61,8 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 };
 
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
-/// One owed address-keyed reply in a single word: the 48-bit address in the
-/// low bits, the sign-extending 16-bit error on top. Backs the freed-slot
-/// notifications and the owed unpair reply. Every error that reaches
-/// it (esp_gatt_status_t, esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits
-/// int16_t.
+/// One owed address-keyed reply in a single word: 48-bit address low, 16-bit
+/// error on top. Every error that reaches it fits int16_t.
 class PendingDisconnect {
  public:
   constexpr void set(uint64_t address, conn_err_t error) {
@@ -298,16 +295,9 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-  // An owed unpair reply. Unpair is the one device-maintenance reply worth
-  // retrying: the bond is already gone when the send is refused, so a client
-  // that times out and retries re-runs unpair_device() against a bond that no
-  // longer exists and is told the unpair failed when it succeeded. Pairing
-  // needs no equivalent (a retried PAIR is answered from is_paired()) and
-  // clear-cache is idempotent. Address-keyed, since unpair acts on an address
-  // with no connection slot at all; the success flag is not stored because
-  // every caller passes exactly (error == 0). One slot: two unpairs refused in
-  // the same drain window displace the older reply, which is what happened to
-  // both before this existed. Home Assistant unpairs one device at a time.
+  // Owed unpair reply. The bond is already gone when the send is refused, so
+  // a retry is told the unpair failed when it succeeded. One slot: a second
+  // refused unpair displaces the first, as happened to both before this.
   PendingDisconnect pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -145,11 +145,13 @@ class BluetoothProxy final : public Component {
   bool send_gatt_services_done(uint64_t address);
   /// False only when the API refused the frame, so the reply is still owed.
   bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
   /// No default error: the drain rebuilds success as (error == CONN_OK), so a
   /// caller that omitted it would have a reported failure resent as a success.
   void send_device_unpairing(uint64_t address, bool success, conn_err_t error);
   void send_device_clear_cache(uint64_t address, bool success, conn_err_t error = CONN_OK);
+#endif
 
   void bluetooth_scanner_set_mode(bool active);
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -286,6 +286,15 @@ class BluetoothProxy final : public Component {
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
 
+  /// Drop everything the ending session was owed.
+  ///
+  /// Every retry latch belongs to exactly one subscriber, so a subscriber
+  /// change invalidates all of them. Keeping the list in one place makes
+  /// adding a latch a single edit: the two callers previously reset five and
+  /// three separate things, and the two sets were not subsets of each other
+  /// in either direction, so an omission read the same as a decision.
+  void reset_owed_replies_();
+
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)
   api::APIConnection *api_connection_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -63,7 +63,7 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
 /// One owed address-keyed reply in a single word: 48-bit address low, 16-bit
 /// error on top. Every error that reaches it fits int16_t.
-class PendingDisconnect {
+class PendingReply {
  public:
   constexpr void set(uint64_t address, conn_err_t error) {
     // Mask: the address originates from the client, and a stray high bit
@@ -71,7 +71,8 @@ class PendingDisconnect {
     this->word_ = (address & ADDRESS_MASK) | (static_cast<uint64_t>(static_cast<uint16_t>(error)) << 48);
   }
   constexpr void clear() { this->word_ = 0; }
-  // Whole-word test: set() is only ever given a live (nonzero) address.
+  // Whole-word test. Slot-sourced addresses are always nonzero; the unpair
+  // caller's is client-supplied, so a zero address reads back as nothing owed.
   constexpr bool empty() const { return this->word_ == 0; }
   // Masked like set(), so a stray high bit cannot defeat the pool lookups.
   constexpr bool matches(uint64_t address) const { return this->address() == (address & ADDRESS_MASK); }
@@ -84,15 +85,15 @@ class PendingDisconnect {
 };
 // Pin the packing at compile time: mask and sign round-trip for every
 // reachable shape (negative, GATT status, ESP_ERR_* range, stray high bit).
-constexpr bool pending_disconnect_round_trips(uint64_t address, uint64_t expected_address, conn_err_t error) {
-  PendingDisconnect p;
+constexpr bool pending_reply_round_trips(uint64_t address, uint64_t expected_address, conn_err_t error) {
+  PendingReply p;
   p.set(address, error);
   return p.address() == expected_address && p.error() == error && !p.empty() && p.matches(address);
 }
-static_assert(pending_disconnect_round_trips(0x0000112233445566ULL, 0x0000112233445566ULL, -1));
-static_assert(pending_disconnect_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
-static_assert(pending_disconnect_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
-static_assert(PendingDisconnect{}.empty());
+static_assert(pending_reply_round_trips(0x0000112233445566ULL, 0x0000112233445566ULL, -1));
+static_assert(pending_reply_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
+static_assert(pending_reply_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
+static_assert(PendingReply{}.empty());
 #endif
 
 class BluetoothProxy final : public Component {
@@ -294,11 +295,11 @@ class BluetoothProxy final : public Component {
   // Address-keyed pool of owed freed-slot notifications; loop() resends.
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
-  std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
+  std::array<PendingReply, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
   // Owed unpair reply. The bond is already gone when the send is refused, so
   // a retry is told the unpair failed when it succeeded. One slot: a second
   // refused unpair displaces the first, as happened to both before this.
-  PendingDisconnect pending_unpairing_{};
+  PendingReply pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -71,8 +71,9 @@ class PendingReply {
     this->word_ = (address & ADDRESS_MASK) | (static_cast<uint64_t>(static_cast<uint16_t>(error)) << 48);
   }
   constexpr void clear() { this->word_ = 0; }
-  // Whole-word test. Slot-sourced addresses are always nonzero; the unpair
-  // caller's is client-supplied, so a zero address reads back as nothing owed.
+  // Whole-word test: only (address 0, error 0) reads back as nothing owed.
+  // A zero-address failure still latches, which is correct - that reply is
+  // owed too. Neither backend can unpair address 0 successfully.
   constexpr bool empty() const { return this->word_ == 0; }
   // Masked like set(), so a stray high bit cannot defeat the pool lookups.
   constexpr bool matches(uint64_t address) const { return this->address() == (address & ADDRESS_MASK); }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -231,10 +231,9 @@ class BluetoothProxy final : public Component {
   void flush_pending_advertisements_() {
     if (this->response_.advertisements_len == 0)
       return;
-    // The one send whose result is deliberately ignored: advertisements are
-    // perishable, so a refused batch is correctly dropped rather than retried,
-    // and this is the highest-frequency send in the component, so reporting
-    // each drop would be the log flood the batch pacing exists to avoid.
+    // The one deliberately ignored result: advertisements are perishable and
+    // this is the highest-frequency send here, so reporting each drop would be
+    // the flood the batch pacing exists to avoid.
     this->api_connection_->send_message(this->response_);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
     this->log_advertisement_flush_();
@@ -288,9 +287,9 @@ class BluetoothProxy final : public Component {
   /// Drop any owed freed-slot notification for this address (client reconnected).
   void clear_pending_disconnection_(uint64_t address);
   /// Send connected=false and pool it for the paced drain if refused. A
-  /// dropped disconnect is the one that desynchronises the proxy: the client
-  /// keeps a link it believes is live and every operation on it times out.
-  void send_device_disconnected_(uint64_t address, conn_err_t error = 0);
+  /// dropped disconnect desynchronises the proxy: the client keeps a link it
+  /// believes is live and every operation on it times out.
+  void send_device_disconnected_(uint64_t address, conn_err_t error = CONN_OK);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
@@ -298,11 +297,13 @@ class BluetoothProxy final : public Component {
   /// Drop everything the ending session was owed.
   ///
   /// Every retry latch belongs to exactly one subscriber, so a subscriber
-  /// change invalidates all of them. Keeping the list in one place makes
-  /// adding a latch a single edit: the two callers previously reset five and
-  /// three separate things, and the two sets were not subsets of each other
-  /// in either direction, so an omission read the same as a decision.
+  /// change invalidates all of them. Keeping the list in one place
+  /// makes adding a latch a single edit rather than two, where an omission
+  /// would read the same as a decision.
   void reset_owed_replies_();
+  /// Report a reply we deliberately do not latch, so no drop is silent.
+  /// Latched replies report their own leading edge instead.
+  void log_reply_dropped_(const char *what);
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)
@@ -315,16 +316,11 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-  // An owed unpair reply. Unpair is the one device-maintenance reply worth
-  // retrying: the bond is already gone when the send is refused, so a client
-  // that times out and retries re-runs unpair_device() against a bond that no
-  // longer exists and is told the unpair failed when it succeeded. Pairing
-  // needs no equivalent (a retried PAIR is answered from is_paired()) and
-  // clear-cache is idempotent. Address-keyed, since unpair acts on an address
-  // with no connection slot at all; the success flag is not stored because
-  // every caller passes exactly (error == 0). One slot: two unpairs refused in
-  // the same drain window displace the older reply, which is what happened to
-  // both before this existed. Home Assistant unpairs one device at a time.
+  // An owed unpair reply: the bond is already gone when the send is refused,
+  // so a client that retries is told the unpair failed when it succeeded.
+  // Address-keyed, since unpair has no connection slot. One slot, so two
+  // unpairs refused in the same drain window displace the older reply, which
+  // is what happened to both before this existed.
   PendingDisconnect pending_unpairing_{};
 #endif
   ble_device_base::BLEHub *hub_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -300,8 +300,11 @@ class BluetoothProxy final : public Component {
   /// subscriber on subscribe and nullptr on unsubscribe.
   void reset_owed_replies_();
   /// Report a reply we deliberately do not latch, so no drop is silent.
-  /// Latched replies report their own leading edge instead.
-  void log_reply_dropped_(const char *what);
+  void log_reply_dropped_(const char *what, uint64_t address);
+  /// A latched reply's leading edge; the drain's re-refusals stay quiet.
+  void log_reply_deferred_(const char *what, uint64_t address);
+  /// A latched reply lost to a newer one for a different address.
+  void log_reply_displaced_(const char *what, uint64_t owed, uint64_t address);
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -136,8 +136,8 @@ class BluetoothProxy final : public Component {
   }
 
   /// False only when a subscriber refused the frame; true = delivered or
-  /// nobody subscribed. Request-answer callers ignore the result (client
-  /// timeouts cover those); only reset_connection_slot_ latches for retry.
+  /// nobody subscribed. Refusals latch in send_device_disconnected_() and
+  /// send_connected_reply_(); other callers report via log_reply_dropped_().
   bool send_device_connection(uint64_t address, bool connected, uint16_t mtu = 0, conn_err_t error = CONN_OK);
   void send_connections_free();
   void send_connections_free(api::APIConnection *api_connection);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -286,6 +286,8 @@ class BluetoothProxy final : public Component {
 
   /// Drop everything the ending session was owed. One list, so a new latch is
   /// one edit rather than two call sites where an omission looks deliberate.
+  /// Drops state only, never sends: api_connection_ is the departing
+  /// subscriber on subscribe and nullptr on unsubscribe.
   void reset_owed_replies_();
 
   // Memory optimized layout for 32-bit systems

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -145,7 +145,9 @@ class BluetoothProxy final : public Component {
   void send_connections_free(api::APIConnection *api_connection);
   /// Same convention as send_device_connection: false only on a refused frame.
   bool send_gatt_services_done(uint64_t address);
-  void send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
+  /// Returns false only when the API refused the frame, so a caller that
+  /// can re-offer it knows the reply is still owed.
+  bool send_gatt_error(uint64_t address, uint16_t handle, conn_err_t error);
   void send_device_pairing(uint64_t address, bool paired, conn_err_t error = CONN_OK);
   void send_device_unpairing(uint64_t address, bool success, conn_err_t error = CONN_OK);
   void send_device_clear_cache(uint64_t address, bool success, conn_err_t error = CONN_OK);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -287,13 +287,8 @@ class BluetoothProxy final : public Component {
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
 
-  /// Drop everything the ending session was owed.
-  ///
-  /// Every retry latch belongs to exactly one subscriber, so a subscriber
-  /// change invalidates all of them. Keeping the list in one place makes
-  /// adding a latch a single edit: the two callers previously reset five and
-  /// three separate things, and the two sets were not subsets of each other
-  /// in either direction, so an omission read the same as a decision.
+  /// Drop everything the ending session was owed. One list, so a new latch is
+  /// one edit rather than two call sites where an omission looks deliberate.
   void reset_owed_replies_();
 
   // Memory optimized layout for 32-bit systems

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -60,8 +60,7 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
   SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
 };
 
-#ifdef BLUETOOTH_CONNECTION_HAS_GATT
-/// One owed freed-slot connected=false notification in a single word: the
+/// One owed address-keyed reply in a single word: the
 /// 48-bit address in the low bits, the sign-extending 16-bit reason on top.
 /// Every reason that reaches the pool (esp_gatt_status_t,
 /// esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits int16_t.
@@ -95,7 +94,6 @@ static_assert(pending_disconnect_round_trips(0x0000112233445566ULL, 0x0000112233
 static_assert(pending_disconnect_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
 static_assert(pending_disconnect_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
 static_assert(PendingDisconnect{}.empty());
-#endif
 
 class BluetoothProxy final : public Component {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
@@ -296,6 +294,27 @@ class BluetoothProxy final : public Component {
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
 #endif
+  // Owed device-maintenance replies, one slot per operation so a pair cannot
+  // evict an owed unpair. Address-keyed rather than slot-keyed: unpair and
+  // clear-cache act on an address with no connection at all. The success flag
+  // is not stored because every caller passes exactly (error == 0). Built on
+  // every proxy variant: the advertisement-only arm answers these too.
+  /// The three device-reply senders share a signature, so one drain covers
+  /// them all.
+  using DeviceReplySender = void (BluetoothProxy::*)(uint64_t, bool, conn_err_t);
+  void drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender);
+  /// Log the deferral and latch it, so all three senders report identically.
+  void defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error);
+  /// A reply owed to the previous subscriber means nothing to the next one.
+  void clear_pending_device_replies_() {
+    this->pending_pairing_.clear();
+    this->pending_unpairing_.clear();
+    this->pending_clear_cache_.clear();
+  }
+
+  PendingDisconnect pending_pairing_{};
+  PendingDisconnect pending_unpairing_{};
+  PendingDisconnect pending_clear_cache_{};
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below
   // start on an even word, closing two alignment holes.

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -60,10 +60,12 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
   SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
 };
 
-/// One owed address-keyed reply in a single word: the
-/// 48-bit address in the low bits, the sign-extending 16-bit reason on top.
-/// Every reason that reaches the pool (esp_gatt_status_t,
-/// esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits int16_t.
+#ifdef BLUETOOTH_CONNECTION_HAS_GATT
+/// One owed address-keyed reply in a single word: the 48-bit address in the
+/// low bits, the sign-extending 16-bit error on top. Backs the freed-slot
+/// notifications and the device-maintenance replies. Every error that reaches
+/// it (esp_gatt_status_t, esp_gatt_conn_reason_t, generic ESP_ERR_*, -1) fits
+/// int16_t.
 class PendingDisconnect {
  public:
   constexpr void set(uint64_t address, conn_err_t error) {
@@ -94,6 +96,7 @@ static_assert(pending_disconnect_round_trips(0x0000112233445566ULL, 0x0000112233
 static_assert(pending_disconnect_round_trips(0x0000FFFFFFFFFFFFULL, 0x0000FFFFFFFFFFFFULL, 0x8F));
 static_assert(pending_disconnect_round_trips(0xABCD112233445566ULL, 0x0000112233445566ULL, 0x110));
 static_assert(PendingDisconnect{}.empty());
+#endif
 
 class BluetoothProxy final : public Component {
 #ifdef BLUETOOTH_CONNECTION_HAS_GATT
@@ -280,6 +283,23 @@ class BluetoothProxy final : public Component {
   void clear_pending_disconnection_(uint64_t address);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
+  /// Take an owed reply and clear the slot, so a repeat refusal re-latches
+  /// through the sender itself. False when nothing is owed. Inline so the
+  /// idle path is a load and a branch rather than a call.
+  static bool take_owed_reply_(PendingDisconnect &owed, uint64_t &address, conn_err_t &error) {
+    if (owed.empty())
+      return false;
+    address = owed.address();
+    error = owed.error();
+    owed.clear();
+    return true;
+  }
+  /// A reply owed to the previous subscriber means nothing to the next one.
+  void clear_pending_device_replies_() {
+    this->pending_pairing_.clear();
+    this->pending_unpairing_.clear();
+    this->pending_clear_cache_.clear();
+  }
 #endif
 
   // Memory optimized layout for 32-bit systems
@@ -293,28 +313,14 @@ class BluetoothProxy final : public Component {
   // Proxy-only state, kept off BluetoothConnection; entries are not tied to
   // slot indices.
   std::array<PendingDisconnect, BLUETOOTH_PROXY_MAX_CONNECTIONS> pending_disconnections_{};
-#endif
   // Owed device-maintenance replies, one slot per operation so a pair cannot
   // evict an owed unpair. Address-keyed rather than slot-keyed: unpair and
   // clear-cache act on an address with no connection at all. The success flag
-  // is not stored because every caller passes exactly (error == 0). Built on
-  // every proxy variant: the advertisement-only arm answers these too.
-  /// The three device-reply senders share a signature, so one drain covers
-  /// them all.
-  using DeviceReplySender = void (BluetoothProxy::*)(uint64_t, bool, conn_err_t);
-  void drain_pending_device_reply_(PendingDisconnect &owed, DeviceReplySender sender);
-  /// Log the deferral and latch it, so all three senders report identically.
-  void defer_device_reply_(PendingDisconnect &owed, uint64_t address, conn_err_t error);
-  /// A reply owed to the previous subscriber means nothing to the next one.
-  void clear_pending_device_replies_() {
-    this->pending_pairing_.clear();
-    this->pending_unpairing_.clear();
-    this->pending_clear_cache_.clear();
-  }
-
+  // is not stored because every caller passes exactly (error == 0).
   PendingDisconnect pending_pairing_{};
   PendingDisconnect pending_unpairing_{};
   PendingDisconnect pending_clear_cache_{};
+#endif
   ble_device_base::BLEHub *hub_{nullptr};
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below
   // start on an even word, closing two alignment holes.

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -285,6 +285,15 @@ class BluetoothProxy final : public Component {
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
 
+  /// Drop everything the ending session was owed.
+  ///
+  /// Every retry latch belongs to exactly one subscriber, so a subscriber
+  /// change invalidates all of them. Keeping the list in one place makes
+  /// adding a latch a single edit: the two callers previously reset five and
+  /// three separate things, and the two sets were not subsets of each other
+  /// in either direction, so an omission read the same as a decision.
+  void reset_owed_replies_();
+
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)
   api::APIConnection *api_connection_{nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -229,6 +229,10 @@ class BluetoothProxy final : public Component {
   void flush_pending_advertisements_() {
     if (this->response_.advertisements_len == 0)
       return;
+    // The one send whose result is deliberately ignored: advertisements are
+    // perishable, so a refused batch is correctly dropped rather than retried,
+    // and this is the highest-frequency send in the component, so reporting
+    // each drop would be the log flood the batch pacing exists to avoid.
     this->api_connection_->send_message(this->response_);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
     this->log_advertisement_flush_();
@@ -281,6 +285,10 @@ class BluetoothProxy final : public Component {
   void reset_connection_slot_(BluetoothConnection *connection, conn_err_t reason);
   /// Drop any owed freed-slot notification for this address (client reconnected).
   void clear_pending_disconnection_(uint64_t address);
+  /// Send connected=false and pool it for the paced drain if refused. A
+  /// dropped disconnect is the one that desynchronises the proxy: the client
+  /// keeps a link it believes is live and every operation on it times out.
+  void send_device_disconnected_(uint64_t address, conn_err_t error = 0);
   /// Pool a refused freed-slot notification for the paced drain.
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -286,13 +286,8 @@ class BluetoothProxy final : public Component {
   void latch_pending_disconnection_(uint64_t address, conn_err_t error);
 #endif
 
-  /// Drop everything the ending session was owed.
-  ///
-  /// Every retry latch belongs to exactly one subscriber, so a subscriber
-  /// change invalidates all of them. Keeping the list in one place makes
-  /// adding a latch a single edit: the two callers previously reset five and
-  /// three separate things, and the two sets were not subsets of each other
-  /// in either direction, so an omission read the same as a decision.
+  /// Drop everything the ending session was owed. One list, so a new latch is
+  /// one edit rather than two call sites where an omission looks deliberate.
   void reset_owed_replies_();
 
   // Memory optimized layout for 32-bit systems


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18276. Three things, all on the proxy's send paths.

**Connection replies are retried.** `send_device_connection()` carries the connection state, so a dropped one desynchronises the proxy: the client keeps a link it believes is live and every operation on it times out. That is the failure #18221 opens with, and only the unsolicited disconnect was latched — eight other sites discarded the result. `connected=false` splits by class: unsolicited disconnects go through `send_device_disconnected_()` and pool a refusal, while request answers use `answer_device_disconnected_()`, which clears an owed entry on success but never pools; their refusals fall back to the client's request timeout, so a request retry loop cannot displace an unsolicited notification from the bounded pool. A connect request supersedes an owed disconnect through `get_connection_()`'s existing hook, and a landed disconnect clears one. `connected=true` latches on the connection instead, rebuilt from `address_` and `mtu_`, so it costs one bit. A side effect: the duplicate-CONNECT reply now carries the negotiated MTU instead of 0, since it goes through the same rebuilt sender.

**Nothing drops silently any more.** Whatever stays unlatched reports through `log_reply_dropped_()`. The one deliberate exception is the advertisement flush: perishable, the highest-frequency send here, and reporting each drop would be the flood the batch pacing exists to avoid.

**Advertisement-only builds lose pairing entirely.** You cannot pair without a connection stack, and the code already agreed: `get_feature_flags()` gates `FEATURE_PAIRING` and `FEATURE_CACHE_CLEARING` behind `active_`, which that arm rejects outright. It was answering requests a client never sends, with operations that were stubs. Removing the three senders and their handling saves **4,968 bytes of flash** there, mostly the protobuf encode machinery for response types that build could never send. The esp32 `unpair_device()`/`clear_gatt_cache()` free functions move behind `USE_BLE_GATT_CLIENT` for the same reason: removing the passive handlers removed their last passive caller. GATT builds are otherwise unchanged.

Also folds in a cleanup pass over the whole chain: eight hand-rolled drop reports collapse to one helper, the three per-slot latches drain through `flush_owed_replies_()` and clear through `clear_owed_flags_()`, and `pending_disconnections_` gets its own loop since it is address-keyed rather than slot-keyed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/18221

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
esphome:
  name: my-proxy

api:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





