### PR TITLE
[core] Warn when running a different source tree than the one you are in

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2527,7 +2527,14 @@ def _warn_if_source_tree_mismatch() -> None:
         return  # not inside a checkout; nothing to compare against
 
     running = Path(__file__).resolve().parent.parent
-    if standing_in == running:
+    # samefile() compares device and inode, so a case-insensitive filesystem
+    # (macOS) reaching the same directory by differently cased paths is not
+    # reported as a mismatch. Falls back to comparing paths if either is gone.
+    try:
+        same = standing_in.samefile(running)
+    except OSError:
+        same = standing_in == running
+    if same:
         return
 
     _LOGGER.warning(

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2518,7 +2518,10 @@ def _warn_if_source_tree_mismatch() -> None:
     compiles, sources the user is not looking at. Only fires inside a checkout,
     so ordinary installs never see it.
     """
-    cwd = Path.cwd()
+    try:
+        cwd = Path.cwd()
+    except OSError:
+        return  # working directory is gone; a diagnostic must not break startup
     for candidate in (cwd, *cwd.parents):
         if (candidate / "esphome" / "__main__.py").is_file():
             standing_in = candidate.resolve()
@@ -2527,9 +2530,10 @@ def _warn_if_source_tree_mismatch() -> None:
         return  # not inside a checkout; nothing to compare against
 
     running = Path(__file__).resolve().parent.parent
-    # samefile() compares device and inode, so a case-insensitive filesystem
-    # (macOS) reaching the same directory by differently cased paths is not
-    # reported as a mismatch. Falls back to comparing paths if either is gone.
+    # Both sides are resolved, so on a case-sensitive filesystem this matches
+    # plain equality. samefile() compares device and inode, which additionally
+    # covers a case-insensitive filesystem (macOS) reaching one directory by
+    # differently cased paths. Falls back to equality if either path is gone.
     try:
         same = standing_in.samefile(running)
     except OSError:
@@ -2541,7 +2545,7 @@ def _warn_if_source_tree_mismatch() -> None:
         "Running ESPHome from a different checkout than the one you are in:\n"
         "  running from: %s\n"
         "  you are in:   %s\n"
-        "The editable install points at the first, so its sources are used.\n"
+        "The installed esphome resolves to the first, so its sources are used.\n"
         "Run 'python -m esphome' from the second to use that one instead.",
         running,
         standing_in,

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2509,6 +2509,37 @@ def parse_args(argv):
     return parser.parse_args(arguments)
 
 
+def _warn_if_source_tree_mismatch() -> None:
+    """Warn when the checkout the user is standing in is not the one being run.
+
+    An editable install records one absolute path, so a venv shared between git
+    worktrees (or reused after a checkout is copied or renamed) keeps importing
+    the tree it was installed from. Every command then silently runs, and
+    compiles, sources the user is not looking at. Only fires inside a checkout,
+    so ordinary installs never see it.
+    """
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / "esphome" / "__main__.py").is_file():
+            standing_in = candidate.resolve()
+            break
+    else:
+        return  # not inside a checkout; nothing to compare against
+
+    running = Path(__file__).resolve().parent.parent
+    if standing_in == running:
+        return
+
+    _LOGGER.warning(
+        "Running ESPHome from %s, but the current directory is inside %s. "
+        "The editable install points at the first tree, so this command is using "
+        "its sources. Run 'python -m esphome' from %s to use that tree instead.",
+        running,
+        standing_in,
+        standing_in,
+    )
+
+
 def run_esphome(argv):
     from esphome.address_cache import AddressCache
 
@@ -2527,6 +2558,7 @@ def run_esphome(argv):
         args.log_level = "CRITICAL"
 
     setup_log(log_level=args.log_level)
+    _warn_if_source_tree_mismatch()
 
     if args.command in PRE_CONFIG_ACTIONS:
         try:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2531,11 +2531,11 @@ def _warn_if_source_tree_mismatch() -> None:
         return
 
     _LOGGER.warning(
-        "Running a different source tree than the current directory:\n"
-        "  running:   %s\n"
-        "  cwd is in: %s\n"
-        "The editable install points at the first tree, so its sources are used.\n"
-        "Run 'python -m esphome' from the second tree to use that one instead.",
+        "Running ESPHome from a different checkout than the one you are in:\n"
+        "  running from: %s\n"
+        "  you are in:   %s\n"
+        "The editable install points at the first, so its sources are used.\n"
+        "Run 'python -m esphome' from the second to use that one instead.",
         running,
         standing_in,
     )

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2531,11 +2531,12 @@ def _warn_if_source_tree_mismatch() -> None:
         return
 
     _LOGGER.warning(
-        "Running ESPHome from %s, but the current directory is inside %s. "
-        "The editable install points at the first tree, so this command is using "
-        "its sources. Run 'python -m esphome' from %s to use that tree instead.",
+        "Running a different source tree than the current directory:\n"
+        "  running:   %s\n"
+        "  cwd is in: %s\n"
+        "The editable install points at the first tree, so its sources are used.\n"
+        "Run 'python -m esphome' from the second tree to use that one instead.",
         running,
-        standing_in,
         standing_in,
     )
 

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -18,6 +18,7 @@ import pytest
 from pytest import CaptureFixture
 from zeroconf import ServiceStateChange
 
+from esphome import __main__ as main
 from esphome.__main__ import (
     Purpose,
     _get_configured_xtal_freq,
@@ -6760,3 +6761,80 @@ def test_check_permissions_unreadable_port() -> None:
         pytest.raises(EsphomeError, match="read or write permission"),
     ):
         check_permissions("/dev/ttyUSB99")
+
+
+def _make_checkout(root: Path) -> Path:
+    """Create a directory that looks like an esphome checkout."""
+    (root / "esphome").mkdir(parents=True)
+    (root / "esphome" / "__main__.py").write_text("", encoding="utf-8")
+    return root
+
+
+def test_warn_source_tree_mismatch_warns_for_other_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Standing in a checkout other than the one being run warns."""
+    standing_in = _make_checkout(tmp_path / "worktree")
+    running = _make_checkout(tmp_path / "main")
+    monkeypatch.chdir(standing_in)
+    monkeypatch.setattr(main, "__file__", str(running / "esphome" / "__main__.py"))
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    assert "worktree" in caplog.text
+    assert "main" in caplog.text
+
+
+def test_warn_source_tree_mismatch_silent_in_same_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Standing in the tree that is running is the normal case and is silent."""
+    tree = _make_checkout(tmp_path / "main")
+    monkeypatch.chdir(tree)
+    monkeypatch.setattr(main, "__file__", str(tree / "esphome" / "__main__.py"))
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    assert not caplog.text
+
+
+def test_warn_source_tree_mismatch_silent_outside_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An ordinary install run from a config directory never warns."""
+    running = _make_checkout(tmp_path / "main")
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    monkeypatch.chdir(config_dir)
+    monkeypatch.setattr(main, "__file__", str(running / "esphome" / "__main__.py"))
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    assert not caplog.text
+
+
+def test_warn_source_tree_mismatch_silent_in_subdirectory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A subdirectory of the running tree resolves to that tree, so no warning."""
+    tree = _make_checkout(tmp_path / "main")
+    subdir = tree / "esphome" / "components"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    monkeypatch.setattr(main, "__file__", str(tree / "esphome" / "__main__.py"))
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    assert not caplog.text

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -6838,3 +6838,43 @@ def test_warn_source_tree_mismatch_silent_in_subdirectory(
         main._warn_if_source_tree_mismatch()
 
     assert not caplog.text
+
+
+def test_warn_source_tree_mismatch_silent_via_symlinked_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Reaching the running tree by another path is the same tree, not a mismatch."""
+    tree = _make_checkout(tmp_path / "main")
+    link = tmp_path / "link"
+    link.symlink_to(tree, target_is_directory=True)
+    monkeypatch.chdir(link)
+    monkeypatch.setattr(main, "__file__", str(tree / "esphome" / "__main__.py"))
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    assert not caplog.text
+
+
+def test_warn_source_tree_mismatch_falls_back_when_stat_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If samefile() cannot stat, fall back to comparing the paths."""
+    tree = _make_checkout(tmp_path / "main")
+    monkeypatch.chdir(tree)
+    monkeypatch.setattr(main, "__file__", str(tree / "esphome" / "__main__.py"))
+
+    def raise_oserror(self: Path, other: Path) -> bool:
+        raise OSError("stat failed")
+
+    monkeypatch.setattr(Path, "samefile", raise_oserror)
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    # Same tree, so the path comparison still finds them equal and stays silent
+    assert not caplog.text

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -6840,17 +6840,41 @@ def test_warn_source_tree_mismatch_silent_in_subdirectory(
     assert not caplog.text
 
 
-def test_warn_source_tree_mismatch_silent_via_symlinked_path(
+def test_warn_source_tree_mismatch_warns_when_stat_fails_on_other_tree(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Reaching the running tree by another path is the same tree, not a mismatch."""
-    tree = _make_checkout(tmp_path / "main")
-    link = tmp_path / "link"
-    link.symlink_to(tree, target_is_directory=True)
-    monkeypatch.chdir(link)
-    monkeypatch.setattr(main, "__file__", str(tree / "esphome" / "__main__.py"))
+    """The samefile() fallback must still warn when the trees really differ."""
+    standing_in = _make_checkout(tmp_path / "worktree")
+    running = _make_checkout(tmp_path / "main")
+    monkeypatch.chdir(standing_in)
+    monkeypatch.setattr(main, "__file__", str(running / "esphome" / "__main__.py"))
+
+    def raise_oserror(self: Path, other: Path) -> bool:
+        raise OSError("stat failed")
+
+    monkeypatch.setattr(Path, "samefile", raise_oserror)
+
+    with caplog.at_level(logging.WARNING):
+        main._warn_if_source_tree_mismatch()
+
+    assert "worktree" in caplog.text
+
+
+def test_warn_source_tree_mismatch_silent_when_cwd_is_gone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A deleted working directory must not turn the diagnostic into a traceback."""
+    running = _make_checkout(tmp_path / "main")
+    monkeypatch.setattr(main, "__file__", str(running / "esphome" / "__main__.py"))
+
+    def raise_filenotfound() -> Path:
+        raise FileNotFoundError("cwd is gone")
+
+    monkeypatch.setattr(Path, "cwd", staticmethod(raise_filenotfound))
 
     with caplog.at_level(logging.WARNING):
         main._warn_if_source_tree_mismatch()


### PR DESCRIPTION
# What does this implement/fix?

An editable install records one absolute path. A venv shared between git worktrees - or reused after a checkout is copied or renamed - keeps importing the tree it was installed from, so `esphome` run from another checkout silently uses that other tree's sources. Nothing reports it: the command works, it just compiles code you are not looking at.

This adds a warning when the checkout you are standing in is not the one being run:

```
WARNING Running ESPHome from a different checkout than the one you are in:
  running from: /home/jon/Work/esphome
  you are in:   /home/jon/Work/esphome-idf6
The editable install points at the first, so its sources are used.
Run 'python -m esphome' from the second to use that one instead.
```

The check walks up from the current directory looking for an `esphome/__main__.py` and compares that against the tree this module was imported from. No subprocess and no git call. It only fires when you are inside a checkout, so ordinary installs never see it, and it sits right after `setup_log()` so every subcommand is covered - including the ones that return early through `PRE_CONFIG_ACTIONS`.

Related: #17446 takes the other approach for the same problem, wrapping the venv's console script so the tree you are in is the tree that runs. That changes which code executes; this only reports the mismatch. If that lands, the trees always match and this warning stops firing on its own.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration change; the warning is emitted by the CLI itself.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).