### PR TITLE
[esp32_ble_tracker] Fix missed BLE advertisements with WiFi on ESP-IDF 5.5.5

### DIFF
--- a/esphome/components/ble_device_base/__init__.py
+++ b/esphome/components/ble_device_base/__init__.py
@@ -243,28 +243,51 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
     return config
 
 
+# The historical scan window default shared by the trackers that do not pin
+# their own; also the fallback for esp32's conditional default.
+DEFAULT_SCAN_WINDOW = "30ms"
+
+
 def scan_parameters_schema(
     interval_default: str,
     *,
-    window_default: str = "30ms",
+    window_default: str = DEFAULT_SCAN_WINDOW,
+    window_defaulter: Callable[[ConfigType], ConfigType] | None = None,
 ) -> cv.All:
     """Build the scan_parameters value schema shared by all BLE trackers.
 
     interval_default and window_default are per chip (e.g. esp32 320/30 ms,
     bk72xx/rp2 100/30 ms — the reference scan rates of the respective stacks;
-    LN882H's SDK recommends 100/50 ms). The `active` option (default on) is
+    LN882H's SDK recommends 100/50 ms). A window_defaulter replaces the
+    schema-level window default: it runs between the schema and
+    validate_scan_parameters and must fill in CONF_WINDOW when the user
+    omitted it (esp32 uses this to pick the default from the loaded
+    integrations and the IDF version, both known by schema-validation time
+    because the target platform validates first and component loading
+    precedes schema validation). The `active` option (default on) is
     unconditional: active scanning is part of the tracker contract — every
     current proxy client assumes it, so a passive-only tracker must not share
     this schema.
     """
-    schema = {
-        cv.Optional(CONF_DURATION, default="5min"): cv.positive_time_period_seconds,
-        cv.Optional(CONF_INTERVAL, default=interval_default): cv.positive_time_period,
-        cv.Optional(CONF_WINDOW, default=window_default): cv.positive_time_period,
-        cv.Optional(CONF_CONTINUOUS, default=True): cv.boolean,
-        cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
-    }
-    return cv.All(cv.Schema(schema), validate_scan_parameters)
+    schema = cv.Schema(
+        {
+            cv.Optional(CONF_DURATION, default="5min"): cv.positive_time_period_seconds,
+            cv.Optional(
+                CONF_INTERVAL, default=interval_default
+            ): cv.positive_time_period,
+            cv.Optional(
+                CONF_WINDOW,
+                default=cv.UNDEFINED
+                if window_defaulter is not None
+                else window_default,
+            ): cv.positive_time_period,
+            cv.Optional(CONF_CONTINUOUS, default=True): cv.boolean,
+            cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
+        }
+    )
+    if window_defaulter is not None:
+        return cv.All(schema, window_defaulter, validate_scan_parameters)
+    return cv.All(schema, validate_scan_parameters)
 
 
 BT_UUID16_FORMAT = "XXXX"

--- a/esphome/components/ble_device_base/__init__.py
+++ b/esphome/components/ble_device_base/__init__.py
@@ -37,7 +37,7 @@ from esphome.const import (
     CONF_INTERVAL,
     KEY_TARGET_PLATFORM,
 )
-from esphome.core import CORE, ID, KEY_CORE
+from esphome.core import CORE, ID, KEY_CORE, TimePeriod
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@Bl00d-B0b"]
@@ -251,43 +251,28 @@ DEFAULT_SCAN_WINDOW = "30ms"
 def scan_parameters_schema(
     interval_default: str,
     *,
-    window_default: str = DEFAULT_SCAN_WINDOW,
-    window_defaulter: Callable[[ConfigType], ConfigType] | None = None,
+    window_default: str | Callable[[], TimePeriod] = DEFAULT_SCAN_WINDOW,
 ) -> cv.All:
     """Build the scan_parameters value schema shared by all BLE trackers.
 
     interval_default and window_default are per chip (e.g. esp32 320/30 ms,
     bk72xx/rp2 100/30 ms — the reference scan rates of the respective stacks;
-    LN882H's SDK recommends 100/50 ms). A window_defaulter replaces the
-    schema-level window default: it runs between the schema and
-    validate_scan_parameters and must fill in CONF_WINDOW when the user
-    omitted it (esp32 uses this to pick the default from the loaded
-    integrations and the IDF version, both known by schema-validation time
-    because the target platform validates first and component loading
-    precedes schema validation). The `active` option (default on) is
-    unconditional: active scanning is part of the tracker contract — every
-    current proxy client assumes it, so a passive-only tracker must not share
-    this schema.
+    LN882H's SDK recommends 100/50 ms). window_default may also be a zero-arg
+    callable evaluated per validation when the user omits the key (esp32 uses
+    this to record that the window was defaulted, so a later validation step
+    can adjust it once sibling keys are resolved). The `active` option
+    (default on) is unconditional: active scanning is part of the tracker
+    contract — every current proxy client assumes it, so a passive-only
+    tracker must not share this schema.
     """
