### PR TITLE
[core] Add type annotations to component Python (8/11)

### DIFF
--- a/esphome/components/atm90e32/button/__init__.py
+++ b/esphome/components/atm90e32/button/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, ENTITY_CATEGORY_CONFIG, ICON_SCALE
+from esphome.types import ConfigType
 
 from .. import atm90e32_ns
 from ..sensor import ATM90E32Component
@@ -67,7 +68,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_ID])
 
     if run_gain := config.get(CONF_RUN_GAIN_CALIBRATION):

--- a/esphome/components/atm90e32/number/__init__.py
+++ b/esphome/components/atm90e32/number/__init__.py
@@ -15,6 +15,7 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_VOLT,
 )
+from esphome.types import ConfigType
 
 from .. import atm90e32_ns
 from ..sensor import ATM90E32Component
@@ -90,7 +91,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_ID])
 
     if voltage_cfg := config.get(CONF_REFERENCE_VOLTAGE):

--- a/esphome/components/atm90e32/sensor.py
+++ b/esphome/components/atm90e32/sensor.py
@@ -41,6 +41,7 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
+from esphome.types import ConfigType
 
 from . import atm90e32_ns
 
@@ -191,7 +192,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_instance_id(str(config[CONF_ID])))
     await cg.register_component(var, config)

--- a/esphome/components/atm90e32/text_sensor/__init__.py
+++ b/esphome/components/atm90e32/text_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PHASE_A, CONF_PHASE_B, CONF_PHASE_C
+from esphome.types import ConfigType
 
 from ..sensor import ATM90E32Component
 
@@ -34,7 +35,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_ID])
 
     if phase_cfg := config.get(CONF_PHASE_STATUS):

--- a/esphome/components/bl0940/button/__init__.py
+++ b/esphome/components/bl0940/button/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_CONFIG, ICON_RESTART
+from esphome.types import ConfigType
 
 from .. import CONF_BL0940_ID, bl0940_ns
 from ..sensor import BL0940
@@ -21,7 +22,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await button.new_button(config)
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_BL0940_ID])

--- a/esphome/components/bl0940/number/__init__.py
+++ b/esphome/components/bl0940/number/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     ENTITY_CATEGORY_CONFIG,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_BL0940_ID, bl0940_ns
 from ..sensor import BL0940
@@ -27,7 +28,7 @@ CalibrationNumber = bl0940_ns.class_(
 )
 
 
-def validate_min_max(config):
+def validate_min_max(config: ConfigType) -> ConfigType:
     if config[CONF_MAX_VALUE] <= config[CONF_MIN_VALUE]:
         raise cv.Invalid("max_value must be greater than min_value")
     return config
@@ -69,7 +70,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     # Get the BL0940 component instance
     bl0940 = await cg.get_variable(config[CONF_BL0940_ID])
 

--- a/esphome/components/bl0940/sensor.py
+++ b/esphome/components/bl0940/sensor.py
@@ -23,6 +23,7 @@ from esphome.const import (
     UNIT_VOLT,
     UNIT_WATT,
 )
+from esphome.types import ConfigType
 
 from . import bl0940_ns
 
@@ -69,27 +70,29 @@ DEFAULT_BL0940_LEGACY_EREF = 3.6e6 / 297
 
 
 # methods to calculate voltage and current reference values
-def calculate_voltage_reference(vref, r_one, r_two):
+def calculate_voltage_reference(vref: float, r_one: float, r_two: float) -> float:
     # formula: 79931 / Vref * (R1 * 1000) / (R1 + R2)
     return 79931 / vref * (r_one * 1000) / (r_one + r_two)
 
 
-def calculate_current_reference(vref, r_shunt):
+def calculate_current_reference(vref: float, r_shunt: float) -> float:
     # formula: 324004 * RL / Vref
     return 324004 * r_shunt / vref
 
 
-def calculate_power_reference(voltage_reference, current_reference):
+def calculate_power_reference(
+    voltage_reference: float, current_reference: float
+) -> float:
     # calculate power reference based on voltage and current reference
     return voltage_reference * current_reference * 4046 / 324004 / 79931
 
 
