### PR TITLE
[core] Retry framework downloads on transient network errors

### DIFF
--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -891,6 +891,16 @@ def _failure_reason(e: Exception) -> str:
     return str(e).split(" for url: ", maxsplit=1)[0] or repr(e)
 
 
+def _spent_attempts_error(e: Exception, attempts: int) -> Exception:
+    """Wrap a failure whose mirror already consumed download attempts, so
+    the sweep classifies it as permanent."""
+    from esphome.core import EsphomeError
+
+    err = EsphomeError(f"failed after {attempts} attempts: {_failure_reason(e)}")
+    err.__cause__ = e
+    return err
+
+
 def _is_transient_download_error(e: Exception) -> bool:
     """Return True when a download failure is worth retrying.
 
@@ -973,9 +983,12 @@ def _try_mirrors_once(
             try:
                 resp, offset = _open_ranged(url, offset, timeout, validator)
             except (requests.RequestException, OSError) as e:
-                # Connect/HTTP error, no bytes flowed — next mirror.
+                # Connect/HTTP error, no bytes flowed — next mirror. Wrap
+                # when earlier attempts were already spent on this mirror.
                 _LOGGER.debug("Failed to download %s: %s", url, str(e))
-                failures.append((url, e))
+                failures.append(
+                    (url, _spent_attempts_error(e, attempt + 1) if attempt else e)
+                )
                 break
 
             try:
@@ -1026,14 +1039,7 @@ def _try_mirrors_once(
                     )
                     offset = 0
                 if attempt == _MIRROR_ATTEMPTS - 1:
-                    # Wrap like download_with_resume so the sweep sees
-                    # these attempts as already spent
-                    err = EsphomeError(
-                        f"failed after {_MIRROR_ATTEMPTS} attempts: "
-                        f"{_failure_reason(e)}"
-                    )
-                    err.__cause__ = e
-                    failures.append((url, err))
+                    failures.append((url, _spent_attempts_error(e, _MIRROR_ATTEMPTS)))
 
     return None
 

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -1112,16 +1112,19 @@ def download_from_mirrors(
     # 3. Sweep the mirror list, retrying transient failures with backoff:
     # a single pass keeps mirror failover fast, re-sweeping keeps one
     # network blip from failing the build when only one mirror applies.
+    failures: list[tuple[str, Exception]] = []
     for sweep in range(1, _MIRROR_SWEEP_ATTEMPTS + 1):
-        failures: list[tuple[str, Exception]] = []
+        sweep_failures: list[tuple[str, Exception]] = []
         if (
-            url := _try_mirrors_once(urls, path_target, f, timeout, failures)
+            url := _try_mirrors_once(urls, path_target, f, timeout, sweep_failures)
         ) is not None:
             return url
+        failures.extend(sweep_failures)
         # Permanent failures (404, verification mismatch) won't heal;
         # only retry when a transient error is in the mix (as git.py does).
         transient = next(
-            ((u, e) for u, e in failures if _is_transient_download_error(e)), None
+            ((u, e) for u, e in sweep_failures if _is_transient_download_error(e)),
+            None,
         )
         if transient is None:
             break
@@ -1137,14 +1140,17 @@ def download_from_mirrors(
             )
             time.sleep(delay)
 
-    # 4. Report every attempted URL if all mirrors failed. Falling back
-    # past an early mirror is normal (e.g. only one of the framework URL
-    # templates matches a given version's tag), so raising only the last
-    # error would hide the failure that actually matters.
+    # 4. Report every attempted URL if all mirrors failed. failures spans
+    # all sweeps (deduplicated by URL and reason), so neither an early
+    # mirror's failure nor an earlier sweep's failure mode is hidden.
     if failures:
-        attempts = "".join(
-            f"\n  {url}\n    {_failure_reason(e)}" for url, e in failures
-        )
+        seen: set[tuple[str, str]] = set()
+        attempts = ""
+        for url, e in failures:
+            reason = _failure_reason(e)
+            if (url, reason) not in seen:
+                seen.add((url, reason))
+                attempts += f"\n  {url}\n    {reason}"
         attempts += "".join(f"\n  {mirror}\n    {reason}" for mirror, reason in skipped)
         raise EsphomeError(
             f"Failed to download from all mirrors:{attempts}"

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -25,8 +25,16 @@ _LOGGER = logging.getLogger(__name__)
 
 # Attempts per mirror URL before falling through to the next mirror; only
 # mid-stream drops retry (resuming when the server gave a validator),
-# connect errors move on immediately.
+# connect errors move on to the next mirror immediately.
 _MIRROR_ATTEMPTS = 3
+
+# Full passes over the mirror list before giving up, when at least one
+# mirror failed with a transient network error (see
+# _is_transient_download_error). Keeps mirror failover fast while a
+# momentary blip (dropped connection, DNS hiccup, 5xx) does not fail the
+# whole build when only one mirror template applies. Matches git.py's
+# _NETWORK_MAX_ATTEMPTS: 3 attempts with 2s/4s backoff.
+_MIRROR_SWEEP_ATTEMPTS = 3
 
 
 def get_project_link_flags() -> list[str]:
@@ -887,37 +895,47 @@ def _failure_reason(e: Exception) -> str:
     return str(e).split(" for url: ", maxsplit=1)[0] or repr(e)
 
 
-def download_from_mirrors(
-    mirrors: list[str],
-    substitutions: dict[str, str],
-    target: io.RawIOBase | IO[bytes] | PathType,
-    timeout: int = 30,
-) -> str:
+def _is_transient_download_error(e: Exception) -> bool:
+    """Return True when a download failure is worth retrying.
+
+    Connection-level failures (the server or a middlebox dropped the
+    connection, DNS hiccup, timeout, truncated body) and retryable HTTP
+    statuses (429, 5xx) are transient. Other HTTP errors (404, 403, ...)
+    and local errors (disk full, verification mismatch) are permanent, as
+    is an EsphomeError from download_with_resume: that failure already
+    exhausted its own resume attempts.
     """
-    Download file from multiple mirrors with substitution support.
+    # Imported lazily: requests is a heavy import (~85ms) and is only
+    # needed when actually downloading, never during config validation.
+    import requests
 
-    Args:
-        mirrors: list of mirror URLs
-        substitutions: Dictionary of substitutions to apply to URLs
-        target: Target file path or file-like object
-        timeout: Download timeout in seconds
+    if isinstance(e, requests.exceptions.HTTPError):
+        resp = e.response
+        return resp is not None and (resp.status_code == 429 or resp.status_code >= 500)
+    return isinstance(
+        e,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+        ),
+    )
 
-    Returns:
-        The source URL.
 
-    Mirror URL templates that reference a substitution not present in
-    ``substitutions`` are skipped, so callers can offer templates that only
-    apply to some downloads.
+def _try_mirrors_once(
+    urls: list[str],
+    path_target: Path | None,
+    f: IO[bytes] | None,
+    timeout: int,
+    failures: list[tuple[str, Exception]],
+) -> str | None:
+    """Single pass over the resolved mirror ``urls``.
 
