### PR TITLE
[core] Add type annotations to component Python (9/11)

### DIFF
--- a/esphome/components/as3935/__init__.py
+++ b/esphome/components/as3935/__init__.py
@@ -14,6 +14,8 @@ from esphome.const import (
     CONF_TUNE_ANTENNA,
     CONF_WATCHDOG_THRESHOLD,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 MULTI_CONF = True
 
@@ -42,7 +44,7 @@ AS3935_SCHEMA = cv.Schema(
 )
 
 
-async def setup_as3935(var, config):
+async def setup_as3935(var: MockObj, config: ConfigType) -> None:
     await cg.register_component(var, config)
 
     irq_pin = await cg.gpio_pin_expression(config[CONF_IRQ_PIN])

--- a/esphome/components/as3935/binary_sensor.py
+++ b/esphome/components/as3935/binary_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from . import AS3935, CONF_AS3935_ID
 
@@ -13,7 +14,7 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_AS3935_ID])
     var = await binary_sensor.new_binary_sensor(config)
     cg.add(hub.set_thunder_alert_binary_sensor(var))

--- a/esphome/components/as3935/sensor.py
+++ b/esphome/components/as3935/sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_KILOMETER,
 )
+from esphome.types import ConfigType
 
 from . import AS3935, CONF_AS3935_ID
 
@@ -31,7 +32,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_AS3935_ID])
 
     if distance_config := config.get(CONF_DISTANCE):

--- a/esphome/components/bthome_mithermometer/__init__.py
+++ b/esphome/components/bthome_mithermometer/__init__.py
@@ -3,6 +3,8 @@ from esphome.components import ble_device_base
 import esphome.config_validation as cv
 from esphome.const import CONF_BINDKEY, CONF_ID, CONF_MAC_ADDRESS
 from esphome.core import HexInt
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@nagyrobi"]
 AUTO_LOAD = ["ble_device_base"]
@@ -14,7 +16,9 @@ BTHomeMiThermometer = bthome_mithermometer_ns.class_(
 )
 
 
-def bthome_mithermometer_base_schema(extra_schema=None):
+def bthome_mithermometer_base_schema(
+    extra_schema: cv.Schema | dict | None = None,
+) -> cv.All:
     if extra_schema is None:
         extra_schema = {}
     return cv.All(
@@ -32,7 +36,7 @@ def bthome_mithermometer_base_schema(extra_schema=None):
     )
 
 
-async def setup_bthome_mithermometer(var, config):
+async def setup_bthome_mithermometer(var: MockObj, config: ConfigType) -> None:
     await cg.register_component(var, config)
     await ble_device_base.register_ble_device(var, config)
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))

--- a/esphome/components/bthome_mithermometer/sensor.py
+++ b/esphome/components/bthome_mithermometer/sensor.py
@@ -20,6 +20,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_VOLT,
 )
+from esphome.types import ConfigType
 
 from . import bthome_mithermometer_base_schema, setup_bthome_mithermometer
 
@@ -67,7 +68,7 @@ CONFIG_SCHEMA = bthome_mithermometer_base_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await setup_bthome_mithermometer(var, config)
 

--- a/esphome/components/color/__init__.py
+++ b/esphome/components/color/__init__.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from esphome import codegen as cg, config_validation as cv
 from esphome.const import CONF_BLUE, CONF_GREEN, CONF_ID, CONF_RED, CONF_WHITE
+from esphome.types import ConfigType
 
 ColorStruct = cg.esphome_ns.struct("Color")
 
@@ -14,7 +17,7 @@ CONF_WHITE_INT = "white_int"
 CONF_HEX = "hex"
 
 
-def hex_color(value):
+def hex_color(value: Any) -> tuple[int, int, int]:
     if isinstance(value, int):
         value = str(value)
     if not isinstance(value, str):
@@ -39,7 +42,7 @@ components = {
 }
 
 
-def validate_color(config):
+def validate_color(config: ConfigType) -> ConfigType:
     has_components = set(config) & components
     has_hex = CONF_HEX in config
     if has_hex and has_components:
@@ -68,7 +71,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def from_rgbw(config):
+def from_rgbw(config: ConfigType) -> tuple[int, int, int, int]:
     r = 0
     if CONF_RED in config:
         r = int(config[CONF_RED] * 255)
@@ -96,7 +99,7 @@ def from_rgbw(config):
     return (r, g, b, w)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     if CONF_HEX in config:
         r, g, b = config[CONF_HEX]
         w = 0

--- a/esphome/components/ds248x/__init__.py
+++ b/esphome/components/ds248x/__init__.py
@@ -3,6 +3,7 @@ import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_SLEEP_PIN, CONF_TYPE
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@tomwellnitz"]
 MULTI_CONF = True
