### PR TITLE
[ci] Compare merge-branch base ref against the default branch

### DIFF
--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -70,6 +70,7 @@ async function isStackedPr(github, context) {
 async function detectMergeBranch(github, context) {
   const labels = new Set();
   const baseRef = context.payload.pull_request.base.ref;
+  const defaultBranch = context.payload.repository.default_branch;
 
   if (baseRef === 'release') {
     labels.add('merging-to-release');
@@ -78,7 +79,7 @@ async function detectMergeBranch(github, context) {
   } else if (await isStackedPr(github, context)) {
     // GitHub manages the merge order for a stack, so these are not blocked.
     labels.add('stacked-pr');
-  } else if (baseRef !== 'dev') {
+  } else if (baseRef !== defaultBranch) {
     // A chain built by hand: it must not merge until its base branch does.
     labels.add('chained-pr');
   }

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -43,14 +43,14 @@ const WITHOUT_SCHEMA = 'CODEOWNERS = ["@esphome/core"]';
 
 // Builds a fresh context for detectMergeBranch tests instead of mutating the
 // shared CONTEXT fixture above (which other describe blocks rely on).
-function makeMergeContext(baseRef, { stack } = {}) {
+function makeMergeContext(baseRef, { stack, defaultBranch = 'dev' } = {}) {
   const pull_request = { number: 1, base: { ref: baseRef } };
   if (stack !== undefined) {
     pull_request.stack = stack;
   }
   return {
     repo: { owner: 'esphome', repo: 'esphome' },
-    payload: { pull_request }
+    payload: { pull_request, repository: { default_branch: defaultBranch } }
   };
 }
 
@@ -135,6 +135,20 @@ describe('detectMergeBranch', () => {
     const labels = await detectMergeBranch(github, context);
     assert.deepEqual(Array.from(labels).sort(), ['chained-pr']);
     assert.equal(state.calls, 1);
+  });
+
+  it('base ref matches a non-dev default branch adds no labels', async () => {
+    const { github } = makeStackGithub({ stack: null });
+    const context = makeMergeContext('dev', { defaultBranch: 'dev' });
+    const labels = await detectMergeBranch(github, context);
+    assert.deepEqual(Array.from(labels).sort(), []);
+  });
+
+  it('base ref dev when the default branch is dev adds chained-pr', async () => {
+    const { github } = makeStackGithub({ stack: null });
+    const context = makeMergeContext('other', { defaultBranch: 'dev' });
+    const labels = await detectMergeBranch(github, context);
+    assert.deepEqual(Array.from(labels).sort(), ['chained-pr']);
   });
 });
 

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -137,14 +137,14 @@ describe('detectMergeBranch', () => {
     assert.equal(state.calls, 1);
   });
 
-  it('base ref matches a non-dev default branch adds no labels', async () => {
+  it('base ref matches default branch adds no labels', async () => {
     const { github } = makeStackGithub({ stack: null });
     const context = makeMergeContext('dev', { defaultBranch: 'dev' });
     const labels = await detectMergeBranch(github, context);
     assert.deepEqual(Array.from(labels).sort(), []);
   });
 
-  it('base ref dev when the default branch is dev adds chained-pr', async () => {
+  it('base ref other when the default branch is dev adds chained-pr', async () => {
     const { github } = makeStackGithub({ stack: null });
     const context = makeMergeContext('other', { defaultBranch: 'dev' });
     const labels = await detectMergeBranch(github, context);

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -144,12 +144,13 @@ describe('detectMergeBranch', () => {
     assert.deepEqual(Array.from(labels).sort(), []);
   });
 
-  it('base ref other when the default branch is dev adds chained-pr', async () => {
+  it('base ref dev when the default branch is main adds chained-pr', async () => {
     const { github } = makeStackGithub({ stack: null });
-    const context = makeMergeContext('other', { defaultBranch: 'dev' });
+    const context = makeMergeContext('dev', { defaultBranch: 'main' });
     const labels = await detectMergeBranch(github, context);
     assert.deepEqual(Array.from(labels).sort(), ['chained-pr']);
   });
+
 });
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/auto-label-pr/tests/detectors.test.js
+++ b/.github/scripts/auto-label-pr/tests/detectors.test.js
@@ -139,7 +139,7 @@ describe('detectMergeBranch', () => {
 
   it('base ref matches default branch adds no labels', async () => {
     const { github } = makeStackGithub({ stack: null });
-    const context = makeMergeContext('dev', { defaultBranch: 'dev' });
+    const context = makeMergeContext('other', { defaultBranch: 'other' });
     const labels = await detectMergeBranch(github, context);
     assert.deepEqual(Array.from(labels).sort(), []);
   });


### PR DESCRIPTION
detectMergeBranch() hardcoded 'dev' as the only non-chained base branch - the real test should be if the base branch is the default branch. This matches the test in close-pr-from-fork-default-branch.yml.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
