### PR TITLE
[api] Mark send_message nodiscard so refused frames are never silent

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1538,7 +1538,7 @@ void APIConnection::on_infrared_rf_transmit_raw_timings_request(const InfraredRF
 #if defined(USE_IR_RF) || defined(USE_RADIO_FREQUENCY)
 void APIConnection::send_infrared_rf_receive_event(const InfraredRFReceiveEvent &msg) {
   if (!this->send_message(msg)) {
-    ESP_LOGV(TAG, "IR/RF event dropped, TCP buffer full");
+    ESP_LOGW(TAG, "IR/RF event dropped, TCP buffer full");
   }
 }
 #endif
@@ -1763,7 +1763,7 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
     // disconnect with the reason. Authentication is intentionally not completed.
     this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("Provisioning closed; rejecting connection"));
     if (!this->send_message(resp)) {
-      ESP_LOGV(TAG, "Hello response dropped, TCP buffer full");
+      ESP_LOGW(TAG, "Hello response dropped, TCP buffer full");
     }
     DisconnectRequest req;
     req.reason = enums::DISCONNECT_REASON_PROVISIONING_CLOSED;
@@ -2054,7 +2054,7 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
   resp.success = success;
   resp.error_message = error_message;
   if (!this->send_message(resp)) {
-    ESP_LOGV(TAG, "Action response dropped, TCP buffer full");
+    ESP_LOGW(TAG, "Action response dropped, TCP buffer full");
   }
 }
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
@@ -2067,7 +2067,7 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
   resp.response_data = response_data;
   resp.response_data_len = response_data_len;
   if (!this->send_message(resp)) {
-    ESP_LOGV(TAG, "Action response dropped, TCP buffer full");
+    ESP_LOGW(TAG, "Action response dropped, TCP buffer full");
   }
 }
 #endif  // USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
@@ -2079,7 +2079,7 @@ bool APIConnection::send_homeassistant_action(const HomeassistantActionRequest &
   if (!this->flags_.service_call_subscription)
     return false;
   if (!this->send_message(call)) {
-    ESP_LOGV(TAG, "Action request dropped, TCP buffer full");
+    ESP_LOGW(TAG, "Action request dropped, TCP buffer full");
   }
   return true;
 }