-    schema = cv.Schema(
-        {
-            cv.Optional(CONF_DURATION, default="5min"): cv.positive_time_period_seconds,
-            cv.Optional(
-                CONF_INTERVAL, default=interval_default
-            ): cv.positive_time_period,
-            cv.Optional(
-                CONF_WINDOW,
-                default=cv.UNDEFINED
-                if window_defaulter is not None
-                else window_default,
-            ): cv.positive_time_period,
-            cv.Optional(CONF_CONTINUOUS, default=True): cv.boolean,
-            cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
-        }
-    )
-    if window_defaulter is not None:
-        return cv.All(schema, window_defaulter, validate_scan_parameters)
-    return cv.All(schema, validate_scan_parameters)
+    schema = {
+        cv.Optional(CONF_DURATION, default="5min"): cv.positive_time_period_seconds,
+        cv.Optional(CONF_INTERVAL, default=interval_default): cv.positive_time_period,
+        cv.Optional(CONF_WINDOW, default=window_default): cv.positive_time_period,
+        cv.Optional(CONF_CONTINUOUS, default=True): cv.boolean,
+        cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
+    }
+    return cv.All(cv.Schema(schema), validate_scan_parameters)
 
 
 BT_UUID16_FORMAT = "XXXX"

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from dataclasses import dataclass
 import logging
 
 from esphome import automation
