### PR TITLE
[core] Add type annotations to component Python (11/11)

### DIFF
--- a/esphome/components/animation/image.py
+++ b/esphome/components/animation/image.py
@@ -6,6 +6,8 @@ from esphome.components.file.image import image_schema, write_image
 from esphome.components.image import Image_, validate_settings
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_REPEAT
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@syndlex"]
@@ -79,7 +81,12 @@ SET_FRAME_SCHEMA = cv.Schema(
 @automation.register_action(
     "animation.set_frame", SetFrameAction, SET_FRAME_SCHEMA, synchronous=True
 )
-async def animation_action_to_code(config, action_id, template_arg, args):
+async def animation_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 

--- a/esphome/components/apds9960/__init__.py
+++ b/esphome/components/apds9960/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = True
@@ -57,7 +58,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/apds9960/binary_sensor.py
+++ b/esphome/components/apds9960/binary_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_DIRECTION, DEVICE_CLASS_MOVING
+from esphome.types import ConfigType
 
 from . import APDS9960, CONF_APDS9960_ID
 
@@ -19,7 +20,7 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_APDS9960_ID])
     var = await binary_sensor.new_binary_sensor(config)
     func = getattr(hub, f"set_{config[CONF_DIRECTION]}_direction_binary_sensor")

--- a/esphome/components/apds9960/sensor.py
+++ b/esphome/components/apds9960/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_PERCENT,
 )
+from esphome.types import ConfigType
 
 from . import APDS9960, CONF_APDS9960_ID
 
@@ -27,7 +28,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_APDS9960_ID])
     var = await sensor.new_sensor(config)
     func = getattr(hub, f"set_{config[CONF_TYPE]}_sensor")

--- a/esphome/components/emc2101/__init__.py
+++ b/esphome/components/emc2101/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_INVERTED, CONF_RESOLUTION
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@ellull"]
 
@@ -68,7 +69,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/emc2101/output/__init__.py
+++ b/esphome/components/emc2101/output/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import output
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 from .. import CONF_EMC2101_ID, EMC2101_COMPONENT_SCHEMA, emc2101_ns
 
@@ -16,7 +17,7 @@ CONFIG_SCHEMA = EMC2101_COMPONENT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_EMC2101_ID])
     var = cg.new_Pvariable(config[CONF_ID], paren)
     await output.register_output(var, config)

--- a/esphome/components/emc2101/sensor/__init__.py
+++ b/esphome/components/emc2101/sensor/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_REVOLUTIONS_PER_MINUTE,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_EMC2101_ID, EMC2101_COMPONENT_SCHEMA, emc2101_ns
 
@@ -53,7 +54,7 @@ CONFIG_SCHEMA = EMC2101_COMPONENT_SCHEMA.extend(
 ).extend(cv.polling_component_schema("60s"))
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_EMC2101_ID])
     var = cg.new_Pvariable(config[CONF_ID], paren)
     await cg.register_component(var, config)

--- a/esphome/components/graph/__init__.py
+++ b/esphome/components/graph/__init__.py
@@ -29,6 +29,7 @@ from esphome.const import (
     CONF_X_GRID,
     CONF_Y_GRID,
 )
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@synco"]
 
@@ -115,7 +116,9 @@ GRAPH_SCHEMA = cv.Schema(
 )
 
 
-def _relocate_fields_to_subfolder(config, subfolder, subschema):
+def _relocate_fields_to_subfolder(
+    config: ConfigType, subfolder: str, subschema: cv.Schema
+) -> ConfigType:
     fields = [k.schema for k in subschema.schema]
     fields.remove(CONF_ID)
     if subfolder in config:
@@ -138,7 +141,7 @@ def _relocate_fields_to_subfolder(config, subfolder, subschema):
     return config
 
 
-def _relocate_trace(config):
+def _relocate_trace(config: ConfigType) -> ConfigType:
     return _relocate_fields_to_subfolder(config, CONF_TRACES, GRAPH_TRACE_SCHEMA)
 
 
@@ -148,7 +151,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_duration(config[CONF_DURATION]))
     cg.add(var.set_width(config[CONF_WIDTH]))