@@ -2089,7 +2089,7 @@ bool APIConnection::send_homeassistant_action(const HomeassistantActionRequest &
 void APIConnection::send_time_request() {
   GetTimeRequest req;
   if (!this->send_message(req)) {
-    ESP_LOGV(TAG, "Time request dropped, TCP buffer full");
+    ESP_LOGW(TAG, "Time request dropped, TCP buffer full");
   }
 }
 #endif  // USE_HOMEASSISTANT_TIME

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -91,8 +91,8 @@ static_assert(ESPHOME_FRIENDLY_NAME_MAX_LEN <= 120, "Update max_data_length for 
 static const char *const TAG = "api.connection";
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_WARN
-void log_dropped_message(const char *tag, const LogString *what) {
-  esp_log_printf_(ESPHOME_LOG_LEVEL_WARN, tag, __LINE__, ESPHOME_LOG_FORMAT("%s dropped, TCP buffer full"),
+void log_dropped_message(const char *tag, int line, const LogString *what) {
+  esp_log_printf_(ESPHOME_LOG_LEVEL_WARN, tag, line, ESPHOME_LOG_FORMAT("%s dropped, TCP buffer full"),
                   LOG_STR_ARG(what));
 }
 #endif
@@ -1545,7 +1545,9 @@ void APIConnection::on_infrared_rf_transmit_raw_timings_request(const InfraredRF
 #if defined(USE_IR_RF) || defined(USE_RADIO_FREQUENCY)
 void APIConnection::send_infrared_rf_receive_event(const InfraredRFReceiveEvent &msg) {
   if (!this->send_message(msg)) {
-    API_LOG_MSG_DROPPED(TAG, "IR/RF event");
+    // V: fires per decoded frame with no subscription gate, so a warning
+    // would flood the congested link it reports on.
+    ESP_LOGV(TAG, "IR/RF event dropped, TCP buffer full");
   }
 }
 #endif
@@ -1590,7 +1592,7 @@ void APIConnection::on_serial_proxy_get_modem_pins_request(const SerialProxyGetM
   resp.instance = msg.instance;
   resp.line_states = proxies[msg.instance]->get_modem_pins();
   if (!this->send_message(resp)) {
-    ESP_LOGV(TAG, "Serial proxy response dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "Serial proxy response");
   }
 }
 
@@ -1624,7 +1626,7 @@ void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
           break;
       }
       if (!this->send_message(resp)) {
-        ESP_LOGV(TAG, "Serial proxy response dropped, TCP buffer full");
+        API_LOG_MSG_DROPPED(TAG, "Serial proxy response");
       }
       break;
     }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1536,7 +1536,11 @@ void APIConnection::on_infrared_rf_transmit_raw_timings_request(const InfraredRF
 #endif
 
 #if defined(USE_IR_RF) || defined(USE_RADIO_FREQUENCY)
-void APIConnection::send_infrared_rf_receive_event(const InfraredRFReceiveEvent &msg) { this->send_message(msg); }
+void APIConnection::send_infrared_rf_receive_event(const InfraredRFReceiveEvent &msg) {
+  if (!this->send_message(msg)) {
+    ESP_LOGV(TAG, "IR/RF event dropped, TCP buffer full");
+  }
+}
 #endif
 
 #ifdef USE_SERIAL_PROXY
@@ -1578,7 +1582,9 @@ void APIConnection::on_serial_proxy_get_modem_pins_request(const SerialProxyGetM
   SerialProxyGetModemPinsResponse resp{};
   resp.instance = msg.instance;
   resp.line_states = proxies[msg.instance]->get_modem_pins();
-  this->send_message(resp);
+  if (!this->send_message(resp)) {
+    ESP_LOGV(TAG, "Serial proxy response dropped, TCP buffer full");
+  }
 }
 
 void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
@@ -1610,7 +1616,9 @@ void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
           resp.status = enums::SERIAL_PROXY_STATUS_ERROR;
           break;
       }
-      this->send_message(resp);
+      if (!this->send_message(resp)) {
+        ESP_LOGV(TAG, "Serial proxy response dropped, TCP buffer full");
+      }
       break;
     }
     default:
@@ -1619,7 +1627,11 @@ void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
   }
 }
 
-void APIConnection::send_serial_proxy_data(const SerialProxyDataReceived &msg) { this->send_message(msg); }
+void APIConnection::send_serial_proxy_data(const SerialProxyDataReceived &msg) {
+  if (!this->send_message(msg)) {
+    ESP_LOGV(TAG, "Serial proxy data dropped, TCP buffer full");
+  }
+}
 #endif
 
 #ifdef USE_INFRARED
@@ -1750,7 +1762,9 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
     // Acknowledge the hello so the client can read the server name, then request
     // disconnect with the reason. Authentication is intentionally not completed.
     this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("Provisioning closed; rejecting connection"));
-    this->send_message(resp);
+    if (!this->send_message(resp)) {
+      ESP_LOGV(TAG, "Hello response dropped, TCP buffer full");
+    }
     DisconnectRequest req;
     req.reason = enums::DISCONNECT_REASON_PROVISIONING_CLOSED;
     return this->send_message(req);
@@ -2039,7 +2053,9 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
   resp.call_id = call_id;
   resp.success = success;
   resp.error_message = error_message;
-  this->send_message(resp);
+  if (!this->send_message(resp)) {
+    ESP_LOGV(TAG, "Action response dropped, TCP buffer full");
+  }
 }
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
 void APIConnection::send_execute_service_response(uint32_t call_id, bool success, StringRef error_message,
@@ -2050,11 +2066,33 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
   resp.error_message = error_message;
   resp.response_data = response_data;
   resp.response_data_len = response_data_len;
-  this->send_message(resp);
+  if (!this->send_message(resp)) {
+    ESP_LOGV(TAG, "Action response dropped, TCP buffer full");
+  }
 }
 #endif  // USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
 #endif  // USE_API_USER_DEFINED_ACTION_RESPONSES
 #endif
