### PR TITLE
[core] Retry gh CLI calls on transient network errors in CI scripts

### DIFF
--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -20,18 +20,21 @@ from jinja2 import Environment, FileSystemLoader
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # pylint: disable=wrong-import-position
-from helpers import run_gh_command as run_gh_command_with_retry  # noqa: E402
+from helpers import run_gh_command  # noqa: E402
 
 # Comment marker to identify our memory impact comments
 COMMENT_MARKER = "<!-- esphome-memory-impact-analysis -->"
 
 
-def run_gh_command(args: list[str], operation: str) -> subprocess.CompletedProcess:
+def run_gh_command_logged(
+    args: list[str], operation: str, *, retry: bool = True
+) -> subprocess.CompletedProcess:
     """Run a gh CLI command with retries and error reporting.
 
     Args:
         args: Command arguments (including 'gh')
         operation: Description of the operation for error messages
+        retry: Pass False for non-idempotent commands (see run_gh_command)
 
     Returns:
         CompletedProcess result
@@ -40,7 +43,7 @@ def run_gh_command(args: list[str], operation: str) -> subprocess.CompletedProce
         subprocess.CalledProcessError: If command fails (with detailed error output)
     """
     try:
-        return run_gh_command_with_retry(args)
+        return run_gh_command(args, retry=retry)
     except subprocess.CalledProcessError as e:
         print(
             f"ERROR: {operation} failed with exit code {e.returncode}", file=sys.stderr
@@ -468,7 +471,7 @@ def find_existing_comment(pr_number: str) -> str | None:
     print(f"DEBUG: Looking for existing comment on PR #{pr_number}", file=sys.stderr)
 
     # Use gh api to get comments directly - this returns the numeric id field
-    result = run_gh_command(
+    result = run_gh_command_logged(
         [
             "gh",
             "api",
@@ -531,7 +534,7 @@ def update_existing_comment(comment_id: str, comment_body: str) -> None:
     """
     print(f"DEBUG: Updating existing comment {comment_id}", file=sys.stderr)
     print(f"DEBUG: Comment body length: {len(comment_body)} bytes", file=sys.stderr)
-    result = run_gh_command(
+    result = run_gh_command_logged(
         [
             "gh",
             "api",
@@ -558,9 +561,12 @@ def create_new_comment(pr_number: str, comment_body: str) -> None:
     """
     print(f"DEBUG: Posting new comment on PR #{pr_number}", file=sys.stderr)
     print(f"DEBUG: Comment body length: {len(comment_body)} bytes", file=sys.stderr)
-    result = run_gh_command(
+    # Creating a comment is not idempotent: a retry after a dropped response
+    # could post the same comment twice, so fail on the first error instead.
+    result = run_gh_command_logged(
         ["gh", "pr", "comment", pr_number, "--body", comment_body],
         operation="Create PR comment",
+        retry=False,
     )
     print(f"DEBUG: Post response: {result.stdout}", file=sys.stderr)
 

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -20,13 +20,14 @@ from jinja2 import Environment, FileSystemLoader
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # pylint: disable=wrong-import-position
+from helpers import run_gh_command as run_gh_command_with_retry  # noqa: E402
 
 # Comment marker to identify our memory impact comments
 COMMENT_MARKER = "<!-- esphome-memory-impact-analysis -->"
 
 
 def run_gh_command(args: list[str], operation: str) -> subprocess.CompletedProcess:
-    """Run a gh CLI command with error handling.
+    """Run a gh CLI command with retries and error reporting.
 
     Args:
         args: Command arguments (including 'gh')
@@ -39,12 +40,7 @@ def run_gh_command(args: list[str], operation: str) -> subprocess.CompletedProce
         subprocess.CalledProcessError: If command fails (with detailed error output)
     """
     try:
-        return subprocess.run(
-            args,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        return run_gh_command_with_retry(args)
     except subprocess.CalledProcessError as e:
         print(
             f"ERROR: {operation} failed with exit code {e.returncode}", file=sys.stderr

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -480,6 +480,10 @@ _TRANSIENT_GH_ERROR_RE = re.compile(
     r"|timed out|timeout"
     r"|connection (?:reset|refused|closed)"
     r"|no such host|could not resolve host"
+    # gh intercepts DNS errors and prints its own "error connecting to
+    # <host>" text; the Go phrases above are kept as a hedge in case a
+    # future gh stops swallowing the underlying error
+    r"|error connecting to"
     r"|failed to verify certificate"
     # Go reports a server-closed connection as 'Post "<url>": EOF'; the
     # quote-and-colon anchor keeps a URL or message body containing the

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -479,6 +479,7 @@ _TRANSIENT_GH_ERROR_RE = re.compile(
     r"|timed out|timeout"
     r"|connection (?:reset|refused|closed)"
     r"|no such host|could not resolve"
+    r"|failed to verify certificate"
     r"|unexpected eof"
     r"|network is unreachable"
     r"|temporary failure"

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -470,15 +470,16 @@ def get_target_branch() -> str | None:
 
 
 # Substrings (matched case-insensitively against gh's stderr) that identify
-# transient failures worth retrying: server errors (HTTP 5xx), rate limiting
-# (HTTP 429), and dropped or failed connections. Permanent failures (bad
-# auth, missing PR, the 300-file diff limit) never match so callers see them
-# immediately.
+# transient failures worth retrying: server errors (HTTP 5xx) and dropped or
+# failed connections. Permanent failures (bad auth, missing PR, the 300-file
+# diff limit) never match so callers see them immediately. Phrases are
+# anchored so gh's GraphQL "Could not resolve to a PullRequest" (a missing
+# PR) never classifies as a DNS failure.
 _TRANSIENT_GH_ERROR_RE = re.compile(
-    r"http (?:5\d\d|429)"
+    r"http 5\d\d"
     r"|timed out|timeout"
     r"|connection (?:reset|refused|closed)"
-    r"|no such host|could not resolve"
+    r"|no such host|could not resolve host"
     r"|failed to verify certificate"
     r"|unexpected eof"
     r"|network is unreachable"
@@ -490,11 +491,16 @@ _TRANSIENT_GH_ERROR_RE = re.compile(
 _GH_MAX_ATTEMPTS = 3
 
 
-def run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+def run_gh_command(
+    args: list[str], *, retry: bool = True
+) -> subprocess.CompletedProcess[str]:
     """Run a gh CLI command, retrying transient network and server failures.
 
     Args:
         args: Full command line, including the leading "gh".
+        retry: Pass False for commands that are not idempotent (e.g. posting
+            a comment), where a retry after a dropped response could repeat
+            a write that already succeeded server-side.
 
     Returns:
         CompletedProcess with captured text output.
@@ -503,6 +509,7 @@ def run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
         subprocess.CalledProcessError: If the command fails with a permanent
             error, or is still failing after the retries are exhausted.
     """
+    attempts = _GH_MAX_ATTEMPTS if retry else 1
     attempt = 0
     while True:
         try:
@@ -512,14 +519,12 @@ def run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
         except subprocess.CalledProcessError as err:
             attempt += 1
             stderr = err.stderr or ""
-            if attempt >= _GH_MAX_ATTEMPTS or not _TRANSIENT_GH_ERROR_RE.search(
-                stderr.lower()
-            ):
+            if attempt >= attempts or not _TRANSIENT_GH_ERROR_RE.search(stderr.lower()):
                 raise
             delay = 2**attempt
             print(
                 f"WARNING: {' '.join(args)} failed: {stderr.strip()}; "
-                f"retrying in {delay}s (attempt {attempt}/{_GH_MAX_ATTEMPTS})",
+                f"retrying in {delay}s (attempt {attempt}/{attempts})",
                 file=sys.stderr,
             )
             time.sleep(delay)

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -481,7 +481,11 @@ _TRANSIENT_GH_ERROR_RE = re.compile(
     r"|connection (?:reset|refused|closed)"
     r"|no such host|could not resolve host"
     r"|failed to verify certificate"
+    # Go reports a server-closed connection as 'Post "<url>": EOF'; the
+    # quote-and-colon anchor keeps a URL or message body containing the
+    # letters from matching
     r"|unexpected eof"
+    r'|": eof'
     r"|network is unreachable"
     r"|temporary failure"
 )
@@ -522,8 +526,10 @@ def run_gh_command(
             if attempt >= attempts or not _TRANSIENT_GH_ERROR_RE.search(stderr.lower()):
                 raise
             delay = 2**attempt
+            # Only the leading arguments: comment-update calls carry the
+            # whole multi-KB comment body in the argument list
             print(
-                f"WARNING: {' '.join(args)} failed: {stderr.strip()}; "
+                f"WARNING: {' '.join(args[:3])} failed: {stderr.strip()}; "
                 f"retrying in {delay}s (attempt {attempt}/{attempts})",
                 file=sys.stderr,
             )

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -469,6 +469,61 @@ def get_target_branch() -> str | None:
     return None
 
 
+# Substrings (matched case-insensitively against gh's stderr) that identify
+# transient failures worth retrying: server errors (HTTP 5xx), rate limiting
+# (HTTP 429), and dropped or failed connections. Permanent failures (bad
+# auth, missing PR, the 300-file diff limit) never match so callers see them
+# immediately.
+_TRANSIENT_GH_ERROR_RE = re.compile(
+    r"http (?:5\d\d|429)"
+    r"|timed out|timeout"
+    r"|connection (?:reset|refused|closed)"
+    r"|no such host|could not resolve"
+    r"|unexpected eof"
+    r"|network is unreachable"
+    r"|temporary failure"
+)
+
+# Same retry policy as git network commands in esphome/git.py: 3 attempts
+# with 2s/4s backoff.
+_GH_MAX_ATTEMPTS = 3
+
+
+def run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a gh CLI command, retrying transient network and server failures.
+
+    Args:
+        args: Full command line, including the leading "gh".
+
+    Returns:
+        CompletedProcess with captured text output.
+
+    Raises:
+        subprocess.CalledProcessError: If the command fails with a permanent
+            error, or is still failing after the retries are exhausted.
+    """
+    attempt = 0
+    while True:
+        try:
+            return subprocess.run(
+                args, check=True, capture_output=True, text=True, close_fds=False
+            )
+        except subprocess.CalledProcessError as err:
+            attempt += 1
+            stderr = err.stderr or ""
+            if attempt >= _GH_MAX_ATTEMPTS or not _TRANSIENT_GH_ERROR_RE.search(
+                stderr.lower()
+            ):
+                raise
+            delay = 2**attempt
+            print(
+                f"WARNING: {' '.join(args)} failed: {stderr.strip()}; "
+                f"retrying in {delay}s (attempt {attempt}/{_GH_MAX_ATTEMPTS})",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+
 @cache
 def _get_changed_files_github_actions() -> list[str] | None:
     """Get changed files in GitHub Actions environment.
@@ -542,10 +597,22 @@ def changed_files(branch: str | None = None) -> list[str]:
 
 
 def _get_changed_files_from_command(command: list[str]) -> list[str]:
-    """Run a git command to get changed files and return them as a list."""
-    proc = subprocess.run(command, capture_output=True, text=True, check=False)
-    if proc.returncode != 0:
-        raise Exception(f"Command failed: {' '.join(command)}\nstderr: {proc.stderr}")
+    """Run a git or gh command to get changed files and return them as a list."""
+    if command[0] == "gh":
+        try:
+            proc = run_gh_command(command)
+        except subprocess.CalledProcessError as e:
+            raise Exception(
+                f"Command failed: {' '.join(command)}\nstderr: {e.stderr}"
+            ) from e
+    else:
+        proc = subprocess.run(
+            command, capture_output=True, text=True, check=False, close_fds=False
+        )
+        if proc.returncode != 0:
+            raise Exception(
+                f"Command failed: {' '.join(command)}\nstderr: {proc.stderr}"
+            )
 
     changed_files = splitlines_no_ends(proc.stdout)
     cwd = Path.cwd()

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1899,7 +1899,11 @@ def test_run_gh_command_retries_transient_error() -> None:
             "helpers.subprocess.run",
             side_effect=[
                 _gh_error("HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)"),
-                _gh_error("net/http: TLS handshake timeout"),
+                _gh_error(
+                    'Post "https://api.github.com/graphql": tls: failed to verify'
+                    " certificate: x509: certificate is not valid for any names,"
+                    " but wanted to match api.github.com"
+                ),
                 _gh_success(),
             ],
         ) as mock_run,

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1937,7 +1937,12 @@ def test_run_gh_command_gives_up_after_max_attempts() -> None:
     [
         "HTTP 404: Not Found (https://api.github.com/repos/x)",
         "HTTP 401: Bad credentials",
+        "HTTP 403: API rate limit exceeded for installation ID 123.",
         "diff exceeded the maximum number of changed files (300)",
+        (
+            "GraphQL: Could not resolve to a PullRequest with the number of 999999."
+            " (repository.pullRequest)"
+        ),
     ],
 )
 def test_run_gh_command_permanent_error_not_retried(stderr: str) -> None:
@@ -1948,6 +1953,22 @@ def test_run_gh_command_permanent_error_not_retried(stderr: str) -> None:
         pytest.raises(subprocess.CalledProcessError),
     ):
         run_gh_command(["gh", "pr", "diff", "123", "--name-only"])
+
+    mock_run.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+def test_run_gh_command_no_retry_for_non_idempotent_commands() -> None:
+    """retry=False fails on the first error even when it looks transient."""
+    with (
+        patch(
+            "helpers.subprocess.run",
+            side_effect=_gh_error("HTTP 502: 502 Bad Gateway"),
+        ) as mock_run,
+        patch("helpers.time.sleep") as mock_sleep,
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        run_gh_command(["gh", "pr", "comment", "123", "--body", "x"], retry=False)
 
     mock_run.assert_called_once()
     mock_sleep.assert_not_called()

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1901,6 +1901,10 @@ def test_run_gh_command_success() -> None:
             " but wanted to match api.github.com"
         ),
         'Post "https://api.github.com/graphql": EOF',
+        (
+            "error connecting to api.github.com\n"
+            "check your internet connection or https://githubstatus.com"
+        ),
     ],
 )
 def test_run_gh_command_retries_transient_error(second_error: str) -> None:

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -20,6 +20,7 @@ changed_files = helpers.changed_files
 filter_changed = helpers.filter_changed
 get_changed_components = helpers.get_changed_components
 _get_changed_files_from_command = helpers._get_changed_files_from_command
+run_gh_command = helpers.run_gh_command
 _get_pr_number_from_github_env = helpers._get_pr_number_from_github_env
 _get_changed_files_github_actions = helpers._get_changed_files_github_actions
 _filter_changed_ci = helpers._filter_changed_ci
@@ -1872,3 +1873,87 @@ def test_is_validate_only_file(filename: str, expected: bool, tmp_path: Path) ->
 def test_base_python_changed(files: list[str], expected: bool) -> None:
     """Only Python modules directly in esphome/ count as base Python changes."""
     assert helpers.base_python_changed(files) is expected
+
+
+def _gh_error(stderr: str) -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(1, ["gh"], output="", stderr=stderr)
+
+
+def _gh_success(stdout: str = "ok\n") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(["gh"], 0, stdout=stdout, stderr="")
+
+
+def test_run_gh_command_success() -> None:
+    """A successful command returns without retrying."""
+    with patch("helpers.subprocess.run", return_value=_gh_success()) as mock_run:
+        result = run_gh_command(["gh", "pr", "diff", "123", "--name-only"])
+
+    assert result.stdout == "ok\n"
+    mock_run.assert_called_once()
+
+
+def test_run_gh_command_retries_transient_error() -> None:
+    """Transient server errors are retried with 2s/4s backoff."""
+    with (
+        patch(
+            "helpers.subprocess.run",
+            side_effect=[
+                _gh_error("HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)"),
+                _gh_error("net/http: TLS handshake timeout"),
+                _gh_success(),
+            ],
+        ) as mock_run,
+        patch("helpers.time.sleep") as mock_sleep,
+    ):
+        result = run_gh_command(["gh", "pr", "diff", "123", "--name-only"])
+
+    assert result.stdout == "ok\n"
+    assert mock_run.call_count == 3
+    assert [call.args[0] for call in mock_sleep.call_args_list] == [2, 4]
+
+
+def test_run_gh_command_gives_up_after_max_attempts() -> None:
+    """A persistent transient error raises after the third attempt."""
+    with (
+        patch(
+            "helpers.subprocess.run",
+            side_effect=_gh_error("HTTP 503: Service Unavailable"),
+        ) as mock_run,
+        patch("helpers.time.sleep") as mock_sleep,
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        run_gh_command(["gh", "pr", "diff", "123", "--name-only"])
+
+    assert mock_run.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "HTTP 404: Not Found (https://api.github.com/repos/x)",
+        "HTTP 401: Bad credentials",
+        "diff exceeded the maximum number of changed files (300)",
+    ],
+)
+def test_run_gh_command_permanent_error_not_retried(stderr: str) -> None:
+    """Permanent failures raise immediately without any retry."""
+    with (
+        patch("helpers.subprocess.run", side_effect=_gh_error(stderr)) as mock_run,
+        patch("helpers.time.sleep") as mock_sleep,
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        run_gh_command(["gh", "pr", "diff", "123", "--name-only"])
+
+    mock_run.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+def test_get_changed_files_from_command_gh_failure_keeps_stderr() -> None:
+    """Failures from gh surface stderr so callers can detect the 300-file limit."""
+    stderr = "diff exceeded the maximum number of changed files (300)"
+    with (
+        patch("helpers.subprocess.run", side_effect=_gh_error(stderr)),
+        pytest.raises(Exception, match="maximum number of changed files"),
+    ):
+        _get_changed_files_from_command(["gh", "pr", "diff", "123", "--name-only"])

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1892,18 +1892,25 @@ def test_run_gh_command_success() -> None:
     mock_run.assert_called_once()
 
 
-def test_run_gh_command_retries_transient_error() -> None:
+@pytest.mark.parametrize(
+    "second_error",
+    [
+        (
+            'Post "https://api.github.com/graphql": tls: failed to verify'
+            " certificate: x509: certificate is not valid for any names,"
+            " but wanted to match api.github.com"
+        ),
+        'Post "https://api.github.com/graphql": EOF',
+    ],
+)
+def test_run_gh_command_retries_transient_error(second_error: str) -> None:
     """Transient server errors are retried with 2s/4s backoff."""
     with (
         patch(
             "helpers.subprocess.run",
             side_effect=[
                 _gh_error("HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)"),
-                _gh_error(
-                    'Post "https://api.github.com/graphql": tls: failed to verify'
-                    " certificate: x509: certificate is not valid for any names,"
-                    " but wanted to match api.github.com"
-                ),
+                _gh_error(second_error),
                 _gh_success(),
             ],
         ) as mock_run,


### PR DESCRIPTION
# What does this implement/fix?

CI jobs can fail when a `gh` call hits a transient GitHub API error; two recent clang-tidy runs failed because `gh pr diff` got an HTTP 502 in one and a TLS certificate verification error in the other:

- https://github.com/esphome/esphome/actions/runs/31528031820/job/93901345008
- https://github.com/esphome/esphome/actions/runs/31529694374/job/93906684722

This adds a `run_gh_command` wrapper in `script/helpers.py` that retries transient failures (HTTP 5xx, TLS errors, dropped connections) with a 2s backoff, up to 3 attempts, matching the retry policy we already use for git network commands in `esphome/git.py`. Permanent errors such as bad credentials, a missing PR, or the 300 file diff limit still fail immediately so callers can react to them. The changed files lookup and `script/ci_memory_impact_comment.py` now go through the wrapper; posting a new PR comment is not retried since it is not idempotent and a retry after a dropped response could post twice.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