-def calculate_energy_reference(power_reference):
+def calculate_energy_reference(power_reference: float) -> float:
     # formula: power_reference * 3600000 / (1638.4 * 256)
     return power_reference * 3600000 / (1638.4 * 256)
 
 
-def validate_legacy_mode(config):
+def validate_legacy_mode(config: ConfigType) -> ConfigType:
     # Only allow schematic calibration options if legacy_mode is False
     if config.get(CONF_LEGACY_MODE, True):
         forbidden = [
@@ -106,7 +109,7 @@ def validate_legacy_mode(config):
     return config
 
 
-def set_command_defaults(config):
+def set_command_defaults(config: ConfigType) -> ConfigType:
     # Set defaults for read_command and write_command based on legacy_mode
     legacy = config.get(CONF_LEGACY_MODE, True)
     if legacy:
@@ -118,7 +121,7 @@ def set_command_defaults(config):
     return config
 
 
-def set_reference_values(config):
+def set_reference_values(config: ConfigType) -> ConfigType:
     # Set default reference values based on legacy_mode
     if config.get(CONF_LEGACY_MODE, True):
         config.setdefault(CONF_VOLTAGE_REFERENCE, DEFAULT_BL0940_LEGACY_UREF)
@@ -223,7 +226,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/bm8563/time.py
+++ b/esphome/components/bm8563/time.py
@@ -3,6 +3,9 @@ import esphome.codegen as cg
 from esphome.components import i2c, time
 import esphome.config_validation as cv
 from esphome.const import CONF_DURATION, CONF_ID
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["i2c"]
 
@@ -35,7 +38,12 @@ CONFIG_SCHEMA = (
     ),
     synchronous=True,
 )
-async def bm8563_write_time_to_code(config, action_id, template_arg, args):
+async def bm8563_write_time_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -52,7 +60,12 @@ async def bm8563_write_time_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def bm8563_start_timer_to_code(config, action_id, template_arg, args):
+async def bm8563_start_timer_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_DURATION], args, cg.uint32)
@@ -70,13 +83,18 @@ async def bm8563_start_timer_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def bm8563_read_time_to_code(config, action_id, template_arg, args):
+async def bm8563_read_time_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/event/__init__.py
+++ b/esphome/components/event/__init__.py
@@ -16,14 +16,15 @@ from esphome.const import (
     DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_MOTION,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CORE, ID, CoroPriority, coroutine_with_priority
 from esphome.core.entity_helpers import (
     entity_duplicate_validator,
     queue_entity_register,
     setup_device_class,
     setup_entity,
 )
-from esphome.cpp_generator import MockObjClass
+from esphome.cpp_generator import MockObj, MockObjClass, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@nohat"]
 IS_PLATFORM_COMPONENT = True
@@ -93,7 +94,9 @@ _CALLBACK_AUTOMATIONS = (
 
 
 @setup_entity("event")
-async def setup_event_core_(var, config, *, event_types: list[str]):
+async def setup_event_core_(
+    var: MockObj, config: ConfigType, *, event_types: list[str]
+) -> None:
     await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)
 
     cg.add(var.set_event_types(event_types))
@@ -108,7 +111,9 @@ async def setup_event_core_(var, config, *, event_types: list[str]):
         await web_server.add_entity_config(var, web_server_config)
 
 
-async def register_event(var, config, *, event_types: list[str]):
+async def register_event(
+    var: MockObj, config: ConfigType, *, event_types: list[str]
+) -> None:
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     queue_entity_register("event", config)
@@ -116,7 +121,7 @@ async def register_event(var, config, *, event_types: list[str]):
     await setup_event_core_(var, config, event_types=event_types)
 
 
-async def new_event(config, *, event_types: list[str]):
+async def new_event(config: ConfigType, *, event_types: list[str]) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await register_event(var, config, event_types=event_types)
     return var
@@ -133,7 +138,12 @@ TRIGGER_EVENT_SCHEMA = cv.Schema(
 @automation.register_action(
     "event.trigger", TriggerEventAction, TRIGGER_EVENT_SCHEMA, synchronous=True
 )
-async def event_fire_to_code(config, action_id, template_arg, args):
+async def event_fire_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     templ = await cg.templatable(config[CONF_EVENT_TYPE], args, cg.std_string)
@@ -142,5 +152,5 @@ async def event_fire_to_code(config, action_id, template_arg, args):
 
 
 @coroutine_with_priority(CoroPriority.CORE)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_global(event_ns.using)

--- a/esphome/components/ld2410/__init__.py
+++ b/esphome/components/ld2410/__init__.py
@@ -4,6 +4,9 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PASSWORD, CONF_THROTTLE, CONF_TIMEOUT
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["ld24xx"]
 DEPENDENCIES = ["uart"]
@@ -69,7 +72,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
@@ -102,7 +105,12 @@ BLUETOOTH_PASSWORD_SET_SCHEMA = cv.Schema(
     BLUETOOTH_PASSWORD_SET_SCHEMA,
     synchronous=True,
 )
-async def bluetooth_password_set_to_code(config, action_id, template_arg, args):
+async def bluetooth_password_set_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_PASSWORD], args, cg.std_string)

