### PR TITLE
[sendspin] Bump sendspin-cpp to v0.7.2

### DIFF
--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -234,7 +234,7 @@ async def to_code(config: ConfigType) -> None:
         psram.request_external_task_stack()
 
     # sendspin-cpp library
-    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.7.1")
+    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.7.2")
 
     cg.add_define("USE_SENDSPIN", True)  # for MDNS
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -98,7 +98,7 @@ dependencies:
   esp32async/asynctcp:
     version: 3.4.91
   sendspin/sendspin-cpp:
-    version: 0.7.1
+    version: 0.7.2
   lvgl/lvgl:
     version: 9.5.0
   fastled/FastLED:


### PR DESCRIPTION
# What does this implement/fix?

Bumps sendspin-cpp ([GitHub](https://github.com/Sendspin/sendspin-cpp) and [Espressif registry](https://components.espressif.com/components/sendspin/sendspin-cpp/versions/0.7.2/readme)) to v0.7.2 ([changelog](https://github.com/Sendspin/sendspin-cpp/compare/v0.7.1...v0.7.2)).

Fixes an issue where the artwork image's `on_clear` never fired.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

sendspin:
  id: sendspin_hub

image:
  - platform: sendspin
    id: sendspin_cover_art
    format: JPEG
    type: rgb565
    resize: 400x400
    source: ALBUM
    display_offset: 1000ms
    current_image:
      id: sendspin_current_cover_art
    transition_image:
      id: sendspin_previous_cover_art
    on_image_display:
      - if:
          condition:
            lvgl.page.is_showing: media_page
          then:
            # LVGL snapshots the image descriptor when a source is set and does not track the
            # underlying buffer, so both widgets are re-pointed on every display: the top widget
            # at the outgoing frame (covering the bottom), the bottom widget at the new frame.
            # The cover_art_crossfade animation then fades the top widget out, and its on_stop
            # signals transition_finished, which releases the outgoing frame and lets the library
            # deliver the next artwork. The animation sets the starting opacity itself, so the
            # top widget needs no explicit reset here.
            - lvgl.image.update:
                id: outgoing_art
                src: sendspin_previous_cover_art
            - lvgl.image.update:
                id: incoming_art
                src: sendspin_current_cover_art
            # Configure the following animation to fire sendspin.image.transition_finished when done
            - lvgl.animation.start:
                id: cover_art_crossfade
                duration: 2s
          else:
            # First frame or page not open: show it instantly and ack -- every display owes
            # exactly one transition_finished.
            - lvgl.image.update:
                id: incoming_art
                src: sendspin_current_cover_art
            - sendspin.image.transition_finished: sendspin_cover_art
      # Artwork exists again: reveal the widgets a previous clear hid. Safe when
      # already visible, and it must run in BOTH branches above.
      - lvgl.widget.show: incoming_art
      - lvgl.widget.show: outgoing_art
      - lvgl.widget.hide: art_placeholder
    # The track has no album art (or the stream ended). The component deliberately
    # does not touch pixels here; its ArtworkImageView placeholder fallback lives
    # in draw(), which only the classic display: path calls, never LVGL, so an
    # LVGL widget keeps drawing the last decoded frame until this automation hides
    # it. Without this handler the previous album's art stays on screen forever.
    # No transition_finished is owed: a clear self-acks in the component.
    on_image_clear:
      - lvgl.widget.hide: incoming_art
      - lvgl.widget.hide: outgoing_art
      - lvgl.widget.show: art_placeholder
      - logger.log: "Album art cleared"
    on_image_error:
      - logger.log: "Failed to decode cover art image"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
