### PR TITLE
Added Waveshare 1.54in-b ePaper display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -28,6 +28,9 @@ WaveshareEPaper7C = waveshare_epaper_ns.class_("WaveshareEPaper7C", WaveshareEPa
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
 )
+WaveshareEPaper1P54InB = waveshare_epaper_ns.class_(
+    "WaveshareEPaper1P54InB", WaveshareEPaperBWR
+)
 WaveshareEpaper1P54INBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper1P54InBV2", WaveshareEPaperBWR
 )
@@ -130,6 +133,7 @@ WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel"
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
     "1.54inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN_V2),
+    "1.54in-b": ("b", WaveshareEPaper1P54InB),
     "1.54inv2-b": ("b", WaveshareEpaper1P54INBV2),
     "2.13in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN),
     "2.13inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN_V2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -975,6 +975,182 @@ void WaveshareEPaper2P7InV2::dump_config() {
 }
 
 // ========================================================
+//                          1.54inch_e-paper_b
+// ========================================================
+// Datasheet:
+//  - https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(B)_Manual
+//  - https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_1in54b.c
+
+static const uint8_t LUT_VCOM0_1_54B[] = {0x0E, 0x14, 0x01, 0x0A, 0x06, 0x04, 0x0A, 0x0A,
+                                           0x0F, 0x03, 0x03, 0x0C, 0x06, 0x0A, 0x00};
+static const uint8_t LUT_W_1_54B[] = {0x0E, 0x14, 0x01, 0x0A, 0x46, 0x04, 0x8A, 0x4A,
+                                       0x0F, 0x83, 0x43, 0x0C, 0x86, 0x0A, 0x04};
+static const uint8_t LUT_B_1_54B[] = {0x0E, 0x14, 0x01, 0x8A, 0x06, 0x04, 0x8A, 0x4A,
+                                       0x0F, 0x83, 0x43, 0x0C, 0x06, 0x4A, 0x04};
+static const uint8_t LUT_G1_1_54B[] = {0x8E, 0x94, 0x01, 0x8A, 0x06, 0x04, 0x8A, 0x4A,
+                                        0x0F, 0x83, 0x43, 0x0C, 0x06, 0x0A, 0x04};
+static const uint8_t LUT_G2_1_54B[] = {0x8E, 0x94, 0x01, 0x8A, 0x06, 0x04, 0x8A, 0x4A,
+                                        0x0F, 0x83, 0x43, 0x0C, 0x06, 0x0A, 0x04};
+static const uint8_t LUT_VCOM1_1_54B[] = {0x03, 0x1D, 0x01, 0x01, 0x08, 0x23, 0x37, 0x37,
+                                           0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+static const uint8_t LUT_RED0_1_54B[] = {0x83, 0x5D, 0x01, 0x81, 0x48, 0x23, 0x77, 0x77,
+                                          0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+static const uint8_t LUT_RED1_1_54B[] = {0x03, 0x1D, 0x01, 0x01, 0x08, 0x23, 0x37, 0x37,
+                                          0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+void WaveshareEPaper1P54InB::initialize() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x00);
+  this->data(0x08);
+  this->data(0x00);
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0x07);
+  this->data(0x07);
+  this->data(0x07);
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0xCF);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x37);
+
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x39);
+
+  // COMMAND TCON RESOLUTION
+  this->command(0x61);
+  this->data(0xC8);  // width: 200
+  this->data(0x00);  // height (high byte)
+  this->data(0xC8);  // height: 200
+
+  // COMMAND VCM DC SETTING
+  this->command(0x82);
+  this->data(0x0E);
+
+  // COMMAND LUT FOR VCOM
+  this->command(0x20);
+  for (uint8_t i : LUT_VCOM0_1_54B)
+    this->data(i);
+  // COMMAND LUT WHITE TO WHITE
+  this->command(0x21);
+  for (uint8_t i : LUT_W_1_54B)
+    this->data(i);
+  // COMMAND LUT BLACK TO WHITE
+  this->command(0x22);
+  for (uint8_t i : LUT_B_1_54B)
+    this->data(i);
+  // COMMAND LUT WHITE TO BLACK
+  this->command(0x23);
+  for (uint8_t i : LUT_G1_1_54B)
+    this->data(i);
+  // COMMAND LUT BLACK TO BLACK
+  this->command(0x24);
+  for (uint8_t i : LUT_G2_1_54B)
+    this->data(i);
+
+  // COMMAND LUT FOR RED VCOM
+  this->command(0x25);
+  for (uint8_t i : LUT_VCOM1_1_54B)
+    this->data(i);
+  // COMMAND LUT RED0
+  this->command(0x26);
+  for (uint8_t i : LUT_RED0_1_54B)
+    this->data(i);
+  // COMMAND LUT RED1
+  this->command(0x27);
+  for (uint8_t i : LUT_RED1_1_54B)
+    this->data(i);
+}
+
+void HOT WaveshareEPaper1P54InB::display() {
+  uint32_t buf_len_half = this->get_buffer_length_() >> 1;
+  this->initialize();
+
+  // COMMAND DATA START TRANSMISSION 1 (BLACK)
+  // This controller only supports a 2-bit-per-pixel black/white plane, so every source bit
+  // (inverted, since a register bit of 1 means "no ink" on this panel, opposite of ESPHome's
+  // on/off polarity) is expanded to a 2-bit "00"/"11" pair understood by the LUTs above.
+  this->command(0x10);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len_half; i++) {
+    uint8_t black_byte = ~this->buffer_[i];
+    uint8_t temp = 0x00;
+    for (uint8_t bit = 0; bit < 4; bit++) {
+      if ((black_byte & (0x80 >> bit)) != 0) {
+        temp |= 0xC0 >> (bit * 2);
+      }
+    }
+    this->data(temp);
+    temp = 0x00;
+    for (uint8_t bit = 4; bit < 8; bit++) {
+      if ((black_byte & (0x80 >> bit)) != 0) {
+        temp |= 0xC0 >> ((bit - 4) * 2);
+      }
+    }
+    this->data(temp);
+  }
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (RED)
+  // Same polarity as the black plane: a register bit of 1 means "no red ink" here, so the
+  // buffer (where a set bit means "draw red") has to be inverted too.
+  this->command(0x13);
+  delay(2);
+  for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
+    this->data(~this->buffer_[i]);
+  }
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  this->wait_until_idle_();
+}
+int WaveshareEPaper1P54InB::get_height_internal() { return 200; }
+int WaveshareEPaper1P54InB::get_width_internal() { return 200; }
+void HOT WaveshareEPaper1P54InB::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  const uint32_t buf_half_len = this->get_buffer_length_() / 2u;
+  const uint32_t pos = (x + y * this->get_width_internal()) / 8u;
+  const uint8_t subpos = x & 0x07;
+  const bool is_red = color.red > 0 && color.green == 0 && color.blue == 0;
+
+  if (color.is_on() && !is_red) {
+    this->buffer_[pos] |= 0x80 >> subpos;
+  } else {
+    this->buffer_[pos] &= ~(0x80 >> subpos);
+  }
+
+  if (is_red) {
+    this->buffer_[pos + buf_half_len] |= 0x80 >> subpos;
+  } else {
+    this->buffer_[pos + buf_half_len] &= ~(0x80 >> subpos);
+  }
+}
+void WaveshareEPaper1P54InB::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 1.54in B");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
 //                          1.54inch_v2_e-paper_b
 // ========================================================
 // Datasheet:

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -183,6 +183,46 @@ enum WaveshareEPaperTypeBModel {
   WAVESHARE_EPAPER_13_3_IN_K,
 };
 
