### PR TITLE
[core] Add type annotations to component Python (4/11)

### DIFF
--- a/esphome/components/aic3204/audio_dac.py
+++ b/esphome/components/aic3204/audio_dac.py
@@ -4,6 +4,9 @@ from esphome.components import i2c
 from esphome.components.audio_dac import AudioDac
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_MODE
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@kbx81"]
 DEPENDENCIES = ["i2c"]
@@ -39,7 +42,12 @@ SET_AUTO_MUTE_ACTION_SCHEMA = cv.maybe_simple_value(
     SET_AUTO_MUTE_ACTION_SCHEMA,
     synchronous=True,
 )
-async def aic3204_set_volume_to_code(config, action_id, template_arg, args):
+async def aic3204_set_volume_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -49,7 +57,7 @@ async def aic3204_set_volume_to_code(config, action_id, template_arg, args):
     return var
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/audio_adc/__init__.py
+++ b/esphome/components/audio_adc/__init__.py
@@ -2,7 +2,9 @@ from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_MIC_GAIN
-from esphome.core import CoroPriority, coroutine_with_priority
+from esphome.core import ID, CoroPriority, coroutine_with_priority
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@kbx81"]
 IS_PLATFORM_COMPONENT = True
@@ -28,7 +30,12 @@ SET_MIC_GAIN_ACTION_SCHEMA = cv.maybe_simple_value(
     SET_MIC_GAIN_ACTION_SCHEMA,
     synchronous=True,
 )
-async def audio_adc_set_mic_gain_to_code(config, action_id, template_arg, args):
+async def audio_adc_set_mic_gain_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -39,6 +46,6 @@ async def audio_adc_set_mic_gain_to_code(config, action_id, template_arg, args):
 
 
 @coroutine_with_priority(CoroPriority.CORE)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_AUDIO_ADC")
     cg.add_global(audio_adc_ns.using)

--- a/esphome/components/audio_dac/__init__.py
+++ b/esphome/components/audio_dac/__init__.py
@@ -3,7 +3,9 @@ from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_VOLUME
-from esphome.core import CoroPriority, coroutine_with_priority
+from esphome.core import ID, CoroPriority, coroutine_with_priority
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@kbx81"]
 IS_PLATFORM_COMPONENT = True
@@ -37,7 +39,12 @@ SET_VOLUME_ACTION_SCHEMA = cv.maybe_simple_value(
 @automation.register_action(
     "audio_dac.mute_on", MuteOnAction, MUTE_ACTION_SCHEMA, synchronous=True
 )
-async def audio_dac_mute_action_to_code(config, action_id, template_arg, args):
+async def audio_dac_mute_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -48,7 +55,12 @@ async def audio_dac_mute_action_to_code(config, action_id, template_arg, args):
     SET_VOLUME_ACTION_SCHEMA,
     synchronous=True,
 )
-async def audio_dac_set_volume_to_code(config, action_id, template_arg, args):
+async def audio_dac_set_volume_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -59,6 +71,6 @@ async def audio_dac_set_volume_to_code(config, action_id, template_arg, args):
 
 
 @coroutine_with_priority(CoroPriority.CORE)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_AUDIO_DAC")
     cg.add_global(audio_dac_ns.using)

--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_SAMPLE_RATE,
     CONF_TEMPERATURE_OFFSET,
 )
+from esphome.cpp_generator import MockObj
 from esphome.external_files import RemoteFile
 from esphome.types import ConfigType
 
@@ -94,7 +95,7 @@ def _compute_url(config: dict) -> str:
     return f"https://raw.githubusercontent.com/boschsensortec/Bosch-BSEC2-Library/{BSEC2_LIBRARY_VERSION}/src/config/{model}/{model}_{algo}_{volts}_{sample_rate}_{operating_age}/{filename}.txt"
 
 
-def download_bme68x_blob(config):
+def download_bme68x_blob(config: ConfigType) -> ConfigType:
     url = _compute_url(config)
     path = _compute_local_file_path(url)
     external_files.download_content(url, path)
@@ -138,7 +139,7 @@ def _extract_blob_ref(entry: ConfigType) -> RemoteFile | None:
 PREFETCH_FILES = external_files.single_stage_prefetch(_extract_blob_ref)
 
 
-def validate_bme68x(config):
+def validate_bme68x(config: ConfigType) -> ConfigType:
     if CONF_ALGORITHM_OUTPUT not in config:
         return config
 
@@ -178,7 +179,7 @@ CONFIG_SCHEMA_BASE = (
 )
 
 
-async def to_code_base(config):
+async def to_code_base(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/bme68x_bsec2/sensor.py
+++ b/esphome/components/bme68x_bsec2/sensor.py
@@ -29,6 +29,8 @@ from esphome.const import (
     UNIT_PARTS_PER_MILLION,
     UNIT_PERCENT,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 from . import CONF_BME68X_BSEC2_ID, SAMPLE_RATE_OPTIONS, BME68xBSEC2Component
 
@@ -119,7 +121,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def setup_conf(config, key, hub):
+async def setup_conf(config: ConfigType, key: str, hub: MockObj) -> None:
     if conf := config.get(key):
         sens = await sensor.new_sensor(conf)
         cg.add(getattr(hub, f"set_{key}_sensor")(sens))
@@ -127,7 +129,7 @@ async def setup_conf(config, key, hub):
             cg.add(getattr(hub, f"set_{key}_sample_rate")(sample_rate))
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_BME68X_BSEC2_ID])
     for key in TYPES:
         await setup_conf(config, key, hub)