@@ -35,7 +36,7 @@ ds248x_ns = cg.esphome_ns.namespace("ds248x")
 DS248xComponent = ds248x_ns.class_("DS248xComponent", cg.Component, i2c.I2CDevice)
 
 
-def _component_schema(*extras):
+def _component_schema(*extras: dict) -> cv.Schema:
     schema = cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(DS248xComponent),
@@ -79,11 +80,11 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-def get_channel_count(config):
+def get_channel_count(config: ConfigType) -> int:
     return CHANNEL_COUNTS[config[CONF_TYPE]]
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/ds248x/one_wire.py
+++ b/esphome/components/ds248x/one_wire.py
@@ -12,6 +12,7 @@ import esphome.codegen as cg
 from esphome.components.one_wire import OneWireBus
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL, CONF_ID
+from esphome.types import ConfigType
 
 from . import CONF_DS248X_ID, DS248xComponent, ds248x_ns, get_channel_count
 
@@ -29,7 +30,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-def _final_validate(config):
+def _final_validate(config: ConfigType) -> None:
     """Validate that the channel is within the parent's channel count."""
     fconf = fv.full_config.get()
     path = fconf.get_path_for_id(config[CONF_DS248X_ID])[:-1]
@@ -47,7 +48,7 @@ def _final_validate(config):
 FINAL_VALIDATE_SCHEMA = _final_validate
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/emontx/__init__.py
+++ b/esphome/components/emontx/__init__.py
@@ -11,7 +11,8 @@ from esphome.const import (
     CONF_RX_BUFFER_SIZE,
     CONF_UART_ID,
 )
-from esphome.core import CORE
+from esphome.core import CORE, ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
@@ -143,8 +144,11 @@ EMONTX_SEND_COMMAND_ACTION_SCHEMA = cv.Schema(
     synchronous=True,
 )
 async def emontx_send_command_action_to_code(
-    config: ConfigType, action_id, template_arg, args
-) -> None:
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_COMMAND], args, cg.std_string)

--- a/esphome/components/gdk101/__init__.py
+++ b/esphome/components/gdk101/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@Szewcson"]
 
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/gdk101/binary_sensor.py
+++ b/esphome/components/gdk101/binary_sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_VIBRATE,
 )
+from esphome.types import ConfigType
 
 from . import CONF_GDK101_ID, GDK101Component
 
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_GDK101_ID])
     var = await binary_sensor.new_binary_sensor(config[CONF_VIBRATIONS])
     cg.add(hub.set_vibration_binary_sensor(var))

--- a/esphome/components/gdk101/sensor.py
+++ b/esphome/components/gdk101/sensor.py
@@ -15,6 +15,7 @@ from esphome.const import (
     UNIT_MICROSILVERTS_PER_HOUR,
     UNIT_SECOND,
 )
+from esphome.types import ConfigType
 
 from . import CONF_GDK101_ID, GDK101Component
 
@@ -59,7 +60,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_GDK101_ID])
 
     if radiation_dose_per_1m := config.get(CONF_RADIATION_DOSE_PER_1M):

--- a/esphome/components/gdk101/text_sensor.py
+++ b/esphome/components/gdk101/text_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_VERSION, ENTITY_CATEGORY_DIAGNOSTIC, ICON_CHIP
+from esphome.types import ConfigType
 
 from . import CONF_GDK101_ID, GDK101Component
 
@@ -17,7 +18,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_GDK101_ID])
     var = await text_sensor.new_text_sensor(config[CONF_VERSION])
     cg.add(hub.set_fw_version_text_sensor(var))

--- a/esphome/components/hc8/sensor.py
+++ b/esphome/components/hc8/sensor.py
@@ -12,6 +12,9 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_PARTS_PER_MILLION,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["uart"]
 
@@ -47,7 +50,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
@@ -73,7 +76,12 @@ CALIBRATION_ACTION_SCHEMA = cv.Schema(
     CALIBRATION_ACTION_SCHEMA,
     synchronous=True,
 )
-async def hc8_calibration_to_code(config, action_id, template_arg, args):
+async def hc8_calibration_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_BASELINE], args, cg.uint16)

--- a/esphome/components/lcd_base/__init__.py
+++ b/esphome/components/lcd_base/__init__.py
@@ -1,7 +1,11 @@
+from typing import Any
+
 import esphome.codegen as cg
 from esphome.components import display
 import esphome.config_validation as cv
 from esphome.const import CONF_DATA, CONF_DIMENSIONS, CONF_POSITION
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CONF_USER_CHARACTERS = "user_characters"
 
@@ -9,7 +13,7 @@ lcd_base_ns = cg.esphome_ns.namespace("lcd_base")
 LCDDisplay = lcd_base_ns.class_("LCDDisplay", cg.PollingComponent)
 
 
