### PR TITLE
Tormatic cover: Add light support and allow for assumed_state customization in HA configuration.yaml to work (Remove UART command lock)

### DIFF
--- a/esphome/components/tormatic/__init__.py
+++ b/esphome/components/tormatic/__init__.py
@@ -1,1 +1,11 @@
 CODEOWNERS = ["@ti-mo"]
+import esphome.codegen as cg
+from esphome.components import cover
+
+tormatic_ns = cg.esphome_ns.namespace("tormatic")
+
+Tormatic = tormatic_ns.class_(
+    "Tormatic",
+    cover.Cover,
+    cg.PollingComponent,
+)

--- a/esphome/components/tormatic/cover.py
+++ b/esphome/components/tormatic/cover.py
@@ -3,8 +3,7 @@ from esphome.components import cover, uart
 import esphome.config_validation as cv
 from esphome.const import CONF_CLOSE_DURATION, CONF_OPEN_DURATION
 
-tormatic_ns = cg.esphome_ns.namespace("tormatic")
-Tormatic = tormatic_ns.class_("Tormatic", cover.Cover, cg.PollingComponent)
+from . import Tormatic
 
 CONFIG_SCHEMA = (
     cover.cover_schema(Tormatic)

--- a/esphome/components/tormatic/switch.py
+++ b/esphome/components/tormatic/switch.py
@@ -1,0 +1,24 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+
+from . import Tormatic, tormatic_ns
+
+CONF_TORMATIC_ID = "tormatic_id"
+
+TormaticLightSwitch = tormatic_ns.class_(
+    "TormaticLightSwitch",
+    switch.Switch,
+    cg.Parented.template(Tormatic),
+)
+
+CONFIG_SCHEMA = switch.switch_schema(TormaticLightSwitch).extend(
+    {
+        cv.GenerateID(CONF_TORMATIC_ID): cv.use_id(Tormatic),
+    }
+)
+
+
+async def to_code(config):
+    var = await switch.new_switch(config)
+    await cg.register_parented(var, config[CONF_TORMATIC_ID])

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -339,27 +339,7 @@ void Tormatic::send_gate_command_(GateStatus s) {
 }
 
 void Tormatic::set_light_state(bool state) {
-  // Cancel any pending commands from a previous switch action.
-  this->cancel_timeout("light_retry_1");
-  this->cancel_timeout("light_retry_2");
-
-  if (state) {
-    // Requested state is ON:
-    // Send 00 0B 00 01 three times.
-    this->send_light_command_(true);
-
-    this->set_timeout("light_retry_1", 100, [this]() { this->send_light_command_(true); });
-
-    this->set_timeout("light_retry_2", 200, [this]() { this->send_light_command_(true); });
-  } else {
-    // Requested state is OFF:
-    // Send 00 0B 00 00 three times.
-    this->send_light_command_(false);
-
-    this->set_timeout("light_retry_1", 100, [this]() { this->send_light_command_(false); });
-
-    this->set_timeout("light_retry_2", 200, [this]() { this->send_light_command_(false); });
-  }
+  this->send_light_command_(state);
 }
 
 void Tormatic::send_light_command_(bool state) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -339,13 +339,35 @@ void Tormatic::send_gate_command_(GateStatus s) {
 }
 
 void Tormatic::set_light_state(bool state) {
-  // Send immediately.
-  this->send_light_command_(state);
+  // Cancel any pending commands from a previous switch action.
+  this->cancel_timeout("light_retry_1");
+  this->cancel_timeout("light_retry_2");
 
-  // Repeat twice in case the first command collides with UART traffic.
-  this->set_timeout("light_retry_1", 100, [this, state]() { this->send_light_command_(state); });
+  if (state) {
+    // Requested state is ON:
+    // Send 00 0B 00 01 three times.
+    this->send_light_command_(true);
 
-  this->set_timeout("light_retry_2", 200, [this, state]() { this->send_light_command_(state); });
+    this->set_timeout("light_retry_1", 100, [this]() {
+      this->send_light_command_(true);
+    });
+
+    this->set_timeout("light_retry_2", 200, [this]() {
+      this->send_light_command_(true);
+    });
+  } else {
+    // Requested state is OFF:
+    // Send 00 0B 00 00 three times.
+    this->send_light_command_(false);
+
+    this->set_timeout("light_retry_1", 100, [this]() {
+      this->send_light_command_(false);
+    });
+
+    this->set_timeout("light_retry_2", 200, [this]() {
+      this->send_light_command_(false);
+    });
+  }
 }
 
 void Tormatic::send_light_command_(bool state) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -343,13 +343,9 @@ void Tormatic::set_light_state(bool state) {
   this->send_light_command_(state);
 
   // Repeat twice in case the first command collides with UART traffic.
-  this->set_timeout("light_retry_1", 100, [this, state]() {
-    this->send_light_command_(state);
-  });
+  this->set_timeout("light_retry_1", 100, [this, state]() { this->send_light_command_(state); });
 
-  this->set_timeout("light_retry_2", 200, [this, state]() {
-    this->send_light_command_(state);
-  });
+  this->set_timeout("light_retry_2", 200, [this, state]() { this->send_light_command_(state); });
 }
 
 void Tormatic::send_light_command_(bool state) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -338,6 +338,13 @@ void Tormatic::send_gate_command_(GateStatus s) {
   this->send_message_(COMMAND, req);
 }
 
+void Tormatic::send_light_command_(bool state) {
+  ESP_LOGI(TAG, "Sending light command %s", state ? "ON" : "OFF");
+
+  LightCommand req(state);
+  this->send_message_(COMMAND, req);
+}
+
 template<typename T> void Tormatic::send_message_(MessageType t, T req) {
   MessageHeader hdr(t, ++this->seq_tx_, sizeof(req));
 

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -339,7 +339,17 @@ void Tormatic::send_gate_command_(GateStatus s) {
 }
 
 void Tormatic::set_light_state(bool state) {
+  // Send immediately.
   this->send_light_command_(state);
+
+  // Repeat twice in case the first command collides with UART traffic.
+  this->set_timeout("light_retry_1", 100, [this, state]() {
+    this->send_light_command_(state);
+  });
+
+  this->set_timeout("light_retry_2", 200, [this, state]() {
+    this->send_light_command_(state);
+  });
 }
 
 void Tormatic::send_light_command_(bool state) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -338,9 +338,7 @@ void Tormatic::send_gate_command_(GateStatus s) {
   this->send_message_(COMMAND, req);
 }
 
-void Tormatic::set_light_state(bool state) {
-  this->send_light_command_(state);
-}
+void Tormatic::set_light_state(bool state) { this->send_light_command_(state); }
 
 void Tormatic::send_light_command_(bool state) {
   ESP_LOGI(TAG, "Sending light command %s", state ? "ON" : "OFF");

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -201,10 +201,6 @@ void Tormatic::recompute_position_() {
 
 // Start moving the gate in the direction of the target position.
 void Tormatic::control_position_(float target) {
-  if (target == this->position) {
-    return;
-  }
-
   if (target == COVER_OPEN) {
     ESP_LOGI(TAG, "Fully opening gate");
     this->send_gate_command_(OPENED);

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -338,6 +338,10 @@ void Tormatic::send_gate_command_(GateStatus s) {
   this->send_message_(COMMAND, req);
 }
 
+void Tormatic::set_light_state(bool state) {
+  this->send_light_command_(state);
+}
+
 void Tormatic::send_light_command_(bool state) {
   ESP_LOGI(TAG, "Sending light command %s", state ? "ON" : "OFF");
 

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -348,25 +348,17 @@ void Tormatic::set_light_state(bool state) {
     // Send 00 0B 00 01 three times.
     this->send_light_command_(true);
 
-    this->set_timeout("light_retry_1", 100, [this]() {
-      this->send_light_command_(true);
-    });
+    this->set_timeout("light_retry_1", 100, [this]() { this->send_light_command_(true); });
 
-    this->set_timeout("light_retry_2", 200, [this]() {
-      this->send_light_command_(true);
-    });
+    this->set_timeout("light_retry_2", 200, [this]() { this->send_light_command_(true); });
   } else {
     // Requested state is OFF:
     // Send 00 0B 00 00 three times.
     this->send_light_command_(false);
 
-    this->set_timeout("light_retry_1", 100, [this]() {
-      this->send_light_command_(false);
-    });
+    this->set_timeout("light_retry_1", 100, [this]() { this->send_light_command_(false); });
 
-    this->set_timeout("light_retry_2", 200, [this]() {
-      this->send_light_command_(false);
-    });
+    this->set_timeout("light_retry_2", 200, [this]() { this->send_light_command_(false); });
   }
 }
 

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -19,6 +19,9 @@ class Tormatic final : public cover::Cover, public uart::UARTDevice, public Poll
   void set_open_duration(uint32_t duration) { this->open_duration_ = duration; }
   void set_close_duration(uint32_t duration) { this->close_duration_ = duration; }
 
+  // Used by the separate TormaticLightSwitch entity.
+  void set_light_state(bool state);
+
   void publish_state(bool save = true, uint32_t ratelimit = 0);
 
   cover::CoverTraits get_traits() override;

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -39,6 +39,7 @@ class Tormatic final : public cover::Cover, public uart::UARTDevice, public Poll
   optional<GateStatus> read_gate_status_();
 
   void send_gate_command_(GateStatus s);
+  void send_light_command_(bool state);
   void handle_gate_status_(GateStatus s);
 
   uint32_t seq_tx_{0};

--- a/esphome/components/tormatic/tormatic_protocol.h
+++ b/esphome/components/tormatic/tormatic_protocol.h
@@ -88,14 +88,8 @@ struct MessageHeader {
   std::string print() {
     char buf[64];
 
-    buf_append_printf(
-        buf,
-        sizeof(buf),
-        0,
-        "MessageHeader: seq %d, len %" PRIu32 ", type %s",
-        this->seq,
-        this->len,
-        message_type_to_str(this->type));
+    buf_append_printf(buf, sizeof(buf), 0, "MessageHeader: seq %d, len %" PRIu32 ", type %s", this->seq, this->len,
+                      message_type_to_str(this->type));
 
     return buf;
   }
@@ -106,21 +100,15 @@ struct MessageHeader {
     this->type = convert_big_endian(this->type);
   }
 
-  uint32_t payload_size() {
-    return this->len > sizeof(this->type)
-               ? this->len - sizeof(this->type)
-               : 0;
-  }
+  uint32_t payload_size() { return this->len > sizeof(this->type) ? this->len - sizeof(this->type) : 0; }
 
 } __attribute__((packed));
-
 
 // Device/function type inside the command payload.
 enum StatusType : uint16_t {
   GATE = 0x0A,
   LIGHT = 0x0B,
 };
-
 
 // GateStatus defines the current state of the gate, received in a StatusReply
 // and sent in a gate command.
@@ -132,7 +120,6 @@ enum GateStatus : uint8_t {
   OPENING,
   CLOSING,
 };
-
 
 inline CoverOperation gate_status_to_cover_operation(GateStatus s) {
   switch (s) {
@@ -151,7 +138,6 @@ inline CoverOperation gate_status_to_cover_operation(GateStatus s) {
 
   return COVER_OPERATION_IDLE;
 }
-
 
 inline const char *gate_status_to_str(GateStatus s) {
   switch (s) {
@@ -178,7 +164,6 @@ inline const char *gate_status_to_str(GateStatus s) {
   }
 }
 
-
 // A StatusRequest is sent to request the gate's current status.
 struct StatusRequest {
   StatusType type;
@@ -186,9 +171,7 @@ struct StatusRequest {
 
   StatusRequest() = default;
 
-  StatusRequest(StatusType type) {
-    this->type = type;
-  }
+  StatusRequest(StatusType type) { this->type = type; }
 
   void byteswap() {
     this->type = convert_big_endian(this->type);
@@ -196,7 +179,6 @@ struct StatusRequest {
   }
 
 } __attribute__((packed));
-
 
 // StatusReply is received from the unit in response to a StatusRequest.
 struct StatusReply {
@@ -207,12 +189,7 @@ struct StatusReply {
   std::string print() {
     char buf[48];
 
-    buf_append_printf(
-        buf,
-        sizeof(buf),
-        0,
-        "StatusReply: state %s",
-        gate_status_to_str(this->state));
+    buf_append_printf(buf, sizeof(buf), 0, "StatusReply: state %s", gate_status_to_str(this->state));
 
     return buf;
   }
@@ -221,11 +198,9 @@ struct StatusReply {
 
 } __attribute__((packed));
 
-
 // Serialize the given object to a new byte vector.
 // Invokes the object's byteswap() method.
-template<typename T>
-std::vector<uint8_t> serialize(T obj) {
+template<typename T> std::vector<uint8_t> serialize(T obj) {
   obj.byteswap();
 
   std::vector<uint8_t> out(sizeof(T));
@@ -233,7 +208,6 @@ std::vector<uint8_t> serialize(T obj) {
 
   return out;
 }
-
 
 // Gate command.
 // Serialized payload:
@@ -252,29 +226,19 @@ struct CommandRequestReply {
 
   CommandRequestReply() = default;
 
-  CommandRequestReply(GateStatus state) {
-    this->state = state;
-  }
+  CommandRequestReply(GateStatus state) { this->state = state; }
 
   std::string print() {
     char buf[56];
 
-    buf_append_printf(
-        buf,
-        sizeof(buf),
-        0,
-        "CommandRequestReply: state %s",
-        gate_status_to_str(this->state));
+    buf_append_printf(buf, sizeof(buf), 0, "CommandRequestReply: state %s", gate_status_to_str(this->state));
 
     return buf;
   }
 
-  void byteswap() {
-    this->type = convert_big_endian(this->type);
-  }
+  void byteswap() { this->type = convert_big_endian(this->type); }
 
 } __attribute__((packed));
-
 
 // Light command.
 // Serialized payload:
@@ -289,15 +253,10 @@ struct LightCommand {
 
   LightCommand() = default;
 
-  explicit LightCommand(bool state) {
-    this->state = state ? 0x01 : 0x00;
-  }
+  explicit LightCommand(bool state) { this->state = state ? 0x01 : 0x00; }
 
-  void byteswap() {
-    this->type = convert_big_endian(this->type);
-  }
+  void byteswap() { this->type = convert_big_endian(this->type); }
 
 } __attribute__((packed));
-
 
 }  // namespace esphome::tormatic

--- a/esphome/components/tormatic/tormatic_protocol.h
+++ b/esphome/components/tormatic/tormatic_protocol.h
@@ -18,32 +18,34 @@
  * | 0xF3 0xCB | 0x00 0x00 0x00 0x06 | 0x01 0x04 | 0x00 0x0A 0x00 0x01 |
  * | 0xF3 0xCB | 0x00 0x00 0x00 0x05 | 0x01 0x04 | 0x02 0x03 0x00      |
  *
- * This request asks for the gate status (0x0A); the only other value observed
- * in the request was 0x0B, but replies were always zero. Presumably this
- * queries another sensor on the unit like a safety breaker, but this is not
- * relevant for an esphome cover component.
+ * Gate status uses type 0x0A.
  *
  * The second byte of the reply is set to 0x03 when the gate is in fully open
  * position. Other valid values for the second byte are: (0x0) Paused, (0x1)
- * Closed, (0x2) Ventilating, (0x3) Opened, (0x4) Opening, (0x5) Closing. The
- * meaning of the other bytes is currently unknown and ignored by the component.
+ * Closed, (0x2) Ventilating, (0x3) Opened, (0x4) Opening, (0x5) Closing.
  *
  * Controlling the gate:
  *
  * | sequence  |        length       |    type   |       payload       |
  * | 0x40 0xFF | 0x00 0x00 0x00 0x06 | 0x01 0x06 | 0x00 0x0A 0x00 0x03 |
- * | 0x40 0xFF | 0x00 0x00 0x00 0x06 | 0x01 0x06 | 0x00 0x0A 0x00 0x03 |
  *
- * The unit acks any commands by echoing back the message in full. However,
- * this does _not_ mean the gate has started closing. The component only
- * considers status replies as authoritative and simply fires off commands,
- * ignoring the echoed messages.
+ * The unit acks commands by echoing back the message in full.
  *
- * The payload structure is as follows: [0x00, 0x0A] (gate), followed by
- * one of the states normally carried in status replies: (0x0) Pause, (0x1)
- * Close, (0x2) Ventilate (open ~20%), (0x3) Open/high-torque reverse. The
- * protocol implementation in this file simply reuses the GateStatus enum
- * for this purpose.
+ * Gate command payload:
+ *
+ *   00 0A 00 XX
+ *
+ * where XX is:
+ *
+ *   00 = pause
+ *   01 = close
+ *   02 = ventilate
+ *   03 = open
+ *
+ * Light command payload:
+ *
+ *   00 0B 00 01 = light on
+ *   00 0B 00 00 = light off
  */
 
 namespace esphome::tormatic {
@@ -56,7 +58,6 @@ enum MessageType : uint16_t {
   COMMAND = 0x0106,
 };
 
-// Max string length: 7 ("Unknown"/"Command"). Update print() buffer sizes if adding longer strings.
 inline const char *message_type_to_str(MessageType t) {
   switch (t) {
     case STATUS:
@@ -75,20 +76,27 @@ struct MessageHeader {
   MessageType type;
 
   MessageHeader() = default;
+
   MessageHeader(MessageType type, uint16_t seq, uint32_t payload_size) {
     this->type = type;
     this->seq = seq;
-    // len includes the length of the type field. It was
-    // included in MessageHeader to avoid having to parse
-    // it as part of the payload.
+
+    // len includes the length of the type field.
     this->len = payload_size + sizeof(this->type);
   }
 
   std::string print() {
-    // 64 bytes: "MessageHeader: seq " + uint16 + ", len " + uint32 + ", type " + type + safety margin
     char buf[64];
-    buf_append_printf(buf, sizeof(buf), 0, "MessageHeader: seq %d, len %" PRIu32 ", type %s", this->seq, this->len,
-                      message_type_to_str(this->type));
+
+    buf_append_printf(
+        buf,
+        sizeof(buf),
+        0,
+        "MessageHeader: seq %d, len %" PRIu32 ", type %s",
+        this->seq,
+        this->len,
+        message_type_to_str(this->type));
+
     return buf;
   }
 
@@ -98,21 +106,24 @@ struct MessageHeader {
     this->type = convert_big_endian(this->type);
   }
 
-  // payload_size returns the amount of payload bytes to be read from the uart
-  // buffer after reading the header.
-  uint32_t payload_size() { return this->len > sizeof(this->type) ? this->len - sizeof(this->type) : 0; }
+  uint32_t payload_size() {
+    return this->len > sizeof(this->type)
+               ? this->len - sizeof(this->type)
+               : 0;
+  }
+
 } __attribute__((packed));
 
-// StatusType denotes which 'page' of information needs to be retrieved.
-// On my Novoferm 423, only the GATE status type returns values, Unknown
-// only contains zeroes.
+
+// Device/function type inside the command payload.
 enum StatusType : uint16_t {
   GATE = 0x0A,
   LIGHT = 0x0B,
 };
 
+
 // GateStatus defines the current state of the gate, received in a StatusReply
-// and sent in a Command.
+// and sent in a gate command.
 enum GateStatus : uint8_t {
   PAUSED,
   CLOSED,
@@ -122,40 +133,51 @@ enum GateStatus : uint8_t {
   CLOSING,
 };
 
+
 inline CoverOperation gate_status_to_cover_operation(GateStatus s) {
   switch (s) {
     case OPENING:
       return COVER_OPERATION_OPENING;
+
     case CLOSING:
       return COVER_OPERATION_CLOSING;
+
     case OPENED:
     case CLOSED:
     case PAUSED:
     case VENTILATING:
       return COVER_OPERATION_IDLE;
   }
+
   return COVER_OPERATION_IDLE;
 }
 
-// Max string length: 11 ("Ventilating"). Update print() buffer sizes if adding longer strings.
+
 inline const char *gate_status_to_str(GateStatus s) {
   switch (s) {
     case PAUSED:
       return "Paused";
+
     case CLOSED:
       return "Closed";
+
     case VENTILATING:
       return "Ventilating";
+
     case OPENED:
       return "Opened";
+
     case OPENING:
       return "Opening";
+
     case CLOSING:
       return "Closing";
+
     default:
       return "Unknown";
   }
 }
+
 
 // A StatusRequest is sent to request the gate's current status.
 struct StatusRequest {
@@ -163,13 +185,18 @@ struct StatusRequest {
   uint16_t trailer = 0x1;
 
   StatusRequest() = default;
-  StatusRequest(StatusType type) { this->type = type; }
+
+  StatusRequest(StatusType type) {
+    this->type = type;
+  }
 
   void byteswap() {
     this->type = convert_big_endian(this->type);
     this->trailer = convert_big_endian(this->trailer);
   }
+
 } __attribute__((packed));
+
 
 // StatusReply is received from the unit in response to a StatusRequest.
 struct StatusReply {
@@ -178,18 +205,27 @@ struct StatusReply {
   uint8_t trailer = 0x0;
 
   std::string print() {
-    // 48 bytes: "StatusReply: state " (19) + state (11) + safety margin
     char buf[48];
-    buf_append_printf(buf, sizeof(buf), 0, "StatusReply: state %s", gate_status_to_str(this->state));
+
+    buf_append_printf(
+        buf,
+        sizeof(buf),
+        0,
+        "StatusReply: state %s",
+        gate_status_to_str(this->state));
+
     return buf;
   }
 
-  void byteswap(){};
+  void byteswap() {}
+
 } __attribute__((packed));
+
 
 // Serialize the given object to a new byte vector.
 // Invokes the object's byteswap() method.
-template<typename T> std::vector<uint8_t> serialize(T obj) {
+template<typename T>
+std::vector<uint8_t> serialize(T obj) {
   obj.byteswap();
 
   std::vector<uint8_t> out(sizeof(T));
@@ -198,38 +234,70 @@ template<typename T> std::vector<uint8_t> serialize(T obj) {
   return out;
 }
 
-// Command tells the gate to start or stop moving.
-// It is echoed back by the unit on success.
+
+// Gate command.
+// Serialized payload:
+//
+//   00 0A 00 XX
+//
 struct CommandRequestReply {
-  // The part of the unit to control. For now only the gate is supported.
   StatusType type = GATE;
   uint8_t pad = 0x0;
-  // The desired state:
-  // PAUSED = stop
+
+  // PAUSED      = stop
+  // CLOSED      = close
   // VENTILATING = move to ~20% open
-  // CLOSED = close
-  // OPENED = open/high-torque reverse when closing
+  // OPENED      = open/high-torque reverse when closing
   GateStatus state;
 
   CommandRequestReply() = default;
-  CommandRequestReply(GateStatus state) { this->state = state; }
+
+  CommandRequestReply(GateStatus state) {
+    this->state = state;
+  }
 
   std::string print() {
-    // 56 bytes: "CommandRequestReply: state " (27) + state (11) + safety margin
     char buf[56];
-    buf_append_printf(buf, sizeof(buf), 0, "CommandRequestReply: state %s", gate_status_to_str(this->state));
+
+    buf_append_printf(
+        buf,
+        sizeof(buf),
+        0,
+        "CommandRequestReply: state %s",
+        gate_status_to_str(this->state));
+
     return buf;
   }
 
+  void byteswap() {
+    this->type = convert_big_endian(this->type);
+  }
+
+} __attribute__((packed));
+
+
+// Light command.
+// Serialized payload:
+//
+//   00 0B 00 01 = ON
+//   00 0B 00 00 = OFF
+//
 struct LightCommand {
   StatusType type = LIGHT;
   uint8_t pad = 0x0;
   uint8_t state;
 
   LightCommand() = default;
-  LightCommand(bool state) { this->state = state ? 0x01 : 0x00; }
 
-  void byteswap() { this->type = convert_big_endian(this->type); }
+  explicit LightCommand(bool state) {
+    this->state = state ? 0x01 : 0x00;
+  }
+
+  void byteswap() {
+    this->type = convert_big_endian(this->type);
+  }
+
 } __attribute__((packed));
+
 
 }  // namespace esphome::tormatic

--- a/esphome/components/tormatic/tormatic_protocol.h
+++ b/esphome/components/tormatic/tormatic_protocol.h
@@ -108,7 +108,7 @@ struct MessageHeader {
 // only contains zeroes.
 enum StatusType : uint16_t {
   GATE = 0x0A,
-  UNKNOWN = 0x0B,
+  LIGHT = 0x0B,
 };
 
 // GateStatus defines the current state of the gate, received in a StatusReply
@@ -220,6 +220,14 @@ struct CommandRequestReply {
     buf_append_printf(buf, sizeof(buf), 0, "CommandRequestReply: state %s", gate_status_to_str(this->state));
     return buf;
   }
+
+struct LightCommand {
+  StatusType type = LIGHT;
+  uint8_t pad = 0x0;
+  uint8_t state;
+
+  LightCommand() = default;
+  LightCommand(bool state) { this->state = state ? 0x01 : 0x00; }
 
   void byteswap() { this->type = convert_big_endian(this->type); }
 } __attribute__((packed));

--- a/esphome/components/tormatic/tormatic_switch.cpp
+++ b/esphome/components/tormatic/tormatic_switch.cpp
@@ -1,0 +1,13 @@
+#include "tormatic_switch.h"
+
+namespace esphome::tormatic {
+
+void TormaticLightSwitch::write_state(bool state) {
+  this->parent_->set_light_state(state);
+
+  // No authoritative light status is currently available from the gate,
+  // so treat the requested state as the current state.
+  this->publish_state(state);
+}
+
+}  // namespace esphome::tormatic

--- a/esphome/components/tormatic/tormatic_switch.h
+++ b/esphome/components/tormatic/tormatic_switch.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/helpers.h"
+
+#include "tormatic_cover.h"
+
+namespace esphome::tormatic {
+
+class TormaticLightSwitch final : public switch_::Switch, public Parented<Tormatic> {
+ protected:
+  void write_state(bool state) override;
+};
+
+}  // namespace esphome::tormatic


### PR DESCRIPTION
# What does this implement/fix?

I have a Novoferm 573s which like most Novoferm/Tormatic has an in-built light and a 230v output that is also used for external lights that I want to be able to control in Home Assistant. 
To do this I used the reverse engineered UART command from feature request #3181 and exposed it as a switch. 

In addition since my model has no sensors attached (or it's a bug), it always reports as closed and the state doesn't update, which blocked me from sending the close UART since it's prevented in 

`void Tormatic::control_position_(float target) {
  if (target == this->position) {
    return;
  }`.

I removed this check since sending a close command when the gate is closed won't actually affect anything and HA still greys out the button unless 

`homeassistant:
  customize_glob:
    "cover.your_cover":
      assumed_state: true` is added.

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/3181
- #18285

## Test Environment

- [X] ESP32

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  id: uart_tormatic
  rx_pin: GPIO16
  tx_pin: GPIO17
  baud_rate: 9600
  data_bits: 8
  parity: NONE
  stop_bits: 1
    
cover:
  - platform: tormatic
    id: garage_gate
    device_class: garage
    name: Novoferm 573s

switch:
  - platform: tormatic
    tormatic_id: garage_gate
    name: "Garage Light"
```

## Checklist:
  - [X] The code change is tested and works locally.
