### PR TITLE
[lvgl] Add missing label dependency to qrcode, keyboard and tabview

### DIFF
--- a/esphome/components/lvgl/widgets/keyboard.py
+++ b/esphome/components/lvgl/widgets/keyboard.py
@@ -15,6 +15,7 @@ from ..defines import (
 from ..types import LvCompound, LvType
 from . import Widget, WidgetType, get_widgets
 from .buttonmatrix import CONF_BUTTONMATRIX
+from .label import CONF_LABEL
 from .textarea import CONF_TEXTAREA, lv_textarea_t
 
 CONF_KEYBOARD = "keyboard"
@@ -49,7 +50,7 @@ class KeyboardType(WidgetType):
         )
 
     def get_uses(self):
-        return CONF_KEYBOARD, CONF_TEXTAREA, CONF_BUTTONMATRIX
+        return CONF_KEYBOARD, CONF_TEXTAREA, CONF_BUTTONMATRIX, CONF_LABEL
 
     async def to_code(self, w: Widget, config: dict):
         add_lv_use("KEY_LISTENER")

--- a/esphome/components/lvgl/widgets/qrcode.py
+++ b/esphome/components/lvgl/widgets/qrcode.py
@@ -10,6 +10,7 @@ from ..types import lv_obj_t
 from . import Widget, WidgetType
 from .canvas import CONF_CANVAS
 from .img import CONF_IMAGE
+from .label import CONF_LABEL
 
 CONF_QRCODE = "qrcode"
 CONF_DARK_COLOR = "dark_color"
@@ -41,7 +42,7 @@ class QrCodeType(WidgetType):
         )
 
     def get_uses(self):
-        return CONF_CANVAS, CONF_IMAGE
+        return CONF_CANVAS, CONF_IMAGE, CONF_LABEL
 
     async def to_code(self, w: Widget, config):
         await w.set_property(

--- a/esphome/components/lvgl/widgets/tabview.py
+++ b/esphome/components/lvgl/widgets/tabview.py
@@ -28,6 +28,7 @@ from ..types import LV_EVENT, LvType, ObjUpdateAction, lv_obj_t, lv_obj_t_ptr
 from . import Widget, WidgetType, add_widgets, get_widgets, set_obj_properties
 from .button import button_spec
 from .buttonmatrix import CONF_BUTTONMATRIX, buttonmatrix_spec
+from .label import CONF_LABEL
 from .obj import obj_spec
 
 CONF_TABVIEW = "tabview"
@@ -74,7 +75,7 @@ class TabviewType(WidgetType):
         )
 
     def get_uses(self):
-        return CONF_BUTTONMATRIX, TYPE_FLEX, CONF_BUTTON
+        return CONF_BUTTONMATRIX, TYPE_FLEX, CONF_BUTTON, CONF_LABEL
 
     async def to_code(self, w: Widget, config: dict):
         await w.set_property(

--- a/tests/component_tests/lvgl/config/keyboard_no_label.yaml
+++ b/tests/component_tests/lvgl/config/keyboard_no_label.yaml
@@ -1,0 +1,32 @@
+esphome:
+  name: test-keyboard-no-label
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+spi:
+  - id: spi_bus
+    clk_pin: GPIO18
+    mosi_pin: GPIO23
+
+display:
+  - platform: mipi_spi
+    spi_id: spi_bus
+    model: st7789v
+    id: tft_display
+    dimensions:
+      width: 240
+      height: 320
+    cs_pin: GPIO22
+    dc_pin: GPIO21
+    auto_clear_enabled: false
+    invert_colors: false
+    update_interval: never
+
+lvgl:
+  displays: tft_display
+  widgets:
+    - keyboard:
+        id: keyboard_widget

--- a/tests/component_tests/lvgl/config/qrcode_no_label.yaml
+++ b/tests/component_tests/lvgl/config/qrcode_no_label.yaml
@@ -1,0 +1,34 @@
+esphome:
+  name: test-qrcode-no-label
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+spi:
+  - id: spi_bus
+    clk_pin: GPIO18
+    mosi_pin: GPIO23
+
+display:
+  - platform: mipi_spi
+    spi_id: spi_bus
+    model: st7789v
+    id: tft_display
+    dimensions:
+      width: 240
+      height: 320
+    cs_pin: GPIO22
+    dc_pin: GPIO21
+    auto_clear_enabled: false
+    invert_colors: false
+    update_interval: never
+
+lvgl:
+  displays: tft_display
+  widgets:
+    - qrcode:
+        id: qr_widget
+        size: 100
+        text: "esphome.io"

--- a/tests/component_tests/lvgl/config/tabview_no_label.yaml
+++ b/tests/component_tests/lvgl/config/tabview_no_label.yaml
@@ -1,0 +1,35 @@
+esphome:
+  name: test-tabview-no-label
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+spi:
+  - id: spi_bus
+    clk_pin: GPIO18
+    mosi_pin: GPIO23
+
+display:
+  - platform: mipi_spi
+    spi_id: spi_bus
+    model: st7789v
+    id: tft_display
+    dimensions:
+      width: 240
+      height: 320
+    cs_pin: GPIO22
+    dc_pin: GPIO21
+    auto_clear_enabled: false
+    invert_colors: false
+    update_interval: never
+
+lvgl:
+  displays: tft_display
+  widgets:
+    - tabview:
+        id: tabview_widget
+        tabs:
+          - name: "Tab 1"
+            id: tab_1

--- a/tests/component_tests/lvgl/test_widget_label_dependency.py
+++ b/tests/component_tests/lvgl/test_widget_label_dependency.py
@@ -1,0 +1,32 @@
+"""Widgets whose LVGL C implementation creates or references labels
+internally (tab titles, key legends, the QR canvas fallback) must declare
+the label dependency in ``get_uses()``. Otherwise a config that contains
+no ``label`` widget of its own compiles LVGL without ``LV_USE_LABEL`` and
+fails at C compile time with undefined ``lv_label_*`` symbols.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from esphome.components.lvgl import defines as df
+
+
+@pytest.mark.parametrize(
+    "yaml_file",
+    [
+        "qrcode_no_label.yaml",
+        "keyboard_no_label.yaml",
+        "tabview_no_label.yaml",
+    ],
+)
+def test_label_less_config_enables_lv_use_label(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+    yaml_file: str,
+) -> None:
+    generate_main(component_config_path(yaml_file))
+    assert "LV_USE_LABEL" in df.get_defines()


### PR DESCRIPTION
# What does this implement/fix?

A config whose only LVGL widgets are `qrcode`, `keyboard` or `tabview`
fails at C compile time:

```
lv_image.h:22:2: error: "lv_img: lv_label is required. Enable it in lv_conf.h (LV_USE_LABEL 1)"
```

These widgets use labels internally (tab titles, key legends) but don't
declare `label` in `get_uses()`, so `LV_USE_LABEL` only gets enabled if
some other widget in the config happens to pull it in. Same fix as
textarea in #15098.

Added tests check that a label-less config of each widget ends up with
`LV_USE_LABEL` set. Verified on `host`: the example config below fails on
current `dev` and compiles with this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested on the `host` platform.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: label-dep-repro
host:
display:
  - platform: sdl
    id: main_display
    dimensions: { width: 320, height: 240 }
lvgl:
  pages:
    - id: page1
      widgets:
        - qrcode:
            id: qr1
            size: 100
            text: "esphome.io"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
