### PR TITLE
[core] Remove deprecated entity_base getters

### DIFF
--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -80,24 +80,6 @@ const char *EntityBase::get_device_class_to([[maybe_unused]] std::span<char, MAX
 #endif
 }
 
-#ifndef USE_ESP8266
-// Deprecated device class accessors — not available on ESP8266 (rodata is RAM)
-StringRef EntityBase::get_device_class_ref() const {
-#ifdef USE_ENTITY_DEVICE_CLASS
-  return StringRef(entity_device_class_lookup(this->device_class_idx_));
-#else
-  return StringRef(entity_device_class_lookup(0));
-#endif
-}
-std::string EntityBase::get_device_class() const {
-#ifdef USE_ENTITY_DEVICE_CLASS
-  return std::string(entity_device_class_lookup(this->device_class_idx_));
-#else
-  return std::string(entity_device_class_lookup(0));
-#endif
-}
-#endif  // !USE_ESP8266
-
 // Entity unit of measurement (from index)
 StringRef EntityBase::get_unit_of_measurement_ref() const {
 #ifdef USE_ENTITY_UNIT_OF_MEASUREMENT
@@ -106,10 +88,6 @@ StringRef EntityBase::get_unit_of_measurement_ref() const {
   return StringRef(entity_uom_lookup(0));
 #endif
 }
-std::string EntityBase::get_unit_of_measurement() const {
-  return std::string(this->get_unit_of_measurement_ref().c_str());
-}
-
 // Entity icon — buffer-based API for PROGMEM safety on ESP8266
 const char *EntityBase::get_icon_to([[maybe_unused]] std::span<char, MAX_ICON_LENGTH> buffer) const {
 #ifdef USE_ENTITY_ICON
@@ -128,24 +106,6 @@ const char *EntityBase::get_icon_to([[maybe_unused]] std::span<char, MAX_ICON_LE
   return entity_icon_lookup(idx);
 #endif
 }
-
-#ifndef USE_ESP8266
-// Deprecated icon accessors — not available on ESP8266 (rodata is RAM)
-StringRef EntityBase::get_icon_ref() const {
-#ifdef USE_ENTITY_ICON
-  return StringRef(entity_icon_lookup(this->icon_idx_));
-#else
-  return StringRef(entity_icon_lookup(0));
-#endif
-}
-std::string EntityBase::get_icon() const {
-#ifdef USE_ENTITY_ICON
-  return std::string(entity_icon_lookup(this->icon_idx_));
-#else
-  return std::string(entity_icon_lookup(0));
-#endif
-}
-#endif  // !USE_ESP8266
 
 // Calculate Object ID Hash directly from name using snake_case + sanitize
 void EntityBase::calc_object_id_() {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -109,59 +109,13 @@ class EntityBase {
   // On ESP8266: copies from PROGMEM to buffer, returns buffer pointer.
   const char *get_device_class_to(std::span<char, MAX_DEVICE_CLASS_LENGTH> buffer) const;
 
-#ifdef USE_ESP8266
-  // On ESP8266, rodata is RAM. Device classes are in PROGMEM and cannot be accessed
-  // directly as const char*. Use get_device_class_to() with a stack buffer instead.
-  template<typename T = int> StringRef get_device_class_ref() const {
-    static_assert(sizeof(T) == 0, "get_device_class_ref() unavailable on ESP8266 (rodata is RAM). "
-                                  "Use get_device_class_to() with a stack buffer.");
-    return StringRef("");
-  }
-  template<typename T = int> std::string get_device_class() const {
-    static_assert(sizeof(T) == 0, "get_device_class() unavailable on ESP8266 (rodata is RAM). "
-                                  "Use get_device_class_to() with a stack buffer.");
-    return "";
-  }
-#else
-  // Deprecated: use get_device_class_to() instead. Device classes are in PROGMEM.
-  ESPDEPRECATED("Use get_device_class_to() instead. Will be removed in ESPHome 2026.9.0", "2026.3.0")
-  StringRef get_device_class_ref() const;
-  ESPDEPRECATED("Use get_device_class_to() instead. Will be removed in ESPHome 2026.9.0", "2026.3.0")
-  std::string get_device_class() const;
-#endif
   // Get unit of measurement as StringRef (from packed index)
   StringRef get_unit_of_measurement_ref() const;
-  /// Get the unit of measurement as std::string (deprecated, prefer get_unit_of_measurement_ref())
-  ESPDEPRECATED("Use get_unit_of_measurement_ref() instead for better performance (avoids string copy). Will be "
-                "removed in ESPHome 2026.9.0",
-                "2026.3.0")
-  std::string get_unit_of_measurement() const;
 
   // Get this entity's icon into a stack buffer.
   // On ESP32: returns pointer to PROGMEM string directly (buffer unused).
   // On ESP8266: copies from PROGMEM to buffer, returns buffer pointer.
   const char *get_icon_to(std::span<char, MAX_ICON_LENGTH> buffer) const;
-
-#ifdef USE_ESP8266
-  // On ESP8266, rodata is RAM. Icons are in PROGMEM and cannot be accessed
-  // directly as const char*. Use get_icon_to() with a stack buffer instead.
-  template<typename T = int> StringRef get_icon_ref() const {
-    static_assert(sizeof(T) == 0,
-                  "get_icon_ref() unavailable on ESP8266 (rodata is RAM). Use get_icon_to() with a stack buffer.");
-    return StringRef("");
-  }
-  template<typename T = int> std::string get_icon() const {
-    static_assert(sizeof(T) == 0,
-                  "get_icon() unavailable on ESP8266 (rodata is RAM). Use get_icon_to() with a stack buffer.");
-    return "";
-  }
-#else
-  // Deprecated: use get_icon_to() instead. Icons are in PROGMEM.
-  ESPDEPRECATED("Use get_icon_to() instead. Will be removed in ESPHome 2026.9.0", "2026.3.0")
-  StringRef get_icon_ref() const;
-  ESPDEPRECATED("Use get_icon_to() instead. Will be removed in ESPHome 2026.9.0", "2026.3.0")
-  std::string get_icon() const;
-#endif
 
 #ifdef USE_DEVICES
   // Get this entity's device id


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated `get_device_class_ref()`, `get_device_class()`, `get_unit_of_measurement()`, `get_icon_ref()` and `get_icon()` methods from `EntityBase`; these were deprecated in 2026.3.0 and scheduled for removal in 2026.9.0. The replacements are `get_device_class_to()`, `get_unit_of_measurement_ref()` and `get_icon_to()`. The ESP8266 `static_assert` stubs that only existed to point users at the replacements are gone too, along with the platform ifdefs around them.

This completes the deprecation started in #11732.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