@@ -37,9 +38,11 @@ from esphome.const import (
     CONF_SERVICE_UUID,
     CONF_TRIGGER_ID,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CORE, CoroPriority, TimePeriod, coroutine_with_priority
 from esphome.enum import StrEnum
 from esphome.types import ConfigType
+
+DOMAIN = "esp32_ble_tracker"
 
 AUTO_LOAD = ["ble_device_base", "esp32_ble"]
 DEPENDENCIES = ["esp32"]
@@ -138,34 +141,59 @@ def validate_max_connections_deprecated(config: ConfigType) -> ConfigType:
 IDF_SCAN_WINDOW_FIX_VERSION = cv.Version(5, 5, 5)
 
 
-def _default_scan_window(params: ConfigType) -> ConfigType:
-    """Fill in the scan window default for a user who did not set one.
+@dataclass
+class TrackerData:
+    """Per-run validation state, namespaced under DOMAIN in CORE.data."""
 
-    With wifi sharing the radio on an IDF that honors the window strictly
-    (>= 5.5.5), the window defaults to the interval, as Espressif recommends;
-    otherwise the historical 30 ms default is kept.
+    scan_window_defaulted: bool = False
+
+
+def _get_data() -> TrackerData:
+    if DOMAIN not in CORE.data:
+        CORE.data[DOMAIN] = TrackerData()
+    return CORE.data[DOMAIN]
+
+
+def _scan_window_default() -> TimePeriod:
+    """Schema default for the scan window.
+
+    Records that the user did not set a window, so _raise_defaulted_scan_window
+    can tell a defaulted 30 ms from an explicit one; the raise itself must wait
+    for the outer schema because it depends on software_coexistence, a sibling
+    key not yet resolved here.
     """
-    if CONF_WINDOW not in params:
-        if (
-            "wifi" in CORE.loaded_integrations
-            and idf_version() >= IDF_SCAN_WINDOW_FIX_VERSION
-        ):
-            # Copy so the config dump shows a plain value instead of a YAML
-            # anchor/alias pair pointing at the interval.
-            params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
-        else:
-            params[CONF_WINDOW] = cv.positive_time_period(
-                ble_device_base.DEFAULT_SCAN_WINDOW
-            )
-    return params
+    _get_data().scan_window_defaulted = True
+    return cv.positive_time_period(ble_device_base.DEFAULT_SCAN_WINDOW)
+
+
+def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
+    """Raise a defaulted scan window to the interval where that is safe.
+
+    Only when the coexistence arbiter is compiled in (software_coexistence,
+    present iff wifi is configured and not disabled by the user) and the IDF
+    honors the window strictly (>= 5.5.5); without the arbiter a full-duty
+    scan would starve wifi outright, and a user-set window is never touched.
+    Raising to the interval cannot invalidate the already-validated
+    parameters, so no re-validation is needed.
+    """
+    if (
+        _get_data().scan_window_defaulted
+        and config.get(CONF_SOFTWARE_COEXISTENCE)
+        and idf_version() >= IDF_SCAN_WINDOW_FIX_VERSION
+    ):
+        params = config[CONF_SCAN_PARAMETERS]
+        # Copy so the config dump shows a plain value instead of a YAML
+        # anchor/alias pair pointing at the interval.
+        params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
+    return config
 
 
 # 320 ms is the ESP-IDF reference scan interval; the shared schema also
 # tightens validation to the controller's 2.5 ms .. 10240 ms range and rejects
 # window/interval pairs that collapse to the same 0.625 ms unit count.
-# The window default is conditional (see _default_scan_window above).
+# The window default is conditional (see _scan_window_default above).
 SCAN_PARAMETERS_SCHEMA = ble_device_base.scan_parameters_schema(
-    "320ms", window_defaulter=_default_scan_window
+    "320ms", window_default=_scan_window_default
 )
 
 # Codegen helpers are owned by ble_device_base; kept under the historical names
@@ -221,6 +249,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ).extend(cv.COMPONENT_SCHEMA),
     validate_max_connections_deprecated,
+    _raise_defaulted_scan_window,
 )
 
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -8,6 +8,7 @@ from esphome.components import ble_device_base, esp32_ble, ota
 from esphome.components.const import CONF_ON_SCAN_END, CONF_SCAN_PARAMETERS, CONF_WINDOW
 from esphome.components.esp32 import (
     add_idf_sdkconfig_option,
+    idf_version,
     request_bluetooth,
     request_software_coexistence,
 )
@@ -125,10 +126,44 @@ def validate_max_connections_deprecated(config: ConfigType) -> ConfigType:
     return config
 
 
+# ESP-IDF 5.5.5 fixed a coexistence bug on the ESP32 where BLE scans ran far
+# longer than the configured window (espressif/esp-idf#18931). Before the fix,
+# the default 30 ms window in a 320 ms interval effectively scanned at a much
+# higher duty cycle than requested; with the fix, that same default only
+# listens 9.4 % of the time and misses most advertisements when wifi shares
+# the radio. Espressif recommends setting the window equal to the interval in
+# that case: the coexistence arbiter still shares the radio with wifi, and
+# BLE uses the airtime wifi does not claim.
+IDF_SCAN_WINDOW_FIX_VERSION = cv.Version(5, 5, 5)
+
+
+def _default_scan_window(params: ConfigType) -> ConfigType:
+    """Fill in the scan window default for a user who did not set one.
+
+    With wifi sharing the radio on an IDF that honors the window strictly
+    (>= 5.5.5), the window defaults to the interval, as Espressif recommends;
+    otherwise the historical 30 ms default is kept.
+    """
+    if CONF_WINDOW not in params:
+        if (
+            "wifi" in CORE.loaded_integrations
+            and idf_version() >= IDF_SCAN_WINDOW_FIX_VERSION
+        ):
+            params[CONF_WINDOW] = params[CONF_INTERVAL]
+        else:
+            params[CONF_WINDOW] = cv.positive_time_period(
+                ble_device_base.DEFAULT_SCAN_WINDOW
+            )
+    return params
+
+
 # 320 ms is the ESP-IDF reference scan interval; the shared schema also
 # tightens validation to the controller's 2.5 ms .. 10240 ms range and rejects
 # window/interval pairs that collapse to the same 0.625 ms unit count.
-SCAN_PARAMETERS_SCHEMA = ble_device_base.scan_parameters_schema("320ms")
+# The window default is conditional (see _default_scan_window above).
+SCAN_PARAMETERS_SCHEMA = ble_device_base.scan_parameters_schema(
+    "320ms", window_defaulter=_default_scan_window
+)
 
 # Codegen helpers are owned by ble_device_base; kept under the historical names
 # here for the components that import them from this module.

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 
 from esphome import automation
@@ -149,7 +150,9 @@ def _default_scan_window(params: ConfigType) -> ConfigType:
             "wifi" in CORE.loaded_integrations
             and idf_version() >= IDF_SCAN_WINDOW_FIX_VERSION
         ):
-            params[CONF_WINDOW] = params[CONF_INTERVAL]
+            # Copy so the config dump shows a plain value instead of a YAML
+            # anchor/alias pair pointing at the interval.
+            params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
         else:
             params[CONF_WINDOW] = cv.positive_time_period(
                 ble_device_base.DEFAULT_SCAN_WINDOW

--- a/tests/component_tests/ble_device_base/test_scan_parameter_validation.py
+++ b/tests/component_tests/ble_device_base/test_scan_parameter_validation.py
@@ -57,7 +57,12 @@ def test_bk72xx_defaults_are_valid() -> None:
 
 
 def test_esp32_defaults_are_valid() -> None:
-    """esp32 pins the ESP-IDF reference rate and exposes active (default on)."""
+    """esp32 pins the ESP-IDF reference rate and exposes active (default on).
+
+    Without wifi loaded, the conditional window default falls back to the
+    historical 30 ms; the wifi-aware resolution is covered by the
+    esp32_ble_tracker component tests.
+    """
     config = ESP32_SCHEMA({})
     assert to_ble_units(config["interval"]) == 512
     assert to_ble_units(config["window"]) == 48

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -1,11 +1,12 @@
 """Tests for the esp32_ble_tracker conditional scan window default.
 
-The scan window default depends on the loaded integrations and the IDF
-version: IDF 5.5.5 fixed a coexistence bug where BLE scans ran far longer
-than the configured window (espressif/esp-idf#18931), so on fixed versions
-the historical 30 ms default would only listen 9.4 % of the time and miss
-most advertisements. With wifi sharing the radio on a fixed IDF, the window
-instead defaults to the interval, as Espressif recommends.
+The scan window default depends on wifi coexistence and the IDF version:
+IDF 5.5.5 fixed a coexistence bug where BLE scans ran far longer than the
+configured window (espressif/esp-idf#18931), so on fixed versions the
+historical 30 ms default would only listen 9.4 % of the time and miss most
+advertisements. With the coexistence arbiter compiled in on a fixed IDF, the
+window instead defaults to the interval, as Espressif recommends; without the
+arbiter a full-duty scan would starve wifi, so the 30 ms default is kept.
 """
 
 from __future__ import annotations
@@ -16,9 +17,12 @@ import pytest
 
 from esphome import config_validation as cv
 from esphome.components.ble_device_base import to_ble_units
-from esphome.components.const import CONF_WINDOW
+from esphome.components.const import CONF_SCAN_PARAMETERS, CONF_WINDOW
 from esphome.components.esp32 import KEY_IDF_VERSION
-from esphome.components.esp32_ble_tracker import SCAN_PARAMETERS_SCHEMA
+from esphome.components.esp32_ble_tracker import (
+    CONF_SOFTWARE_COEXISTENCE,
+    CONFIG_SCHEMA,
+)
 from esphome.const import CONF_INTERVAL, PlatformFramework
 from esphome.core import CORE
 from esphome.types import ConfigType
@@ -38,59 +42,81 @@ def stage_esp32(
             platform_data={KEY_IDF_VERSION: cv.Version.parse(idf)},
         )
         if wifi:
+            # Makes cv.OnlyWith default software_coexistence to True, exactly
+            # as a real config with wifi: does.
             CORE.loaded_integrations.add("wifi")
 
     return stage
 
 
+def _scan_params(config: ConfigType) -> ConfigType:
+    return CONFIG_SCHEMA(config)[CONF_SCAN_PARAMETERS]
+
+
 @pytest.mark.parametrize(
-    ("idf", "scan_params", "expected_units"),
+    ("idf", "config", "expected_units"),
     [
         ("5.5.5", {}, 512),  # first fixed version, default 320 ms interval
         ("6.0.1", {}, 512),  # any newer version behaves the same
-        ("5.5.5", {"interval": "1s"}, 1600),  # follows a user-set interval
+        # Follows a user-set interval.
+        ("5.5.5", {"scan_parameters": {"interval": "1s"}}, 1600),
     ],
 )
 def test_wifi_on_fixed_idf_defaults_window_to_interval(
     stage_esp32: Callable[..., None],
     idf: str,
-    scan_params: ConfigType,
+    config: ConfigType,
     expected_units: int,
 ) -> None:
-    """With wifi on a fixed IDF, the window defaults to the interval."""
+    """With wifi coexistence on a fixed IDF, the window defaults to the interval."""
     stage_esp32(idf, wifi=True)
-    params = SCAN_PARAMETERS_SCHEMA(scan_params)
+    params = _scan_params(config)
     assert params[CONF_WINDOW] == params[CONF_INTERVAL]
     assert to_ble_units(params[CONF_WINDOW]) == expected_units
 
 
 @pytest.mark.parametrize(
-    ("idf", "wifi"),
+    ("idf", "wifi", "config"),
     [
-        ("5.5.4", True),  # buggy IDF over-scans anyway; keep the 30 ms default
-        ("5.5.5", False),  # no wifi (e.g. ethernet) means no radio contention
+        # Buggy IDF over-scans anyway; keep the 30 ms default.
+        ("5.5.4", True, {}),
+        # No wifi (e.g. ethernet) means no radio contention.
+        ("5.5.5", False, {}),
+        # Coexistence disabled: no arbiter, so a full-duty scan would starve
+        # wifi outright.
+        ("5.5.5", True, {CONF_SOFTWARE_COEXISTENCE: False}),
     ],
 )
 def test_30ms_default_kept(
-    stage_esp32: Callable[..., None], idf: str, wifi: bool
+    stage_esp32: Callable[..., None],
+    idf: str,
+    wifi: bool,
+    config: ConfigType,
 ) -> None:
     stage_esp32(idf, wifi=wifi)
-    assert to_ble_units(SCAN_PARAMETERS_SCHEMA({})[CONF_WINDOW]) == 48
+    assert to_ble_units(_scan_params(config)[CONF_WINDOW]) == 48
 
 
+@pytest.mark.parametrize("window", ["60ms", "30ms"])
 def test_explicit_window_is_never_touched(
+    stage_esp32: Callable[..., None], window: str
+) -> None:
+    """A user-set window wins over the conditional default.
+
+    The explicit 30 ms case matters: it is indistinguishable from the
+    defaulted value by inspection, so the defaulted flag must separate them.
+    """
+    stage_esp32("5.5.5", wifi=True)
+    params = _scan_params({"scan_parameters": {"window": window}})
+    assert to_ble_units(params[CONF_WINDOW]) == to_ble_units(
+        cv.positive_time_period(window)
+    )
+
+
+def test_short_interval_without_window_still_rejected(
     stage_esp32: Callable[..., None],
 ) -> None:
-    """A user-set window wins over the conditional default."""
+    """The provisional 30 ms default validates against the interval as before."""
     stage_esp32("5.5.5", wifi=True)
-    params = SCAN_PARAMETERS_SCHEMA({"window": "60ms"})
-    assert to_ble_units(params[CONF_WINDOW]) == 96
-
-
-def test_filled_default_is_validated(stage_esp32: Callable[..., None]) -> None:
-    """The filled-in default still goes through the shared window validation."""
-    # A user interval below the 30 ms fallback makes the filled-in default
-    # invalid; the shared validator runs after the defaulter and must catch it.
-    stage_esp32("5.5.5", wifi=False)
     with pytest.raises(cv.Invalid, match="needs to be smaller than scan interval"):
-        SCAN_PARAMETERS_SCHEMA({"interval": "20ms"})
+        _scan_params({"scan_parameters": {"interval": "20ms"}})

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -1,0 +1,96 @@
+"""Tests for the esp32_ble_tracker conditional scan window default.
+
+The scan window default depends on the loaded integrations and the IDF
+version: IDF 5.5.5 fixed a coexistence bug where BLE scans ran far longer
+than the configured window (espressif/esp-idf#18931), so on fixed versions
+the historical 30 ms default would only listen 9.4 % of the time and miss
+most advertisements. With wifi sharing the radio on a fixed IDF, the window
+instead defaults to the interval, as Espressif recommends.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.ble_device_base import to_ble_units
+from esphome.components.const import CONF_WINDOW
+from esphome.components.esp32 import KEY_IDF_VERSION
+from esphome.components.esp32_ble_tracker import SCAN_PARAMETERS_SCHEMA
+from esphome.const import CONF_INTERVAL, PlatformFramework
+from esphome.core import CORE
+from esphome.types import ConfigType
+
+from ..types import SetCoreConfigCallable
+
+
+@pytest.fixture
+def stage_esp32(
+    set_core_config: SetCoreConfigCallable,
+) -> Callable[..., None]:
+    """Stage an esp32 build with a given IDF version and wifi presence."""
+
+    def stage(idf: str, *, wifi: bool) -> None:
+        set_core_config(
+            PlatformFramework.ESP32_IDF,
+            platform_data={KEY_IDF_VERSION: cv.Version.parse(idf)},
+        )
+        if wifi:
+            CORE.loaded_integrations.add("wifi")
+
+    return stage
+
+
+@pytest.mark.parametrize(
+    ("idf", "scan_params", "expected_units"),
+    [
+        ("5.5.5", {}, 512),  # first fixed version, default 320 ms interval
+        ("6.0.1", {}, 512),  # any newer version behaves the same
+        ("5.5.5", {"interval": "1s"}, 1600),  # follows a user-set interval
+    ],
+)
+def test_wifi_on_fixed_idf_defaults_window_to_interval(
+    stage_esp32: Callable[..., None],
+    idf: str,
+    scan_params: ConfigType,
+    expected_units: int,
+) -> None:
+    """With wifi on a fixed IDF, the window defaults to the interval."""
+    stage_esp32(idf, wifi=True)
+    params = SCAN_PARAMETERS_SCHEMA(scan_params)
+    assert params[CONF_WINDOW] == params[CONF_INTERVAL]
+    assert to_ble_units(params[CONF_WINDOW]) == expected_units
+
+
+@pytest.mark.parametrize(
+    ("idf", "wifi"),
+    [
+        ("5.5.4", True),  # buggy IDF over-scans anyway; keep the 30 ms default
+        ("5.5.5", False),  # no wifi (e.g. ethernet) means no radio contention
+    ],
+)
+def test_30ms_default_kept(
+    stage_esp32: Callable[..., None], idf: str, wifi: bool
+) -> None:
+    stage_esp32(idf, wifi=wifi)
+    assert to_ble_units(SCAN_PARAMETERS_SCHEMA({})[CONF_WINDOW]) == 48
+
+
+def test_explicit_window_is_never_touched(
+    stage_esp32: Callable[..., None],
+) -> None:
+    """A user-set window wins over the conditional default."""
+    stage_esp32("5.5.5", wifi=True)
+    params = SCAN_PARAMETERS_SCHEMA({"window": "60ms"})
+    assert to_ble_units(params[CONF_WINDOW]) == 96
+
+
+def test_filled_default_is_validated(stage_esp32: Callable[..., None]) -> None:
+    """The filled-in default still goes through the shared window validation."""
+    # A user interval below the 30 ms fallback makes the filled-in default
+    # invalid; the shared validator runs after the defaulter and must catch it.
+    stage_esp32("5.5.5", wifi=False)
+    with pytest.raises(cv.Invalid, match="needs to be smaller than scan interval"):
+        SCAN_PARAMETERS_SCHEMA({"interval": "20ms"})


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 5.5.5 fixed a coexistence bug where BLE scans on the ESP32 ran much longer than the configured window (espressif/esp-idf#18931). Our default 30ms window in a 320ms interval relied on that bug to work well; with the fix the scanner only listens 9.4% of the time and misses most advertisements when WiFi is active, which is why trackers and proxies became unreliable starting with 2026.7.1.

When WiFi coexistence is active and the build uses ESP-IDF 5.5.5 or newer, the scan window now defaults to the scan interval, as Espressif recommends; the radio arbiter still shares airtime with WiFi. A window set in the config is never changed. The 30ms default is kept without WiFi, on builds pinned to older IDF versions where the old behavior still applies, and when software_coexistence is disabled, since without the arbiter a full duty scan would starve WiFi.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/17805

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7186

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

esp32_ble_tracker:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
