### PR TITLE
[api] Move the generic buffer-full log to very verbose

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2177,8 +2177,9 @@ bool APIConnection::try_to_clear_buffer_slow_(bool log_out_of_space) {
   if (this->helper_->can_write_without_blocking())
     return true;
   if (log_out_of_space) {
-    // VV: every refused send_message() call site reports its own drop with
-    // what was lost, so this generic line only adds a duplicate per refusal.
+    // VV: refusals are either reported by the sending call site (naming what
+    // was lost) or retried without loss (the deferred batch), so this generic
+    // line only duplicates them.
     ESP_LOGVV(TAG, "Cannot send message because of TCP buffer space");
   }
   return false;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2177,7 +2177,9 @@ bool APIConnection::try_to_clear_buffer_slow_(bool log_out_of_space) {
   if (this->helper_->can_write_without_blocking())
     return true;
   if (log_out_of_space) {
-    ESP_LOGV(TAG, "Cannot send message because of TCP buffer space");
+    // VV: every refused send_message() call site reports its own drop with
+    // what was lost, so this generic line only adds a duplicate per refusal.
+    ESP_LOGVV(TAG, "Cannot send message because of TCP buffer space");
   }
   return false;
 }


### PR DESCRIPTION
# What does this implement/fix?

With #18293 every refused `send_message()` call site reports its own drop, naming what was lost; the api layer's generic "Cannot send message because of TCP buffer space" line then only duplicates each refusal, and under congestion it fires several times per loop pass, drowning the specific reports between it:

```
[V][api.connection:2180]: Cannot send message because of TCP buffer space
[V][bluetooth_proxy:159]: Batch of 16 BLE advertisements dropped, TCP buffer full
[V][api.connection:2180]: Cannot send message because of TCP buffer space
[V][bluetooth_proxy:756]: Connections-free update deferred, TCP buffer full
```

It moves to very verbose; the per-site reports carry the signal at verbose and warning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/18277

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
api:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