--- a/esphome/components/pylontech/__init__.py
+++ b/esphome/components/pylontech/__init__.py
@@ -4,6 +4,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/pylontech/sensor/__init__.py
+++ b/esphome/components/pylontech/sensor/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_VOLT,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_BATTERY, CONF_PYLONTECH_ID, PYLONTECH_COMPONENT_SCHEMA, pylontech_ns
 
@@ -90,7 +91,7 @@ CONFIG_SCHEMA = PYLONTECH_COMPONENT_SCHEMA.extend(
 ).extend({cv.Optional(marker): schema for marker, schema in TYPES.items()})
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PYLONTECH_ID])
     bat = cg.new_Pvariable(config[CONF_ID], config[CONF_BATTERY])
 

--- a/esphome/components/pylontech/text_sensor/__init__.py
+++ b/esphome/components/pylontech/text_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 from .. import CONF_BATTERY, CONF_PYLONTECH_ID, PYLONTECH_COMPONENT_SCHEMA, pylontech_ns
 
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = PYLONTECH_COMPONENT_SCHEMA.extend(
 ).extend({cv.Optional(marker): text_sensor.text_sensor_schema() for marker in MARKERS})
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     paren = await cg.get_variable(config[CONF_PYLONTECH_ID])
     bat = cg.new_Pvariable(config[CONF_ID], config[CONF_BATTERY])
 

--- a/esphome/components/rd03d/__init__.py
+++ b/esphome/components/rd03d/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_THROTTLE
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@jasstrong"]
 DEPENDENCIES = ["uart"]
@@ -38,7 +39,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/rd03d/binary_sensor.py
+++ b/esphome/components/rd03d/binary_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_TARGET, DEVICE_CLASS_OCCUPANCY
+from esphome.types import ConfigType
 
 from . import CONF_RD03D_ID, RD03DComponent
 
@@ -26,7 +27,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_RD03D_ID])
 
     if target_config := config.get(CONF_TARGET):

--- a/esphome/components/rd03d/sensor.py
+++ b/esphome/components/rd03d/sensor.py
@@ -15,6 +15,7 @@ from esphome.const import (
     UNIT_DEGREES,
     UNIT_MILLIMETER,
 )
+from esphome.types import ConfigType
 
 from . import CONF_RD03D_ID, RD03DComponent
 
@@ -75,7 +76,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend({cv.Optional(f"target_{i + 1}"): TARGET_SCHEMA for i in range(MAX_TARGETS)})
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_RD03D_ID])
 
     if target_count_config := config.get(CONF_TARGET_COUNT):

--- a/esphome/components/sun_gtil2/__init__.py
+++ b/esphome/components/sun_gtil2/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@Mat931"]
 MULTI_CONF = True
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/sun_gtil2/sensor.py
+++ b/esphome/components/sun_gtil2/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     UNIT_VOLT,
     UNIT_WATT,
 )
+from esphome.types import ConfigType
 
 from . import CONF_SUN_GTIL2_ID, SunGTIL2Component
 
@@ -73,7 +74,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_SUN_GTIL2_ID])
     if ac_voltage_config := config.get(CONF_AC_VOLTAGE):
         sens = await sensor.new_sensor(ac_voltage_config)

--- a/esphome/components/sun_gtil2/text_sensor.py
+++ b/esphome/components/sun_gtil2/text_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_STATE
+from esphome.types import ConfigType
 
 from . import CONF_SUN_GTIL2_ID, SunGTIL2Component
 
@@ -22,7 +23,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_SUN_GTIL2_ID])
     if state_config := config.get(CONF_STATE):
         sens = await text_sensor.new_text_sensor(state_config)

--- a/esphome/components/teleinfo/__init__.py
+++ b/esphome/components/teleinfo/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@0hax"]
 MULTI_CONF = True
@@ -34,7 +35,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID], config[CONF_HISTORICAL_MODE])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/teleinfo/sensor/__init__.py
+++ b/esphome/components/teleinfo/sensor/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_WATT_HOURS,
 )
+from esphome.types import ConfigType
 
 from .. import CONF_TAG_NAME, CONF_TELEINFO_ID, TELEINFO_LISTENER_SCHEMA, teleinfo_ns
 