--- a/esphome/components/ld2410/binary_sensor.py
+++ b/esphome/components/ld2410/binary_sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     ICON_ACCOUNT,
     ICON_MOTION_SENSOR,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2410_ID, LD2410Component
 
@@ -46,7 +47,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if has_target_config := config.get(CONF_HAS_TARGET):
         sens = await binary_sensor.new_binary_sensor(has_target_config)

--- a/esphome/components/ld2410/button/__init__.py
+++ b/esphome/components/ld2410/button/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     ICON_RESTART,
     ICON_RESTART_ALERT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2410_ID, LD2410Component, ld2410_ns
 
@@ -44,7 +45,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if factory_reset_config := config.get(CONF_FACTORY_RESET):
         b = await button.new_button(factory_reset_config)

--- a/esphome/components/ld2410/number/__init__.py
+++ b/esphome/components/ld2410/number/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_SECOND,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2410_ID, LD2410Component, ld2410_ns
 
@@ -85,7 +86,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if timeout_config := config.get(CONF_TIMEOUT):
         n = await number.new_number(

--- a/esphome/components/ld2410/select/__init__.py
+++ b/esphome/components/ld2410/select/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     ICON_SCALE,
     ICON_THERMOMETER,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2410_ID, LD2410Component, ld2410_ns
 
@@ -48,7 +49,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if distance_resolution_config := config.get(CONF_DISTANCE_RESOLUTION):
         s = await select.new_select(

--- a/esphome/components/ld2410/sensor.py
+++ b/esphome/components/ld2410/sensor.py
@@ -15,6 +15,7 @@ from esphome.const import (
     UNIT_CENTIMETER,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2410_ID, LD2410Component
 
@@ -155,7 +156,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if moving_distance_config := config.get(CONF_MOVING_DISTANCE):
         sens = await sensor.new_sensor(moving_distance_config)

--- a/esphome/components/ld2410/switch/__init__.py
+++ b/esphome/components/ld2410/switch/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     ICON_BLUETOOTH,
     ICON_PULSE,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2410_ID, LD2410Component, ld2410_ns
 
@@ -35,7 +36,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if engineering_mode_config := config.get(CONF_ENGINEERING_MODE):
         s = await switch.new_switch(engineering_mode_config)

--- a/esphome/components/ld2410/text_sensor.py
+++ b/esphome/components/ld2410/text_sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     ICON_BLUETOOTH,
     ICON_CHIP,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2410_ID, LD2410Component
 
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2410_component = await cg.get_variable(config[CONF_LD2410_ID])
     if version_config := config.get(CONF_VERSION):
         sens = await text_sensor.new_text_sensor(version_config)

--- a/esphome/components/ld2412/__init__.py
+++ b/esphome/components/ld2412/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_THROTTLE
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["ld24xx"]
 CODEOWNERS = ["@Rihan9"]
@@ -40,7 +41,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/ld2412/binary_sensor.py
+++ b/esphome/components/ld2412/binary_sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     ICON_ACCOUNT,
     ICON_MOTION_SENSOR,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2412_ID, LD2412Component
 
@@ -48,7 +49,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if dynamic_background_correction_status_config := config.get(
         CONF_DYNAMIC_BACKGROUND_CORRECTION_STATUS

--- a/esphome/components/ld2412/button/__init__.py
+++ b/esphome/components/ld2412/button/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     ICON_RESTART,
     ICON_RESTART_ALERT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2412_ID, LD2412_ns, LD2412Component
 
@@ -54,7 +55,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if factory_reset_config := config.get(CONF_FACTORY_RESET):
         b = await button.new_button(factory_reset_config)

--- a/esphome/components/ld2412/number/__init__.py
+++ b/esphome/components/ld2412/number/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_SECOND,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2412_ID, LD2412_ns, LD2412Component
 
@@ -85,7 +86,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if light_threshold_config := config.get(CONF_LIGHT_THRESHOLD):
         n = await number.new_number(

--- a/esphome/components/ld2412/select/__init__.py
+++ b/esphome/components/ld2412/select/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     ICON_SCALE,
     ICON_THERMOMETER,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2412_ID, LD2412_ns, LD2412Component
 
@@ -48,7 +49,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if baud_rate_config := config.get(CONF_BAUD_RATE):
         s = await select.new_select(

--- a/esphome/components/ld2412/sensor.py
+++ b/esphome/components/ld2412/sensor.py
@@ -16,6 +16,7 @@ from esphome.const import (
     UNIT_EMPTY,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2412_ID, LD2412Component
 
@@ -156,7 +157,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if detection_distance_config := config.get(CONF_DETECTION_DISTANCE):
         sens = await sensor.new_sensor(detection_distance_config)

--- a/esphome/components/ld2412/switch/__init__.py
+++ b/esphome/components/ld2412/switch/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     ICON_BLUETOOTH,
     ICON_PULSE,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2412_ID, LD2412_ns, LD2412Component
 
@@ -35,7 +36,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if bluetooth_config := config.get(CONF_BLUETOOTH):
         s = await switch.new_switch(bluetooth_config)

--- a/esphome/components/ld2412/text_sensor.py
+++ b/esphome/components/ld2412/text_sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     ICON_BLUETOOTH,
     ICON_CHIP,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2412_ID, LD2412Component
 
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2412_component = await cg.get_variable(config[CONF_LD2412_ID])
     if version_config := config.get(CONF_VERSION):
         sens = await text_sensor.new_text_sensor(version_config)

--- a/esphome/components/ld2420/__init__.py
+++ b/esphome/components/ld2420/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@descipher"]
 
@@ -33,7 +34,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/ld2420/binary_sensor/__init__.py
+++ b/esphome/components/ld2420/binary_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_HAS_TARGET, CONF_ID, DEVICE_CLASS_OCCUPANCY
+from esphome.types import ConfigType
 
 from .. import CONF_LD2420_ID, LD2420Component, ld2420_ns
 
@@ -23,7 +24,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     if CONF_HAS_TARGET in config:

--- a/esphome/components/ld2420/button/__init__.py
+++ b/esphome/components/ld2420/button/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     ICON_RESTART,
     ICON_RESTART_ALERT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2420_ID, LD2420Component, ld2420_ns
 
@@ -50,7 +51,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2420_component = await cg.get_variable(config[CONF_LD2420_ID])
     if apply_config := config.get(CONF_APPLY_CONFIG):
         b = await button.new_button(apply_config)

--- a/esphome/components/ld2420/number/__init__.py
+++ b/esphome/components/ld2420/number/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     ICON_TIMELAPSE,
     UNIT_SECOND,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2420_ID, LD2420Component, ld2420_ns
 
@@ -113,7 +114,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2420_component = await cg.get_variable(config[CONF_LD2420_ID])
     if gate_timeout_config := config.get(CONF_PRESENCE_TIMEOUT):
         n = await number.new_number(

--- a/esphome/components/ld2420/select/__init__.py
+++ b/esphome/components/ld2420/select/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import select
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_CONFIG
+from esphome.types import ConfigType
 
 from .. import CONF_LD2420_ID, LD2420Component, ld2420_ns
 
@@ -23,7 +24,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     LD2420_component = await cg.get_variable(config[CONF_LD2420_ID])
     if operating_mode_config := config.get(CONF_OPERATING_MODE):
         sel = await select.new_select(

--- a/esphome/components/ld2420/sensor/__init__.py
+++ b/esphome/components/ld2420/sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CENTIMETER,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2420_ID, LD2420Component, ld2420_ns
 
@@ -30,7 +31,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     if CONF_MOVING_DISTANCE in config:

--- a/esphome/components/ld2420/text_sensor/__init__.py
+++ b/esphome/components/ld2420/text_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC, ICON_CHIP
+from esphome.types import ConfigType
 
 from .. import CONF_LD2420_ID, LD2420Component, ld2420_ns
 
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     if CONF_FW_VERSION in config:

--- a/esphome/components/ld2450/__init__.py
+++ b/esphome/components/ld2450/__init__.py
@@ -3,6 +3,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_ON_DATA, CONF_THROTTLE
+from esphome.types import ConfigType
 
 AUTO_LOAD = ["ld24xx"]
 DEPENDENCIES = ["uart"]
@@ -49,7 +50,7 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/ld2450/binary_sensor.py
+++ b/esphome/components/ld2450/binary_sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2450_ID, LD2450Component
 
@@ -39,7 +40,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
     if has_target_config := config.get(CONF_HAS_TARGET):
         sens = await binary_sensor.new_binary_sensor(has_target_config)

--- a/esphome/components/ld2450/button/__init__.py
+++ b/esphome/components/ld2450/button/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     ICON_RESTART,
     ICON_RESTART_ALERT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2450_ID, LD2450Component, ld2450_ns
 
@@ -35,7 +36,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
     if factory_reset_config := config.get(CONF_FACTORY_RESET):
         b = await button.new_button(factory_reset_config)

--- a/esphome/components/ld2450/number/__init__.py
+++ b/esphome/components/ld2450/number/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     UNIT_MILLIMETER,
     UNIT_SECOND,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2450_ID, LD2450Component, ld2450_ns
 
@@ -78,7 +79,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
     if presence_timeout_config := config.get(CONF_PRESENCE_TIMEOUT):
         n = await number.new_number(

--- a/esphome/components/ld2450/select/__init__.py
+++ b/esphome/components/ld2450/select/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     ENTITY_CATEGORY_CONFIG,
     ICON_THERMOMETER,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2450_ID, LD2450Component, ld2450_ns
 
@@ -31,7 +32,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
     if baud_rate_config := config.get(CONF_BAUD_RATE):
         s = await select.new_select(

--- a/esphome/components/ld2450/sensor.py
+++ b/esphome/components/ld2450/sensor.py
@@ -15,6 +15,7 @@ from esphome.const import (
     UNIT_DEGREES,
     UNIT_MILLIMETER,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2450_ID, LD2450Component
 
@@ -226,7 +227,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
 
     if target_count_config := config.get(CONF_TARGET_COUNT):

--- a/esphome/components/ld2450/switch/__init__.py
+++ b/esphome/components/ld2450/switch/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     ICON_BLUETOOTH,
     ICON_PULSE,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_LD2450_ID, LD2450Component, ld2450_ns
 
@@ -35,7 +36,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
     if bluetooth_config := config.get(CONF_BLUETOOTH):
         s = await switch.new_switch(bluetooth_config)

--- a/esphome/components/ld2450/text_sensor.py
+++ b/esphome/components/ld2450/text_sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     ICON_CHIP,
     ICON_SIGN_DIRECTION,
 )
+from esphome.types import ConfigType
 
 from . import CONF_LD2450_ID, LD2450Component
 
@@ -49,7 +50,7 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ld2450_component = await cg.get_variable(config[CONF_LD2450_ID])
     if version_config := config.get(CONF_VERSION):
         sens = await text_sensor.new_text_sensor(version_config)

--- a/esphome/components/max6956/__init__.py
+++ b/esphome/components/max6956/__init__.py
@@ -11,6 +11,9 @@ from esphome.const import (
     CONF_OUTPUT,
     CONF_PULLUP,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@looping40"]
 
@@ -54,7 +57,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
@@ -62,7 +65,7 @@ async def to_code(config):
     cg.add(var.set_brightness_global(config[CONF_BRIGHTNESS_GLOBAL]))
 
 
-def validate_mode(value):
+def validate_mode(value: ConfigType) -> ConfigType:
     if not (value[CONF_INPUT] or value[CONF_OUTPUT]):
         raise cv.Invalid("Mode must be either input or output")
     if value[CONF_INPUT] and value[CONF_OUTPUT]:
@@ -87,7 +90,7 @@ MAX6956_PIN_SCHEMA = pins.gpio_base_schema(
 
 
 @pins.PIN_SCHEMA_REGISTRY.register(CONF_MAX6956, MAX6956_PIN_SCHEMA)
-async def max6956_pin_to_code(config):
+async def max6956_pin_to_code(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_MAX6956])
 
@@ -114,7 +117,12 @@ async def max6956_pin_to_code(config):
     ),
     synchronous=True,
 )
-async def max6956_set_brightness_global_to_code(config, action_id, template_arg, args):
+async def max6956_set_brightness_global_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_BRIGHTNESS_GLOBAL], args, cg.uint8)
@@ -136,7 +144,12 @@ async def max6956_set_brightness_global_to_code(config, action_id, template_arg,
     ),
     synchronous=True,
 )
-async def max6956_set_brightness_mode_to_code(config, action_id, template_arg, args):
+async def max6956_set_brightness_mode_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(

--- a/esphome/components/max6956/output/__init__.py
+++ b/esphome/components/max6956/output/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PIN
+from esphome.types import ConfigType
 
 from .. import CONF_MAX6956, MAX6956, max6956_ns
 
@@ -20,7 +21,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_MAX6956])
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -10,6 +10,9 @@ from esphome.const import (
     CONF_NUM_CHIPS,
     CONF_STATE,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@rspaargaren"]
 DEPENDENCIES = ["spi"]
@@ -84,7 +87,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
@@ -144,7 +147,12 @@ MAX7219_ON_ACTION_SCHEMA = automation.maybe_simple_id(
     MAX7219_ON_ACTION_SCHEMA,
     synchronous=True,
 )
-async def max7219digit_invert_to_code(config, action_id, template_arg, args):
+async def max7219digit_invert_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
@@ -164,7 +172,12 @@ async def max7219digit_invert_to_code(config, action_id, template_arg, args):
     MAX7219_ON_ACTION_SCHEMA,
     synchronous=True,
 )
-async def max7219digit_visible_to_code(config, action_id, template_arg, args):
+async def max7219digit_visible_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
@@ -184,7 +197,12 @@ async def max7219digit_visible_to_code(config, action_id, template_arg, args):
     MAX7219_ON_ACTION_SCHEMA,
     synchronous=True,
 )
-async def max7219digit_reverse_to_code(config, action_id, template_arg, args):
+async def max7219digit_reverse_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
@@ -209,7 +227,12 @@ MAX7219_INTENSITY_SCHEMA = cv.maybe_simple_value(
     MAX7219_INTENSITY_SCHEMA,
     synchronous=True,
 )
-async def max7219digit_intensity_to_code(config, action_id, template_arg, args):
+async def max7219digit_intensity_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_INTENSITY], args, cg.uint8)

--- a/esphome/components/micronova/__init__.py
+++ b/esphome/components/micronova/__init__.py
@@ -7,6 +7,8 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.core import CORE, coroutine_with_priority
 from esphome.coroutine import CoroPriority
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@jorre05", "@edenhaus"]
 
@@ -63,7 +65,7 @@ def MICRONOVA_ADDRESS_SCHEMA(
     default_memory_location: int | None = None,
     default_memory_address: int | None = None,
     is_polling_component: bool,
-):
+) -> cv.Schema:
     location_key = (
         cv.Optional(CONF_MEMORY_LOCATION, default=default_memory_location)
         if default_memory_location is not None
@@ -91,7 +93,9 @@ def register_micronova_writer() -> None:
     _get_data().has_writer = True
 
 
-async def to_code_micronova_listener(mv, var, config):
+async def to_code_micronova_listener(
+    mv: MockObj, var: MockObj, config: ConfigType
+) -> None:
     _get_data().listener_count += 1
     await cg.register_component(var, config)
     cg.add(var.set_memory_location(config[CONF_MEMORY_LOCATION]))
@@ -100,7 +104,7 @@ async def to_code_micronova_listener(mv, var, config):
     cg.add(mv.register_micronova_listener(var))
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     enable_rx_pin = await cg.gpio_pin_expression(config[CONF_ENABLE_RX_PIN])
     var = cg.new_Pvariable(config[CONF_ID], enable_rx_pin)
     await cg.register_component(var, config)

--- a/esphome/components/micronova/button/__init__.py
+++ b/esphome/components/micronova/button/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import (
     CONF_MEMORY_ADDRESS,
@@ -33,7 +34,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     mv = await cg.get_variable(config[CONF_MICRONOVA_ID])
 
     if custom_button_config := config.get(CONF_CUSTOM_BUTTON):

--- a/esphome/components/micronova/number/__init__.py
+++ b/esphome/components/micronova/number/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import CONF_STEP, DEVICE_CLASS_TEMPERATURE, UNIT_CELSIUS
+from esphome.types import ConfigType
 
 from .. import (
     CONF_MICRONOVA_ID,
@@ -56,7 +57,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     mv = await cg.get_variable(config[CONF_MICRONOVA_ID])
 
     if thermostat_temperature_config := config.get(CONF_THERMOSTAT_TEMPERATURE):

--- a/esphome/components/micronova/sensor/__init__.py
+++ b/esphome/components/micronova/sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_REVOLUTIONS_PER_MINUTE,
 )
+from esphome.types import ConfigType
 
 from .. import (
     CONF_MICRONOVA_ID,
@@ -125,7 +126,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     mv = await cg.get_variable(config[CONF_MICRONOVA_ID])
 
     for key, divisor in {

--- a/esphome/components/micronova/switch/__init__.py
+++ b/esphome/components/micronova/switch/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import ICON_POWER
+from esphome.types import ConfigType
 
 from .. import (
     CONF_MICRONOVA_ID,
@@ -49,7 +50,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     mv = await cg.get_variable(config[CONF_MICRONOVA_ID])
 
     if stove_config := config.get(CONF_STOVE):

--- a/esphome/components/micronova/text_sensor/__init__.py
+++ b/esphome/components/micronova/text_sensor/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import (
     CONF_MICRONOVA_ID,
@@ -33,7 +34,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     mv = await cg.get_variable(config[CONF_MICRONOVA_ID])
 
     if stove_state_config := config.get(CONF_STOVE_STATE):

--- a/esphome/components/pipsolar/__init__.py
+++ b/esphome/components/pipsolar/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@andreashergert1984"]
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/pipsolar/binary_sensor/__init__.py
+++ b/esphome/components/pipsolar/binary_sensor/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA
 
@@ -132,7 +133,7 @@ CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
     for type in TYPES:
         if type in config:

--- a/esphome/components/pipsolar/output/__init__.py
+++ b/esphome/components/pipsolar/output/__init__.py
@@ -3,6 +3,9 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_VALUE
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA, pipsolar_ns
 
@@ -75,7 +78,7 @@ CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
 
     for type, (_, command) in TYPES.items():
@@ -100,7 +103,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def output_pipsolar_set_level_to_code(config, action_id, template_arg, args):
+async def output_pipsolar_set_level_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_VALUE], args, cg.float_)

--- a/esphome/components/pipsolar/sensor/__init__.py
+++ b/esphome/components/pipsolar/sensor/__init__.py
@@ -25,6 +25,7 @@ from esphome.const import (
     UNIT_VOLT_AMPS,
     UNIT_WATT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA
 
@@ -325,7 +326,7 @@ CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
 
     for type in TYPES:

--- a/esphome/components/pipsolar/switch/__init__.py
+++ b/esphome/components/pipsolar/switch/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import ICON_POWER
+from esphome.types import ConfigType
 
 from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA, pipsolar_ns
 
@@ -36,7 +37,7 @@ CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
 
     for type, (on, off) in TYPES.items():

--- a/esphome/components/pipsolar/text_sensor/__init__.py
+++ b/esphome/components/pipsolar/text_sensor/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import CONF_PIPSOLAR_ID, PIPSOLAR_COMPONENT_SCHEMA
 
@@ -31,7 +32,7 @@ CONFIG_SCHEMA = PIPSOLAR_COMPONENT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PIPSOLAR_ID])
 
     for type in TYPES:

--- a/esphome/components/text/__init__.py
+++ b/esphome/components/text/__init__.py
@@ -13,13 +13,14 @@ from esphome.const import (
     CONF_VALUE,
     CONF_WEB_SERVER,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CORE, ID, CoroPriority, coroutine_with_priority
 from esphome.core.entity_helpers import (
     entity_duplicate_validator,
     queue_entity_register,
     setup_entity,
 )
-from esphome.cpp_generator import MockObjClass
+from esphome.cpp_generator import MockObj, MockObjClass, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@mauritskorse"]
 IS_PLATFORM_COMPONENT = True
@@ -90,13 +91,13 @@ def text_schema(
 
 @setup_entity("text")
 async def setup_text_core_(
-    var,
-    config,
+    var: MockObj,
+    config: ConfigType,
     *,
     min_length: int | None,
     max_length: int | None,
     pattern: str | None,
-):
+) -> None:
     cg.add(var.traits.set_min_length(min_length))
     cg.add(var.traits.set_max_length(max_length))
     if pattern is not None:
@@ -117,13 +118,13 @@ async def setup_text_core_(
 
 
 async def register_text(
-    var,
-    config,
+    var: MockObj,
+    config: ConfigType,
     *,
     min_length: int | None = 0,
     max_length: int | None = 255,
     pattern: str | None = None,
-):
+) -> None:
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     queue_entity_register("text", config)
@@ -134,12 +135,12 @@ async def register_text(
 
 
 async def new_text(
-    config,
+    config: ConfigType,
     *,
     min_length: int | None = 0,
     max_length: int | None = 255,
     pattern: str | None = None,
-):
+) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await register_text(
         var, config, min_length=min_length, max_length=max_length, pattern=pattern
@@ -148,7 +149,7 @@ async def new_text(
 
 
 @coroutine_with_priority(CoroPriority.CORE)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_global(text_ns.using)
 
 
@@ -169,7 +170,12 @@ OPERATION_BASE_SCHEMA = cv.Schema(
     ),
     synchronous=True,
 )
-async def text_set_to_code(config, action_id, template_arg, args):
+async def text_set_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_VALUE], args, cg.std_string)

--- a/esphome/components/text/text_sensor/__init__.py
+++ b/esphome/components/text/text_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_SOURCE_ID
+from esphome.types import ConfigType
 
 from .. import Text, text_ns
 
@@ -19,7 +20,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     source = await cg.get_variable(config[CONF_SOURCE_ID])
     var = await text_sensor.new_text_sensor(config, source)
     await cg.register_component(var, config)


### PR DESCRIPTION
# What does this implement/fix?

Adds parameter and return type annotations to the Python code of 13 components, as part of a repo-wide sweep to get everything under `esphome/components` fully annotated. This is part 8 of 11 covering the mid-sized components.

Components are grouped so that each code owner's components land in a single pull request rather than being spread across many.

Annotations only. No behaviour changes, no renames, no reordering, no docstring edits. Component files have no `from __future__ import annotations`, so annotations are evaluated at import time and every name used in one is imported at module level.

Components in this pull request: `atm90e32`, `bl0940`, `bm8563`, `event`, `ld2410`, `ld2412`, `ld2420`, `ld2450`, `max6956`, `max7219digit`, `micronova`, `pipsolar`, `text`

Verified with `ruff check`, `ruff format --check`, `pylint`, `script/ci-custom.py`, the unit and component test suites, and an import of all 1637 component modules. That last check is the important one: because annotations are evaluated at import time, a missing import for an annotation name shows up there as a hard failure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing configuration change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