-def validate_lcd_dimensions(value):
+def validate_lcd_dimensions(value: Any) -> list[int]:
     value = cv.dimensions(value)
     if value[0] > 0x40:
         raise cv.Invalid("LCD displays can't have more than 64 columns")
@@ -18,7 +22,7 @@ def validate_lcd_dimensions(value):
     return value
 
 
-def validate_user_characters(value):
+def validate_user_characters(value: list[ConfigType]) -> list[ConfigType]:
     positions = set()
     for conf in value:
         if conf[CONF_POSITION] in positions:
@@ -51,7 +55,7 @@ LCD_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
 ).extend(cv.polling_component_schema("1s"))
 
 
-async def setup_lcd_display(var, config):
+async def setup_lcd_display(var: MockObj, config: ConfigType) -> None:
     await display.register_display(var, config)
     cg.add(var.set_dimensions(config[CONF_DIMENSIONS][0], config[CONF_DIMENSIONS][1]))
     if CONF_USER_CHARACTERS in config:

--- a/esphome/components/libretiny_pwm/output.py
+++ b/esphome/components/libretiny_pwm/output.py
@@ -3,6 +3,9 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_FREQUENCY, CONF_ID, CONF_PIN
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["libretiny"]
 
@@ -21,7 +24,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     gpio = await cg.gpio_pin_expression(config[CONF_PIN])
     var = cg.new_Pvariable(config[CONF_ID], gpio)
     await cg.register_component(var, config)
@@ -40,7 +43,12 @@ async def to_code(config):
     ),
     synchronous=True,
 )
-async def libretiny_pwm_set_frequency_to_code(config, action_id, template_arg, args):
+async def libretiny_pwm_set_frequency_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)

