### PR TITLE
[zigbee] Add ESP32 switch support using On/Off cluster

### DIFF
--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -43,6 +43,7 @@ from .zigbee_esp32 import (
     final_validate_esp32,
     validate_binary_sensor_esp32,
     validate_sensor_esp32,
+    validate_switch_esp32,
     zigbee_require_vfs_select,
 )
 from .zigbee_zephyr import (
@@ -89,7 +90,7 @@ BASE_SCHEMA = cv.Schema(
 )
 BINARY_SENSOR_SCHEMA = cv.Schema({}).extend(BASE_SCHEMA).extend(zephyr_binary_sensor)
 SENSOR_SCHEMA = cv.Schema({}).extend(BASE_SCHEMA).extend(zephyr_sensor)
-SWITCH_SCHEMA = cv.Schema({}).extend(zephyr_switch)
+SWITCH_SCHEMA = cv.Schema({}).extend(BASE_SCHEMA).extend(zephyr_switch)
 NUMBER_SCHEMA = cv.Schema({}).extend(zephyr_number)
 
 
@@ -273,7 +274,7 @@ def validate_switch(config: ConfigType) -> ConfigType:
     if "zigbee" not in CORE.loaded_integrations or config.get(CONF_INTERNAL):
         return config
     if CORE.is_esp32:
-        return config
+        return validate_switch_esp32(config)
     return consume_endpoint(config)
 
 

--- a/esphome/components/zigbee/const_esp32.py
+++ b/esphome/components/zigbee/const_esp32.py
@@ -13,6 +13,7 @@ KEY_ZIGBEE_EP_NO_NUM = "zigbee_ep_no_num"
 DEVICE_ID = {
     "RANGE_EXTENDER": cg.RawExpression("EZB_ZHA_RANGE_EXTENDER_DEVICE_ID"),
     "SIMPLE_SENSOR": cg.RawExpression("EZB_ZHA_SIMPLE_SENSOR_DEVICE_ID"),
+    "ON_OFF_OUTPUT": cg.RawExpression("EZB_ZHA_ON_OFF_OUTPUT_DEVICE_ID"),
     "CUSTOM_ATTR": 0xFFF2,
 }
 cluster_id = cg.esphome_ns.enum("ezb_zcl_cluster_id_e")
@@ -20,6 +21,7 @@ CLUSTER_ID = {
     "BASIC": cluster_id.EZB_ZCL_CLUSTER_ID_BASIC,
     "BINARY_INPUT": cluster_id.EZB_ZCL_CLUSTER_ID_BINARY_INPUT,
     "ANALOG_INPUT": cluster_id.EZB_ZCL_CLUSTER_ID_ANALOG_INPUT,
+    "ON_OFF": cluster_id.EZB_ZCL_CLUSTER_ID_ON_OFF,
 }
 CLUSTER_ROLE = {
     "SERVER": cg.RawExpression("EZB_ZCL_CLUSTER_SERVER"),

--- a/esphome/components/zigbee/zigbee_attribute_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_attribute_esp32.cpp
@@ -86,6 +86,21 @@ void ZigbeeAttribute::loop() {
   }
 }
 
+void ZigbeeAttribute::on_remote_write(const void *value) {
+#ifdef USE_SWITCH
+  if (this->switch_ != nullptr) {
+    bool val = *static_cast<const uint8_t *>(value) != 0;
+    this->defer([this, val]() {
+      if (val) {
+        this->switch_->turn_on();
+      } else {
+        this->switch_->turn_off();
+      }
+    });
+  }
+#endif
+}
+
 }  // namespace esphome::zigbee
 
 #endif