-    A path target downloads through ``download_with_resume``, so an
-    interrupted download resumes on the next esphome run; a file-like target
-    only resumes mid-stream drops within this call.
-
-    Raises:
-        ValueError: If mirrors list is empty.
-        EsphomeError: If all download attempts fail; the message lists every
-            attempted URL with its individual failure reason. Also raised if
-            no template matched the provided substitutions.
+    The mechanism under ``download_from_mirrors``'s retry policy: each URL
+    is tried once, falling through to the next on any failure so a dead
+    mirror never delays a healthy one. Returns the source URL on success;
+    on failure returns None with each URL's exception appended to
+    ``failures``.
     """
     # Imported lazily: requests is a heavy import (~85ms) and is only
     # needed when actually downloading, never during config validation.
@@ -925,43 +943,7 @@ def download_from_mirrors(
 
     from esphome.core import EsphomeError
 
-    ensure_happy_eyeballs()
-
-    # 1. Classify the target: filesystem path or open file object
-    path_target: Path | None = None
-    f: IO[bytes] | None = None
-    if isinstance(target, (str, os.PathLike)):
-        path_target = Path(target)
-    elif isinstance(target, (io.RawIOBase, io.IOBase)):
-        f = target
-    else:
-        raise TypeError(
-            f"target must be str, Path, or file-like object: {type(target)}"
-        )
-
-    # 2. Try each mirror in order
-    failures: list[tuple[str, Exception]] = []
-    skipped: list[tuple[str, str]] = []
-
-    for mirror in mirrors:
-        # 3. Apply substitutions to URL
-        try:
-            url = mirror.format(**substitutions)
-        except KeyError as e:
-            # The template references a substitution not provided for
-            # this download (e.g. SHORT_VERSION only exists for x.y.0
-            # versions) - expected, the template just doesn't apply.
-            _LOGGER.debug("Skipping mirror %s: %s not available", mirror, e)
-            skipped.append((mirror, f"not applicable ({e.args[0]} not available)"))
-            continue
-        except (IndexError, ValueError) as e:
-            # A malformed template (unbalanced braces, bad format spec)
-            # is an authoring error, not an expected fallthrough - warn
-            # even if a later mirror succeeds.
-            _LOGGER.warning("Skipping malformed mirror URL template %s: %r", mirror, e)
-            skipped.append((mirror, f"skipped ({e!r})"))
-            continue
-
+    for url in urls:
         _LOGGER.debug("Trying to download from %s", url)
 
         # Path targets delegate to download_with_resume so a partial
@@ -986,14 +968,14 @@ def download_from_mirrors(
                 failures.append((url, e))
                 continue
 
-        # 4. Download; mid-stream failures retry the same mirror with
-        # resume (see download_with_resume) instead of starting over.
-        # There is no checksum to verify a resumed file against, so a
-        # stitch is only trusted when the server proves consistency: the
-        # If-Range validator guarantees 206 only for unchanged content,
-        # and the expected total length (when the first response carried
-        # one) guards against short or shifted bodies. Without a
-        # validator the retry restarts from zero.
+        # File-like targets download here; mid-stream failures retry the
+        # same mirror with resume (see download_with_resume) instead of
+        # starting over. There is no checksum to verify a resumed file
+        # against, so a stitch is only trusted when the server proves
+        # consistency: the If-Range validator guarantees 206 only for
+        # unchanged content, and the expected total length (when the first
+        # response carried one) guards against short or shifted bodies.
+        # Without a validator the retry restarts from zero.
         offset = 0
         expected_total = 0
         validator = None
@@ -1031,7 +1013,7 @@ def download_from_mirrors(
 
                 _LOGGER.debug("Downloaded successfully from: %s", url)
 
-                # 5. Reset file pointer and return
+                # Reset file pointer and return
                 f.seek(0)
                 return url
 
@@ -1056,7 +1038,110 @@ def download_from_mirrors(
                 if attempt == _MIRROR_ATTEMPTS - 1:
                     failures.append((url, e))
 
-    # 6. Report every attempted URL if all mirrors failed. Falling back
+    return None
+
+
+def download_from_mirrors(
+    mirrors: list[str],
+    substitutions: dict[str, str],
+    target: io.RawIOBase | IO[bytes] | PathType,
+    timeout: int = 30,
+) -> str:
+    """
+    Download file from multiple mirrors with substitution support.
+
+    Args:
+        mirrors: list of mirror URLs
+        substitutions: Dictionary of substitutions to apply to URLs
+        target: Target file path or file-like object
+        timeout: Download timeout in seconds
+
+    Returns:
+        The source URL.
+
+    Mirror URL templates that reference a substitution not present in
+    ``substitutions`` are skipped, so callers can offer templates that only
+    apply to some downloads.
+
+    A path target downloads through ``download_with_resume``, so an
+    interrupted download resumes on the next esphome run; a file-like target
+    only resumes mid-stream drops within this call.
+
+    When every mirror fails and at least one failure is a transient network
+    error (dropped connection, timeout, HTTP 429/5xx), the whole mirror list
+    is retried with a short backoff (up to ``_MIRROR_SWEEP_ATTEMPTS``
+    passes) before giving up. Permanent failures (e.g. HTTP 404 on every
+    applicable mirror) raise immediately.
+
+    Raises:
+        ValueError: If mirrors list is empty.
+        EsphomeError: If all download attempts fail; the message lists every
+            attempted URL with its individual failure reason. Also raised if
+            no template matched the provided substitutions.
+    """
+    from esphome.core import EsphomeError
+
+    ensure_happy_eyeballs()
+
+    # 1. Classify the target: filesystem path or open file object
+    path_target: Path | None = None
+    f: IO[bytes] | None = None
+    if isinstance(target, (str, os.PathLike)):
+        path_target = Path(target)
+    elif isinstance(target, (io.RawIOBase, io.IOBase)):
+        f = target
+    else:
+        raise TypeError(
+            f"target must be str, Path, or file-like object: {type(target)}"
+        )
+
+    # 2. Resolve the mirror templates; they depend only on the inputs and
+    # never change between retry sweeps.
+    urls: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for mirror in mirrors:
+        try:
+            urls.append(mirror.format(**substitutions))
+        except KeyError as e:
+            # The template references a substitution not provided for
+            # this download (e.g. SHORT_VERSION only exists for x.y.0
+            # versions) - expected, the template just doesn't apply.
+            _LOGGER.debug("Skipping mirror %s: %s not available", mirror, e)
+            skipped.append((mirror, f"not applicable ({e.args[0]} not available)"))
+        except (IndexError, ValueError) as e:
+            # A malformed template (unbalanced braces, bad format spec)
+            # is an authoring error, not an expected fallthrough - warn
+            # even if a later mirror succeeds.
+            _LOGGER.warning("Skipping malformed mirror URL template %s: %r", mirror, e)
+            skipped.append((mirror, f"skipped ({e!r})"))
+
+    # 3. Sweep the mirror list, retrying transient failures with backoff.
+    # A single pass keeps mirror failover fast (a dead mirror never delays
+    # trying the next one); sweeping the whole list again keeps a momentary
+    # network blip from failing the build when only one mirror applies.
+    for sweep in range(_MIRROR_SWEEP_ATTEMPTS):
+        if sweep:
+            delay = 2**sweep
+            _LOGGER.warning(
+                "Download failed with a transient error; retrying in %d seconds "
+                "(attempt %d/%d)",
+                delay,
+                sweep + 1,
+                _MIRROR_SWEEP_ATTEMPTS,
+            )
+            time.sleep(delay)
+        failures: list[tuple[str, Exception]] = []
+        if (
+            url := _try_mirrors_once(urls, path_target, f, timeout, failures)
+        ) is not None:
+            return url
+        # A permanent failure (404, verification mismatch) on every mirror
+        # will not heal on its own; only retry when a transient network
+        # error is in the mix, matching git.py's transient-only retries.
+        if not any(_is_transient_download_error(e) for _, e in failures):
+            break
+
+    # 4. Report every attempted URL if all mirrors failed. Falling back
     # past an early mirror is normal (e.g. only one of the framework URL
     # templates matches a given version's tag), so raising only the last
     # error would hide the failure that actually matters.

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -28,12 +28,8 @@ _LOGGER = logging.getLogger(__name__)
 # connect errors move on to the next mirror immediately.
 _MIRROR_ATTEMPTS = 3
 
-# Full passes over the mirror list before giving up, when at least one
-# mirror failed with a transient network error (see
-# _is_transient_download_error). Keeps mirror failover fast while a
-# momentary blip (dropped connection, DNS hiccup, 5xx) does not fail the
-# whole build when only one mirror template applies. Matches git.py's
-# _NETWORK_MAX_ATTEMPTS: 3 attempts with 2s/4s backoff.
+# Passes over the whole mirror list when a transient network error is in
+# the mix; matches git.py's _NETWORK_MAX_ATTEMPTS (3 tries, 2s/4s backoff).
 _MIRROR_SWEEP_ATTEMPTS = 3
 
 
@@ -898,12 +894,9 @@ def _failure_reason(e: Exception) -> str:
 def _is_transient_download_error(e: Exception) -> bool:
     """Return True when a download failure is worth retrying.
 