--- a/esphome/components/lightwaverf/__init__.py
+++ b/esphome/components/lightwaverf/__init__.py
@@ -11,7 +11,10 @@ from esphome.const import (
     CONF_REPEAT,
     CONF_WRITE_PIN,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.cpp_helpers import gpio_pin_expression
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@max246"]
 
@@ -57,7 +60,12 @@ LIGHTWAVE_SEND_SCHEMA = cv.Any(
     LIGHTWAVE_SEND_SCHEMA,
     synchronous=True,
 )
-async def send_raw_to_code(config, action_id, template_arg, args):
+async def send_raw_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -71,7 +79,7 @@ async def send_raw_to_code(config, action_id, template_arg, args):
     return var
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/max17043/sensor.py
+++ b/esphome/components/max17043/sensor.py
@@ -14,6 +14,9 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_VOLT,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["i2c"]
 
@@ -50,7 +53,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
@@ -74,6 +77,11 @@ MAX17043_ACTION_SCHEMA = maybe_simple_id(
 @automation.register_action(
     "max17043.sleep_mode", SleepAction, MAX17043_ACTION_SCHEMA, synchronous=True
 )
-async def max17043_sleep_mode_to_code(config, action_id, template_arg, args):
+async def max17043_sleep_mode_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/nau7802/sensor.py
+++ b/esphome/components/nau7802/sensor.py
@@ -4,6 +4,9 @@ import esphome.codegen as cg
 from esphome.components import i2c, sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_GAIN, CONF_ID, ICON_SCALE, STATE_CLASS_MEASUREMENT
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@cujomalainey"]
 DEPENDENCIES = ["i2c"]
@@ -93,7 +96,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
@@ -131,7 +134,12 @@ NAU7802_CALIBRATE_SCHEMA = maybe_simple_id(
     NAU7802_CALIBRATE_SCHEMA,
     synchronous=True,
 )
-async def nau7802_calibrate_to_code(config, action_id, template_arg, args):
+async def nau7802_calibrate_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var

--- a/esphome/components/ntc/sensor.py
+++ b/esphome/components/ntc/sensor.py
@@ -1,4 +1,5 @@
 from math import log
+from typing import Any
 
 import esphome.codegen as cg
 from esphome.components import sensor
@@ -15,6 +16,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
 )
+from esphome.types import ConfigType
 
 ntc_ns = cg.esphome_ns.namespace("ntc")
 NTC = ntc_ns.class_("NTC", cg.Component, sensor.Sensor)
@@ -25,7 +27,7 @@ CONF_C = "c"
 ZERO_POINT = 273.15
 
 
-def validate_calibration_parameter(value):
+def validate_calibration_parameter(value: Any) -> ConfigType:
     if isinstance(value, dict):
         return cv.Schema(
             {
@@ -48,7 +50,7 @@ def validate_calibration_parameter(value):
     )
 
 
-def calc_steinhart_hart(value):
+def calc_steinhart_hart(value: list[ConfigType]) -> tuple[float, float, float]:
     r1 = value[0][CONF_VALUE]
     r2 = value[1][CONF_VALUE]
     r3 = value[2][CONF_VALUE]
@@ -73,7 +75,7 @@ def calc_steinhart_hart(value):
     return a, b, c
 
 
-def calc_b(value):
+def calc_b(value: ConfigType) -> tuple[float, float, float]:
     beta = value[CONF_B_CONSTANT]
     t0 = value[CONF_REFERENCE_TEMPERATURE] + ZERO_POINT
     r0 = value[CONF_REFERENCE_RESISTANCE]
@@ -85,7 +87,7 @@ def calc_b(value):
     return a, b, c
 
 
-def process_calibration(value):
+def process_calibration(value: Any) -> ConfigType:
     if isinstance(value, dict):
         value = cv.Schema(
             {
@@ -132,7 +134,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
 

--- a/esphome/components/openthread_info/sensor.py
+++ b/esphome/components/openthread_info/sensor.py
@@ -9,6 +9,7 @@ from esphome.const import (
     UNIT_DECIBEL_MILLIWATT,
     UNIT_EMPTY,
 )
+from esphome.types import ConfigType
 
 CONF_PARENT_AVERAGE_RSSI = "parent_average_rssi"
 CONF_PARENT_LAST_RSSI = "parent_last_rssi"
@@ -166,13 +167,13 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def setup_conf(config: dict, key: str):
+async def setup_conf(config: dict, key: str) -> None:
     if conf := config.get(key):
         var = await sensor.new_sensor(conf)
         await cg.register_component(var, conf)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     await setup_conf(config, CONF_PARENT_AVERAGE_RSSI)
     await setup_conf(config, CONF_PARENT_LAST_RSSI)
     await setup_conf(config, CONF_PARENT_LINK_QUALITY_IN)

--- a/esphome/components/openthread_info/text_sensor.py
+++ b/esphome/components/openthread_info/text_sensor.py
@@ -8,6 +8,7 @@ from esphome.components.openthread.const import (
 )
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL, CONF_IP_ADDRESS, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.types import ConfigType
 
 CONF_ROLE = "role"
 CONF_RLOC16 = "rloc16"
@@ -86,13 +87,13 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def setup_conf(config: dict, key: str):
+async def setup_conf(config: dict, key: str) -> None:
     if conf := config.get(key):
         var = await text_sensor.new_text_sensor(conf)
         await cg.register_component(var, conf)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     await setup_conf(config, CONF_IP_ADDRESS)
     await setup_conf(config, CONF_ROLE)
     await setup_conf(config, CONF_RLOC16)

--- a/esphome/components/pmsx003/sensor.py
+++ b/esphome/components/pmsx003/sensor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import esphome.codegen as cg
 from esphome.components import sensor, uart
 import esphome.config_validation as cv
@@ -32,6 +34,8 @@ from esphome.const import (
     UNIT_MICROGRAMS_PER_CUBIC_METER,
     UNIT_PERCENT,
 )
+from esphome.core import TimePeriodMilliseconds
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@ximex"]
 DEPENDENCIES = ["uart"]
@@ -167,14 +171,14 @@ SENSORS_TO_TYPE = {
 }
 
 
-def validate_pmsx003_sensors(value):
+def validate_pmsx003_sensors(value: ConfigType) -> ConfigType:
     for key, types in SENSORS_TO_TYPE.items():
         if key in value and value[CONF_TYPE] not in types:
             raise cv.Invalid(f"{value[CONF_TYPE]} does not have {key} sensor!")
     return value
 
 
-def validate_update_interval(value):
+def validate_update_interval(value: Any) -> TimePeriodMilliseconds:
     value = cv.positive_time_period_milliseconds(value)
     if value == cv.time_period("0s"):
         return value
@@ -295,7 +299,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def final_validate(config):
+def final_validate(config: ConfigType) -> None:
     require_tx = config[CONF_UPDATE_INTERVAL] > cv.time_period("0s")
     schema = uart.final_validate_device_schema(
         "pmsx003", baud_rate=9600, require_rx=True, require_tx=require_tx
@@ -306,7 +310,7 @@ def final_validate(config):
 FINAL_VALIDATE_SCHEMA = final_validate
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/pzemac/sensor.py
+++ b/esphome/components/pzemac/sensor.py
@@ -26,6 +26,8 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 AUTO_LOAD = ["modbus"]
@@ -93,7 +95,12 @@ CONFIG_SCHEMA = (
     ),
     synchronous=True,
 )
-async def reset_energy_to_code(config, action_id, template_arg, args):
+async def reset_energy_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -105,7 +112,7 @@ def _final_validate(config: ConfigType) -> ConfigType:
 FINAL_VALIDATE_SCHEMA = _final_validate
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await modbus.register_modbus_client_device(var, config)

--- a/esphome/components/pzemdc/sensor.py
+++ b/esphome/components/pzemdc/sensor.py
@@ -20,6 +20,8 @@ from esphome.const import (
     UNIT_VOLT,
     UNIT_WATT,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 AUTO_LOAD = ["modbus"]
@@ -75,7 +77,12 @@ CONFIG_SCHEMA = (
     ),
     synchronous=True,
 )
-async def reset_energy_to_code(config, action_id, template_arg, args):
+async def reset_energy_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -87,7 +94,7 @@ def _final_validate(config: ConfigType) -> ConfigType:
 FINAL_VALIDATE_SCHEMA = _final_validate
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await modbus.register_modbus_client_device(var, config)

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, esp32_rmt, remote_base
@@ -21,6 +23,7 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE, TimePeriod
+from esphome.types import ConfigType
 
 CONF_FILTER_SYMBOLS = "filter_symbols"
 CONF_RECEIVE_SYMBOLS = "receive_symbols"
@@ -62,7 +65,7 @@ RemoteReceiverComponent = remote_receiver_ns.class_(
 )
 
 
-def validate_config(config):
+def validate_config(config: ConfigType) -> ConfigType:
     if CORE.is_esp32:
         variant = esp32.get_esp32_variant()
         if variant in esp32_rmt.VARIANTS_NO_RMT:
@@ -78,7 +81,7 @@ def validate_config(config):
     return config
 
 
-def validate_tolerance(value):
+def validate_tolerance(value: Any) -> ConfigType:
     if isinstance(value, dict):
         return TOLERANCE_SCHEMA(value)
 
@@ -196,7 +199,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
     if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)

--- a/esphome/components/remote_receiver/binary_sensor.py
+++ b/esphome/components/remote_receiver/binary_sensor.py
@@ -1,4 +1,5 @@
 from esphome.components import binary_sensor, remote_base
+from esphome.types import ConfigType
 
 from . import FILTER_SOURCE_FILES  # noqa: F401  pylint: disable=unused-import
 
@@ -7,6 +8,6 @@ DEPENDENCIES = ["remote_receiver"]
 CONFIG_SCHEMA = remote_base.validate_binary_sensor
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await remote_base.build_binary_sensor(config)
     await binary_sensor.register_binary_sensor(var, config)

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -22,6 +22,9 @@ from esphome.const import (
     UNIT_PARTS_PER_MILLION,
     UNIT_PERCENT,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["sensirion_common"]
@@ -82,7 +85,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
@@ -131,8 +134,11 @@ async def to_code(config):
     synchronous=True,
 )
 async def scd30_force_recalibration_with_reference_to_code(
-    config, action_id, template_arg, args
-):
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint16)

--- a/esphome/components/senseair/sensor.py
+++ b/esphome/components/senseair/sensor.py
@@ -11,6 +11,9 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_PARTS_PER_MILLION,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["uart"]
 
@@ -62,7 +65,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
@@ -109,6 +112,11 @@ CALIBRATION_ACTION_SCHEMA = maybe_simple_id(
     CALIBRATION_ACTION_SCHEMA,
     synchronous=True,
 )
-async def senseair_action_to_code(config, action_id, template_arg, args):
+async def senseair_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/sml/__init__.py
+++ b/esphome/components/sml/__init__.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from esphome import automation
 import esphome.codegen as cg
@@ -54,7 +55,7 @@ async def to_code(config: ConfigType) -> None:
     await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)
 
 
-def obis_code(value: str) -> str:
+def obis_code(value: Any) -> str:
     value = cv.string(value)
     match = re.match(r"^\d{1,3}-\d{1,3}:\d{1,3}\.\d{1,3}\.\d{1,3}$", value)
     if match is None:

--- a/esphome/components/sml/__init__.py
+++ b/esphome/components/sml/__init__.py
@@ -5,6 +5,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_ON_DATA
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@alengwenus"]
 
@@ -46,14 +47,14 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
     await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)
 
 
