### PR TITLE
[core] Remove deprecated gamma_correct and gamma_uncorrect

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -710,23 +710,6 @@ bool base64_decode_int32_vector(const std::string &base64, std::vector<int32_t> 
 
 // Colors
 
-float gamma_correct(float value, float gamma) {
-  if (value <= 0.0f)
-    return 0.0f;
-  if (gamma <= 0.0f)
-    return value;
-
-  return powf(value, gamma);  // NOLINT - deprecated, removal 2026.9.0
-}
-float gamma_uncorrect(float value, float gamma) {
-  if (value <= 0.0f)
-    return 0.0f;
-  if (gamma <= 0.0f)
-    return value;
-
-  return powf(value, 1 / gamma);  // NOLINT - deprecated, removal 2026.9.0
-}
-
 void rgb_to_hsv(float red, float green, float blue, int &hue, float &saturation, float &value) {
   float max_color_value = std::max({red, green, blue});
   float min_color_value = std::min({red, green, blue});

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1627,15 +1627,6 @@ bool base64_decode_int32_vector(const std::string &base64, std::vector<int32_t> 
 /// @name Colors
 ///@{
 
-/// Applies gamma correction of \p gamma to \p value.
-// Remove before 2026.9.0
-ESPDEPRECATED("Use LightState::gamma_correct_lut() instead. Removed in 2026.9.0.", "2026.3.0")
-float gamma_correct(float value, float gamma);
-/// Reverts gamma correction of \p gamma to \p value.
-// Remove before 2026.9.0
-ESPDEPRECATED("Use LightState::gamma_uncorrect_lut() instead. Removed in 2026.9.0.", "2026.3.0")
-float gamma_uncorrect(float value, float gamma);
-
 /// Convert \p red, \p green and \p blue (all 0-1) values to \p hue (0-360), \p saturation (0-1) and \p value (0-1).
 void rgb_to_hsv(float red, float green, float blue, int &hue, float &saturation, float &value);
 /// Convert \p hue (0-360), \p saturation (0-1) and \p value (0-1) to \p red, \p green and \p blue (all 0-1).


### PR DESCRIPTION
# What does this implement/fix?

Removes the deprecated free functions `gamma_correct()` and `gamma_uncorrect()` from core helpers; they were deprecated in 2026.3.0 and scheduled for removal in 2026.9.0. The light component already uses the lookup table based `LightState::gamma_correct_lut()` and `LightState::gamma_uncorrect_lut()` replacements, and nothing in the tree calls the old functions anymore.

This completes the deprecation started in #14123.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