+
+#ifdef USE_API_HOMEASSISTANT_SERVICES
+bool APIConnection::send_homeassistant_action(const HomeassistantActionRequest &call) {
+  if (!this->flags_.service_call_subscription)
+    return false;
+  if (!this->send_message(call)) {
+    ESP_LOGV(TAG, "Action request dropped, TCP buffer full");
+  }
+  return true;
+}
+#endif  // USE_API_HOMEASSISTANT_SERVICES
+
+#ifdef USE_HOMEASSISTANT_TIME
+void APIConnection::send_time_request() {
+  GetTimeRequest req;
+  if (!this->send_message(req)) {
+    ESP_LOGV(TAG, "Time request dropped, TCP buffer full");
+  }
+}
+#endif  // USE_HOMEASSISTANT_TIME
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
 void APIConnection::on_homeassistant_action_response(const HomeassistantActionResponse &msg) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -89,6 +89,13 @@ static_assert(ESPHOME_DEVICE_NAME_MAX_LEN <= 31, "Update max_data_length for nam
 static_assert(ESPHOME_FRIENDLY_NAME_MAX_LEN <= 120, "Update max_data_length for friendly_name in api.proto");
 
 static const char *const TAG = "api.connection";
+
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_WARN
+void log_dropped_message(const char *tag, const LogString *what) {
+  esp_log_printf_(ESPHOME_LOG_LEVEL_WARN, tag, __LINE__, ESPHOME_LOG_FORMAT("%s dropped, TCP buffer full"),
+                  LOG_STR_ARG(what));
+}
+#endif
 #ifdef USE_CAMERA
 static const int CAMERA_STOP_STREAM = 5000;
 #endif
@@ -1538,7 +1545,7 @@ void APIConnection::on_infrared_rf_transmit_raw_timings_request(const InfraredRF
 #if defined(USE_IR_RF) || defined(USE_RADIO_FREQUENCY)
 void APIConnection::send_infrared_rf_receive_event(const InfraredRFReceiveEvent &msg) {
   if (!this->send_message(msg)) {
-    ESP_LOGW(TAG, "IR/RF event dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "IR/RF event");
   }
 }
 #endif
@@ -1763,7 +1770,7 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
     // disconnect with the reason. Authentication is intentionally not completed.
     this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("Provisioning closed; rejecting connection"));
     if (!this->send_message(resp)) {
-      ESP_LOGW(TAG, "Hello response dropped, TCP buffer full");
+      API_LOG_MSG_DROPPED(TAG, "Hello response");
     }
     DisconnectRequest req;
     req.reason = enums::DISCONNECT_REASON_PROVISIONING_CLOSED;
@@ -2054,7 +2061,7 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
   resp.success = success;
   resp.error_message = error_message;
   if (!this->send_message(resp)) {
-    ESP_LOGW(TAG, "Action response dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "Action response");
   }
 }
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
@@ -2067,7 +2074,7 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
   resp.response_data = response_data;
   resp.response_data_len = response_data_len;
   if (!this->send_message(resp)) {
-    ESP_LOGW(TAG, "Action response dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "Action response");
   }
 }
 #endif  // USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
@@ -2079,7 +2086,7 @@ bool APIConnection::send_homeassistant_action(const HomeassistantActionRequest &
   if (!this->flags_.service_call_subscription)
     return false;
   if (!this->send_message(call)) {
-    ESP_LOGW(TAG, "Action request dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "Action request");
   }
   return true;
 }
@@ -2089,7 +2096,7 @@ bool APIConnection::send_homeassistant_action(const HomeassistantActionRequest &
 void APIConnection::send_time_request() {
   GetTimeRequest req;
   if (!this->send_message(req)) {
-    ESP_LOGW(TAG, "Time request dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "Time request");
   }
 }
 #endif  // USE_HOMEASSISTANT_TIME

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -25,6 +25,7 @@
 #include "esphome/components/esp8266/crash_handler.h"
 #endif
 #include "esphome/core/entity_base.h"
+#include "esphome/core/log.h"
 #include "esphome/core/string_ref.h"
 
 #include <functional>
@@ -44,8 +45,8 @@ class APIServer;
 // fails as soon as the TCP buffer is full, and each caller only pays for its
 // short name. The guard drops the helper and its arguments below WARN.
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_WARN
-void log_dropped_message(const char *tag, const LogString *what);
-#define API_LOG_MSG_DROPPED(tag, what) esphome::api::log_dropped_message(tag, LOG_STR(what))
+void log_dropped_message(const char *tag, int line, const LogString *what);
+#define API_LOG_MSG_DROPPED(tag, what) esphome::api::log_dropped_message(tag, __LINE__, LOG_STR(what))
 #else
 #define API_LOG_MSG_DROPPED(tag, what)
 #endif

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -169,12 +169,7 @@ class APIConnection final : public APIServerConnectionBase {
   // Returns whether this client has subscribed to Home Assistant actions; the message
   // is only handed to the send path when subscribed. A true return does not guarantee
   // delivery - it lets the caller warn when no connected client has the subscription.
-  bool send_homeassistant_action(const HomeassistantActionRequest &call) {
-    if (!this->flags_.service_call_subscription)
-      return false;
-    this->send_message(call);
-    return true;
-  }
+  bool send_homeassistant_action(const HomeassistantActionRequest &call);
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
   void on_homeassistant_action_response(const HomeassistantActionResponse &msg);
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
@@ -198,10 +193,7 @@ class APIConnection final : public APIServerConnectionBase {
 
 #endif
 #ifdef USE_HOMEASSISTANT_TIME
-  void send_time_request() {
-    GetTimeRequest req;
-    this->send_message(req);
-  }
+  void send_time_request();
 #endif
 
 #ifdef USE_VOICE_ASSISTANT
@@ -337,7 +329,9 @@ class APIConnection final : public APIServerConnectionBase {
   // Function pointer type for type-erased size calculation
   using CalculateSizeFn = uint32_t (*)(const void *);
 
-  template<typename T> bool send_message(const T &msg) {
+  /// Returns false as soon as the TCP buffer is full. Marked nodiscard so we
+  /// have no silent failures: every caller must handle (or log) a refusal.
+  template<typename T> [[nodiscard]] bool send_message(const T &msg) {
     if constexpr (T::ESTIMATED_SIZE == 0) {
       return this->send_message_(0, T::MESSAGE_TYPE, &encode_msg_noop, &msg);
     } else {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -40,6 +40,16 @@ namespace esphome::api {
 // Forward-declared to break the api_server.h cycle; full-type inlines are in api_connection_buffer.h.
 class APIServer;
 
+// One shared flash string for every refused-frame warning: send_message()
+// fails as soon as the TCP buffer is full, and each caller only pays for its
+// short name. The guard drops the helper and its arguments below WARN.
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_WARN
+void log_dropped_message(const char *tag, const LogString *what);
+#define API_LOG_MSG_DROPPED(tag, what) esphome::api::log_dropped_message(tag, LOG_STR(what))
+#else
+#define API_LOG_MSG_DROPPED(tag, what)
+#endif
+
 // Keepalive timeout in milliseconds
 static constexpr uint32_t KEEPALIVE_TIMEOUT_MS = 60000;
 // Maximum number of entities to process in a single batch during initial state/info sending

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -124,7 +124,7 @@ void APIServer::setup() {
         // client still learns the window is closed when it reconnects (rejected at
         // hello) or via the socket close.
         if (!c->send_message(req)) {
-          ESP_LOGV(TAG, "Disconnect request dropped, TCP buffer full");
+          ESP_LOGW(TAG, "Disconnect request dropped, TCP buffer full");
         }
       }
     });
@@ -582,7 +582,7 @@ bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString 
       for (auto &c : this->active_clients()) {
         DisconnectRequest req;
         if (!c->send_message(req)) {
-          ESP_LOGV(TAG, "Disconnect request dropped, TCP buffer full");
+          ESP_LOGW(TAG, "Disconnect request dropped, TCP buffer full");
         }
       }
     });

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -123,7 +123,9 @@ void APIServer::setup() {
         // Best-effort: if the send buffer is full the reason is dropped, but the
         // client still learns the window is closed when it reconnects (rejected at
         // hello) or via the socket close.
-        c->send_message(req);
+        if (!c->send_message(req)) {
+          ESP_LOGV(TAG, "Disconnect request dropped, TCP buffer full");
+        }
       }
     });
   }
@@ -394,8 +396,11 @@ void APIServer::on_update(update::UpdateEntity *obj) {
 void APIServer::on_zwave_proxy_request(const ZWaveProxyRequest &msg) {
   // We could add code to manage a second subscription type, but, since this message type is
   //  very infrequent and small, we simply send it to all clients
-  for (auto &c : this->active_clients())
-    c->send_message(msg);
+  for (auto &c : this->active_clients()) {
+    if (!c->send_message(msg)) {
+      ESP_LOGV(TAG, "Z-Wave frame dropped, TCP buffer full");
+    }
+  }
 }
 #endif
 
@@ -576,7 +581,9 @@ bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString 
       ESP_LOGW(TAG, "Disconnecting all clients to reset PSK");
       for (auto &c : this->active_clients()) {
         DisconnectRequest req;
-        c->send_message(req);
+        if (!c->send_message(req)) {
+          ESP_LOGV(TAG, "Disconnect request dropped, TCP buffer full");
+        }
       }
     });
   }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -124,7 +124,7 @@ void APIServer::setup() {
         // client still learns the window is closed when it reconnects (rejected at
         // hello) or via the socket close.
         if (!c->send_message(req)) {
-          ESP_LOGW(TAG, "Disconnect request dropped, TCP buffer full");
+          API_LOG_MSG_DROPPED(TAG, "Disconnect request");
         }
       }
     });
@@ -582,7 +582,7 @@ bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString 
       for (auto &c : this->active_clients()) {
         DisconnectRequest req;
         if (!c->send_message(req)) {
-          ESP_LOGW(TAG, "Disconnect request dropped, TCP buffer full");
+          API_LOG_MSG_DROPPED(TAG, "Disconnect request");
         }
       }
     });

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -398,7 +398,7 @@ void APIServer::on_zwave_proxy_request(const ZWaveProxyRequest &msg) {
   //  very infrequent and small, we simply send it to all clients
   for (auto &c : this->active_clients()) {
     if (!c->send_message(msg)) {
-      ESP_LOGV(TAG, "Z-Wave frame dropped, TCP buffer full");
+      API_LOG_MSG_DROPPED(TAG, "Home ID notification");
     }
   }
 }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -150,8 +150,12 @@ void BluetoothProxy::handle_gatt_not_connected_(uint64_t address, uint16_t handl
 }
 #endif
 