-def obis_code(value):
+def obis_code(value: str) -> str:
     value = cv.string(value)
     match = re.match(r"^\d{1,3}-\d{1,3}:\d{1,3}\.\d{1,3}\.\d{1,3}$", value)
     if match is None:

--- a/esphome/components/sml/sensor/__init__.py
+++ b/esphome/components/sml/sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 from .. import CONF_OBIS_CODE, CONF_SERVER_ID, CONF_SML_ID, Sml, obis_code, sml_ns
 
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(
         config[CONF_ID], config[CONF_SERVER_ID], config[CONF_OBIS_CODE]
     )

--- a/esphome/components/sml/text_sensor/__init__.py
+++ b/esphome/components/sml/text_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_FORMAT
+from esphome.types import ConfigType
 
 from .. import CONF_OBIS_CODE, CONF_SERVER_ID, CONF_SML_ID, Sml, obis_code, sml_ns
 
@@ -33,7 +34,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await text_sensor.new_text_sensor(
         config,
         config[CONF_SERVER_ID],

--- a/esphome/components/sn74hc595/__init__.py
+++ b/esphome/components/sn74hc595/__init__.py
@@ -12,6 +12,8 @@ from esphome.const import (
     CONF_OUTPUT,
     CONF_TYPE,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 MULTI_CONF = True
 
@@ -65,7 +67,7 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     if config[CONF_TYPE] == TYPE_GPIO:
@@ -84,7 +86,7 @@ async def to_code(config):
     cg.add(var.set_sr_count(config[CONF_SR_COUNT]))
 
 
-def _validate_output_mode(value):
+def _validate_output_mode(value: ConfigType) -> ConfigType:
     if value.get(CONF_OUTPUT) is not True:
         raise cv.Invalid("Only output mode is supported")
     return value
@@ -103,7 +105,9 @@ SN74HC595_PIN_SCHEMA = pins.gpio_base_schema(
 )
 
 
-def sn74hc595_pin_final_validate(pin_config, parent_config):
+def sn74hc595_pin_final_validate(
+    pin_config: ConfigType, parent_config: ConfigType
+) -> None:
     max_pins = parent_config[CONF_SR_COUNT] * 8
     if pin_config[CONF_NUMBER] >= max_pins:
         raise cv.Invalid(f"Pin number must be less than {max_pins}")
@@ -112,7 +116,7 @@ def sn74hc595_pin_final_validate(pin_config, parent_config):
 @pins.PIN_SCHEMA_REGISTRY.register(
     CONF_SN74HC595, SN74HC595_PIN_SCHEMA, sn74hc595_pin_final_validate
 )
-async def sn74hc595_pin_to_code(config):
+async def sn74hc595_pin_to_code(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_parented(var, config[CONF_SN74HC595])
 

--- a/esphome/components/spa06_base/__init__.py
+++ b/esphome/components/spa06_base/__init__.py
@@ -15,6 +15,8 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_PASCAL,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@danielkent-net"]
 
@@ -55,7 +57,7 @@ OVERSAMPLING_OPTIONS = {
 SPA06Component = spa06_ns.class_("SPA06Component", cg.PollingComponent)
 
 
-def spa_oversample_time(oversample):
+def spa_oversample_time(oversample: str) -> float:
     # Pressure oversampling conversion times are listed on datasheet Pg. 26
     # Datasheet does not have a table for temperature oversampling;
     # assumption is that it is the same as pressure
@@ -72,7 +74,7 @@ def spa_oversample_time(oversample):
     return OVERSAMPLING_CONVERSION_TIMES[oversample]
 
 
-def spa_sample_rate(rate):
+def spa_sample_rate(rate: str) -> float:
     SAMPLE_RATE_OPTIONS_HZ = {
         "1": 1.0,
         "2": 2.0,
@@ -94,7 +96,7 @@ def spa_sample_rate(rate):
     return SAMPLE_RATE_OPTIONS_HZ[rate]
 
 
-def compute_measurement_conversion_time(config):
+def compute_measurement_conversion_time(config: ConfigType) -> int:
     # - adds up sensor conversion time based on temperature and pressure oversampling rates given in datasheet
     # - returns a rounded up time in ms
 
@@ -115,7 +117,7 @@ def compute_measurement_conversion_time(config):
     return math.ceil(1.05 * (pressure_conversion_time + temperature_conversion_time))
 
 
-def measurement_timing_check(config):
+def measurement_timing_check(config: ConfigType) -> ConfigType:
 
     temp_time = 0.0
     if temperature_config := config.get(CONF_TEMPERATURE):
@@ -176,7 +178,7 @@ CONFIG_SCHEMA_BASE = cv.Schema(
 CONFIG_SCHEMA_BASE.add_extra(measurement_timing_check)
 
 
-async def to_code_base(config):
+async def to_code_base(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     if temperature_config := config.get(CONF_TEMPERATURE):

--- a/esphome/components/sy6970/__init__.py
+++ b/esphome/components/sy6970/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@linkedupbits"]
 DEPENDENCIES = ["i2c"]
@@ -48,7 +49,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(
         config[CONF_ID],
         config[CONF_ENABLE_STATUS_LED],

--- a/esphome/components/sy6970/binary_sensor/__init__.py
+++ b/esphome/components/sy6970/binary_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_POWER
+from esphome.types import ConfigType
 
 from .. import CONF_SY6970_ID, SY6970Component, sy6970_ns
 
@@ -40,7 +41,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_SY6970_ID])
 
     if vbus_connected_config := config.get(CONF_VBUS_CONNECTED):

--- a/esphome/components/sy6970/sensor/__init__.py
+++ b/esphome/components/sy6970/sensor/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
     UNIT_MILLIAMP,
     UNIT_VOLT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_SY6970_ID, SY6970Component, sy6970_ns
 
@@ -71,7 +72,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_SY6970_ID])
 
     if vbus_voltage_config := config.get(CONF_VBUS_VOLTAGE):

--- a/esphome/components/sy6970/text_sensor/__init__.py
+++ b/esphome/components/sy6970/text_sensor/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.types import ConfigType
 
 from .. import CONF_SY6970_ID, SY6970Component, sy6970_ns
 
@@ -36,7 +37,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_SY6970_ID])
 
     if bus_status_config := config.get(CONF_BUS_STATUS):

--- a/esphome/components/tm1638/binary_sensor/__init__.py
+++ b/esphome/components/tm1638/binary_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_KEY
+from esphome.types import ConfigType
 
 from ..display import CONF_TM1638_ID, TM1638Component, tm1638_ns
 
@@ -15,7 +16,7 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(TM1638Key).extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await binary_sensor.new_binary_sensor(config)
     cg.add(var.set_keycode(config[CONF_KEY]))
     hub = await cg.get_variable(config[CONF_TM1638_ID])

--- a/esphome/components/tm1638/display.py
+++ b/esphome/components/tm1638/display.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_STB_PIN,
 )
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@skykingjwc"]
 
@@ -31,7 +32,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
 ).extend(cv.polling_component_schema("1s"))
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
 

