### PR TITLE
[adc] Deprecate pin: TEMPERATURE in favour of internal_temperature

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -231,6 +231,7 @@ def validate_adc_pin(value):
             return pins.internal_gpio_input_pin_schema(29)
         return cv.only_on([PLATFORM_ESP8266])("VCC")
 
+    # Deprecated in favour of the `internal_temperature` platform, remove before 2027.2.0
     if str(value).upper() == "TEMPERATURE":
         return cv.only_on_rp2("TEMPERATURE")
 

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -67,6 +67,13 @@ def validate_config(config):
         # Alter value here so `config` command prints the recommended change
         config[CONF_ATTENUATION] = _attenuation("12db")
 
+    # Remove before 2027.2.0
+    if config[CONF_PIN] == "TEMPERATURE":
+        _LOGGER.warning(
+            "[adc] `pin: TEMPERATURE` is deprecated, use the `internal_temperature` "
+            "sensor platform instead. Will be removed in 2027.2.0"
+        )
+
     return config
 
 
@@ -133,6 +140,7 @@ async def to_code(config):
     if config[CONF_PIN] == "VCC":
         cg.add_define("USE_ADC_SENSOR_VCC")
     elif config[CONF_PIN] == "TEMPERATURE":
+        # Remove before 2027.2.0
         cg.add(var.set_is_temperature())
     elif not CORE.is_nrf52 or config[CONF_PIN][CONF_NUMBER] not in EXTRA_ADC:
         pin = await cg.gpio_pin_expression(config[CONF_PIN])

--- a/tests/component_tests/adc/test_adc_sensor.py
+++ b/tests/component_tests/adc/test_adc_sensor.py
@@ -1,0 +1,32 @@
+"""Tests for the ADC sensor component."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+def test_adc_temperature_pin_is_deprecated(
+    generate_main: Callable[[str | Path], str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`pin: TEMPERATURE` still works, but warns and points at internal_temperature."""
+    main_cpp = generate_main("tests/component_tests/adc/test_adc_sensor.yaml")
+
+    assert "adc_temperature->set_is_temperature();" in main_cpp
+    assert "`pin: TEMPERATURE` is deprecated" in caplog.text
+    assert "internal_temperature" in caplog.text
+    assert "2027.2.0" in caplog.text
+
+
+def test_adc_regular_pin_is_not_deprecated(
+    generate_main: Callable[[str | Path], str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A normal ADC pin does not emit the temperature deprecation warning."""
+    main_cpp = generate_main("tests/component_tests/adc/test_adc_sensor.yaml")
+
+    assert "adc_voltage->set_is_temperature();" not in main_cpp
+    assert caplog.text.count("`pin: TEMPERATURE` is deprecated") == 1

--- a/tests/component_tests/adc/test_adc_sensor.yaml
+++ b/tests/component_tests/adc/test_adc_sensor.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: test
+
+rp2:
+  board: rpipicow
+
+sensor:
+  - platform: adc
+    pin: TEMPERATURE
+    name: Deprecated ADC Temperature
+    id: adc_temperature
+
+  - platform: adc
+    pin: 26
+    name: ADC Voltage
+    id: adc_voltage

--- a/tests/components/adc/validate.rp2040-ard.yaml
+++ b/tests/components/adc/validate.rp2040-ard.yaml
@@ -1,0 +1,7 @@
+# Deprecated `pin: TEMPERATURE`, superseded by the `internal_temperature` platform.
+# Remove before 2027.2.0
+sensor:
+  - id: adc_temperature_sensor
+    platform: adc
+    pin: TEMPERATURE
+    name: ADC Test temperature


### PR DESCRIPTION
# What does this implement/fix?

The `adc` sensor platform accepts `pin: TEMPERATURE` on RP2040/RP2350 to read the chip's internal temperature sensor. That reading comes back as a raw voltage, so every user has to paste a datasheet lambda (`return 27 - (x - 0.706f) / 0.001721f;`) to turn it into degrees Celsius, and the resulting entity is a voltage sensor wearing a temperature costume: wrong device class, wrong unit, wrong state class, unless the user overrides all three by hand.

The `internal_temperature` sensor platform already covers RP2 and does all of that correctly out of the box. This deprecates the ADC pin value and points users at it. `pin: TEMPERATURE` keeps working exactly as before; it now logs a warning during config validation and will be removed in 2027.2.0.

```
WARNING [adc] `pin: TEMPERATURE` is deprecated, use the `internal_temperature` sensor platform instead. Will be removed in 2027.2.0
```

The C++ side is untouched, and the `# Remove before 2027.2.0` comments mark the validation branch and the codegen branch so the eventual cleanup is easy to find.

Migration:

```yaml
# Before
sensor:
  - platform: adc
    pin: TEMPERATURE
    name: "Core Temperature"
    unit_of_measurement: "°C"
    filters:
      - lambda: return 27 - (x - 0.706f) / 0.001721f;

# After
sensor:
  - platform: internal_temperature
    name: "Core Temperature"
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7163

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: internal_temperature
    name: "Core Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