--- a/esphome/components/bme68x_bsec2/text_sensor.py
+++ b/esphome/components/bme68x_bsec2/text_sensor.py
@@ -2,6 +2,8 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_IAQ_ACCURACY
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 from . import CONF_BME68X_BSEC2_ID, BME68xBSEC2Component
 
@@ -21,13 +23,13 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def setup_conf(config, key, hub):
+async def setup_conf(config: ConfigType, key: str, hub: MockObj) -> None:
     if conf := config.get(key):
         sens = await text_sensor.new_text_sensor(conf)
         cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_BME68X_BSEC2_ID])
     for key in TYPES:
         await setup_conf(config, key, hub)

--- a/esphome/components/dfrobot_sen0395/__init__.py
+++ b/esphome/components/dfrobot_sen0395/__init__.py
@@ -1,9 +1,14 @@
+from typing import Any
+
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_FACTORY_RESET, CONF_ID, CONF_SENSITIVITY
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@niklasweber"]
 DEPENDENCIES = ["uart"]
@@ -38,7 +43,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
@@ -54,14 +59,19 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def dfrobot_sen0395_reset_to_code(config, action_id, template_arg, args):
+async def dfrobot_sen0395_reset_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 
     return var
 
 
-def range_segment_list(input):
+def range_segment_list(input: Any) -> list:
     """Validate input is a list of ranges which can be used to configure the dfrobot mmwave radar
 
     A list of segments should be provided. A minimum of one segment is required and a maximum of
@@ -154,7 +164,12 @@ MMWAVE_SETTINGS_SCHEMA = cv.Schema(
     MMWAVE_SETTINGS_SCHEMA,
     synchronous=True,
 )
-async def dfrobot_sen0395_settings_to_code(config, action_id, template_arg, args):
+async def dfrobot_sen0395_settings_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 

--- a/esphome/components/dfrobot_sen0395/binary_sensor.py
+++ b/esphome/components/dfrobot_sen0395/binary_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import DEVICE_CLASS_MOTION
+from esphome.types import ConfigType
 
 from . import CONF_DFROBOT_SEN0395_ID, DfrobotSen0395Component
 
@@ -16,7 +17,7 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_DFROBOT_SEN0395_ID])
     binary_sens = await binary_sensor.new_binary_sensor(config)
 

--- a/esphome/components/dfrobot_sen0395/switch/__init__.py
+++ b/esphome/components/dfrobot_sen0395/switch/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import CONF_TYPE, ENTITY_CATEGORY_CONFIG
 from esphome.cpp_generator import MockObjClass
+from esphome.types import ConfigType
 
 from .. import CONF_DFROBOT_SEN0395_ID, DfrobotSen0395Component
 
@@ -55,7 +56,7 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_DFROBOT_SEN0395_ID])
     var = await switch.new_switch(config)
     await cg.register_component(var, config)

--- a/esphome/components/dlms_meter/__init__.py
+++ b/esphome/components/dlms_meter/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from typing import Any
 
 import esphome.codegen as cg
 from esphome.components import esp32, uart
@@ -12,6 +13,7 @@ from esphome.const import (
     CONF_RECEIVE_TIMEOUT,
 )
 from esphome.core import CORE
+from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,13 +35,13 @@ DlmsMeterComponent = dlms_meter_component_ns.class_(
 )
 
 
-def obis_code(value):
+def obis_code(value: Any) -> str:
     # Normalize the OBIS code to the strict A.B.C.D.E.F format
     bytes_list = parse_obis_code_bytes(value)
     return ".".join(str(b) for b in bytes_list)
 
 
-def parse_obis_code_bytes(value):
+def parse_obis_code_bytes(value: Any) -> list[int]:
     value = cv.string(value)
     normalized = re.sub(r"[\-\:\*]", ".", value)
     parts = normalized.split(".")
@@ -57,19 +59,19 @@ def parse_obis_code_bytes(value):
     return bytes_list
 
 
-def custom_pattern_dict(value):
+def custom_pattern_dict(value: Any) -> ConfigType:
     if isinstance(value, str):
         return {CONF_PATTERN: value}
     return value
 
 
-def validate_custom_pattern(value):
+def validate_custom_pattern(value: ConfigType) -> ConfigType:
     if CONF_DEFAULT_OBIS in value and CONF_NAME not in value:
         raise cv.Invalid(f"'{CONF_DEFAULT_OBIS}' requires '{CONF_NAME}' to be set")
     return value
 
 
-def validate_provider_deprecation(config):
+def validate_provider_deprecation(config: ConfigType) -> ConfigType:
     if CONF_PROVIDER in config:
         provider = str(config[CONF_PROVIDER]).lower()
         if provider == "netznoe":
@@ -154,7 +156,7 @@ CONFIG_SCHEMA = cv.All(
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema("dlms_meter", require_rx=True)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     dec_key_expr = cg.RawExpression("std::nullopt")
     if dec_key := config.get(CONF_DECRYPTION_KEY):
         key_bytes = [str(int(dec_key[i : i + 2], 16)) for i in range(0, 32, 2)]

--- a/esphome/components/dlms_meter/binary_sensor/__init__.py
+++ b/esphome/components/dlms_meter/binary_sensor/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import CONF_DLMS_METER_ID, CONF_OBIS_CODE, DlmsMeterComponent, obis_code
 
@@ -14,7 +15,7 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_DLMS_METER_ID])
     var = await binary_sensor.new_binary_sensor(config)
     cg.add(hub.register_binary_sensor(config[CONF_OBIS_CODE], var))

--- a/esphome/components/dlms_meter/sensor/__init__.py
+++ b/esphome/components/dlms_meter/sensor/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_DLMS_METER_ID, CONF_OBIS_CODE, DlmsMeterComponent, obis_code
 
@@ -47,7 +48,7 @@ DYNAMIC_SCHEMA = sensor.sensor_schema().extend(
 )
 
 
-def deprecation_warning(config):
+def deprecation_warning(config: ConfigType) -> ConfigType:
     _LOGGER.warning(
         "The dlms_meter sensor schema using predefined keys (e.g., 'voltage_l1') is deprecated and will be removed in 2026.11.0. "
         "Please update your configuration to use the new schema with 'obis_code'."
@@ -145,7 +146,7 @@ OLD_SCHEMA = cv.All(
 CONFIG_SCHEMA = cv.Any(DYNAMIC_SCHEMA, OLD_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_DLMS_METER_ID])
 
     if obis := config.get(CONF_OBIS_CODE):

--- a/esphome/components/dlms_meter/text_sensor/__init__.py
+++ b/esphome/components/dlms_meter/text_sensor/__init__.py
@@ -3,6 +3,7 @@ import logging
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import CONF_DLMS_METER_ID, CONF_OBIS_CODE, DlmsMeterComponent, obis_code
 
@@ -23,7 +24,7 @@ DYNAMIC_SCHEMA = text_sensor.text_sensor_schema().extend(
 )
 
 
-def deprecation_warning(config):
+def deprecation_warning(config: ConfigType) -> ConfigType:
     _LOGGER.warning(
         "The dlms_meter text_sensor schema using predefined keys (e.g., 'timestamp') is deprecated and will be removed in 2026.11.0. "
         "Please update your configuration to use the new schema with 'obis_code'."
@@ -46,7 +47,7 @@ OLD_SCHEMA = cv.All(
 CONFIG_SCHEMA = cv.Any(DYNAMIC_SCHEMA, OLD_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_DLMS_METER_ID])
 
     if obis := config.get(CONF_OBIS_CODE):

--- a/esphome/components/ina2xx_base/__init__.py
+++ b/esphome/components/ina2xx_base/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import esphome.codegen as cg
 from esphome.components import sensor
 from esphome.components.const import UNIT_AMPERE_HOUR
@@ -26,6 +28,9 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
+from esphome.core import EnumValue
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@latonita"]
 
@@ -76,7 +81,7 @@ SENSOR_MODEL_OPTIONS = {
 }
 
 
-def validate_model_config(config):
+def validate_model_config(config: ConfigType) -> ConfigType:
     model = config[CONF_MODEL]
 
     for key in config:
@@ -92,7 +97,7 @@ def validate_model_config(config):
     return config
 
 
-def validate_adc_time(value):
+def validate_adc_time(value: Any) -> EnumValue:
     value = cv.positive_time_period_microseconds(value).total_microseconds
     return cv.enum(ADC_TIMES, int=True)(value)
 
@@ -198,7 +203,7 @@ INA2XX_SCHEMA = cv.Schema(
 ).extend(cv.polling_component_schema("60s"))
 
 
-async def setup_ina2xx(var, config):
+async def setup_ina2xx(var: MockObj, config: ConfigType) -> None:
     await cg.register_component(var, config)
 
     cg.add(var.set_model(config[CONF_MODEL]))

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -58,7 +58,8 @@ from esphome.const import (
     PLATFORM_RTL87XX,
     PlatformFramework,
 )
-from esphome.core import CORE, CoroPriority, Lambda, coroutine_with_priority
+from esphome.core import CORE, ID, CoroPriority, Lambda, coroutine_with_priority
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core"]
@@ -164,7 +165,7 @@ HARDWARE_UART_TO_SERIAL = {
 is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 
-def uart_selection(value):
+def uart_selection(value: str) -> str:
     if CORE.is_esp32:
         variant = get_esp32_variant()
         if variant in UART_SELECTION_ESP32:
@@ -187,7 +188,7 @@ def uart_selection(value):
     raise NotImplementedError
 
 
-def validate_local_no_higher_than_global(config):
+def validate_local_no_higher_than_global(config: ConfigType) -> ConfigType:
     global_level = config[CONF_LEVEL]
     global_level_index = LOG_LEVEL_SEVERITY.index(global_level)
     errs = []
@@ -204,7 +205,7 @@ def validate_local_no_higher_than_global(config):
     return config
 
 
-def validate_initial_no_higher_than_global(config):
+def validate_initial_no_higher_than_global(config: ConfigType) -> ConfigType:
     if initial_level := config.get(CONF_INITIAL_LEVEL):
         global_level = config[CONF_LEVEL]
         if LOG_LEVEL_SEVERITY.index(initial_level) > LOG_LEVEL_SEVERITY.index(
@@ -217,7 +218,7 @@ def validate_initial_no_higher_than_global(config):
     return config
 
 
-def validate_wait_for_cdc(config):
+def validate_wait_for_cdc(config: ConfigType) -> ConfigType:
     if config.get(CONF_WAIT_FOR_CDC) and config.get(CONF_HARDWARE_UART) != USB_CDC:
         raise cv.Invalid("wait_for_cdc requires hardware_uart: USB_CDC")
     return config
@@ -518,7 +519,7 @@ async def _late_logger_init(config: ConfigType) -> None:
     CORE.add_job(final_step)
 
 
-def validate_printf(value):
+def validate_printf(value: ConfigType) -> ConfigType:
     # https://stackoverflow.com/questions/30011379/how-can-i-parse-a-c-format-string-in-python
     cfmt = r"""
     (                                   # start of capture group 1
@@ -559,7 +560,12 @@ LOGGER_LOG_ACTION_SCHEMA = cv.All(
 @automation.register_action(
     CONF_LOGGER_LOG, LambdaAction, LOGGER_LOG_ACTION_SCHEMA, synchronous=True
 )
-async def logger_log_action_to_code(config, action_id, template_arg, args):
+async def logger_log_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     esp_log = LOG_LEVEL_TO_ESP_LOG[config[CONF_LEVEL]]
     args_ = [cg.RawExpression(str(x)) for x in config[CONF_ARGS]]
 
@@ -584,7 +590,12 @@ async def logger_log_action_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def logger_set_level_to_code(config, action_id, template_arg, args):
+async def logger_set_level_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     level = LOG_LEVELS[config[CONF_LEVEL]]
     logger = await cg.get_variable(config[CONF_LOGGER_ID])
     if tag := config.get(CONF_TAG):
@@ -656,7 +667,7 @@ def request_log_listener() -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
-async def final_step():
+async def final_step() -> None:
     """Final code generation step to configure optional logger features."""
     domain_data = CORE.data.get(DOMAIN, {})
     if domain_data.get(KEY_LEVEL_LISTENERS, False):

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from esphome import automation
 from esphome.automation import LambdaAction, StatelessLambdaAction
@@ -165,7 +166,7 @@ HARDWARE_UART_TO_SERIAL = {
 is_log_level = cv.one_of(*LOG_LEVELS, upper=True)
 
 
-def uart_selection(value: str) -> str:
+def uart_selection(value: Any) -> str:
     if CORE.is_esp32:
         variant = get_esp32_variant()
         if variant in UART_SELECTION_ESP32:

--- a/esphome/components/logger/select/__init__.py
+++ b/esphome/components/logger/select/__init__.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_LEVEL, CONF_LOGGER, ENTITY_CATEGORY_CONFIG, ICON_BUG
 from esphome.core import CORE
 from esphome.cpp_helpers import register_component, register_parented
+from esphome.types import ConfigType
 
 from .. import (
     CONF_LOGGER_ID,
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = select.select_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     request_logger_level_listeners()
     parent = await cg.get_variable(config[CONF_LOGGER_ID])
     levels = list(LOG_LEVELS)

--- a/esphome/components/ltr501/sensor.py
+++ b/esphome/components/ltr501/sensor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import i2c, sensor
@@ -24,6 +26,7 @@ from esphome.const import (
     UNIT_LUX,
     UNIT_MILLISECOND,
 )
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@latonita"]
 DEPENDENCIES = ["i2c"]
@@ -87,17 +90,17 @@ PS_GAINS = {
 }
 
 
-def validate_integration_time(value):
+def validate_integration_time(value: Any) -> Any:
     value = cv.positive_time_period_milliseconds(value).total_milliseconds
     return cv.enum(INTEGRATION_TIMES, int=True)(value)
 
 
-def validate_repeat_rate(value):
+def validate_repeat_rate(value: Any) -> Any:
     value = cv.positive_time_period_milliseconds(value).total_milliseconds
     return cv.enum(MEASUREMENT_REPEAT_RATES, int=True)(value)
 
 
-def validate_time_and_repeat_rate(config):
+def validate_time_and_repeat_rate(config: ConfigType) -> ConfigType:
     integraton_time = config[CONF_INTEGRATION_TIME]
     repeat_rate = config[CONF_REPEAT]
     if integraton_time > repeat_rate:
@@ -107,7 +110,7 @@ def validate_time_and_repeat_rate(config):
     return config
 
 
-def validate_als_gain_and_integration_time(config):
+def validate_als_gain_and_integration_time(config: ConfigType) -> ConfigType:
     integraton_time = config[CONF_INTEGRATION_TIME]
     if config[CONF_GAIN] == "1X" and integraton_time > 100:
         raise cv.Invalid(
@@ -221,7 +224,7 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/ltr_als_ps/sensor.py
+++ b/esphome/components/ltr_als_ps/sensor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import i2c, sensor
@@ -23,6 +25,7 @@ from esphome.const import (
     UNIT_LUX,
     UNIT_MILLISECOND,
 )
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@latonita"]
 DEPENDENCIES = ["i2c"]
@@ -93,17 +96,17 @@ PS_GAINS = {
 }
 
 
-def validate_integration_time(value):
+def validate_integration_time(value: Any) -> Any:
     value = cv.positive_time_period_milliseconds(value).total_milliseconds
     return cv.enum(INTEGRATION_TIMES, int=True)(value)
 
 
-def validate_repeat_rate(value):
+def validate_repeat_rate(value: Any) -> Any:
     value = cv.positive_time_period_milliseconds(value).total_milliseconds
     return cv.enum(MEASUREMENT_REPEAT_RATES, int=True)(value)
 
 
-def validate_time_and_repeat_rate(config):
+def validate_time_and_repeat_rate(config: ConfigType) -> ConfigType:
     integraton_time = config[CONF_INTEGRATION_TIME]
     repeat_rate = config[CONF_REPEAT]
     if integraton_time > repeat_rate:
@@ -211,7 +214,7 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/msa3xx/__init__.py
+++ b/esphome/components/msa3xx/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     CONF_TRANSFORM,
     CONF_TYPE,
 )
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@latonita"]
 DEPENDENCIES = ["i2c"]
@@ -123,7 +124,7 @@ MSA_SENSOR_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/msa3xx/binary_sensor.py
+++ b/esphome/components/msa3xx/binary_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ACTIVE, CONF_NAME, DEVICE_CLASS_VIBRATION, ICON_VIBRATE
+from esphome.types import ConfigType
 
 from . import CONF_MSA3XX_ID, MSA_SENSOR_SCHEMA
 
@@ -31,7 +32,7 @@ CONFIG_SCHEMA = MSA_SENSOR_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_MSA3XX_ID])
 
     for sensor in EVENT_SENSORS:

--- a/esphome/components/msa3xx/sensor.py
+++ b/esphome/components/msa3xx/sensor.py
@@ -10,6 +10,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_METER_PER_SECOND_SQUARED,
 )
+from esphome.types import ConfigType
 
 from . import CONF_MSA3XX_ID, MSA_SENSOR_SCHEMA
 
@@ -34,7 +35,7 @@ CONFIG_SCHEMA = MSA_SENSOR_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_MSA3XX_ID])
     for accel_key in ACCELERATION_SENSORS:
         if accel_key in config:

--- a/esphome/components/msa3xx/text_sensor.py
+++ b/esphome/components/msa3xx/text_sensor.py
@@ -2,6 +2,8 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_NAME
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 from . import CONF_MSA3XX_ID, MSA_SENSOR_SCHEMA
 
@@ -25,13 +27,13 @@ CONFIG_SCHEMA = MSA_SENSOR_SCHEMA.extend(
 )
 
 
-async def setup_conf(config, key, hub):
+async def setup_conf(config: ConfigType, key: str, hub: MockObj) -> None:
     if sensor_config := config.get(key):
         var = await text_sensor.new_text_sensor(sensor_config)
         cg.add(getattr(hub, f"set_{key}_text_sensor")(var))
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_MSA3XX_ID])
 
     for key in ORIENTATION_SENSORS:

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -12,6 +12,8 @@ from esphome.const import (
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.coroutine import CoroPriority
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 OTA_STATE_LISTENER_KEY = "ota_state_listener"
 
@@ -49,7 +51,7 @@ OTAStateChangeTrigger = ota_ns.class_(
 )
 
 
-def _ota_final_validate(config):
+def _ota_final_validate(config: ConfigType) -> None:
     if len(config) < 1:
         raise cv.Invalid(
             f"At least one platform must be specified for '{CONF_OTA}'; add '{CONF_PLATFORM}: {CONF_ESPHOME}' for original OTA functionality"
@@ -95,7 +97,7 @@ BASE_OTA_SCHEMA = cv.Schema(
 
 
 @coroutine_with_priority(CoroPriority.OTA_UPDATES)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_OTA")
     CORE.add_job(final_step)
 
@@ -103,7 +105,7 @@ async def to_code(config):
         cg.add_library("Updater", None)
 
 
-async def ota_to_code(var, config):
+async def ota_to_code(var: MockObj, config: ConfigType) -> None:
     await cg.past_safe_mode()
     use_state_callback = False
     for conf in config.get(CONF_ON_STATE_CHANGE, []):
@@ -145,7 +147,7 @@ def request_ota_state_listeners() -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
-async def final_step():
+async def final_step() -> None:
     """Final code generation step to configure optional OTA features."""
     if CORE.data.get(OTA_STATE_LISTENER_KEY, False):
         cg.add_define("USE_OTA_STATE_LISTENER")

--- a/esphome/components/safe_mode/__init__.py
+++ b/esphome/components/safe_mode/__init__.py
@@ -10,8 +10,9 @@ from esphome.const import (
     CONF_STORAGE,
     KEY_PAST_SAFE_MODE,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
-from esphome.cpp_generator import RawExpression
+from esphome.core import CORE, ID, CoroPriority, coroutine_with_priority
+from esphome.cpp_generator import MockObj, RawExpression, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@paulmonigatti", "@jsuanet", "@kbx81"]
 
@@ -24,7 +25,7 @@ SafeModeComponent = safe_mode_ns.class_("SafeModeComponent", cg.Component)
 MarkSuccessfulAction = safe_mode_ns.class_("MarkSuccessfulAction", automation.Action)
 
 
-def _remove_id_if_disabled(value):
+def _remove_id_if_disabled(value: ConfigType) -> ConfigType:
     value = value.copy()
     if value[CONF_DISABLED]:
         value.pop(CONF_ID)
@@ -62,7 +63,12 @@ CONFIG_SCHEMA = cv.All(
     ),
     synchronous=True,
 )
-async def safe_mode_mark_successful_to_code(config, action_id, template_arg, args):
+async def safe_mode_mark_successful_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     parent = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg)
     cg.add(var.set_parent(parent))
@@ -75,7 +81,7 @@ _CALLBACK_AUTOMATIONS = (
 
 
 @coroutine_with_priority(CoroPriority.APPLICATION)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     if not config[CONF_DISABLED]:
         var = cg.new_Pvariable(config[CONF_ID])
         await cg.register_component(var, config)

--- a/esphome/components/safe_mode/button/__init__.py
+++ b/esphome/components/safe_mode/button/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     ENTITY_CATEGORY_CONFIG,
     ICON_RESTART_ALERT,
 )
+from esphome.types import ConfigType
 
 from .. import SafeModeComponent, safe_mode_ns
 
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await button.new_button(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/safe_mode/switch/__init__.py
+++ b/esphome/components/safe_mode/switch/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import CONF_SAFE_MODE, ENTITY_CATEGORY_CONFIG, ICON_RESTART_ALERT
+from esphome.types import ConfigType
 
 from .. import SafeModeComponent, safe_mode_ns
 
@@ -21,7 +22,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await switch.new_switch(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -83,7 +83,7 @@ def _render_hz(value: float) -> str:
     return formatted + unit
 
 
-def _frequency_validator(value):
+def _frequency_validator(value: Any) -> float:
     platform = get_target_platform()
     frequency = PLATFORM_SPI_CLOCKS[platform]
     value = cv.frequency(value)
@@ -153,17 +153,17 @@ RP_SPI_PINSETS = [
 ]
 
 
-def get_target_platform():
+def get_target_platform() -> str:
     return CORE.data[KEY_CORE][KEY_TARGET_PLATFORM]
 
 
-def get_target_variant():
+def get_target_variant() -> str:
     return CORE.data[KEY_ESP32].get(KEY_VARIANT, "")
 
 
 # Get a list of available hardware interfaces based on target and variant.
 # The returned value is a list of lists of names
-def get_hw_interface_list():
+def get_hw_interface_list() -> list[list[str]]:
     target_platform = get_target_platform()
     if target_platform == PLATFORM_ESP8266:
         return [["spi", "hspi"]]
@@ -206,7 +206,7 @@ def one_of_interface_validator(additional_values: list[str] | None = None) -> An
 
 
 # Given an SPI name, return the index of it in the available list
-def get_spi_index(name):
+def get_spi_index(name: str) -> int:
     for i, ilist in enumerate(get_hw_interface_list()):
         if name in ilist:
             return i
@@ -218,7 +218,7 @@ def get_spi_index(name):
 # \param spi the config data for the spi instance
 # \param index the selected hw interface number, -1 if not yet known
 # TODO verify that the pins are internal
-def validate_hw_pins(spi, index=-1):
+def validate_hw_pins(spi: ConfigType, index: int = -1) -> bool:
     clk_pin = spi[CONF_CLK_PIN]
     if clk_pin[CONF_INVERTED]:
         return False
@@ -265,7 +265,7 @@ def validate_hw_pins(spi, index=-1):
     return False
 
 
-def get_hw_spi(config, available):
+def get_hw_spi(config: ConfigType, available: list[int]) -> int | None:
     """Get an available hardware spi interface suitable for this config"""
     matching = list(filter(lambda idx: validate_hw_pins(config, idx), available))
     if len(matching) != 0:
@@ -273,7 +273,7 @@ def get_hw_spi(config, available):
     return None
 
 
-def validate_spi_config(config):
+def validate_spi_config(config: list[ConfigType]) -> list[ConfigType]:
     available = list(range(len(get_hw_interface_list())))
     for spi in config:
         interface = spi[CONF_INTERFACE]
@@ -317,7 +317,7 @@ def validate_spi_config(config):
 
 
 # Given an SPI index, convert to a string that represents the C++ object for it.
-def get_spi_interface(index):
+def get_spi_interface(index: int) -> str:
     platform = get_target_platform()
     if platform == PLATFORM_ESP32:
         # ESP32 uses ESP-IDF SPI driver for both Arduino and IDF frameworks
@@ -353,7 +353,7 @@ SPI_SINGLE_SCHEMA = cv.All(
 )
 
 
-def spi_mode_schema(mode):
+def spi_mode_schema(mode: str) -> cv.Schema:
     if mode == TYPE_SINGLE:
         return SPI_SINGLE_SCHEMA
     pin_count = 4 if mode == TYPE_QUAD else 8
@@ -400,7 +400,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 @coroutine_with_priority(CoroPriority.BUS)
-async def to_code(configs):
+async def to_code(configs: list[ConfigType]) -> None:
     cg.add_define("USE_SPI")
     cg.add_global(spi_ns.using)
     if CORE.using_arduino and not CORE.is_esp32:
@@ -427,11 +427,11 @@ async def to_code(configs):
 
 
 def spi_device_schema(
-    cs_pin_required=True,
-    default_data_rate=cv.UNDEFINED,
-    default_mode=cv.UNDEFINED,
-    mode=TYPE_SINGLE,
-):
+    cs_pin_required: bool = True,
+    default_data_rate: Any = cv.UNDEFINED,
+    default_mode: Any = cv.UNDEFINED,
+    mode: str = TYPE_SINGLE,
+) -> cv.Schema:
     """Create a schema for an SPI device.
     :param cs_pin_required: If true, make the CS_PIN required in the config.
     :param default_data_rate: Optional data_rate to use as default
@@ -456,7 +456,7 @@ def spi_device_schema(
 
 
 async def register_spi_device(
-    var: cg.Pvariable, config: ConfigType, write_only: bool = False
+    var: cg.MockObj, config: ConfigType, write_only: bool = False
 ) -> None:
     parent = await cg.get_variable(config[CONF_SPI_ID])
     cg.add(var.set_spi_parent(parent))
@@ -473,7 +473,9 @@ async def register_spi_device(
         cg.add(var.set_release_device(release_device))
 
 
-def final_validate_device_schema(name: str, *, require_mosi: bool, require_miso: bool):
+def final_validate_device_schema(
+    name: str, *, require_mosi: bool, require_miso: bool
+) -> cv.Schema:
     hub_schema = {}
     if require_miso:
         hub_schema[

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -196,7 +196,7 @@ def one_of_interface_validator(additional_values: list[str] | None = None) -> An
     if additional_values is None:
         additional_values = []
 
-    def validator(value: str) -> str:
+    def validator(value: Any) -> str:
         return cv.one_of(
             *sum(get_hw_interface_list(), additional_values),
             lower=True,

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from esphome import pins
 import esphome.codegen as cg
@@ -19,6 +20,7 @@ from esphome.const import (
     CONF_ROTATION,
     CONF_WIDTH,
 )
+from esphome.types import ConfigType
 
 from . import st7789v_ns
 
@@ -38,7 +40,9 @@ MODEL_PRESETS = "model_presets"
 REQUIRE_PS = "require_ps"
 
 
-def model_spec(require_ps=False, presets=None):
+def model_spec(
+    require_ps: bool = False, presets: dict[str, Any] | None = None
+) -> dict[str, Any]:
     if presets is None:
         presets = {}
     return {MODEL_PRESETS: presets, REQUIRE_PS: require_ps}
@@ -119,7 +123,7 @@ MODELS = {
 }
 
 
-def validate_st7789v(config):
+def validate_st7789v(config: ConfigType) -> ConfigType:
     model_data = MODELS[config[CONF_MODEL]]
     presets = model_data[MODEL_PRESETS]
     for key, value in presets.items():
@@ -178,7 +182,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LOGGER.warning(
         "The 'st7789v' component is deprecated, it is recommended to use 'mipi_spi' instead."
     )

--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -43,23 +43,23 @@ SAFE_GLOBALS = {
 
 
 class JinjaError(Exception):
-    def __init__(self, context_trace: dict, expr: str):
+    def __init__(self, context_trace: dict, expr: str) -> None:
         self.context_trace = context_trace
         self.eval_stack = [expr]
 
-    def parent(self):
+    def parent(self) -> BaseException | None:
         return self.__context__
 
-    def error_name(self):
+    def error_name(self) -> str:
         return type(self.parent()).__name__
 
-    def context_trace_str(self):
+    def context_trace_str(self) -> str:
         return "\n".join(
             f"  {k} = {repr(v)} ({type(v).__name__})"
             for k, v in self.context_trace.items()
         )
 
-    def stack_trace_str(self):
+    def stack_trace_str(self) -> str:
         return "\n".join(
             f" {len(self.eval_stack) - i}: {expr}{i == 0 and ' <-- ' + self.error_name() or ''}"
             for i, expr in enumerate(self.eval_stack)
@@ -67,7 +67,7 @@ class JinjaError(Exception):
 
 
 class TrackerContext(jinja.runtime.Context):
-    def resolve_or_missing(self, key):
+    def resolve_or_missing(self, key: str) -> Any:
         val = super().resolve_or_missing(key)
         if val is Missing:
             # Variable not in the template context — check if a resolver callback

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import climate, sensor
@@ -70,6 +72,7 @@ from esphome.const import (
     CONF_TARGET_TEMPERATURE_CHANGE_ACTION,
     CONF_VISUAL,
 )
+from esphome.types import ConfigType
 
 CONF_DEFAULT_PRESET = "default_preset"
 CONF_HUMIDITY_CONTROL_DEHUMIDIFY_ACTION = "humidity_control_dehumidify_action"
@@ -124,7 +127,12 @@ PRESET_CONFIG_SCHEMA = cv.Schema(
 )
 
 
-def validate_temperature_preset(preset, root_config, name, requirements):
+def validate_temperature_preset(
+    preset: ConfigType,
+    root_config: ConfigType,
+    name: str,
+    requirements: dict[str, list[str]],
+) -> None:
     # verify temperature settings for the provided preset / default / away configuration
     for config_temp, req_actions in requirements.items():
         for req_action in req_actions:
@@ -140,7 +148,7 @@ def validate_temperature_preset(preset, root_config, name, requirements):
                 )
 
 
-def generate_comparable_preset(config, name):
+def generate_comparable_preset(config: ConfigType, name: str) -> str:
     comparable_preset = f"{CONF_PRESET}:\n  -  {CONF_NAME}: {name}\n"
 
     if CONF_DEFAULT_TARGET_TEMPERATURE_LOW in config:
@@ -151,7 +159,7 @@ def generate_comparable_preset(config, name):
     return comparable_preset
 
 
-def validate_heat_cool_mode(value) -> list:
+def validate_heat_cool_mode(value: Any) -> list:
     """Validate heat_cool_mode - accepts either True or an automation."""
     if value is True:
         # Convert True to empty automation list
@@ -164,7 +172,7 @@ def validate_heat_cool_mode(value) -> list:
     return automation.validate_automation(single=True)(value)
 
 
-def validate_thermostat(config):
+def validate_thermostat(config: ConfigType) -> ConfigType:
     # verify corresponding action(s) exist(s) for any defined climate mode or action
     requirements = {
         CONF_HEAT_COOL_MODE: [
@@ -681,7 +689,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await climate.new_climate(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/waveshare_io_ch32v003/__init__.py
+++ b/esphome/components/waveshare_io_ch32v003/__init__.py
@@ -10,6 +10,8 @@ from esphome.const import (
     CONF_NUMBER,
     CONF_OUTPUT,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@latonita"]
 
@@ -41,13 +43,13 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
 
-def validate_mode(value):
+def validate_mode(value: ConfigType) -> ConfigType:
     if not (value[CONF_INPUT] or value[CONF_OUTPUT]):
         raise cv.Invalid("Mode must be either input or output")
     if value[CONF_INPUT] and value[CONF_OUTPUT]:
@@ -71,7 +73,7 @@ WAVESHARE_IO_PIN_SCHEMA = pins.gpio_base_schema(
 
 
 @pins.PIN_SCHEMA_REGISTRY.register(CONF_WAVESHARE_IO_CH32V003, WAVESHARE_IO_PIN_SCHEMA)
-async def waveshare_io_pin_to_code(config):
+async def waveshare_io_pin_to_code(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_WAVESHARE_IO_CH32V003])
 

--- a/esphome/components/waveshare_io_ch32v003/output/__init__.py
+++ b/esphome/components/waveshare_io_ch32v003/output/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_MAX_VALUE, CONF_MIN_VALUE
+from esphome.types import ConfigType
 
 from .. import (
     CONF_WAVESHARE_IO_CH32V003_ID,
@@ -23,7 +24,7 @@ DUTY_DEFAULT_MIN = 1
 DUTY_DEFAULT_MAX = 247
 
 
-def validate_pwm_limits(config):
+def validate_pwm_limits(config: ConfigType) -> ConfigType:
     """Validate that safe_pwm_levels.min_value <= safe_pwm_levels.max_value."""
 
     min_val = config.get(CONF_SAFE_PWM_LEVELS, {}).get(CONF_MIN_VALUE, DUTY_DEFAULT_MIN)
@@ -61,7 +62,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await output.register_output(var, config)
     await cg.register_parented(var, config[CONF_WAVESHARE_IO_CH32V003_ID])

--- a/esphome/components/waveshare_io_ch32v003/sensor/__init__.py
+++ b/esphome/components/waveshare_io_ch32v003/sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
 )
+from esphome.types import ConfigType
 
 from .. import (
     CONF_WAVESHARE_IO_CH32V003_ID,
@@ -46,7 +47,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_parented(var, config[CONF_WAVESHARE_IO_CH32V003_ID])
     await cg.register_component(var, config)

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -39,6 +39,7 @@ from esphome.const import (
     PLATFORM_RTL87XX,
 )
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.cpp_generator import MockObj
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
@@ -307,7 +308,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def add_sorting_groups(web_server_var, config):
+def add_sorting_groups(web_server_var: MockObj, config: list[ConfigType]) -> None:
     for group in config:
         sorting_groups[group[CONF_ID]] = group[CONF_NAME]
         group_sorting_weight = group.get(CONF_SORTING_WEIGHT, 50)
@@ -318,7 +319,7 @@ def add_sorting_groups(web_server_var, config):
         )
 
 
-async def add_entity_config(entity, config):
+async def add_entity_config(entity: MockObj, config: ConfigType) -> None:
     web_server = await cg.get_variable(config[CONF_WEB_SERVER_ID])
     sorting_weight = config.get(CONF_SORTING_WEIGHT, 50)
     sorting_group_hash = hash(config.get(CONF_SORTING_GROUP_ID))
@@ -333,7 +334,7 @@ async def add_entity_config(entity, config):
     )
 
 
-def build_index_html(config) -> str:
+def build_index_html(config: ConfigType) -> str:
     html = "<!DOCTYPE html><html><head><meta charset=UTF-8><link rel=icon href=data:>"
     css_include = config.get(CONF_CSS_INCLUDE)
     js_include = config.get(CONF_JS_INCLUDE)
@@ -367,7 +368,7 @@ def add_resource_as_progmem(
 
 
 @coroutine_with_priority(CoroPriority.WEB)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_WEB_SERVER_BASE_ID])
 
     var = cg.new_Pvariable(config[CONF_ID], paren)

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -4,6 +4,7 @@ import base64
 import gzip
 import logging
 import re
+from typing import Any
 
 import esphome.codegen as cg
 from esphome.components import web_server_base
@@ -129,7 +130,7 @@ def validate_ota(config: ConfigType) -> ConfigType:
 _ORIGIN_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://[^/\s]+$")
 
 
-def validate_origin(value: str) -> str:
+def validate_origin(value: Any) -> str:
     # "*" is the wildcard that allows any origin.
     if value == "*":
         return value

--- a/esphome/components/web_server/ota/__init__.py
+++ b/esphome/components/web_server/ota/__init__.py
@@ -80,7 +80,7 @@ FINAL_VALIDATE_SCHEMA = _web_server_ota_final_validate
 
 
 @coroutine_with_priority(CoroPriority.WEB_SERVER_OTA)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await ota_to_code(var, config)
     await cg.register_component(var, config)


### PR DESCRIPTION
# What does this implement/fix?

Adds parameter and return type annotations to the Python code of 19 components, as part of a repo-wide sweep to get everything under `esphome/components` fully annotated. This is part 4 of 11 covering the mid-sized components.

Components are grouped so that each code owner's components land in a single pull request rather than being spread across many.

Annotations only. No behaviour changes, no renames, no reordering, no docstring edits. Component files have no `from __future__ import annotations`, so annotations are evaluated at import time and every name used in one is imported at module level.

Components in this pull request: `aic3204`, `audio_adc`, `audio_dac`, `bme68x_bsec2`, `dfrobot_sen0395`, `dlms_meter`, `ina2xx_base`, `logger`, `ltr501`, `ltr_als_ps`, `msa3xx`, `ota`, `safe_mode`, `spi`, `st7789v`, `substitutions`, `thermostat`, `waveshare_io_ch32v003`, `web_server`

Verified with `ruff check`, `ruff format --check`, `pylint`, `script/ci-custom.py`, the unit and component test suites, and an import of all 1637 component modules. That last check is the important one: because annotations are evaluated at import time, a missing import for an annotation name shows up there as a hard failure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing configuration change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
