### PR TITLE
[web_server_base] Stop deleting the web server on captive portal teardown

### DIFF
--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -249,7 +249,7 @@ void WebServerOTAComponent::setup() {
     return;
   }
 
-  // AsyncWebServer takes ownership of the handler and will delete it when the server is destroyed
+  // The handler lives for the life of the process; WebServerBase never destroys its server
   base->add_handler(new OTARequestHandler(this));  // NOLINT
 }
 

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -113,8 +113,12 @@ class AuthMiddlewareHandler : public MiddlewareHandler {
 class WebServerBase final {
  public:
   void init() {
-    if (this->initialized_) {
-      this->initialized_++;
+    this->initialized_++;
+    if (this->server_ != nullptr) {
+      if (this->initialized_ == 1) {
+        // Restart the listener after a previous deinit(); handlers are still registered.
+        this->server_->begin();
+      }
       return;
     }
     this->server_ = new AsyncWebServer(this->port_);
@@ -126,14 +130,14 @@ class WebServerBase final {
 
     for (auto *handler : this->handlers_)
       this->server_->addHandler(handler);
-
-    this->initialized_++;
   }
   void deinit() {
     this->initialized_--;
-    if (this->initialized_ == 0) {
-      delete this->server_;
-      this->server_ = nullptr;
+    if (this->initialized_ == 0 && this->server_ != nullptr) {
+      // Stop listening but never delete the server: on Arduino platforms
+      // ESPAsyncWebServer owns its handlers, so deleting it would delete
+      // registered components (e.g. the captive portal) out from under us.
+      this->server_->end();
     }
   }
   AsyncWebServer *get_server() const { return this->server_; }

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -112,11 +112,16 @@ class AuthMiddlewareHandler : public MiddlewareHandler {
 
 class WebServerBase final {
  public:
+  // The AsyncWebServer is created once and intentionally never deleted: on Arduino
+  // platforms ESPAsyncWebServer owns its registered handlers, so destroying it would
+  // also destroy live components (e.g. the captive portal) out from under us.
+  // init()/deinit() refcount users and start/stop the listener; handlers are
+  // registered once at creation and survive listener restarts.
   void init() {
     this->initialized_++;
     if (this->server_ != nullptr) {
       if (this->initialized_ == 1) {
-        // Restart the listener after a previous deinit(); handlers are still registered.
+        // Restart the listener after a previous deinit()
         this->server_->begin();
       }
       return;
@@ -132,11 +137,10 @@ class WebServerBase final {
       this->server_->addHandler(handler);
   }
   void deinit() {
+    if (this->initialized_ == 0)
+      return;  // unbalanced deinit()
     this->initialized_--;
-    if (this->initialized_ == 0 && this->server_ != nullptr) {
-      // Stop listening but never delete the server: on Arduino platforms
-      // ESPAsyncWebServer owns its handlers, so deleting it would delete
-      // registered components (e.g. the captive portal) out from under us.
+    if (this->initialized_ == 0) {
       this->server_->end();
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

When the captive portal shuts down after Wi-Fi connects, `WebServerBase::deinit()` deleted the `AsyncWebServer`. Since the switch to ESP32Async/ESPAsyncWebServer in #8867 the server owns its registered handlers, so deleting it also deletes the captive portal component itself while its `end()` method is still running, plus the auto loaded web server OTA handler. The captive portal then touches its already freed DNS server, the device aborts and reboots. On the esphome-web factory image this broke Improv serial provisioning on ESP8266, the board rebooted before `improv_serial` could save the credentials, so it came back up in AP mode and web.esphome.io spun forever. Provisioning through the captive portal itself appeared to work because credentials are saved before connecting, but it hit the same crash and reboot after connect. ESP32 is unaffected because `web_server_idf` does not own its handlers; the old ESPAsyncWebServer fork was patched to not own them either, and that patch was lost in the library upgrade. Affects all ESPAsyncWebServer platforms: ESP8266, RP2040, LibreTiny, LN882x.

The server is now created once and kept for the life of the process; `init()` and `deinit()` start and stop the listener instead of allocating and deleting the server, so components registered as handlers are never destroyed and the listening socket still closes after provisioning. Both backends support restarting the listener. One observable difference for external code: after teardown `get_server()` now returns a pointer to the stopped server instead of `nullptr`; there are no in tree callers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18323

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp8266:
  board: esp01_1m

logger:

api:

ota:
  - platform: esphome

improv_serial:

wifi:
  ap: {}

captive_portal:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
