### PR TITLE
[wifi] Fix ESP8266 crash in cnx_node_search when lwIP transmits after disconnect

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -550,6 +550,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       // https://lbsfilm.at/blog/wpa2-authenticationmode-downgrade-in-espressif-microprocessors
       if (it.old_mode != AUTH_OPEN && it.new_mode == AUTH_OPEN) {
         ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting");
+#if LWIP_VERSION_MAJOR != 1
+        sta_netif_down();
+#endif
         wifi_station_disconnect();
         global_wifi_component->error_from_callback_ = true;
       }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -136,10 +136,21 @@ bool WiFiComponent::wifi_apply_power_save_() {
   https://github.com/d-a-v/Arduino/blob/0e7d21e17144cfc5f53c016191daca8723e89ee8/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp#L251
  */
 #undef netif_set_addr  // need to call lwIP-v1.4 netif_set_addr()
+#undef netif_set_down  // need to call lwIP-v1.4 netif_set_down()
 extern "C" {
 struct netif *eagle_lwip_getif(int netif_index);
 void netif_set_addr(struct netif *netif, const ip4_addr_t *ip, const ip4_addr_t *netmask, const ip4_addr_t *gw);
+void netif_set_down(struct netif *netif);
 };
+
+// The SDK can free its WiFi connection node before taking the STA netif down, letting lwIP
+// timers (e.g. IGMP reports armed by mDNS) transmit into the dead driver and crash in
+// cnx_node_search; taking the netif down first makes the glue drop such frames (#18308).
+static void sta_netif_down() {
+  struct netif *iface = eagle_lwip_getif(STATION_IF);
+  if (iface != nullptr)
+    netif_set_down(iface);
+}
 #endif
 
 bool WiFiComponent::wifi_sta_ip_config_(const optional<ManualIP> &manual_ip) {
@@ -523,6 +534,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
         global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ERROR_FAILED);
       }
       global_wifi_component->error_from_callback_ = true;
+#if LWIP_VERSION_MAJOR != 1
+      sta_netif_down();
+#endif
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       global_wifi_component->pending_.disconnect = true;
 #endif
@@ -719,8 +733,12 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
 bool WiFiComponent::wifi_disconnect_() {
   bool ret = true;
   // Only call disconnect if interface is up
-  if (wifi_get_opmode() & WIFI_STA)
+  if (wifi_get_opmode() & WIFI_STA) {
+#if LWIP_VERSION_MAJOR != 1
+    sta_netif_down();
+#endif
     ret = wifi_station_disconnect();
+  }
   station_config conf{};
   memset(&conf, 0, sizeof(conf));
   ETS_UART_INTR_DISABLE();


### PR DESCRIPTION
# What does this implement/fix?

Fixes an ESP8266 LoadProhibit crash in `cnx_node_search` (EXCVADDR 0x98) seen on ratgdo and Athom devices. mDNS keeps an IGMP membership on the STA interface, and the delayed membership report timers survive disconnects; the only thing that stops lwIP from transmitting into the WiFi driver is the interface link flag, which the SDK clears asynchronously after a disconnect. If the IGMP timer fires while the driver has already freed its connection node but the interface is still up, `ieee80211_output_pbuf` walks a null node and crashes.

The fix takes the STA interface down as soon as we know the station is disconnected, in the disconnect event handler and right before `wifi_station_disconnect()`. This is the same glue `netif_set_down()` teardown the SDK performs on every normal disconnect, just done deterministically before lwIP can transmit, so pending timer traffic is dropped at the glue instead of reaching the dead driver. IGMP group membership is not removed by this call, and LEAmDNS re-joins and re-announces through its own netif status callback on reconnect, so mDNS recovers the same way it does today.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18308
- fixes https://github.com/esphome/esphome/issues/17955

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