--- a/esphome/components/zigbee/zigbee_attribute_esp32.h
+++ b/esphome/components/zigbee/zigbee_attribute_esp32.h
@@ -18,6 +18,9 @@
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
 
 namespace esphome::zigbee {
 
@@ -51,6 +54,10 @@ class ZigbeeAttribute final : public Component {
 #ifdef USE_BINARY_SENSOR
   template<typename T> void connect(binary_sensor::BinarySensor *sensor);
 #endif
+#ifdef USE_SWITCH
+  template<typename T> void connect(switch_::Switch *sw);
+#endif
+  void on_remote_write(const void *value);
   bool report_enabled = false;
 
  protected:
@@ -68,6 +75,9 @@ class ZigbeeAttribute final : public Component {
   bool set_attr_requested_{false};
   bool report_requested_{false};
   bool force_report_{false};
+#ifdef USE_SWITCH
+  switch_::Switch *switch_{nullptr};
+#endif
 };
 
 template<typename T> void ZigbeeAttribute::add_attr(T value) {
@@ -93,6 +103,12 @@ template<typename T> void ZigbeeAttribute::connect(sensor::Sensor *sensor) {
 #ifdef USE_BINARY_SENSOR
 template<typename T> void ZigbeeAttribute::connect(binary_sensor::BinarySensor *sensor) {
   sensor->add_on_state_callback([this](bool value) { this->set_attr((T) (this->scale_ * value)); });
+}
+#endif
+#ifdef USE_SWITCH
+template<typename T> void ZigbeeAttribute::connect(switch_::Switch *sw) {
+  this->switch_ = sw;
+  sw->add_on_state_callback([this](bool state) { this->set_attr((T) state); });
 }
 #endif
 

--- a/esphome/components/zigbee/zigbee_ep_esp32.py
+++ b/esphome/components/zigbee/zigbee_ep_esp32.py
@@ -80,6 +80,23 @@ ep_configs: dict[str, dict[str, Any]] = {
             },
         ],
     },
+    "on_off_output": {
+        DEVICE_TYPE: "ON_OFF_OUTPUT",
+        CONF_CLUSTERS: [
+            {
+                CONF_ID: "ON_OFF",
+                ROLE: "SERVER",
+                CONF_ATTRIBUTES: [
+                    {
+                        CONF_ATTRIBUTE_ID: 0x0000,
+                        CONF_TYPE: "BOOL",
+                        CONF_REPORT: cv.enum(REPORT, lower=True)("force"),
+                        CONF_DEVICE: None,
+                    },
+                ],
+            },
+        ],
+    },
 }
 
 

--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -158,6 +158,10 @@ static void zb_attribute_handler(ezb_zcl_set_attr_value_message_t *message) {
   ESP_LOGD(TAG, "ZCL SetAttributeValue message for endpoint(%d) cluster(0x%04x) %s with status(0x%02x)",
            message->info.dst_ep, message->info.cluster_id,
            message->info.cluster_role == EZB_ZCL_CLUSTER_SERVER ? "server" : "client", message->info.status);
+  if (global_zigbee) {
+    global_zigbee->handle_attr_write(message->info.dst_ep, message->info.cluster_id, message->info.cluster_role,
+                                     message->in.attribute.id, message->in.attribute.data.value);
+  }
 }
 
 static void zb_action_handler(ezb_zcl_core_action_callback_id_t callback_id, void *message) {
@@ -348,6 +352,15 @@ void ZigbeeComponent::loop() {
     this->factory_new_ = false;
   }
   this->disable_loop();
+}
+
+void ZigbeeComponent::handle_attr_write(uint8_t endpoint, uint16_t cluster_id, uint8_t role, uint16_t attr_id,
+                                        const void *value) {
+  auto key = std::make_tuple(endpoint, cluster_id, role, attr_id);
+  auto it = this->attributes_.find(key);
+  if (it != this->attributes_.end() && it->second != nullptr) {
+    it->second->on_remote_write(value);
+  }
 }
 
 void ZigbeeComponent::dump_config() {

--- a/esphome/components/zigbee/zigbee_esp32.h
+++ b/esphome/components/zigbee/zigbee_esp32.h
@@ -59,6 +59,8 @@ class ZigbeeComponent final : public Component {
   template<typename F> void add_on_join_callback(F &&cb) { this->join_cb_.add(std::forward<F>(cb)); }
   template<typename F> void add_on_start_callback(F &&cb) { this->start_cb_.add(std::forward<F>(cb)); }
 
+  void handle_attr_write(uint8_t endpoint, uint16_t cluster_id, uint8_t role, uint16_t attr_id, const void *value);
+
   bool is_battery_powered() { return this->basic_cluster_data_.power_source == EZB_ZCL_BASIC_POWER_SOURCE_BATTERY; }
 
   // True after the Zigbee stack has been initialized and the device has started up. Is set before the stack started

--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -223,6 +223,13 @@ def validate_binary_sensor_esp32(config: ConfigType) -> ConfigType:
     return config
 
 
+def validate_switch_esp32(config: ConfigType) -> ConfigType:
+    ep = copy.deepcopy(ep_configs["on_off_output"])
+    setup_attributes(config, ep[CONF_CLUSTERS])
+    add_ep(ep, config.get(CONF_ENDPOINT), config.get(CONF_USE_DEVICE_TYPE))
+    return config
+
+
 def zigbee_require_vfs_select(config: ConfigType) -> ConfigType:
     """Register VFS select requirement during config validation."""
     # Zigbee uses esp_vfs_eventfd which requires VFS select support

--- a/esphome/components/zigbee/zigbee_helpers_esp32.c
+++ b/esphome/components/zigbee/zigbee_helpers_esp32.c
@@ -34,6 +34,8 @@ ezb_zcl_cluster_desc_t esphome_zb_default_cluster_dscr_create(uint16_t cluster_i
       return ezb_zcl_analog_input_create_cluster_desc(NULL, role_mask);
     case EZB_ZCL_CLUSTER_ID_BINARY_INPUT:
       return ezb_zcl_binary_input_create_cluster_desc(NULL, role_mask);
+    case EZB_ZCL_CLUSTER_ID_ON_OFF:
+      return ezb_zcl_on_off_create_cluster_desc(NULL, role_mask);
     default: {
       ezb_zcl_custom_cluster_config_t config = {0};
       config.cluster_id = cluster_id;
@@ -53,6 +55,8 @@ ezb_err_t esphome_zb_cluster_add_attr(uint16_t cluster_id, ezb_zcl_cluster_desc_
       return ezb_zcl_analog_input_cluster_desc_add_attr(cluster_desc, attr_id, value_p);
     case EZB_ZCL_CLUSTER_ID_BINARY_INPUT:
       return ezb_zcl_binary_input_cluster_desc_add_attr(cluster_desc, attr_id, value_p);
+    case EZB_ZCL_CLUSTER_ID_ON_OFF:
+      return ezb_zcl_on_off_cluster_desc_add_attr(cluster_desc, attr_id, value_p);
     default:
       return EZB_ERR_NOT_FOUND;
   }


### PR DESCRIPTION
# What does this implement/fix?

Adds ESP32 switch platform support to the Zigbee component. Switch entities are exposed as standard ZCL On/Off Output devices, allowing Zigbee coordinators (Home Assistant ZHA, Zigbee2MQTT, etc.) to control them. State changes from both ESPHome and the coordinator are synchronized bidirectionally.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
switch:
  - platform: gpio
    pin: GPIO5
    name: "Zigbee Switch"