-    Connection-level failures (the server or a middlebox dropped the
-    connection, DNS hiccup, timeout, truncated body) and retryable HTTP
-    statuses (429, 5xx) are transient. Other HTTP errors (404, 403, ...)
-    and local errors (disk full, verification mismatch) are permanent, as
-    is an EsphomeError from download_with_resume: that failure already
-    exhausted its own resume attempts.
+    Connection-level failures and HTTP 429/5xx are transient. Other HTTP
+    errors, local errors, and EsphomeError from download_with_resume
+    (which already exhausted its own resume attempts) are permanent.
     """
     # Imported lazily: requests is a heavy import (~85ms) and is only
     # needed when actually downloading, never during config validation.
@@ -929,13 +922,10 @@ def _try_mirrors_once(
     timeout: int,
     failures: list[tuple[str, Exception]],
 ) -> str | None:
-    """Single pass over the resolved mirror ``urls``.
+    """Single pass over the resolved mirror ``urls``, one try per URL.
 
-    The mechanism under ``download_from_mirrors``'s retry policy: each URL
-    is tried once, falling through to the next on any failure so a dead
-    mirror never delays a healthy one. Returns the source URL on success;
-    on failure returns None with each URL's exception appended to
-    ``failures``.
+    Returns the source URL on success, or None with each URL's exception
+    appended to ``failures``.
     """
     # Imported lazily: requests is a heavy import (~85ms) and is only
     # needed when actually downloading, never during config validation.
