### PR TITLE
[zephyr_mcumgr] Enable MCUMGR_GRP_OS for UART transport, not just BLE

### DIFF
--- a/esphome/components/zephyr_mcumgr/ota/__init__.py
+++ b/esphome/components/zephyr_mcumgr/ota/__init__.py
@@ -131,13 +131,14 @@ async def to_code(config: ConfigType) -> None:
     zephyr_add_prj_conf("MCUMGR_MGMT_NOTIFICATION_HOOKS", True)
     zephyr_add_prj_conf("MCUMGR_GRP_IMG_STATUS_HOOKS", True)
     zephyr_add_prj_conf("MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK", True)
+    # OS management group (reset, MCUMGR_PARAMETERS query, etc.) isn't transport-specific --
+    # every mcumgr transport needs it, not just BLE.
+    zephyr_add_prj_conf("MCUMGR_GRP_OS", True)
+    zephyr_add_prj_conf("MCUMGR_GRP_OS_MCUMGR_PARAMS", True)
     transport = config[CONF_TRANSPORT]
     if transport[CONF_BLE]:
         zephyr_add_prj_conf("MCUMGR_TRANSPORT_BT", True)
         zephyr_add_prj_conf("MCUMGR_TRANSPORT_BT_REASSEMBLY", True)
-
-        zephyr_add_prj_conf("MCUMGR_GRP_OS", True)
-        zephyr_add_prj_conf("MCUMGR_GRP_OS_MCUMGR_PARAMS", True)
 
         zephyr_add_prj_conf("NCS_SAMPLE_MCUMGR_BT_OTA_DFU_SPEEDUP", True)
     if CONF_HARDWARE_UART in transport:


### PR DESCRIPTION
# What does this implement/fix?

The mcumgr OS management group (which provides the `reset` command and the `MCUMGR_PARAMETERS` query) was only being enabled for the BLE transport:

```python
if transport[CONF_BLE]:
    ...
    zephyr_add_prj_conf("MCUMGR_GRP_OS", True)
    zephyr_add_prj_conf("MCUMGR_GRP_OS_MCUMGR_PARAMS", True)
    ...
if CONF_HARDWARE_UART in transport:
    ...  # never enabled here
```

This isn't BLE-specific functionality -- both `MCUMGR_GRP_OS` and `MCUMGR_GRP_OS_MCUMGR_PARAMS` are generic Zephyr mcumgr subsystem options with no BLE dependency. For the UART/CDC transport this meant:

- Every OTA upload logged a spurious `WARNING Timeout waiting for MCUMgr parameters` (the `MCUMGR_PARAMETERS` command doesn't exist on the device, so it always times out).
- The `reset` request `esphome upload` sends after marking an image for testing always failed with `MGMT_ERR.ENOTSUP`, since the reset command handler was never compiled in either. In practice this means every OTA update over UART/CDC requires a manual power cycle to actually boot the new image -- the whole point of "OTA" is defeated.

Fix: move the two `zephyr_add_prj_conf` calls out of the BLE-only branch so they apply regardless of transport.

Tested on real nRF52840 hardware (UART/CDC transport): before this change, a raw SMP `reset` request against the device always returned `rc=MGMT_ERR.ENOTSUP` and a manual power cycle was required after every upload. After the fix, the same reset request returns a clean success response and the device reboots on its own -- confirmed via USB re-enumeration and a fresh boot log, no physical intervention needed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ota:
  - platform: zephyr_mcumgr
    transport:
      hardware_uart: CDC
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). Existing hardware_uart tests already exercise this code path; no new test was added specifically for this fix.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
