### PR TITLE
[core] Add type annotations to component Python (3/11)

### DIFF
--- a/esphome/components/copy/binary_sensor/__init__.py
+++ b/esphome/components/copy/binary_sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_SOURCE_ID,
 )
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -33,7 +34,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/button/__init__.py
+++ b/esphome/components/copy/button/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_SOURCE_ID,
 )
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -32,7 +33,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await button.register_button(var, config)
     await cg.register_component(var, config)

--- a/esphome/components/copy/cover/__init__.py
+++ b/esphome/components/copy/cover/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_SOURCE_ID,
 )
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -31,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await cover.new_cover(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/fan/__init__.py
+++ b/esphome/components/copy/fan/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import fan
 import esphome.config_validation as cv
 from esphome.const import CONF_ENTITY_CATEGORY, CONF_ICON, CONF_SOURCE_ID
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -25,7 +26,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await fan.new_fan(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/lock/__init__.py
+++ b/esphome/components/copy/lock/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import lock
 import esphome.config_validation as cv
 from esphome.const import CONF_ENTITY_CATEGORY, CONF_ICON, CONF_SOURCE_ID
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -25,7 +26,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await lock.new_lock(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/number/__init__.py
+++ b/esphome/components/copy/number/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -33,7 +34,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await number.new_number(config, min_value=0, max_value=0, step=0)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/select/__init__.py
+++ b/esphome/components/copy/select/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import select
 import esphome.config_validation as cv
 from esphome.const import CONF_ENTITY_CATEGORY, CONF_ICON, CONF_ID, CONF_SOURCE_ID
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -25,7 +26,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await select.register_select(var, config, options=[])
     await cg.register_component(var, config)

--- a/esphome/components/copy/sensor/__init__.py
+++ b/esphome/components/copy/sensor/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -37,7 +38,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/switch/__init__.py
+++ b/esphome/components/copy/switch/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_SOURCE_ID,
 )
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -31,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await switch.new_switch(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/text/__init__.py
+++ b/esphome/components/copy/text/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import text
 import esphome.config_validation as cv
 from esphome.const import CONF_ENTITY_CATEGORY, CONF_ICON, CONF_MODE, CONF_SOURCE_ID
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -26,7 +27,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await text.new_text(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/copy/text_sensor/__init__.py
+++ b/esphome/components/copy/text_sensor/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ENTITY_CATEGORY, CONF_ICON, CONF_SOURCE_ID
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.types import ConfigType
 
 from .. import copy_ns
 
@@ -25,7 +26,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await text_sensor.new_text_sensor(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/integration/sensor.py
+++ b/esphome/components/integration/sensor.py
@@ -11,7 +11,10 @@ from esphome.const import (
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE,
 )
+from esphome.core import ID
 from esphome.core.entity_helpers import inherit_property_from
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 integration_ns = cg.esphome_ns.namespace("integration")
 IntegrationSensor = integration_ns.class_(
@@ -39,14 +42,14 @@ CONF_TIME_UNIT = "time_unit"
 CONF_INTEGRATION_METHOD = "integration_method"
 
 
-def inherit_unit_of_measurement(uom, config):
+def inherit_unit_of_measurement(uom: str, config: ConfigType) -> str:
     suffix = config[CONF_TIME_UNIT]
     if uom.endswith("/" + suffix):
         return uom[0 : -len("/" + suffix)]
     return uom + suffix
 
 
-def inherit_accuracy_decimals(decimals, config):
+def inherit_accuracy_decimals(decimals: int, config: ConfigType) -> int:
     return decimals + 2
 
 
@@ -90,7 +93,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
 
     await cg.register_component(var, config)
@@ -113,7 +116,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def sensor_integration_reset_to_code(config, action_id, template_arg, args):
+async def sensor_integration_reset_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -130,7 +138,12 @@ async def sensor_integration_reset_to_code(config, action_id, template_arg, args
     ),
     synchronous=True,
 )
-async def sensor_integration_set_value_to_code(config, action_id, template_arg, args):
+async def sensor_integration_set_value_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_VALUE], args, cg.float_)

--- a/esphome/components/key_collector/__init__.py
+++ b/esphome/components/key_collector/__init__.py
@@ -15,8 +15,9 @@ from esphome.const import (
     CONF_TIMEOUT,
     CONF_TRIGGER_ID,
 )
+from esphome.core import ID
 from esphome.cpp_generator import MockObj, literal
-from esphome.types import TemplateArgsType
+from esphome.types import ConfigType, TemplateArgsType
 
 CODEOWNERS = ["@ssieb"]
 
@@ -90,7 +91,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     for source_conf in config.get(CONF_SOURCE_ID, ()):
@@ -144,7 +145,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def enable_to_code(config, action_id, template_arg, args):
+async def enable_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -160,7 +166,12 @@ async def enable_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def disable_to_code(config, action_id, template_arg, args):
+async def disable_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var

--- a/esphome/components/key_collector/text_sensor/__init__.py
+++ b/esphome/components/key_collector/text_sensor/__init__.py
@@ -4,7 +4,7 @@ from esphome.components.text_sensor import TextSensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.cpp_generator import literal
-from esphome.types import TemplateArgsType
+from esphome.types import ConfigType, TemplateArgsType
 
 from .. import CONF_ON_RESULT, CONF_SOURCE_ID, TRIGGER_TYPES, KeyCollector
 
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = text_sensor.text_sensor_schema(TextSensor).extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_SOURCE_ID])
     var = cg.new_Pvariable(config[CONF_ID])
     await text_sensor.register_text_sensor(var, config)

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import output
@@ -9,20 +11,23 @@ from esphome.const import (
     CONF_PHASE_ANGLE,
     CONF_PIN,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["esp32"]
 
 
-def calc_max_frequency(bit_depth):
+def calc_max_frequency(bit_depth: int) -> float:
     return 80e6 / (2**bit_depth)
 
 
-def calc_min_frequency(bit_depth):
+def calc_min_frequency(bit_depth: int) -> float:
     max_div_num = ((2**20) - 1) / 256.0
     return 80e6 / (max_div_num * (2**bit_depth))
 
 
-def validate_frequency(value):
+def validate_frequency(value: Any) -> float:
     value = cv.frequency(value)
     min_freq = calc_min_frequency(20)
     max_freq = calc_max_frequency(1)
@@ -56,7 +61,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     gpio = await cg.gpio_pin_expression(config[CONF_PIN])
     var = cg.new_Pvariable(config[CONF_ID], gpio)
     await cg.register_component(var, config)
@@ -79,7 +84,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def ledc_set_frequency_to_code(config, action_id, template_arg, args):
+async def ledc_set_frequency_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)

--- a/esphome/components/matrix_keypad/__init__.py
+++ b/esphome/components/matrix_keypad/__init__.py
@@ -4,6 +4,7 @@ from esphome.components import key_provider
 from esphome.components.const import CONF_ROWS
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_ON_KEY, CONF_PIN, CONF_TRIGGER_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@ssieb"]
 
@@ -27,7 +28,7 @@ CONF_HAS_DIODES = "has_diodes"
 CONF_HAS_PULLDOWNS = "has_pulldowns"
 
 
-def check_keys(obj):
+def check_keys(obj: ConfigType) -> ConfigType:
     if CONF_KEYS in obj and len(obj[CONF_KEYS]) != len(obj[CONF_ROWS]) * len(
         obj[CONF_COLUMNS]
     ):
@@ -62,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     row_pins = []

--- a/esphome/components/matrix_keypad/binary_sensor/__init__.py
+++ b/esphome/components/matrix_keypad/binary_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_COL, CONF_ID, CONF_KEY, CONF_ROW
+from esphome.types import ConfigType
 
 from .. import CONF_KEYPAD_ID, MatrixKeypad, matrix_keypad_ns
 
@@ -12,7 +13,7 @@ MatrixKeypadBinarySensor = matrix_keypad_ns.class_(
 )
 
 
-def check_button(obj):
+def check_button(obj: ConfigType) -> ConfigType:
     if CONF_ROW in obj or CONF_COL in obj:
         if CONF_KEY in obj:
             raise cv.Invalid("You can't provide both a key and a position")
@@ -40,7 +41,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     if CONF_KEY in config:
         var = cg.new_Pvariable(config[CONF_ID], config[CONF_KEY][0])
     else:

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -3,6 +3,9 @@ import esphome.codegen as cg
 from esphome.components import climate, output, sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_HUMIDITY_SENSOR, CONF_ID, CONF_SENSOR
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 pid_ns = cg.esphome_ns.namespace("pid")
 PIDClimate = pid_ns.class_("PIDClimate", climate.Climate, cg.Component)
@@ -82,7 +85,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await climate.new_climate(config)
     await cg.register_component(var, config)
 
@@ -141,7 +144,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def pid_reset_integral_term(config, action_id, template_arg, args):
+async def pid_reset_integral_term(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -163,7 +171,12 @@ async def pid_reset_integral_term(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
+async def esp8266_set_frequency_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     cg.add(var.set_noiseband(config[CONF_NOISEBAND]))
@@ -185,7 +198,12 @@ async def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def set_control_parameters(config, action_id, template_arg, args):
+async def set_control_parameters(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 

--- a/esphome/components/pid/sensor/__init__.py
+++ b/esphome/components/pid/sensor/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import sensor
 from esphome.components.const import CONF_CLIMATE_ID
 import esphome.config_validation as cv
 from esphome.const import CONF_TYPE, ICON_GAUGE, STATE_CLASS_MEASUREMENT, UNIT_PERCENT
+from esphome.types import ConfigType
 
 from ..climate import PIDClimate, pid_ns
 
@@ -40,7 +41,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_CLIMATE_ID])
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)

--- a/esphome/components/rp2/__init__.py
+++ b/esphome/components/rp2/__init__.py
@@ -179,7 +179,7 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
     return f"https://github.com/earlephilhower/arduino-pico/releases/download/{ver}/rp2040-{ver}.zip"
 
 
-def _parse_platform_version(value: str) -> str:
+def _parse_platform_version(value: Any) -> str:
     value = cv.string(value)
     if value.startswith("http"):
         return value

--- a/esphome/components/rp2/__init__.py
+++ b/esphome/components/rp2/__init__.py
@@ -34,6 +34,7 @@ from esphome.core import (
 from esphome.core.config import BOARD_MAX_LENGTH
 from esphome.helpers import copy_file_if_changed, read_file, write_file_if_changed
 from esphome.platformio.toolchain import copy_ccache_script
+from esphome.storage_json import StorageJSON
 from esphome.types import ConfigType
 
 from . import boards
@@ -145,7 +146,7 @@ def only_on_variant(
     return validator_
 
 
-def get_download_types(storage_json):
+def get_download_types(storage_json: StorageJSON) -> list[dict[str, str]]:
     """Binary-download entries for a built RP2040 firmware.
 
     Used by device-builder (esphome/device-builder), via
@@ -178,7 +179,7 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
     return f"https://github.com/earlephilhower/arduino-pico/releases/download/{ver}/rp2040-{ver}.zip"
 
 
-def _parse_platform_version(value):
+def _parse_platform_version(value: str) -> str:
     value = cv.string(value)
     if value.startswith("http"):
         return value
@@ -202,7 +203,7 @@ RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(6, 0, 0)
 RECOMMENDED_ARDUINO_PLATFORM_VERSION = "9c167c6b8aac4f4cfa6d55a0c4e5b848795150c0"
 
 
-def _arduino_check_versions(value):
+def _arduino_check_versions(value: ConfigType) -> ConfigType:
     value = value.copy()
     lookups = {
         "dev": (cv.Version(6, 0, 0), "https://github.com/earlephilhower/arduino-pico"),
@@ -313,7 +314,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 @coroutine_with_priority(CoroPriority.PLATFORM)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add(rp2_ns.setup_preferences())
 
     # Allow LDF to properly discover dependency including those in preprocessor
@@ -585,7 +586,7 @@ def _generate_lwipopts_h() -> None:
     write_file_if_changed(lwip_dir / "lwipopts.h", content)
 
 
-def add_pio_file(component: str, key: str, data: str):
+def add_pio_file(component: str, key: str, data: str) -> None:
     try:
         cv.validate_id_name(key)
     except cv.Invalid as e:
@@ -626,7 +627,7 @@ def generate_pio_files() -> bool:
 
 
 # Called by writer.py
-def copy_files():
+def copy_files() -> None:
     dir = Path(__file__).parent
     post_build_file = dir / "post_build.py.script"
     copy_file_if_changed(
@@ -667,7 +668,7 @@ def _addr2line(tool: str, elf: Path, addr: str) -> str:
         return f"{addr} (decode failed)"
 
 
-def process_stacktrace(config, line: str, backtrace_state: bool) -> bool:
+def process_stacktrace(config: ConfigType, line: str, backtrace_state: bool) -> bool:
     """Decode RP2040 crash handler output using addr2line."""
     if _CRASH_RE.search(line):
         _LOGGER.error("RP2040 crash detected - decoding addresses")

--- a/esphome/components/rp2/generate_boards.py
+++ b/esphome/components/rp2/generate_boards.py
@@ -256,7 +256,7 @@ def generate(arduino_pico_path: Path) -> str:
     return result.stdout.decode()
 
 
-def main():
+def main() -> None:
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <arduino-pico-path>", file=sys.stderr)
         sys.exit(1)

--- a/esphome/components/rp2/gpio.py
+++ b/esphome/components/rp2/gpio.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
@@ -14,6 +16,8 @@ from esphome.const import (
     CONF_PULLUP,
 )
 from esphome.core import CORE
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 from . import boards
 from .const import KEY_BOARD, KEY_RP2, rp2_ns
@@ -21,7 +25,7 @@ from .const import KEY_BOARD, KEY_RP2, rp2_ns
 RP2GPIOPin = rp2_ns.class_("RP2GPIOPin", cg.InternalGPIOPin)
 
 
-def _lookup_pin(value):
+def _lookup_pin(value: str) -> int:
     board = CORE.data[KEY_RP2][KEY_BOARD]
     board_pins = boards.RP2_BOARD_PINS.get(board, {})
 
@@ -35,7 +39,7 @@ def _lookup_pin(value):
     raise cv.Invalid(f"Cannot resolve pin name '{value}' for board {board}.")
 
 
-def _translate_pin(value):
+def _translate_pin(value: Any) -> int:
     if isinstance(value, dict) or value is None:
         raise cv.Invalid(
             "This variable only supports pin numbers, not full pin schemas "
@@ -54,12 +58,12 @@ def _translate_pin(value):
     return _lookup_pin(value)
 
 
-def _board_max_virtual_pin(board):
+def _board_max_virtual_pin(board: str) -> int | None:
     """Get the max CYW43 virtual pin for this board, or None if no virtual pins."""
     return boards.BOARDS.get(board, {}).get("max_virtual_pin")
 
 
-def validate_gpio_pin(value):
+def validate_gpio_pin(value: Any) -> int:
     value = _translate_pin(value)
     board = CORE.data[KEY_RP2][KEY_BOARD]
     max_virtual = _board_max_virtual_pin(board)
@@ -71,7 +75,7 @@ def validate_gpio_pin(value):
     return value
 
 
-def validate_supports(value):
+def validate_supports(value: ConfigType) -> ConfigType:
     board = CORE.data[KEY_RP2][KEY_BOARD]
     if (
         _board_max_virtual_pin(board) is None
@@ -100,7 +104,7 @@ RP2_PIN_SCHEMA = cv.All(
 
 
 @pins.PIN_SCHEMA_REGISTRY.register("rp2", RP2_PIN_SCHEMA)
-async def rp2_pin_to_code(config):
+async def rp2_pin_to_code(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     num = config[CONF_NUMBER]
     cg.add(var.set_pin(num))

--- a/esphome/components/rp2040_pwm/output.py
+++ b/esphome/components/rp2040_pwm/output.py
@@ -3,6 +3,9 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_FREQUENCY, CONF_ID, CONF_PIN
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["rp2"]
@@ -22,7 +25,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await output.register_output(var, config)
@@ -44,7 +47,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def rp2040_set_frequency_to_code(config, action_id, template_arg, args):
+async def rp2040_set_frequency_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)

--- a/esphome/components/sn74hc165/__init__.py
+++ b/esphome/components/sn74hc165/__init__.py
@@ -10,6 +10,8 @@ from esphome.const import (
     CONF_MODE,
     CONF_NUMBER,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = []
@@ -38,7 +40,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     data_pin = await cg.gpio_pin_expression(config[CONF_DATA_PIN])
@@ -54,7 +56,7 @@ async def to_code(config):
     cg.add(var.set_sr_count(config[CONF_SR_COUNT]))
 
 
-def _validate_input_mode(value):
+def _validate_input_mode(value: bool) -> bool:
     if value is not True:
         raise cv.Invalid("Only input mode is supported")
     return value
@@ -77,7 +79,9 @@ SN74HC165_PIN_SCHEMA = cv.All(
 )
 
 
-def sn74hc165_pin_final_validate(pin_config, parent_config):
+def sn74hc165_pin_final_validate(
+    pin_config: ConfigType, parent_config: ConfigType
+) -> None:
     max_pins = parent_config[CONF_SR_COUNT] * 8
     if pin_config[CONF_NUMBER] >= max_pins:
         raise cv.Invalid(f"Pin number must be less than {max_pins}")
@@ -86,7 +90,7 @@ def sn74hc165_pin_final_validate(pin_config, parent_config):
 @pins.PIN_SCHEMA_REGISTRY.register(
     CONF_SN74HC165, SN74HC165_PIN_SCHEMA, sn74hc165_pin_final_validate
 )
-async def sn74hc165_pin_to_code(config):
+async def sn74hc165_pin_to_code(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_parented(var, config[CONF_SN74HC165])
 

--- a/esphome/components/sun/__init__.py
+++ b/esphome/components/sun/__init__.py
@@ -1,5 +1,6 @@
 import contextlib
 import re
+from typing import Any
 
 from esphome import automation
 import esphome.codegen as cg
@@ -12,6 +13,9 @@ from esphome.const import (
     CONF_TIME_ID,
     CONF_TRIGGER_ID,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@OttoWinter"]
 sun_ns = cg.esphome_ns.namespace("sun")
@@ -40,7 +44,7 @@ ELEVATION_MAP = {
 }
 
 
-def elevation(value):
+def elevation(value: Any) -> float:
     if isinstance(value, str):
         with contextlib.suppress(cv.Invalid):
             value = ELEVATION_MAP[
@@ -60,7 +64,7 @@ LAT_LON_REGEX = re.compile(
 )
 
 
-def parse_latlon(value):
+def parse_latlon(value: Any) -> float:
     if isinstance(value, str) and value.endswith("°"):
         # strip trailing degree character
         value = value[:-1]
@@ -114,7 +118,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     time_ = await cg.get_variable(config[CONF_TIME_ID])
     cg.add(var.set_time(time_))
@@ -150,7 +154,12 @@ async def to_code(config):
         }
     ),
 )
-async def sun_above_horizon_to_code(config, condition_id, template_arg, args):
+async def sun_above_horizon_to_code(
+    config: ConfigType,
+    condition_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     templ = await cg.templatable(config[CONF_ELEVATION], args, cg.double)
@@ -171,7 +180,12 @@ async def sun_above_horizon_to_code(config, condition_id, template_arg, args):
         }
     ),
 )
-async def sun_below_horizon_to_code(config, condition_id, template_arg, args):
+async def sun_below_horizon_to_code(
+    config: ConfigType,
+    condition_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     templ = await cg.templatable(config[CONF_ELEVATION], args, cg.double)

--- a/esphome/components/sun/sensor/__init__.py
+++ b/esphome/components/sun/sensor/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_DEGREES,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_SUN_ID, Sun, sun_ns
 
@@ -37,7 +38,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/sun/text_sensor/__init__.py
+++ b/esphome/components/sun/text_sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     ICON_WEATHER_SUNSET_DOWN,
     ICON_WEATHER_SUNSET_UP,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_ELEVATION, CONF_SUN_ID, DEFAULT_ELEVATION, Sun, elevation, sun_ns
 
@@ -22,7 +23,7 @@ SUN_TYPES = {
 }
 
 
-def validate_optional_icon(config):
+def validate_optional_icon(config: ConfigType) -> ConfigType:
     if CONF_ICON not in config:
         config = config.copy()
         config[CONF_ICON] = {
@@ -48,7 +49,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await text_sensor.new_text_sensor(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+import voluptuous as vol
+
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display
@@ -14,6 +18,8 @@ from esphome.const import (
     CONF_TRANSFORM,
 )
 from esphome.core import CoroPriority, coroutine_with_priority
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz", "@nielsnl68"]
 DEPENDENCIES = ["display"]
@@ -40,7 +46,7 @@ CONF_Y_MIN = "y_min"
 CONF_Y_MAX = "y_max"
 
 
-def validate_calibration(calibration_config):
+def validate_calibration(calibration_config: ConfigType) -> ConfigType:
     x_min = calibration_config[CONF_X_MIN]
     x_max = calibration_config[CONF_X_MAX]
     y_min = calibration_config[CONF_Y_MIN]
@@ -60,7 +66,9 @@ def validate_calibration(calibration_config):
     return calibration_config
 
 
-def option_with_default(option: str, defaults: dict, required: bool = False):
+def option_with_default(
+    option: str, defaults: dict, required: bool = False
+) -> vol.Marker:
     if option in defaults or not required:
         return cv.Optional(option, default=defaults.get(option, cv.UNDEFINED))
     return cv.Required(option)
@@ -119,8 +127,8 @@ def _transform_schema(defaults: dict) -> dict:
 
 
 def touchscreen_schema(
-    default_touch_timeout=cv.UNDEFINED,
-    calibration_required=False,
+    default_touch_timeout: Any = cv.UNDEFINED,
+    calibration_required: bool = False,
     defaults: dict = None,
 ) -> cv.Schema:
     defaults = defaults or {}
@@ -143,7 +151,7 @@ def touchscreen_schema(
 TOUCHSCREEN_SCHEMA = touchscreen_schema(cv.UNDEFINED)
 
 
-async def register_touchscreen(var, config):
+async def register_touchscreen(var: MockObj, config: ConfigType) -> None:
     await cg.register_component(var, config)
 
     disp = await cg.get_variable(config[CONF_DISPLAY])
@@ -192,6 +200,6 @@ async def register_touchscreen(var, config):
 
 
 @coroutine_with_priority(CoroPriority.CORE)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_global(touchscreen_ns.using)
     cg.add_define("USE_TOUCHSCREEN")

--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -129,7 +129,7 @@ def _transform_schema(defaults: dict) -> dict:
 def touchscreen_schema(
     default_touch_timeout: Any = cv.UNDEFINED,
     calibration_required: bool = False,
-    defaults: dict = None,
+    defaults: dict | None = None,
 ) -> cv.Schema:
     defaults = defaults or {}
     return cv.Schema(

--- a/esphome/components/touchscreen/binary_sensor/__init__.py
+++ b/esphome/components/touchscreen/binary_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor, display
 import esphome.config_validation as cv
 from esphome.const import CONF_PAGE_ID, CONF_PAGES
+from esphome.types import ConfigType
 
 from .. import CONF_TOUCHSCREEN_ID, TouchListener, Touchscreen, touchscreen_ns
 
@@ -22,7 +23,7 @@ CONF_Y_MAX = "y_max"
 CONF_USE_RAW = "use_raw"
 
 
-def _validate_coords(config):
+def _validate_coords(config: ConfigType) -> ConfigType:
     if (
         config[CONF_X_MAX] < config[CONF_X_MIN]
         or config[CONF_Y_MAX] < config[CONF_Y_MIN]
@@ -66,7 +67,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_TOUCHSCREEN_ID])

--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -14,14 +14,15 @@ from esphome.const import (
     DEVICE_CLASS_FIRMWARE,
     ENTITY_CATEGORY_CONFIG,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CORE, ID, CoroPriority, coroutine_with_priority
 from esphome.core.entity_helpers import (
     entity_duplicate_validator,
     queue_entity_register,
     setup_device_class,
     setup_entity,
 )
-from esphome.cpp_generator import MockObjClass
+from esphome.cpp_generator import MockObj, MockObjClass, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz"]
 IS_PLATFORM_COMPONENT = True
@@ -95,7 +96,7 @@ def update_schema(
 
 
 @setup_entity("update")
-async def setup_update_core_(var, config):
+async def setup_update_core_(var: MockObj, config: ConfigType) -> None:
     setup_device_class(config)
 
     if on_update_available := config.get(CONF_ON_UPDATE_AVAILABLE):
@@ -113,7 +114,7 @@ async def setup_update_core_(var, config):
         await web_server.add_entity_config(var, web_server_config)
 
 
-async def register_update(var, config):
+async def register_update(var: MockObj, config: ConfigType) -> None:
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     queue_entity_register("update", config)
@@ -121,14 +122,14 @@ async def register_update(var, config):
     await setup_update_core_(var, config)
 
 
-async def new_update(config):
+async def new_update(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await register_update(var, config)
     return var
 
 
 @coroutine_with_priority(CoroPriority.CORE)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_global(update_ns.using)
 
 
@@ -145,7 +146,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def update_perform_action_to_code(config, action_id, template_arg, args):
+async def update_perform_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 
@@ -164,7 +170,12 @@ async def update_perform_action_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def update_check_action_to_code(config, action_id, template_arg, args):
+async def update_check_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -180,8 +191,11 @@ async def update_check_action_to_code(config, action_id, template_arg, args):
     ),
 )
 async def update_is_available_condition_to_code(
-    config, condition_id, template_arg, args
-):
+    config: ConfigType,
+    condition_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var

--- a/esphome/components/vbus/__init__.py
+++ b/esphome/components/vbus/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@ssieb"]
 
@@ -29,7 +30,7 @@ CONFIG_SCHEMA = uart.UART_DEVICE_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     DEVICE_CLASS_PROBLEM,
     ENTITY_CATEGORY_DIAGNOSTIC,
 )
+from esphome.types import ConfigType
 
 from .. import (
     CONF_DELTASOL_BS2,
@@ -256,7 +257,7 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/vbus/sensor/__init__.py
+++ b/esphome/components/vbus/sensor/__init__.py
@@ -29,6 +29,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_WATT_HOURS,
 )
+from esphome.types import ConfigType
 
 from .. import (
     CONF_DELTASOL_BS2,
@@ -650,7 +651,7 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -14,6 +14,9 @@ from esphome.const import (
     CONF_ON_START,
     CONF_SPEAKER,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["audio", "ring_buffer", "socket"]
 DEPENDENCIES = ["api", "microphone"]
@@ -78,7 +81,7 @@ ConnectedCondition = voice_assistant_ns.class_(
 Timer = voice_assistant_ns.struct("Timer")
 
 
-def tts_stream_validate(config):
+def tts_stream_validate(config: ConfigType) -> ConfigType:
     if CONF_SPEAKER not in config and (
         CONF_ON_TTS_STREAM_START in config or CONF_ON_TTS_STREAM_END in config
     ):
@@ -199,7 +202,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
@@ -420,7 +423,12 @@ VOICE_ASSISTANT_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(VoiceAssis
     ),
     synchronous=True,
 )
-async def voice_assistant_listen_to_code(config, action_id, template_arg, args):
+async def voice_assistant_listen_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     if CONF_SILENCE_DETECTION in config:
@@ -434,7 +442,12 @@ async def voice_assistant_listen_to_code(config, action_id, template_arg, args):
 @register_action(
     "voice_assistant.stop", StopAction, VOICE_ASSISTANT_ACTION_SCHEMA, synchronous=True
 )
-async def voice_assistant_stop_to_code(config, action_id, template_arg, args):
+async def voice_assistant_stop_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -443,7 +456,12 @@ async def voice_assistant_stop_to_code(config, action_id, template_arg, args):
 @register_condition(
     "voice_assistant.is_running", IsRunningCondition, VOICE_ASSISTANT_ACTION_SCHEMA
 )
-async def voice_assistant_is_running_to_code(config, condition_id, template_arg, args):
+async def voice_assistant_is_running_to_code(
+    config: ConfigType,
+    condition_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -452,7 +470,12 @@ async def voice_assistant_is_running_to_code(config, condition_id, template_arg,
 @register_condition(
     "voice_assistant.connected", ConnectedCondition, VOICE_ASSISTANT_ACTION_SCHEMA
 )
-async def voice_assistant_connected_to_code(config, condition_id, template_arg, args):
+async def voice_assistant_connected_to_code(
+    config: ConfigType,
+    condition_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(condition_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var

--- a/esphome/components/xiaomi_rtcgq02lm/__init__.py
+++ b/esphome/components/xiaomi_rtcgq02lm/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_BINDKEY, CONF_ID, CONF_MAC_ADDRESS
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["ble_device_base", "xiaomi_ble"]
 CODEOWNERS = ["@jesserockz"]
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await ble_device_base.register_ble_device(var, config)

--- a/esphome/components/xiaomi_rtcgq02lm/binary_sensor.py
+++ b/esphome/components/xiaomi_rtcgq02lm/binary_sensor.py
@@ -11,6 +11,7 @@ from esphome.const import (
     DEVICE_CLASS_MOTION,
 )
 from esphome.core import TimePeriod
+from esphome.types import ConfigType
 
 from . import XiaomiRTCGQ02LM
 
@@ -45,7 +46,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_ID])
 
     if CONF_MOTION in config:

--- a/esphome/components/xiaomi_rtcgq02lm/sensor.py
+++ b/esphome/components/xiaomi_rtcgq02lm/sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 from . import XiaomiRTCGQ02LM
 
@@ -29,7 +30,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_ID])
 
     if CONF_BATTERY_LEVEL in config:


### PR DESCRIPTION
# What does this implement/fix?

Adds parameter and return type annotations to the Python code of 15 components, as part of a repo-wide sweep to get everything under `esphome/components` fully annotated. This is part 3 of 11 covering the mid-sized components.

Components are grouped so that each code owner's components land in a single pull request rather than being spread across many.

Annotations only. No behaviour changes, no renames, no reordering, no docstring edits. Component files have no `from __future__ import annotations`, so annotations are evaluated at import time and every name used in one is imported at module level.

Components in this pull request: `copy`, `integration`, `key_collector`, `ledc`, `matrix_keypad`, `pid`, `rp2`, `rp2040_pwm`, `sn74hc165`, `sun`, `touchscreen`, `update`, `vbus`, `voice_assistant`, `xiaomi_rtcgq02lm`

Verified with `ruff check`, `ruff format --check`, `pylint`, `script/ci-custom.py`, the unit and component test suites, and an import of all 1637 component modules. That last check is the important one: because annotations are evaluated at import time, a missing import for an annotation name shows up there as a hard failure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing configuration change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