@@ -1067,11 +1057,9 @@ def download_from_mirrors(
     interrupted download resumes on the next esphome run; a file-like target
     only resumes mid-stream drops within this call.
 
-    When every mirror fails and at least one failure is a transient network
-    error (dropped connection, timeout, HTTP 429/5xx), the whole mirror list
-    is retried with a short backoff (up to ``_MIRROR_SWEEP_ATTEMPTS``
-    passes) before giving up. Permanent failures (e.g. HTTP 404 on every
-    applicable mirror) raise immediately.
+    When every mirror fails and at least one failure is transient (dropped
+    connection, timeout, HTTP 429/5xx), the whole list is retried with a
+    short backoff; permanent failures (e.g. 404) raise immediately.
 
     Raises:
         ValueError: If mirrors list is empty.
@@ -1095,8 +1083,7 @@ def download_from_mirrors(
             f"target must be str, Path, or file-like object: {type(target)}"
         )
 
-    # 2. Resolve the mirror templates; they depend only on the inputs and
-    # never change between retry sweeps.
+    # 2. Resolve the mirror templates (invariant across retry sweeps)
     urls: list[str] = []
     skipped: list[tuple[str, str]] = []
     for mirror in mirrors:
@@ -1115,9 +1102,8 @@ def download_from_mirrors(
             _LOGGER.warning("Skipping malformed mirror URL template %s: %r", mirror, e)
             skipped.append((mirror, f"skipped ({e!r})"))
 
-    # 3. Sweep the mirror list, retrying transient failures with backoff.
-    # A single pass keeps mirror failover fast (a dead mirror never delays
-    # trying the next one); sweeping the whole list again keeps a momentary
+    # 3. Sweep the mirror list, retrying transient failures with backoff:
+    # a single pass keeps mirror failover fast, re-sweeping keeps one
     # network blip from failing the build when only one mirror applies.
     for sweep in range(_MIRROR_SWEEP_ATTEMPTS):
         if sweep:
@@ -1135,9 +1121,8 @@ def download_from_mirrors(
             url := _try_mirrors_once(urls, path_target, f, timeout, failures)
         ) is not None:
             return url
-        # A permanent failure (404, verification mismatch) on every mirror
-        # will not heal on its own; only retry when a transient network
-        # error is in the mix, matching git.py's transient-only retries.
+        # Permanent failures (404, verification mismatch) won't heal;
+        # only retry when a transient error is in the mix (as git.py does).
         if not any(_is_transient_download_error(e) for _, e in failures):
             break
 

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -1123,18 +1123,19 @@ def download_from_mirrors(
         transient = next(
             ((u, e) for u, e in failures if _is_transient_download_error(e)), None
         )
-        if transient is None or sweep == _MIRROR_SWEEP_ATTEMPTS:
+        if transient is None:
             break
-        delay = 2**sweep
-        _LOGGER.warning(
-            "Download of %s failed (%s); retrying in %d seconds (attempt %d/%d)",
-            transient[0],
-            _failure_reason(transient[1]),
-            delay,
-            sweep + 1,
-            _MIRROR_SWEEP_ATTEMPTS,
-        )
-        time.sleep(delay)
+        if sweep < _MIRROR_SWEEP_ATTEMPTS:
+            delay = 2**sweep
+            _LOGGER.warning(
+                "Download of %s failed (%s); retrying in %d seconds (attempt %d/%d)",
+                transient[0],
+                _failure_reason(transient[1]),
+                delay,
+                sweep + 1,
+                _MIRROR_SWEEP_ATTEMPTS,
+            )
+            time.sleep(delay)
 
     # 4. Report every attempted URL if all mirrors failed. Falling back
     # past an early mirror is normal (e.g. only one of the framework URL

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -895,8 +895,8 @@ def _is_transient_download_error(e: Exception) -> bool:
     """Return True when a download failure is worth retrying.
 
     Connection-level failures and HTTP 429/5xx are transient. Other HTTP
-    errors, local errors, and EsphomeError from download_with_resume
-    (which already exhausted its own resume attempts) are permanent.
+    errors, local errors, and exhausted-attempts EsphomeError wrappers
+    (their per-mirror retries are already spent) are permanent.
     """
     # Imported lazily: requests is a heavy import (~85ms) and is only
     # needed when actually downloading, never during config validation.
@@ -1026,7 +1026,14 @@ def _try_mirrors_once(
                     )
                     offset = 0
                 if attempt == _MIRROR_ATTEMPTS - 1:
-                    failures.append((url, e))
+                    # Wrap like download_with_resume so the sweep sees
+                    # these attempts as already spent
+                    err = EsphomeError(
+                        f"failed after {_MIRROR_ATTEMPTS} attempts: "
+                        f"{_failure_reason(e)}"
+                    )
+                    err.__cause__ = e
+                    failures.append((url, err))
 
     return None
 
@@ -1105,17 +1112,7 @@ def download_from_mirrors(
     # 3. Sweep the mirror list, retrying transient failures with backoff:
     # a single pass keeps mirror failover fast, re-sweeping keeps one
     # network blip from failing the build when only one mirror applies.
-    for sweep in range(_MIRROR_SWEEP_ATTEMPTS):
-        if sweep:
-            delay = 2**sweep
-            _LOGGER.warning(
-                "Download failed with a transient error; retrying in %d seconds "
-                "(attempt %d/%d)",
-                delay,
-                sweep + 1,
-                _MIRROR_SWEEP_ATTEMPTS,
-            )
-            time.sleep(delay)
+    for sweep in range(1, _MIRROR_SWEEP_ATTEMPTS + 1):
         failures: list[tuple[str, Exception]] = []
         if (
             url := _try_mirrors_once(urls, path_target, f, timeout, failures)
@@ -1123,8 +1120,21 @@ def download_from_mirrors(
             return url
         # Permanent failures (404, verification mismatch) won't heal;
         # only retry when a transient error is in the mix (as git.py does).
-        if not any(_is_transient_download_error(e) for _, e in failures):
+        transient = next(
+            ((u, e) for u, e in failures if _is_transient_download_error(e)), None
+        )
+        if transient is None or sweep == _MIRROR_SWEEP_ATTEMPTS:
             break
+        delay = 2**sweep
+        _LOGGER.warning(
+            "Download of %s failed (%s); retrying in %d seconds (attempt %d/%d)",
+            transient[0],
+            _failure_reason(transient[1]),
+            delay,
+            sweep + 1,
+            _MIRROR_SWEEP_ATTEMPTS,
+        )
+        time.sleep(delay)
 
     # 4. Report every attempted URL if all mirrors failed. Falling back
     # past an early mirror is normal (e.g. only one of the framework URL

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -519,20 +519,20 @@ class TestArchiveExtractAll:
 def _mock_response(
     content: bytes, ok: bool = True, status: int | None = None
 ) -> MagicMock:
-    """A fake requests response. ``status`` attaches a response with that
-    code to the HTTPError (as ``raise_for_status`` does on a real response)
-    so the transient classifier can see it."""
+    """A fake requests response. The HTTPError carries the response (as
+    ``raise_for_status`` on a real response) so the transient classifier
+    can see its ``status``; failures default to a permanent 404."""
+    if status is None:
+        status = 200 if ok else 404
     r = MagicMock()
     r.__enter__.return_value = r
     r.__exit__.return_value = False
-    r.status_code = status if status is not None else 200
+    r.status_code = status
     r.ok = ok
     if ok:
         r.raise_for_status.return_value = None
-    elif status is not None:
-        r.raise_for_status.side_effect = req.HTTPError(str(status), response=r)
     else:
-        r.raise_for_status.side_effect = req.HTTPError("503")
+        r.raise_for_status.side_effect = req.HTTPError(str(status), response=r)
     r.headers = {"content-length": "0"}  # suppress ProgressBar
     r.iter_content.return_value = [content] if content else []
     return r
@@ -1541,8 +1541,8 @@ class TestDownloadFromMirrors:
 
     def test_exhausted_mid_stream_attempts_not_swept(self) -> None:
         """A file-like mirror that spent all its mid-stream attempts is not
-        retried again at the sweep level; both target kinds get the same
-        per-mirror attempt ceiling."""
+        retried again at the sweep level (unlike a path target, it has no
+        part file to resume from on a later sweep)."""
         buf = io.BytesIO()
         with (
             patch(

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -1500,6 +1500,41 @@ class TestDownloadFromMirrors:
         assert dest.read_bytes() == b"data"
         mock_sleep.assert_called_once_with(2)
 
+    def test_http_5xx_retries_sweep(self, tmp_path: Path) -> None:
+        """A real 5xx (response attached to the HTTPError) is transient."""
+        dest = tmp_path / "out.bin"
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    _mock_response(b"", ok=False, status=503),
+                    _mock_response(b"data"),
+                ],
+            ),
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+        ):
+            url = download_from_mirrors(["https://mirror1.com/f"], {}, dest)
+        assert url == "https://mirror1.com/f"
+        assert dest.read_bytes() == b"data"
+        mock_sleep.assert_called_once_with(2)
+
+    def test_exhausted_mid_stream_attempts_not_swept(self) -> None:
+        """A file-like mirror that spent all its mid-stream attempts is not
+        retried again at the sweep level; both target kinds get the same
+        per-mirror attempt ceiling."""
+        buf = io.BytesIO()
+        with (
+            patch(
+                "requests.get",
+                side_effect=[_interrupted_response(b"1234") for _ in range(3)],
+            ) as mock_get,
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+            pytest.raises(EsphomeError, match="failed after 3 attempts"),
+        ):
+            download_from_mirrors(["https://mirror1.com/f"], {}, buf)
+        assert mock_get.call_count == 3
+        mock_sleep.assert_not_called()
+
 
 def _http_error(status: int) -> req.HTTPError:
     """An HTTPError carrying a response with the given status, as raised by

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import subprocess
 import sys
 import tarfile
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 import zipfile
 
 import pytest
@@ -23,6 +23,7 @@ from esphome.core import EsphomeError
 from esphome.framework_helpers import (
     _7z_extract_all,
     _detect_archive_root,
+    _is_transient_download_error,
     _rename_with_retry,
     _tar_extract_all,
     _zip_extract_all,
@@ -515,14 +516,25 @@ class TestArchiveExtractAll:
 # ---------------------------------------------------------------------------
 
 
-def _mock_response(content: bytes, ok: bool = True) -> MagicMock:
+def _mock_response(
+    content: bytes, ok: bool = True, status: int | None = None
+) -> MagicMock:
+    """A fake requests response.
+
+    ``status`` attaches a response carrying that code to the HTTPError (as
+    ``raise_for_status`` does on a real response), so the sweep-retry
+    transient classifier can see it; without it the error carries no
+    response and classifies as permanent.
+    """
     r = MagicMock()
     r.__enter__.return_value = r
     r.__exit__.return_value = False
-    r.status_code = 200
+    r.status_code = status if status is not None else 200
     r.ok = ok
     if ok:
         r.raise_for_status.return_value = None
+    elif status is not None:
+        r.raise_for_status.side_effect = req.HTTPError(str(status), response=r)
     else:
         r.raise_for_status.side_effect = req.HTTPError("503")
     r.headers = {"content-length": "0"}  # suppress ProgressBar
@@ -1418,6 +1430,116 @@ class TestDownloadFromMirrors:
             download_from_mirrors(["https://example.com/f"], {}, target)
         assert target.exists()
         assert target.read_bytes() == b""
+
+    @pytest.mark.parametrize("target_kind", ["path", "file-like"])
+    def test_transient_failure_retries_mirror_sweep(
+        self, tmp_path: Path, target_kind: str
+    ) -> None:
+        """A transient connect error on the only applicable mirror retries the
+        whole mirror list with backoff instead of failing the build."""
+        target = tmp_path / "idf.tar.xz" if target_kind == "path" else io.BytesIO()
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    req.ConnectionError("Remote end closed connection"),
+                    _mock_response(b"data"),
+                ],
+            ) as mock_get,
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+        ):
+            url = download_from_mirrors(["https://mirror1.com/f"], {}, target)
+        assert url == "https://mirror1.com/f"
+        data = target.read_bytes() if target_kind == "path" else target.getvalue()
+        assert data == b"data"
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+    def test_permanent_failure_does_not_retry_sweep(self, tmp_path: Path) -> None:
+        """An HTTP 404 will not heal on its own; fail after a single pass."""
+        with (
+            patch(
+                "requests.get", return_value=_mock_response(b"", ok=False, status=404)
+            ) as mock_get,
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+            pytest.raises(EsphomeError, match="all mirrors"),
+        ):
+            download_from_mirrors(["https://mirror1.com/f"], {}, tmp_path / "out.bin")
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_transient_failure_exhausts_sweeps(self, tmp_path: Path) -> None:
+        """A persistent transient error gives up after the configured number
+        of passes, with 2s/4s backoff, and still lists the attempted URL."""
+        with (
+            patch("requests.get", side_effect=req.ConnectionError("down")) as mock_get,
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+            pytest.raises(EsphomeError, match="all mirrors") as ei,
+        ):
+            download_from_mirrors(["https://mirror1.com/f"], {}, tmp_path / "out.bin")
+        assert mock_get.call_count == 3
+        assert mock_sleep.call_args_list == [call(2), call(4)]
+        assert "https://mirror1.com/f" in str(ei.value)
+
+    def test_mixed_permanent_and_transient_retries_sweep(self, tmp_path: Path) -> None:
+        """One mirror 404s permanently while another hits a transient error;
+        the transient failure makes the whole list worth another pass."""
+        dest = tmp_path / "out.bin"
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    _mock_response(b"", ok=False, status=404),
+                    req.ConnectionError("down"),
+                    _mock_response(b"", ok=False, status=404),
+                    _mock_response(b"data"),
+                ],
+            ),
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+        ):
+            url = download_from_mirrors(
+                ["https://mirror1.com/f", "https://mirror2.com/f"], {}, dest
+            )
+        assert url == "https://mirror2.com/f"
+        assert dest.read_bytes() == b"data"
+        mock_sleep.assert_called_once_with(2)
+
+
+def _http_error(status: int) -> req.HTTPError:
+    """An HTTPError carrying a response with the given status, as raised by
+    ``raise_for_status`` on a real response."""
+    resp = MagicMock()
+    resp.status_code = status
+    return req.HTTPError(str(status), response=resp)
+
+
+class TestIsTransientDownloadError:
+    def test_connection_errors_are_transient(self) -> None:
+        assert _is_transient_download_error(req.ConnectionError("reset"))
+        assert _is_transient_download_error(req.Timeout("timed out"))
+        assert _is_transient_download_error(
+            req.exceptions.ChunkedEncodingError("dropped")
+        )
+
+    def test_http_statuses(self) -> None:
+        assert not _is_transient_download_error(_http_error(404))
+        assert not _is_transient_download_error(_http_error(403))
+        assert _is_transient_download_error(_http_error(429))
+        assert _is_transient_download_error(_http_error(503))
+
+    def test_http_error_without_response_is_permanent(self) -> None:
+        assert not _is_transient_download_error(req.HTTPError("boom"))
+
+    def test_exhausted_resume_attempts_are_permanent(self) -> None:
+        """download_with_resume already spent its own resume attempts; its
+        EsphomeError wrapper is not retried again at the sweep level."""
+        wrapped = EsphomeError("Failed to download after 3 attempts")
+        wrapped.__cause__ = req.ConnectionError("down")
+        assert not _is_transient_download_error(wrapped)
+
+    def test_unrelated_errors_are_permanent(self) -> None:
+        assert not _is_transient_download_error(OSError("disk full"))
+        assert not _is_transient_download_error(EsphomeError("size mismatch"))
 
 
 def test_importing_framework_helpers_does_not_import_requests() -> None:

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -1556,6 +1556,25 @@ class TestDownloadFromMirrors:
         assert mock_get.call_count == 3
         mock_sleep.assert_not_called()
 
+    def test_mid_stream_drop_then_connect_error_not_swept(self) -> None:
+        """A connect error on a later attempt (after a mid-stream drop spent
+        one) also counts as spent budget and does not re-arm the sweep."""
+        buf = io.BytesIO()
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    _interrupted_response(b"1234"),
+                    req.ConnectionError("down"),
+                ],
+            ) as mock_get,
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+            pytest.raises(EsphomeError, match="failed after 2 attempts"),
+        ):
+            download_from_mirrors(["https://mirror1.com/f"], {}, buf)
+        assert mock_get.call_count == 2
+        mock_sleep.assert_not_called()
+
 
 def _http_error(status: int) -> req.HTTPError:
     """An HTTPError carrying a response with the given status, as raised by

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -519,13 +519,9 @@ class TestArchiveExtractAll:
 def _mock_response(
     content: bytes, ok: bool = True, status: int | None = None
 ) -> MagicMock:
-    """A fake requests response.
-
-    ``status`` attaches a response carrying that code to the HTTPError (as
-    ``raise_for_status`` does on a real response), so the sweep-retry
-    transient classifier can see it; without it the error carries no
-    response and classifies as permanent.
-    """
+    """A fake requests response. ``status`` attaches a response with that
+    code to the HTTPError (as ``raise_for_status`` does on a real response)
+    so the transient classifier can see it."""
     r = MagicMock()
     r.__enter__.return_value = r
     r.__exit__.return_value = False

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -1518,6 +1518,27 @@ class TestDownloadFromMirrors:
         assert dest.read_bytes() == b"data"
         mock_sleep.assert_called_once_with(2)
 
+    def test_error_reports_failure_modes_from_all_sweeps(self, tmp_path: Path) -> None:
+        """A failure mode that changes between sweeps stays in the final
+        error; the first failure (the one that started the retries) is
+        chained as the cause."""
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    req.ConnectionError("dropped by middlebox"),
+                    _mock_response(b"", ok=False, status=404),
+                ],
+            ),
+            patch("esphome.framework_helpers.time.sleep") as mock_sleep,
+            pytest.raises(EsphomeError, match="all mirrors") as ei,
+        ):
+            download_from_mirrors(["https://mirror1.com/f"], {}, tmp_path / "out.bin")
+        assert "dropped by middlebox" in str(ei.value)
+        assert "404" in str(ei.value)
+        assert isinstance(ei.value.__cause__, req.ConnectionError)
+        mock_sleep.assert_called_once_with(2)
+
     def test_exhausted_mid_stream_attempts_not_swept(self) -> None:
         """A file-like mirror that spent all its mid-stream attempts is not
         retried again at the sweep level; both target kinds get the same