--- a/esphome/components/tm1638/output/__init__.py
+++ b/esphome/components/tm1638/output/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_LED
+from esphome.types import ConfigType
 
 from ..display import CONF_TM1638_ID, TM1638Component, tm1638_ns
 
@@ -17,7 +18,7 @@ CONFIG_SCHEMA = output.BINARY_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await output.register_output(var, config)
     await cg.register_component(var, config)

--- a/esphome/components/tm1638/switch/__init__.py
+++ b/esphome/components/tm1638/switch/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import CONF_LED
+from esphome.types import ConfigType
 
 from ..display import CONF_TM1638_ID, TM1638Component, tm1638_ns
 
@@ -20,7 +21,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await switch.new_switch(config)
     await cg.register_component(var, config)
     cg.add(var.set_lednum(config[CONF_LED]))

--- a/esphome/components/uponor_smatrix/__init__.py
+++ b/esphome/components/uponor_smatrix/__init__.py
@@ -2,6 +2,8 @@ import esphome.codegen as cg
 from esphome.components import time, uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ADDRESS, CONF_ID, CONF_TIME_ID
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@kroimon"]
 
@@ -61,7 +63,7 @@ UPONOR_SMATRIX_DEVICE_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     cg.add_global(uponor_smatrix_ns.using)
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
@@ -74,7 +76,7 @@ async def to_code(config):
             cg.add(var.set_time_device_address(time_device_address))
 
 