-void BluetoothProxy::log_advertisement_flush_() {
-  ESP_LOGV(TAG, "Sent batch of %u BLE advertisements", this->response_.advertisements_len);
+void BluetoothProxy::log_advertisement_flush_(bool sent) {
+  if (sent) {
+    ESP_LOGV(TAG, "Sent batch of %u BLE advertisements", this->response_.advertisements_len);
+  } else {
+    ESP_LOGV(TAG, "Batch of %u BLE advertisements dropped, TCP buffer full", this->response_.advertisements_len);
+  }
 }
 
 void BluetoothProxy::dump_config() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -234,16 +234,15 @@ class BluetoothProxy final : public Component {
   void flush_pending_advertisements_() {
     if (this->response_.advertisements_len == 0)
       return;
-    // The one deliberately ignored result: advertisements are perishable and
-    // this is the highest-frequency send here, so reporting each drop would be
-    // the flood the batch pacing exists to avoid.
-    this->api_connection_->send_message(this->response_);
+    // Perishable and the highest-frequency send here: a drop only reports at
+    // V, anything louder would be the flood the batch pacing exists to avoid.
+    [[maybe_unused]] bool sent = this->api_connection_->send_message(this->response_);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-    this->log_advertisement_flush_();
+    this->log_advertisement_flush_(sent);
 #endif
     this->response_.advertisements_len = 0;
   }
-  void log_advertisement_flush_();
+  void log_advertisement_flush_(bool sent);
 
 #ifdef USE_BLUETOOTH_PROXY_CONNECTIONS
   BluetoothConnection *get_connection_(uint64_t address, bool reserve);

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -480,7 +480,7 @@ void VoiceAssistant::loop() {
           api::VoiceAssistantAnnounceFinished msg;
           msg.success = true;
           if (!this->api_client_->send_message(msg)) {
-            ESP_LOGW(TAG, "Announce-finished dropped, TCP buffer full");
+            API_LOG_MSG_DROPPED(TAG, "Announce-finished");
           }
           break;
         }
@@ -746,7 +746,7 @@ void VoiceAssistant::signal_stop_() {
   api::VoiceAssistantRequest msg;
   msg.start = false;
   if (!this->api_client_->send_message(msg)) {
-    ESP_LOGW(TAG, "Stop request dropped, TCP buffer full");
+    API_LOG_MSG_DROPPED(TAG, "Stop request");
   }
 }
 
@@ -760,7 +760,7 @@ void VoiceAssistant::start_playback_timeout_() {
     api::VoiceAssistantAnnounceFinished msg;
     msg.success = true;
     if (!this->api_client_->send_message(msg)) {
-      ESP_LOGW(TAG, "Announce-finished dropped, TCP buffer full");
+      API_LOG_MSG_DROPPED(TAG, "Announce-finished");
     }
   });
 }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -480,7 +480,7 @@ void VoiceAssistant::loop() {
           api::VoiceAssistantAnnounceFinished msg;
           msg.success = true;
           if (!this->api_client_->send_message(msg)) {
-            ESP_LOGV(TAG, "Announce-finished dropped, TCP buffer full");
+            ESP_LOGW(TAG, "Announce-finished dropped, TCP buffer full");
           }
           break;
         }