### PR DESCRIPTION
# What does this implement/fix?

Framework downloads currently give up on the first connect error. Each mirror gets exactly one try per run; only drops in the middle of a transfer are retried. When just one mirror template applies to a version (the SHORT_VERSION template only exists for x.y.0 releases), a single transient failure such as a dropped connection fails the whole build. We hit this in device-builder CI, where the ESP-IDF 5.5.5 download died on one RemoteDisconnected: https://github.com/esphome/device-builder/actions/runs/31637979078/job/94253024410

Git operations already retry transient network failures three times with 2s/4s backoff. This applies the same policy to `download_from_mirrors`: mirror failover stays fast, and when a full pass over the list fails with a transient error in the mix (dropped connection, timeout, HTTP 429/5xx), the list is swept again after a short backoff. Permanent failures, for example a 404 on every applicable mirror, still fail immediately.

Measured against a real localhost server that reads the request and closes the connection without a response, reproducing the exact `RemoteDisconnected` from the CI failure, with a single mirror URL:

| Scenario | Baseline (dev 9967739) | This PR |
| --- | --- | --- |
| 1 dropped connection, then healthy | fails in 0.05s, 1 request | succeeds in 2.1s, 2 requests |
| 2 dropped connections, then healthy | fails in 0.06s, 1 request | succeeds in 6.1s, 3 requests |
| HTTP 404 (permanent) | fails in 0.06s, 1 request | fails in 0.05s, 1 request, no retry delay |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