@@ -22,7 +23,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(
 ).extend(TELEINFO_LISTENER_SCHEMA)
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID], config[CONF_TAG_NAME])
     await cg.register_component(var, config)
     await sensor.register_sensor(var, config)

--- a/esphome/components/teleinfo/text_sensor/__init__.py
+++ b/esphome/components/teleinfo/text_sensor/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 from .. import CONF_TAG_NAME, CONF_TELEINFO_ID, TELEINFO_LISTENER_SCHEMA, teleinfo_ns
 
@@ -13,7 +14,7 @@ CONFIG_SCHEMA = text_sensor.text_sensor_schema(TeleInfoTextSensor).extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID], config[CONF_TAG_NAME])
     await cg.register_component(var, config)
     await text_sensor.register_text_sensor(var, config)

--- a/esphome/components/ufm01/__init__.py
+++ b/esphome/components/ufm01/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@ljungqvist"]
 
@@ -34,7 +35,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/esphome/components/ufm01/binary_sensor.py
+++ b/esphome/components/ufm01/binary_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.types import ConfigType
 
 from . import CONF_UFM01_ID, UFM01Component
 
@@ -32,7 +33,7 @@ CONFIG_SCHEMA = {
 }
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ufm01_component = await cg.get_variable(config[CONF_UFM01_ID])
 
     if ufc_chip_error_config := config.get(CONF_UFC_CHIP_ERROR):

--- a/esphome/components/ufm01/sensor.py
+++ b/esphome/components/ufm01/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     UNIT_CUBIC_METER_PER_HOUR,
     UNIT_LITRE,
 )
+from esphome.types import ConfigType
 
 from . import CONF_UFM01_ID, UFM01Component
 
@@ -47,7 +48,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     ufm01_component = await cg.get_variable(config[CONF_UFM01_ID])
 
     if CONF_ACCUMULATED_FLOW in config:

--- a/esphome/components/xl9535/__init__.py
+++ b/esphome/components/xl9535/__init__.py
@@ -10,6 +10,8 @@ from esphome.const import (
     CONF_NUMBER,
     CONF_OUTPUT,
 )
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CONF_XL9535 = "xl9535"
 
@@ -29,13 +31,13 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
 
-def validate_mode(mode):
+def validate_mode(mode: ConfigType) -> ConfigType:
     if not (mode[CONF_INPUT] or mode[CONF_OUTPUT]) or (
         mode[CONF_INPUT] and mode[CONF_OUTPUT]
     ):
@@ -43,7 +45,7 @@ def validate_mode(mode):
     return mode
 
 
-def validate_pin(pin):
+def validate_pin(pin: int) -> int:
     if pin in (8, 9):
         raise cv.Invalid(f"pin {pin} doesn't exist")
     return pin
@@ -67,7 +69,7 @@ XL9535_PIN_SCHEMA = cv.All(
 
 
 @pins.PIN_SCHEMA_REGISTRY.register(CONF_XL9535, XL9535_PIN_SCHEMA)
-async def xl9535_pin_to_code(config):
+async def xl9535_pin_to_code(config: ConfigType) -> MockObj:
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_XL9535])
 


### PR DESCRIPTION
# What does this implement/fix?

Adds parameter and return type annotations to the Python code of 10 components, as part of a repo-wide sweep to get everything under `esphome/components` fully annotated. This is part 11 of 11 covering the mid-sized components.

Components are grouped so that each code owner's components land in a single pull request rather than being spread across many.

Annotations only. No behaviour changes, no renames, no reordering, no docstring edits. Component files have no `from __future__ import annotations`, so annotations are evaluated at import time and every name used in one is imported at module level.

Components in this pull request: `animation`, `apds9960`, `emc2101`, `graph`, `pylontech`, `rd03d`, `sun_gtil2`, `teleinfo`, `ufm01`, `xl9535`

Verified with `ruff check`, `ruff format --check`, `pylint`, `script/ci-custom.py`, the unit and component test suites, and an import of all 1637 component modules. That last check is the important one: because annotations are evaluated at import time, a missing import for an annotation name shows up there as a hard failure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing configuration change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