@@ -746,7 +746,7 @@ void VoiceAssistant::signal_stop_() {
   api::VoiceAssistantRequest msg;
   msg.start = false;
   if (!this->api_client_->send_message(msg)) {
-    ESP_LOGV(TAG, "Stop request dropped, TCP buffer full");
+    ESP_LOGW(TAG, "Stop request dropped, TCP buffer full");
   }
 }
 
@@ -760,7 +760,7 @@ void VoiceAssistant::start_playback_timeout_() {
     api::VoiceAssistantAnnounceFinished msg;
     msg.success = true;
     if (!this->api_client_->send_message(msg)) {
-      ESP_LOGV(TAG, "Announce-finished dropped, TCP buffer full");
+      ESP_LOGW(TAG, "Announce-finished dropped, TCP buffer full");
     }
   });
 }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -248,7 +248,9 @@ void VoiceAssistant::stream_api_audio_() {
       msg.data2_len = available2;
     }
 
-    this->api_client_->send_message(msg);
+    if (!this->api_client_->send_message(msg)) {
+      ESP_LOGV(TAG, "Audio frame dropped, TCP buffer full");
+    }
 
     this->audio_source_->consume(available);
     if (this->audio_source2_ != nullptr) {
@@ -477,7 +479,9 @@ void VoiceAssistant::loop() {
 
           api::VoiceAssistantAnnounceFinished msg;
           msg.success = true;
-          this->api_client_->send_message(msg);
+          if (!this->api_client_->send_message(msg)) {
+            ESP_LOGV(TAG, "Announce-finished dropped, TCP buffer full");
+          }
           break;
         }
       }