+// NOTE: this panel's BUSY line idles HIGH and is LOW while busy -- the opposite of the newer
+// SSD1681-based "V2" panels that WaveshareEPaperBase::wait_until_idle_() was written against.
+// Configure busy_pin with `inverted: true` in YAML, or every wait_until_idle_() call will return
+// immediately (mistaking "busy" for "idle") and desync the init/display command sequence.
+class WaveshareEPaper1P54InB : public WaveshareEPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM_AND_DATA_INTERVAL_SETTING
+    this->command(0x50);
+    this->data(0x17);
+    // COMMAND VCM_DC_SETTING_REGISTER
+    this->command(0x82);
+    this->data(0x00);
+    // COMMAND POWER SETTING
+    this->command(0x01);
+    this->data(0x02);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->wait_until_idle_();
+    // COMMAND POWER OFF
+    this->command(0x02);
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+  // WaveshareEPaperBWR::draw_absolute_pixel_internal() flags a pixel "black ink" whenever
+  // color.is_on() is true, which includes pure red -- so red pixels also mark the black plane.
+  // On this panel, a pixel with both planes set to "ink" renders black instead of red, so black
+  // and red must be kept mutually exclusive here.
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+};
+
 class WaveshareEPaper1P54InBV2 : public WaveshareEPaperBWR {
  public:
   void initialize() override;

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -39,6 +39,25 @@ display:
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
   - platform: waveshare_epaper
+    id: epd_1_54b
+    model: 1.54in-b
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+      inverted: true
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
+  - platform: waveshare_epaper
     id: epd_1_54v2b
     model: 1.54inv2-b
     cs_pin:


### PR DESCRIPTION
# What does this implement/fix?

Added the missing 1.54 inch red/black Waveshare 1.54in-b ePaper display

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

# Board: Generic ESP8266 Board (Generic)
# Definition: definitions/boards/generic-esp8266/manifest.yaml

esphome:
  name: eink-display-1
  friendly_name: eInk Display 1

esp8266:
  board: esp01_1m

logger:

api:
  encryption:
    key: "qs3H8cMkpTMPrRvyfTJzR/o7JPCOGwBDSAsAWtUfRNk="

ota:
  - platform: esphome

wifi:
  ssid: GaiaDzu
  password: cickafark
  ap:
    ssid: TestDisplay Fallback Hotspot
    password: "cickafark"

captive_portal:

spi:
  - clk_pin: 14
    miso_pin: 12
    mosi_pin: 13
    id: spi_1

display:
  - platform: waveshare_epaper
    spi_id: spi_1
    model: 1.54in-b
    cs_pin: GPIO16
    dc_pin: GPIO4
    reset_pin: GPIO2
    busy_pin:
      number: GPIO5
      inverted: true
    id: display_waveshare_epaper_1
    update_interval: 60s
    lambda: |-
      it.print(it.get_width() / 2, 80, id(font_1), TextAlign::CENTER, "Hello World!");
      it.print(it.get_width() / 2, 120, id(font_1), Color(255, 0, 0), TextAlign::CENTER, "In red!");
      it.filled_circle(it.get_width() / 2, 160, 20, Color(255, 0, 0));

font:
  - id: font_1
    file:
      type: gfonts
      family: Roboto
    size: 24


```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
