### PR TITLE
[core] Restore cv.parse_esphome_version as a deprecated helper

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -99,6 +99,10 @@ from esphome.schema_extractors import (
     schema_extractor_registry,
     schema_extractor_typed,
 )
+
+# Deprecated re-export for external components; remove before 2027.2.0
+# pylint: disable-next=unused-import
+from esphome.util import parse_esphome_version  # noqa: F401
 from esphome.voluptuous_schema import _Schema
 from esphome.yaml_util import SensitiveStr, make_data_base
 
@@ -2639,17 +2643,6 @@ def require_esphome_version(
         return value
 
     return validator
-
-
-# Remove before 2027.2.0
-def parse_esphome_version() -> tuple[int, int, int]:
-    """Deprecated: use require_esphome_version instead."""
-    _LOGGER.warning(
-        "cv.parse_esphome_version() is deprecated, use "
-        "cv.require_esphome_version instead. Removed in 2027.2.0"
-    )
-    version = Version.parse(ESPHOME_VERSION)
-    return version.major, version.minor, version.patch
 
 
 @contextmanager

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2641,6 +2641,17 @@ def require_esphome_version(
     return validator
 
 
+# Remove before 2027.2.0
+def parse_esphome_version() -> tuple[int, int, int]:
+    """Deprecated: use require_esphome_version instead."""
+    _LOGGER.warning(
+        "cv.parse_esphome_version() is deprecated, use "
+        "cv.require_esphome_version instead. Removed in 2027.2.0"
+    )
+    version = Version.parse(ESPHOME_VERSION)
+    return version.major, version.minor, version.patch
+
+
 @contextmanager
 def suppress_invalid():
     with suppress(vol.Invalid):

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -396,8 +396,10 @@ def parse_esphome_version() -> tuple[int, int, int]:
     from esphome.core import Version
 
     _LOGGER.warning(
-        "parse_esphome_version() is deprecated, use "
-        "cv.require_esphome_version instead. Removed in 2027.2.0"
+        "parse_esphome_version() is deprecated. Use "
+        "cv.require_esphome_version to gate on a minimum version, or "
+        "Version.parse(const.__version__) from esphome.core to inspect "
+        "the current version. Removed in 2027.2.0"
     )
     version = Version.parse(const.__version__)
     return version.major, version.minor, version.patch

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -390,6 +390,19 @@ def is_dev_esphome_version():
     return "dev" in const.__version__
 
 
+# Remove before 2027.2.0
+def parse_esphome_version() -> tuple[int, int, int]:
+    """Deprecated: use esphome.config_validation.require_esphome_version instead."""
+    from esphome.core import Version
+
+    _LOGGER.warning(
+        "parse_esphome_version() is deprecated, use "
+        "cv.require_esphome_version instead. Removed in 2027.2.0"
+    )
+    version = Version.parse(const.__version__)
+    return version.major, version.minor, version.patch
+
+
 # Custom OrderedDict with nicer repr method for debugging
 class OrderedDict(collections.OrderedDict):
     def __repr__(self):

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -397,9 +397,8 @@ def parse_esphome_version() -> tuple[int, int, int]:
 
     _LOGGER.warning(
         "parse_esphome_version() is deprecated. Use "
-        "cv.require_esphome_version to gate on a minimum version, or "
-        "Version.parse(const.__version__) from esphome.core to inspect "
-        "the current version. Removed in 2027.2.0"
+        "cv.require_esphome_version to gate on a minimum version. "
+        "Removed in 2027.2.0"
     )
     version = Version.parse(const.__version__)
     return version.major, version.minor, version.patch

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -2967,6 +2967,19 @@ def test_require_esphome_version_older_prerelease_fails() -> None:
         cv.require_esphome_version(2026, 8, 0)("test")
 
 
+def test_parse_esphome_version_deprecated_shim(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The removed helper still works for external components and warns."""
+    with (
+        patch.object(cv, "ESPHOME_VERSION", "2026.9.0-dev"),
+        caplog.at_level(logging.WARNING),
+    ):
+        assert cv.parse_esphome_version() == (2026, 9, 0)
+        assert cv.parse_esphome_version() < (9999, 0, 0)
+    assert "cv.parse_esphome_version() is deprecated" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # suppress_invalid / validate_source_shorthand / rename_key
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -2971,13 +2971,17 @@ def test_parse_esphome_version_deprecated_shim(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The removed helper still works for external components and warns."""
+    from esphome import const, util
+
     with (
-        patch.object(cv, "ESPHOME_VERSION", "2026.9.0-dev"),
+        patch.object(const, "__version__", "2026.9.0-dev"),
         caplog.at_level(logging.WARNING),
     ):
         assert cv.parse_esphome_version() == (2026, 9, 0)
         assert cv.parse_esphome_version() < (9999, 0, 0)
-    assert "cv.parse_esphome_version() is deprecated" in caplog.text
+    assert "parse_esphome_version() is deprecated" in caplog.text
+    # Both historical import paths resolve to the same function
+    assert cv.parse_esphome_version is util.parse_esphome_version
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

#18065 removed `parse_esphome_version` from `esphome.util`, which also removed the accidental re-export `cv.parse_esphome_version` that external components call; for example fujitsu-halcyon does `cv.parse_esphome_version() < (2026, 3, 0)` and now fails config validation with an `AttributeError`.

This restores `parse_esphome_version()` at its original `esphome.util` location and re-exports it from `config_validation.py`, so both historical import paths work again. It logs a deprecation warning pointing at `cv.require_esphome_version` and returns the same `(year, month, patch)` tuple as before, built from the existing `Version.parse`. Remove after the 6 month deprecation window, in 2027.2.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