@@ -741,7 +745,9 @@ void VoiceAssistant::signal_stop_() {
   ESP_LOGD(TAG, "Signaling stop");
   api::VoiceAssistantRequest msg;
   msg.start = false;
-  this->api_client_->send_message(msg);
+  if (!this->api_client_->send_message(msg)) {
+    ESP_LOGV(TAG, "Stop request dropped, TCP buffer full");
+  }
 }
 
 void VoiceAssistant::start_playback_timeout_() {
@@ -753,7 +759,9 @@ void VoiceAssistant::start_playback_timeout_() {
       return;
     api::VoiceAssistantAnnounceFinished msg;
     msg.success = true;
-    this->api_client_->send_message(msg);
+    if (!this->api_client_->send_message(msg)) {
+      ESP_LOGV(TAG, "Announce-finished dropped, TCP buffer full");
+    }
   });
 }
 

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -166,7 +166,9 @@ void ZWaveProxy::process_uart_slow_() {
           // If this is a data frame, use frame length indicator + 2 (for SoF + checksum), else assume 1 for ACK/NAK/CAN
           this->outgoing_proto_msg_.data_len = this->buffer_[0] == ZWAVE_FRAME_TYPE_START ? this->buffer_[1] + 2 : 1;
         }
-        this->api_connection_->send_message(this->outgoing_proto_msg_);
+        if (!this->api_connection_->send_message(this->outgoing_proto_msg_)) {
+          ESP_LOGV(TAG, "Frame dropped, TCP buffer full");
+        }
       }
     }
   } while (this->available());
