### PR TITLE
[logger] Defer platform imports out of module scope

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -3,36 +3,6 @@ import re
 from esphome import automation
 from esphome.automation import LambdaAction, StatelessLambdaAction
 import esphome.codegen as cg
-from esphome.components.esp32 import (
-    VARIANT_ESP32,
-    VARIANT_ESP32C2,
-    VARIANT_ESP32C3,
-    VARIANT_ESP32C5,
-    VARIANT_ESP32C6,
-    VARIANT_ESP32C61,
-    VARIANT_ESP32H2,
-    VARIANT_ESP32H4,
-    VARIANT_ESP32H21,
-    VARIANT_ESP32P4,
-    VARIANT_ESP32S2,
-    VARIANT_ESP32S3,
-    VARIANT_ESP32S31,
-    add_idf_sdkconfig_option,
-    get_esp32_variant,
-    require_usb_serial_jtag_secondary,
-    require_vfs_termios,
-)
-from esphome.components.libretiny import get_libretiny_component, get_libretiny_family
-from esphome.components.libretiny.const import (
-    COMPONENT_BK72XX,
-    COMPONENT_LN882X,
-    COMPONENT_RTL87XX,
-)
-from esphome.components.zephyr import (
-    zephyr_add_cdc_acm,
-    zephyr_add_overlay,
-    zephyr_add_prj_conf,
-)
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -108,29 +78,7 @@ CONF_TASK_LOG_BUFFER_SIZE = "task_log_buffer_size"
 CONF_WAIT_FOR_CDC = "wait_for_cdc"
 CONF_EARLY_MESSAGE = "early_message"
 
-UART_SELECTION_ESP32 = {
-    VARIANT_ESP32: [UART0, UART1, UART2],
-    VARIANT_ESP32C2: [UART0, UART1],
-    VARIANT_ESP32C3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32C5: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32C6: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32C61: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32H2: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32H4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32H21: [UART0, UART1, USB_SERIAL_JTAG],
-    VARIANT_ESP32P4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32S2: [UART0, UART1, USB_CDC],
-    VARIANT_ESP32S3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-    VARIANT_ESP32S31: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-}
-
 UART_SELECTION_ESP8266 = [UART0, UART0_SWAP, UART1]
-
-UART_SELECTION_LIBRETINY = {
-    COMPONENT_BK72XX: [DEFAULT, UART1, UART2],
-    COMPONENT_LN882X: [DEFAULT, UART0, UART1, UART2],
-    COMPONENT_RTL87XX: [DEFAULT, UART0, UART1, UART2],
-}
 
 UART_SELECTION_RP2040 = [USB_CDC, UART0, UART1]
 
@@ -166,20 +114,67 @@ is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 def uart_selection(value):
     if CORE.is_esp32:
+        from esphome.components.esp32 import (
+            VARIANT_ESP32,
+            VARIANT_ESP32C2,
+            VARIANT_ESP32C3,
+            VARIANT_ESP32C5,
+            VARIANT_ESP32C6,
+            VARIANT_ESP32C61,
+            VARIANT_ESP32H2,
+            VARIANT_ESP32H4,
+            VARIANT_ESP32H21,
+            VARIANT_ESP32P4,
+            VARIANT_ESP32S2,
+            VARIANT_ESP32S3,
+            VARIANT_ESP32S31,
+            get_esp32_variant,
+        )
+
+        uart_selection_esp32 = {
+            VARIANT_ESP32: [UART0, UART1, UART2],
+            VARIANT_ESP32C2: [UART0, UART1],
+            VARIANT_ESP32C3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32C5: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32C6: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32C61: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32H2: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32H4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32H21: [UART0, UART1, USB_SERIAL_JTAG],
+            VARIANT_ESP32P4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32S2: [UART0, UART1, USB_CDC],
+            VARIANT_ESP32S3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+            VARIANT_ESP32S31: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        }
         variant = get_esp32_variant()
-        if variant in UART_SELECTION_ESP32:
-            return cv.one_of(*UART_SELECTION_ESP32[variant], upper=True)(value)
+        if variant in uart_selection_esp32:
+            return cv.one_of(*uart_selection_esp32[variant], upper=True)(value)
     if CORE.is_esp8266:
         return cv.one_of(*UART_SELECTION_ESP8266, upper=True)(value)
     if CORE.is_rp2:
         return cv.one_of(*UART_SELECTION_RP2040, upper=True)(value)
     if CORE.is_libretiny:
+        from esphome.components.libretiny import (
+            get_libretiny_component,
+            get_libretiny_family,
+        )
+        from esphome.components.libretiny.const import (
+            COMPONENT_BK72XX,
+            COMPONENT_LN882X,
+            COMPONENT_RTL87XX,
+        )
+
+        uart_selection_libretiny = {
+            COMPONENT_BK72XX: [DEFAULT, UART1, UART2],
+            COMPONENT_LN882X: [DEFAULT, UART0, UART1, UART2],
+            COMPONENT_RTL87XX: [DEFAULT, UART0, UART1, UART2],
+        }
         family = get_libretiny_family()
-        if family in UART_SELECTION_LIBRETINY:
-            return cv.one_of(*UART_SELECTION_LIBRETINY[family], upper=True)(value)
+        if family in uart_selection_libretiny:
+            return cv.one_of(*uart_selection_libretiny[family], upper=True)(value)
         component = get_libretiny_component()
-        if component in UART_SELECTION_LIBRETINY:
-            return cv.one_of(*UART_SELECTION_LIBRETINY[component], upper=True)(value)
+        if component in uart_selection_libretiny:
+            return cv.one_of(*uart_selection_libretiny[component], upper=True)(value)
     if CORE.is_host:
         raise cv.Invalid("Uart selection not valid for host platform")
     if CORE.is_nrf52:
@@ -384,6 +379,8 @@ async def _late_logger_init(config: ConfigType) -> None:
     level = config[CONF_LEVEL]
     baud_rate: int = config[CONF_BAUD_RATE]
     if CORE.using_zephyr:
+        from esphome.components.zephyr import zephyr_add_prj_conf
+
         task_log_buffer_size = config.get(CONF_TASK_LOG_BUFFER_SIZE, 0)
         if task_log_buffer_size > 0:
             zephyr_add_prj_conf("MPSC_PBUF", True)
@@ -451,6 +448,8 @@ async def _late_logger_init(config: ConfigType) -> None:
         cg.add_build_flag("-DUSE_STORE_LOG_STR_IN_FLASH")
 
     if CORE.is_esp32:
+        from esphome.components.esp32 import add_idf_sdkconfig_option
+
         if config[CONF_HARDWARE_UART] == USB_CDC:
             add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_USB_CDC", True)
             cg.add_define("USE_LOGGER_UART_SELECTION_USB_CDC")
@@ -468,6 +467,11 @@ async def _late_logger_init(config: ConfigType) -> None:
             and config[CONF_HARDWARE_UART] != USB_SERIAL_JTAG
             and has_serial_logging
         ):
+            from esphome.components.esp32 import (
+                require_usb_serial_jtag_secondary,
+                require_vfs_termios,
+            )
+
             require_usb_serial_jtag_secondary()
             require_vfs_termios()
     except cv.Invalid:
@@ -484,6 +488,12 @@ async def _late_logger_init(config: ConfigType) -> None:
         cg.add_define("USE_LOGGER_EARLY_MESSAGE")
 
     if CORE.is_nrf52:
+        from esphome.components.zephyr import (
+            zephyr_add_cdc_acm,
+            zephyr_add_overlay,
+            zephyr_add_prj_conf,
+        )
+
         # esphome implement own fatal error handler which save PC/LR before reset
         zephyr_add_prj_conf("RESET_ON_FATAL_ERROR", False)
         zephyr_add_prj_conf("THREAD_LOCAL_STORAGE", True)

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -1,3 +1,4 @@
+import functools
 import re
 
 from esphome import automation
