### PR TITLE
[bluetooth_proxy] Give partial advertisement batches 200ms to fill on Wi-Fi

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -688,8 +688,8 @@ void BluetoothProxy::loop() {
     this->adv_flush_toggle_ = true;
   }
 #else
-  // No Wi-Fi in the build (ethernet, openthread): no airtime worth trading
-  // latency for, so partial batches flush every tick.
+  // No Wi-Fi in the build (ethernet): no airtime worth trading latency for,
+  // so partial batches flush every tick.
   this->flush_pending_advertisements_();
 #endif
 }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -672,9 +672,14 @@ void BluetoothProxy::loop() {
   }
 #endif
 
-  // Every other non-empty 100 ms tick (~200 ms): gives partial batches time
-  // to fill toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so the link is
-  // fed fewer, fuller frames. Full batches still ship immediately from the
+#ifdef USE_ETHERNET
+  // Wired uplink: no airtime or congestion worth trading latency for, so
+  // partial batches flush every tick.
+  this->flush_pending_advertisements_();
+#else
+  // Wi-Fi: every other non-empty 100 ms tick (~200 ms) gives partial batches
+  // time to fill toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so the air
+  // gets fewer, fuller frames. Full batches still ship immediately from the
   // queueing path, and the owed-reply drains above keep the 100 ms cadence.
   if (this->response_.advertisements_len != 0) {
     if (this->adv_flush_toggle_) {
@@ -685,6 +690,7 @@ void BluetoothProxy::loop() {
     // Idle: arm so the first batch after a gap ships on the next tick.
     this->adv_flush_toggle_ = true;
   }
+#endif
 }
 
 void BluetoothProxy::reset_owed_replies_() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -672,13 +672,17 @@ void BluetoothProxy::loop() {
   }
 #endif
 
-  // Every other 100 ms tick (~200 ms): gives partial batches time to fill
-  // toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so congestion is fed
-  // fewer, fuller frames. Full batches still ship immediately from the
-  // queueing path; the owed-reply drains above keep the 100 ms cadence.
-  this->adv_flush_toggle_ = !this->adv_flush_toggle_;
-  if (this->adv_flush_toggle_) {
-    this->flush_pending_advertisements_();
+  // Every other non-empty 100 ms tick (~200 ms): gives partial batches time
+  // to fill toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so the link is
+  // fed fewer, fuller frames. Full batches still ship immediately from the
+  // queueing path, the owed-reply drains above keep the 100 ms cadence, and
+  // empty ticks leave the phase alone so the first advertisement after an
+  // idle gap ships on the next tick instead of paying the worst case.
+  if (this->response_.advertisements_len != 0) {
+    this->adv_flush_toggle_ = !this->adv_flush_toggle_;
+    if (this->adv_flush_toggle_) {
+      this->flush_pending_advertisements_();
+    }
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -684,7 +684,8 @@ void BluetoothProxy::loop() {
     }
     this->adv_flush_toggle_ = !this->adv_flush_toggle_;
   } else {
-    // Idle: arm so the first batch after a gap ships on the next tick.
+    // Nothing pending (idle, or a full batch just shipped inline): arm so
+    // the next batch ships on the next tick.
     this->adv_flush_toggle_ = true;
   }
 #else

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -675,14 +675,15 @@ void BluetoothProxy::loop() {
   // Every other non-empty 100 ms tick (~200 ms): gives partial batches time
   // to fill toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so the link is
   // fed fewer, fuller frames. Full batches still ship immediately from the
-  // queueing path, the owed-reply drains above keep the 100 ms cadence, and
-  // empty ticks leave the phase alone so the first advertisement after an
-  // idle gap ships on the next tick instead of paying the worst case.
+  // queueing path, and the owed-reply drains above keep the 100 ms cadence.
   if (this->response_.advertisements_len != 0) {
-    this->adv_flush_toggle_ = !this->adv_flush_toggle_;
     if (this->adv_flush_toggle_) {
       this->flush_pending_advertisements_();
     }
+    this->adv_flush_toggle_ = !this->adv_flush_toggle_;
+  } else {
+    // Idle: arm so the first batch after a gap ships on the next tick.
+    this->adv_flush_toggle_ = true;
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -672,15 +672,12 @@ void BluetoothProxy::loop() {
   }
 #endif
 
-#ifdef USE_ETHERNET
-  // Wired uplink: no airtime or congestion worth trading latency for, so
-  // partial batches flush every tick.
-  this->flush_pending_advertisements_();
-#else
-  // Wi-Fi: every other non-empty 100 ms tick (~200 ms) gives partial batches
-  // time to fill toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so the air
-  // gets fewer, fuller frames. Full batches still ship immediately from the
-  // queueing path, and the owed-reply drains above keep the 100 ms cadence.
+#ifdef USE_WIFI
+  // Wi-Fi (or a coexistence build that can fall back to it): every other
+  // non-empty 100 ms tick (~200 ms) gives partial batches time to fill
+  // toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so the air gets fewer,
+  // fuller frames. Full batches still ship immediately from the queueing
+  // path, and the owed-reply drains above keep the 100 ms cadence.
   if (this->response_.advertisements_len != 0) {
     if (this->adv_flush_toggle_) {
       this->flush_pending_advertisements_();
@@ -690,6 +687,10 @@ void BluetoothProxy::loop() {
     // Idle: arm so the first batch after a gap ships on the next tick.
     this->adv_flush_toggle_ = true;
   }
+#else
+  // No Wi-Fi in the build (ethernet, openthread): no airtime worth trading
+  // latency for, so partial batches flush every tick.
+  this->flush_pending_advertisements_();
 #endif
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -672,7 +672,14 @@ void BluetoothProxy::loop() {
   }
 #endif
 
-  this->flush_pending_advertisements_();
+  // Every other 100 ms tick (~200 ms): gives partial batches time to fill
+  // toward BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE, so congestion is fed
+  // fewer, fuller frames. Full batches still ship immediately from the
+  // queueing path; the owed-reply drains above keep the 100 ms cadence.
+  this->adv_flush_toggle_ = !this->adv_flush_toggle_;
+  if (this->adv_flush_toggle_) {
+    this->flush_pending_advertisements_();
+  }
 }
 
 void BluetoothProxy::reset_owed_replies_() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -348,6 +348,8 @@ class BluetoothProxy final : public Component {
   uint8_t connection_count_{0};
 #endif
   bool configured_scan_active_{false};  // Configured scan mode from YAML
+  /// Halves the timer flush rate to ~200 ms (see loop()).
+  bool adv_flush_toggle_{false};
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   // A dropped push (full TX buffer) is re-queried from the hub and resent
   // from loop(); the hub's current state is idempotent by construction.

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -348,8 +348,10 @@ class BluetoothProxy final : public Component {
   uint8_t connection_count_{0};
 #endif
   bool configured_scan_active_{false};  // Configured scan mode from YAML
-#ifndef USE_ETHERNET
-  /// Halves the Wi-Fi timer flush rate to ~200 ms (see loop()).
+#ifdef USE_WIFI
+  /// Wi-Fi only: flush on every other non-empty tick (~200 ms) so partial
+  /// batches fill; an idle tick re-arms, so the first batch after a gap
+  /// still ships on the next tick. See loop().
   bool adv_flush_toggle_{false};
 #endif
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -348,8 +348,10 @@ class BluetoothProxy final : public Component {
   uint8_t connection_count_{0};
 #endif
   bool configured_scan_active_{false};  // Configured scan mode from YAML
-  /// Halves the timer flush rate to ~200 ms (see loop()).
+#ifndef USE_ETHERNET
+  /// Halves the Wi-Fi timer flush rate to ~200 ms (see loop()).
   bool adv_flush_toggle_{false};
+#endif
 #ifdef USE_BLE_SCANNER_STATE_CALLBACK
   // A dropped push (full TX buffer) is re-queried from the hub and resent
   // from loop(); the hub's current state is idempotent by construction.


### PR DESCRIPTION
# What does this implement/fix?

Under load the 100 ms timer flush ships advertisement batches 1 to 15 deep, so the air gets many partial frames:

```
[V][bluetooth_proxy:159]: Batch of 7 BLE advertisements dropped, TCP buffer full
[V][bluetooth_proxy:159]: Batch of 5 BLE advertisements dropped, TCP buffer full
[V][bluetooth_proxy:159]: Batch of 1 BLE advertisements dropped, TCP buffer full
```

When the build has Wi-Fi the timer flush now runs on every other non-empty 100 ms tick, giving partial batches ~200 ms to fill toward the batch size; the same traffic ships in fewer, fuller frames. Builds without Wi-Fi keep the 100 ms flush, since a wired uplink has no airtime or congestion worth trading latency for; gating on the Wi-Fi define rather than the ethernet one means a coexistence build that can fall back to Wi-Fi also defers.

Full batches still ship immediately from the queueing path, so heavy traffic is not delayed, and the owed-reply drains keep the 100 ms cadence so the retry limits stay calibrated as reviewed. While idle the phase is armed, so the first batch after a gap ships on the next tick rather than paying the worst case. The Wi-Fi deferral is deliberately unconditional rather than congestion-gated: congestion-gating it would restore 100 ms half-full frames as the healthy-path norm, and shipping partial frames on a healthy link is the inefficiency this PR exists to change, not just the congested symptom. Costs one bool in existing padding on Wi-Fi builds; ethernet builds are unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/18221

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed.
bluetooth_proxy:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





