### PR TITLE
[adc] Fix internal temperature channel on RP2350A under arduino-pico

### DIFF
--- a/esphome/components/adc/adc_sensor_rp2.cpp
+++ b/esphome/components/adc/adc_sensor_rp2.cpp
@@ -19,6 +19,25 @@ namespace esphome::adc {
 
 static const char *const TAG = "adc.rp2";
 
+// The on-die temperature sensor sits on the last ADC channel: input 4 on RP2040
+// and RP2350A, but input 8 on RP2350B, which has eight external channels rather
+// than four.
+//
+// This deliberately does not use the SDK's ADC_TEMPERATURE_CHANNEL_NUM. That
+// derives from NUM_ADC_CHANNELS, which <pico.h> settles from a board header, and
+// arduino-pico supplies a fixed B-die one for every RP2350 build. The real die
+// is only declared later, by the variant's pins_arduino.h, so the SDK constant
+// reads 8 on A-die boards. PICO_RP2350A itself is correct by the time this file
+// is compiled, on both arduino-pico and pico-sdk builds.
+#if defined(PICO_RP2350) && !defined(PICO_RP2350A)
+#error "PICO_RP2350A is not defined, so the RP2350 die is unknown and the temperature ADC channel cannot be chosen"
+#endif
+#if defined(PICO_RP2350) && !PICO_RP2350A
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = 8;
+#else
+static constexpr uint8_t TEMPERATURE_ADC_INPUT = 4;
+#endif
+
 void ADCSensor::setup() {
   static bool initialized = false;
   if (!initialized) {
@@ -52,11 +71,7 @@ float ADCSensor::sample() {
   if (this->is_temperature_) {
     adc_set_temp_sensor_enabled(true);
     delay(1);
-    // The on-die temperature sensor sits on the last ADC channel, and which one
-    // that is depends on the chip: input 4 on RP2040 and RP2350A, but input 8 on
-    // RP2350B, which has eight external channels instead of four. The SDK
-    // resolves it for the target being built, so do not hardcode it.
-    adc_select_input(ADC_TEMPERATURE_CHANNEL_NUM);
+    adc_select_input(TEMPERATURE_ADC_INPUT);
 
     for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
       raw = adc_read();


### PR DESCRIPTION
# What does this implement/fix?

PR #18270 switched the RP2 ADC internal temperature reading from a hardcoded `adc_select_input(4)` to `adc_select_input(ADC_TEMPERATURE_CHANNEL_NUM)`. That constant is not reliable under arduino-pico, so instead of fixing the channel selection it moved the breakage from RP2350B to RP2350A (Pico 2 / Pico 2 W):

| | RP2040 | RP2350A (Pico 2 / Pico 2 W) | RP2350B |
|---------------|--------|-----------------------------|---------|
| before #18270 | ok     | ok                          | wrong   |
| after #18270  | ok     | wrong                       | ok      |

`ADC_TEMPERATURE_CHANNEL_NUM` is `(NUM_ADC_CHANNELS - 1)`, and `NUM_ADC_CHANNELS` comes from `hardware/platform_defs.h`, which picks 5 or 9 based on `PICO_RP2350A`. Under arduino-pico that flag is not yet visible at that point. arduino-pico ships a single prebuilt `include/rp2350/pico_base/pico/config_autogen.h` that hardcodes an include of the `solderparty_rp2350_stamp_xl` board header for every RP2350 build, and that header sets `PICO_RP2350A 0` unconditionally because it describes a B-die board. This happens inside the `<pico.h>` chain, so `platform_defs.h` bakes in the B-die channel count and its include guard freezes it. The variant's `pins_arduino.h` only declares the real die afterwards. The result is that `ADC_TEMPERATURE_CHANNEL_NUM` reads 8 even on A-die boards.

The ordering problem is specific to `NUM_ADC_CHANNELS`, not to `PICO_RP2350A` itself. By the time a component `.cpp` is compiled the flag is correct on both toolchains: arduino-pico sets it from the variant's `pins_arduino.h`, and a pico-sdk build sets it from the board header selected through `PICO_BOARD`. So this reads the flag directly and picks the channel from it, which needs no toolchain conditional. This is the same computation arduino-pico itself performs, under the identical condition `#if defined(PICO_RP2350) && !PICO_RP2350A` (`cores/rp2040/Arduino.h`).

The `#error` guard is deliberate. Without it a missing `PICO_RP2350A` would silently select channel 8 and report a wrong temperature, which is the exact failure mode that produced this regression.

Known limitation, unchanged from before: on generic RP2350 boards `PICO_RP2350A` is a build-time menu placeholder that evaluates as 0, yielding channel 8.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes a regression introduced in #18270

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: adc
    pin: TEMPERATURE
    name: Internal Temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