-async def register_uponor_smatrix_device(var, config):
+async def register_uponor_smatrix_device(var: MockObj, config: ConfigType) -> None:
     parent = await cg.get_variable(config[CONF_UPONOR_SMATRIX_ID])
     cg.add(var.set_parent(parent))
     cg.add(var.set_address(config[CONF_ADDRESS]))

--- a/esphome/components/uponor_smatrix/climate/__init__.py
+++ b/esphome/components/uponor_smatrix/climate/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import climate
+from esphome.types import ConfigType
 
 from .. import (
     UPONOR_SMATRIX_DEVICE_SCHEMA,
@@ -22,7 +23,7 @@ CONFIG_SCHEMA = climate.climate_schema(UponorSmatrixClimate).extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await climate.new_climate(config)
     await cg.register_component(var, config)
     await register_uponor_smatrix_device(var, config)

--- a/esphome/components/uponor_smatrix/sensor/__init__.py
+++ b/esphome/components/uponor_smatrix/sensor/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 from .. import (
     UPONOR_SMATRIX_DEVICE_SCHEMA,
@@ -61,7 +62,7 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
 ).extend(UPONOR_SMATRIX_DEVICE_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await register_uponor_smatrix_device(var, config)

--- a/esphome/components/vl53l0x/sensor.py
+++ b/esphome/components/vl53l0x/sensor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import i2c, sensor
@@ -10,6 +12,8 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_METER,
 )
+from esphome.core import TimePeriodMicroseconds
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["i2c"]
 
@@ -23,7 +27,7 @@ CONF_LONG_RANGE = "long_range"
 CONF_TIMING_BUDGET = "timing_budget"
 
 
-def check_keys(obj):
+def check_keys(obj: ConfigType) -> ConfigType:
     if obj[CONF_ADDRESS] != 0x29 and CONF_ENABLE_PIN not in obj:
         msg = "Address other then 0x29 requires enable_pin definition to allow sensor\r"
         msg += "re-addressing. Also if you have more then one VL53 device on the same\r"
@@ -32,7 +36,7 @@ def check_keys(obj):
     return obj
 
 
-def check_timeout(value):
+def check_timeout(value: Any) -> TimePeriodMicroseconds:
     value = cv.positive_time_period_microseconds(value)
     if value.total_seconds > 60:
         raise cv.Invalid("Maximum timeout can not be greater then 60 seconds")
@@ -70,7 +74,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
     cg.add(var.set_signal_rate_limit(config[CONF_SIGNAL_RATE_LIMIT]))

--- a/esphome/components/weikai/__init__.py
+++ b/esphome/components/weikai/__init__.py
@@ -12,6 +12,8 @@ from esphome.const import (
     CONF_NUMBER,
     CONF_OUTPUT,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@DrCoolZic"]
 AUTO_LOAD = ["uart"]
@@ -26,7 +28,7 @@ WeikaiComponent = weikai_ns.class_("WeikaiComponent", cg.Component)
 WeikaiChannel = weikai_ns.class_("WeikaiChannel", uart.UARTComponent)
 
 
-def check_channel_max(value, max):
+def check_channel_max(value: ConfigType, max: int) -> ConfigType:
     channel_uniq = []
     channel_dup = []
     for x in value[CONF_UART]:
@@ -41,11 +43,11 @@ def check_channel_max(value, max):
     return value
 
 
-def check_channel_max_4(value):
+def check_channel_max_4(value: ConfigType) -> ConfigType:
     return check_channel_max(value, 4)
 
 
-def check_channel_max_2(value):
+def check_channel_max_2(value: ConfigType) -> ConfigType:
     return check_channel_max(value, 2)
 
 
@@ -70,7 +72,7 @@ WKBASE_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def register_weikai(var, config):
+async def register_weikai(var: MockObj, config: ConfigType) -> None:
     """Register an weikai device with the given config."""
     cg.add(var.set_crystal(config[CONF_CRYSTAL]))
     cg.add(var.set_test_mode(config[CONF_TEST_MODE]))
@@ -85,7 +87,7 @@ async def register_weikai(var, config):
         cg.add(chan.set_parity(uart_elem[CONF_PARITY]))
 
 
-def validate_pin_mode(value):
+def validate_pin_mode(value: ConfigType) -> ConfigType:
     """Checks input/output mode inconsistency"""
     if not (value[CONF_MODE][CONF_INPUT] or value[CONF_MODE][CONF_OUTPUT]):
         raise cv.Invalid("Mode must be either input or output")

--- a/esphome/components/zephyr_ble_server/__init__.py
+++ b/esphome/components/zephyr_ble_server/__init__.py
@@ -3,7 +3,9 @@ import esphome.codegen as cg
 from esphome.components.zephyr import zephyr_add_prj_conf
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, Framework
-from esphome.core import CORE
+from esphome.core import CORE, ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
 
 zephyr_ble_server_ns = cg.esphome_ns.namespace("zephyr_ble_server")
 BLEServer = zephyr_ble_server_ns.class_("BLEServer", cg.Component)
@@ -32,7 +34,7 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     zephyr_add_prj_conf("BT", True)
     zephyr_add_prj_conf("BT_PERIPHERAL", True)
@@ -65,7 +67,12 @@ BLE_NUMERIC_COMPARISON_REPLY_ACTION_SCHEMA = cv.Schema(
     BLE_NUMERIC_COMPARISON_REPLY_ACTION_SCHEMA,
     synchronous=True,
 )
-async def numeric_comparison_reply_to_code(config, action_id, template_arg, args):
+async def numeric_comparison_reply_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     parent = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, parent)
 


### PR DESCRIPTION
# What does this implement/fix?

Adds parameter and return type annotations to the Python code of 29 components, as part of a repo-wide sweep to get everything under `esphome/components` fully annotated. This is part 9 of 11 covering the mid-sized components.

Components are grouped so that each code owner's components land in a single pull request rather than being spread across many.

Annotations only. No behaviour changes, no renames, no reordering, no docstring edits. Component files have no `from __future__ import annotations`, so annotations are evaluated at import time and every name used in one is imported at module level.

Components in this pull request: `as3935`, `bthome_mithermometer`, `color`, `ds248x`, `emontx`, `gdk101`, `hc8`, `lcd_base`, `libretiny_pwm`, `lightwaverf`, `max17043`, `nau7802`, `ntc`, `openthread_info`, `pmsx003`, `pzemac`, `pzemdc`, `remote_receiver`, `scd30`, `senseair`, `sml`, `sn74hc595`, `spa06_base`, `sy6970`, `tm1638`, `uponor_smatrix`, `vl53l0x`, `weikai`, `zephyr_ble_server`

Verified with `ruff check`, `ruff format --check`, `pylint`, `script/ci-custom.py`, the unit and component test suites, and an import of all 1637 component modules. That last check is the important one: because annotations are evaluated at import time, a missing import for an annotation name shows up there as a hard failure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing configuration change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