@@ -328,7 +330,9 @@ void ZWaveProxy::send_homeid_changed_msg_(api::APIConnection *conn) {
   msg.data_len = this->home_id_.size();
   if (conn != nullptr) {
     // Send to specific connection
-    conn->send_message(msg);
+    if (!conn->send_message(msg)) {
+      ESP_LOGV(TAG, "Home ID notification dropped, TCP buffer full");
+    }
   } else if (api::global_api_server != nullptr) {
     // We could add code to manage a second subscription type, but, since this message is
     //  very infrequent and small, we simply send it to all clients
@@ -483,7 +487,9 @@ void ZWaveProxy::parse_start_(uint8_t byte) {
     this->buffer_[0] = byte;
     this->outgoing_proto_msg_.data = this->buffer_.data();
     this->outgoing_proto_msg_.data_len = 1;
-    this->api_connection_->send_message(this->outgoing_proto_msg_);
+    if (!this->api_connection_->send_message(this->outgoing_proto_msg_)) {
+      ESP_LOGV(TAG, "Frame dropped, TCP buffer full");
+    }
   }
 }
 

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -331,7 +331,7 @@ void ZWaveProxy::send_homeid_changed_msg_(api::APIConnection *conn) {
   if (conn != nullptr) {
     // Send to specific connection
     if (!conn->send_message(msg)) {
-      ESP_LOGV(TAG, "Home ID notification dropped, TCP buffer full");
+      API_LOG_MSG_DROPPED(TAG, "Home ID notification");
     }
   } else if (api::global_api_server != nullptr) {
     // We could add code to manage a second subscription type, but, since this message is


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18281. `send_message()` fails as soon as the TCP buffer is full, and a discarded result is a silently lost message; that class of bug is what the #18221 latch work spent five PRs cleaning up. The method is now `[[nodiscard]]`, so the compiler flags every new caller that ignores a refusal.

The remaining call sites that discarded the result now log the drop. One-off messages that are never resent warn at `ESP_LOGW`: action requests and responses, time requests, IR/RF events, the provisioning and PSK-reset disconnect replies, and the voice assistant control messages. High-rate streaming paths log at `ESP_LOGV` so a congested link does not flood: serial proxy, Z-Wave proxy, voice assistant audio frames and the advertisement batch flush. None of these gain retry behaviour here; the point is that a refused frame is never invisible. The two inline senders in the header move to the .cpp so they can log. External components that discard the result will see a new unused-result compiler warning; firmware builds do not use -Werror, so nothing breaks.

Builds on the GATT and advertisement-only proxy arms, voice_assistant, zwave_proxy, serial_proxy, ir_rf_proxy, provisioning, homeassistant and the host api target.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18277

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
api:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

