### PR TITLE
[esp32_ble_tracker] Don't log an error when a scan stop is already in flight

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -199,8 +199,9 @@ void ESP32BLETracker::ble_before_disabled_event_handler() { this->stop_scan_(); 
 
 void ESP32BLETracker::stop_scan_() {
   if (this->scanner_state_ != ScannerState::RUNNING && this->scanner_state_ != ScannerState::FAILED) {
-    // If scanner is already idle, there's nothing to stop - this is not an error
-    if (this->scanner_state_ != ScannerState::IDLE) {
+    // IDLE means there is nothing to stop; STOPPING means a stop is already in
+    // flight and will finish on its own. Neither is an error.
+    if (this->scanner_state_ != ScannerState::IDLE && this->scanner_state_ != ScannerState::STOPPING) {
       ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
     }
     return;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Bluetooth proxies print a scary looking error now and then during normal operation:

```
[14:35:33.082][D][bluetooth_proxy:522]: Setting scanner mode to passive
[14:35:33.085][D][esp32_ble_tracker:193]: Stopping scan.
[14:35:33.089][D][bluetooth_proxy:522]: Setting scanner mode to active
[14:35:33.091][D][esp32_ble_tracker:193]: Stopping scan.
[14:35:33.096][E][esp32_ble_tracker:204]: Cannot stop scan: STOPPING
```

Two scanner mode changes arrived 7 ms apart, and each one calls `stop_scan()`. The first moved the scanner from `RUNNING` to `STOPPING` and asked Bluedroid to stop; the second arrived before that stop finished, so `stop_scan_()` logged an error.

Nothing is wrong here. The scanner is already going where the second caller wants it to go, and that caller's mode still takes effect; `set_scan_active()` runs before `stop_scan()`, and the new scan parameters are read when the pending stop completes and the scan restarts. `IDLE` already had this exemption, added in #12560; `STOPPING` is the second harmless case and was just missed.

`STARTING` keeps the error on purpose. A stop asked for while a start is in flight really is dropped, so that one is a separate problem and should not be quietly hidden here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_tracker:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