@@ -112,6 +113,7 @@ HARDWARE_UART_TO_SERIAL = {
 is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 
+@functools.cache
 def _uart_selection_esp32() -> dict[str, list[str]]:
     from esphome.components.esp32 import (
         VARIANT_ESP32,
@@ -146,6 +148,7 @@ def _uart_selection_esp32() -> dict[str, list[str]]:
     }
 
 
+@functools.cache
 def _uart_selection_libretiny() -> dict[str, list[str]]:
     from esphome.components.libretiny.const import (
         COMPONENT_BK72XX,
@@ -160,14 +163,22 @@ def _uart_selection_libretiny() -> dict[str, list[str]]:
     }
 
 
-def __getattr__(name: str):
-    # These tables are introspected by external tooling (esphome/device-builder);
-    # built on access so the platform packages stay out of module import.
-    if name == "UART_SELECTION_ESP32":
-        return _uart_selection_esp32()
-    if name == "UART_SELECTION_LIBRETINY":
-        return _uart_selection_libretiny()
+# These tables are introspected by external tooling (esphome/device-builder);
+# built on access so the platform packages stay out of module import.
+_LAZY_UART_SELECTION_TABLES = {
+    "UART_SELECTION_ESP32": _uart_selection_esp32,
+    "UART_SELECTION_LIBRETINY": _uart_selection_libretiny,
+}
+
+
+def __getattr__(name: str) -> dict[str, list[str]]:
+    if (table := _LAZY_UART_SELECTION_TABLES.get(name)) is not None:
+        return table()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return [*globals(), *_LAZY_UART_SELECTION_TABLES]
 
 
 def uart_selection(value):

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -112,40 +112,69 @@ HARDWARE_UART_TO_SERIAL = {
 is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 
+def _uart_selection_esp32() -> dict[str, list[str]]:
+    from esphome.components.esp32 import (
+        VARIANT_ESP32,
+        VARIANT_ESP32C2,
+        VARIANT_ESP32C3,
+        VARIANT_ESP32C5,
+        VARIANT_ESP32C6,
+        VARIANT_ESP32C61,
+        VARIANT_ESP32H2,
+        VARIANT_ESP32H4,
+        VARIANT_ESP32H21,
+        VARIANT_ESP32P4,
+        VARIANT_ESP32S2,
+        VARIANT_ESP32S3,
+        VARIANT_ESP32S31,
+    )
+
+    return {
+        VARIANT_ESP32: [UART0, UART1, UART2],
+        VARIANT_ESP32C2: [UART0, UART1],
+        VARIANT_ESP32C3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32C5: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32C6: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32C61: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32H2: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32H4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32H21: [UART0, UART1, USB_SERIAL_JTAG],
+        VARIANT_ESP32P4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32S2: [UART0, UART1, USB_CDC],
+        VARIANT_ESP32S3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+        VARIANT_ESP32S31: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
+    }
+
+
+def _uart_selection_libretiny() -> dict[str, list[str]]:
+    from esphome.components.libretiny.const import (
+        COMPONENT_BK72XX,
+        COMPONENT_LN882X,
+        COMPONENT_RTL87XX,
+    )
+
+    return {
+        COMPONENT_BK72XX: [DEFAULT, UART1, UART2],
+        COMPONENT_LN882X: [DEFAULT, UART0, UART1, UART2],
+        COMPONENT_RTL87XX: [DEFAULT, UART0, UART1, UART2],
+    }
+
+
+def __getattr__(name: str):
+    # These tables are introspected by external tooling (esphome/device-builder);
+    # built on access so the platform packages stay out of module import.
+    if name == "UART_SELECTION_ESP32":
+        return _uart_selection_esp32()
+    if name == "UART_SELECTION_LIBRETINY":
+        return _uart_selection_libretiny()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def uart_selection(value):
     if CORE.is_esp32:
-        from esphome.components.esp32 import (
-            VARIANT_ESP32,
-            VARIANT_ESP32C2,
-            VARIANT_ESP32C3,
-            VARIANT_ESP32C5,
-            VARIANT_ESP32C6,
-            VARIANT_ESP32C61,
-            VARIANT_ESP32H2,
-            VARIANT_ESP32H4,
-            VARIANT_ESP32H21,
-            VARIANT_ESP32P4,
-            VARIANT_ESP32S2,
-            VARIANT_ESP32S3,
-            VARIANT_ESP32S31,
-            get_esp32_variant,
-        )
+        from esphome.components.esp32 import get_esp32_variant
 
-        uart_selection_esp32 = {
-            VARIANT_ESP32: [UART0, UART1, UART2],
-            VARIANT_ESP32C2: [UART0, UART1],
-            VARIANT_ESP32C3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32C5: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32C6: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32C61: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32H2: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32H4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32H21: [UART0, UART1, USB_SERIAL_JTAG],
-            VARIANT_ESP32P4: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32S2: [UART0, UART1, USB_CDC],
-            VARIANT_ESP32S3: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-            VARIANT_ESP32S31: [UART0, UART1, USB_CDC, USB_SERIAL_JTAG],
-        }
+        uart_selection_esp32 = _uart_selection_esp32()
         variant = get_esp32_variant()
         if variant in uart_selection_esp32:
             return cv.one_of(*uart_selection_esp32[variant], upper=True)(value)
@@ -158,17 +187,8 @@ def uart_selection(value):
             get_libretiny_component,
             get_libretiny_family,
         )
-        from esphome.components.libretiny.const import (
-            COMPONENT_BK72XX,
-            COMPONENT_LN882X,
-            COMPONENT_RTL87XX,
-        )
 
-        uart_selection_libretiny = {
-            COMPONENT_BK72XX: [DEFAULT, UART1, UART2],
-            COMPONENT_LN882X: [DEFAULT, UART0, UART1, UART2],
-            COMPONENT_RTL87XX: [DEFAULT, UART0, UART1, UART2],
-        }
+        uart_selection_libretiny = _uart_selection_libretiny()
         family = get_libretiny_family()
         if family in uart_selection_libretiny:
             return cv.one_of(*uart_selection_libretiny[family], upper=True)(value)

--- a/tests/unit_tests/components/test_logger.py
+++ b/tests/unit_tests/components/test_logger.py
@@ -1,0 +1,24 @@
+"""Tests for the logger component's lazy platform tables."""
+
+import sys
+
+
+def test_uart_selection_tables_exposed_for_external_tooling() -> None:
+    """device-builder introspects these names off the module; keep them
+    accessible (and discoverable) without importing the platform packages."""
+    for mod in ("esphome.components.esp32", "esphome.components.libretiny"):
+        sys.modules.pop(mod, None)
+
+    from esphome.components import logger
+
+    assert "UART_SELECTION_ESP32" in dir(logger)
+    assert "UART_SELECTION_LIBRETINY" in dir(logger)
+    assert logger.UART_SELECTION_ESP32["ESP32C3"] == [
+        "UART0",
+        "UART1",
+        "USB_CDC",
+        "USB_SERIAL_JTAG",
+    ]
+    assert "bk72xx" in logger.UART_SELECTION_LIBRETINY
+    # Repeated access returns the same cached object
+    assert logger.UART_SELECTION_ESP32 is logger.UART_SELECTION_ESP32

--- a/tests/unit_tests/components/test_logger.py
+++ b/tests/unit_tests/components/test_logger.py
@@ -13,6 +13,9 @@ def test_uart_selection_tables_exposed_for_external_tooling() -> None:
 
     assert "UART_SELECTION_ESP32" in dir(logger)
     assert "UART_SELECTION_LIBRETINY" in dir(logger)
+    # dir() must not import the platform packages; only table access may
+    assert "esphome.components.esp32" not in sys.modules
+    assert "esphome.components.libretiny" not in sys.modules
     assert logger.UART_SELECTION_ESP32["ESP32C3"] == [
         "UART0",
         "UART1",


### PR DESCRIPTION
# What does this implement/fix?

Importing the logger component pulled in the esp32, libretiny and zephyr packages at module scope; the esp32 chain alone brings espidf, platformio and writer helpers, about 32 ms and dozens of modules, paid on every platform including builds that never touch an ESP32. Since mqtt, web_server, syslog, ble_nus and api all import logger, every chain that reaches logger paid it too.

The platform imports now happen inside the functions that use them, matching the existing esp8266 lazy import in `_late_logger_init`; the two UART selection tables become cached module level helpers next to the imports that supply their keys. Since esphome/device-builder introspects `UART_SELECTION_ESP32` and `UART_SELECTION_LIBRETINY`, a module `__getattr__` keeps both names importable and a `__dir__` keeps them discoverable, with a unit test pinning that contract. Importing logger drops from 66 ms to 34 ms and no longer loads any platform package.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
