### PR TITLE
[external_components] Support doc_url for documentation links

### DIFF
--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -28,18 +28,20 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            // Find a linked esphome.io documentation PR in the PR description, if any.
-            // Supports both the shorthand the PR template asks for (esphome/esphome.io#1234)
-            // and a full PR URL. Returns null if no such link is present (e.g. the PR
-            // template's unfilled placeholder, which has no digits and won't match).
-            function extractDocsPrUrl(body) {
+            // Find a linked esphome.io documentation PR in the PR description, if any, and
+            // return the base URL of its Netlify deploy preview. Supports both the shorthand
+            // the PR template asks for (esphome/esphome.io#1234) and a full PR URL. `doc_url`
+            // is used as a documentation *base* URL (ESPHome appends /components/<name>/ to
+            // it), so this must be a link to rendered docs, not the GitHub PR page itself.
+            // Returns null if no such link is present (e.g. the PR template's unfilled
+            // placeholder, which has no digits and won't match).
+            function extractDocsPreviewUrl(body) {
                 if (!body)
                     return null;
                 const shorthand = body.match(/esphome\/esphome\.io#(\d+)/);
-                if (shorthand)
-                    return `https://github.com/esphome/esphome.io/pull/${shorthand[1]}`;
                 const full = body.match(/https:\/\/github\.com\/esphome\/esphome\.io\/pull\/(\d+)/);
-                return full ? full[0] : null;
+                const prNumber = shorthand ? shorthand[1] : full ? full[1] : null;
+                return prNumber ? `https://deploy-preview-${prNumber}--esphome.netlify.app/` : null;
             }
 
             // Generate external component usage instructions
@@ -179,7 +181,7 @@ jobs:
             const {owner, repo} = context.repo;
 
             const {esphomeChanges, componentChanges} = await getEsphomeAndComponentChanges(github, owner, repo, prNumber);
-            const docUrl = extractDocsPrUrl(context.payload.pull_request.body);
+            const docUrl = extractDocsPreviewUrl(context.payload.pull_request.body);
             if (componentChanges.length !== 0) {
                 await createComment(github, owner, repo, prNumber, esphomeChanges, componentChanges, docUrl);
             }

--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -2,7 +2,7 @@ name: Add External Component Comment
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, edited]
 
 # All API calls (pulls.listFiles + issues.{list,create,update}Comment) are performed with
 # the App token minted below, so the workflow's GITHUB_TOKEN does not need any scopes.

--- a/.github/workflows/external-component-bot.yml
+++ b/.github/workflows/external-component-bot.yml
@@ -28,20 +28,38 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
+            // Find a linked esphome.io documentation PR in the PR description, if any.
+            // Supports both the shorthand the PR template asks for (esphome/esphome.io#1234)
+            // and a full PR URL. Returns null if no such link is present (e.g. the PR
+            // template's unfilled placeholder, which has no digits and won't match).
+            function extractDocsPrUrl(body) {
+                if (!body)
+                    return null;
+                const shorthand = body.match(/esphome\/esphome\.io#(\d+)/);
+                if (shorthand)
+                    return `https://github.com/esphome/esphome.io/pull/${shorthand[1]}`;
+                const full = body.match(/https:\/\/github\.com\/esphome\/esphome\.io\/pull\/(\d+)/);
+                return full ? full[0] : null;
+            }
+
             // Generate external component usage instructions
-            function generateExternalComponentInstructions(prNumber, componentNames, owner, repo) {
+            function generateExternalComponentInstructions(prNumber, componentNames, owner, repo, docUrl) {
                 let source;
                 if (owner === 'esphome' && repo === 'esphome')
                     source = `github://pr#${prNumber}`;
                 else
                     source = `github://${owner}/${repo}@pull/${prNumber}/head`;
+                // Note: this literal is not subject to the workflow YAML's block-scalar
+                // dedent (that only strips the raw source layout), so it must already be
+                // written at the post-dedent indentation the surrounding lines end up at.
+                const docUrlLine = docUrl ? `\n    doc_url: ${docUrl}` : '';
                 return `To use the changes from this PR as an external component, add the following to your ESPHome configuration YAML file:
 
             \`\`\`yaml
             external_components:
               - source: ${source}
                 components: [${componentNames.join(', ')}]
-                refresh: 1h
+                refresh: 1h${docUrlLine}
             \`\`\``;
             }
 
@@ -69,12 +87,12 @@ jobs:
             `;
             }
 
-            async function createComment(octokit, owner, repo, prNumber, esphomeChanges, componentChanges) {
+            async function createComment(octokit, owner, repo, prNumber, esphomeChanges, componentChanges, docUrl) {
                 const commentMarker = "<!-- This comment was generated automatically by the external-component-bot workflow. -->";
                 const legacyCommentMarker = "<!-- This comment was generated automatically by a GitHub workflow. -->";
                 let commentBody;
                 if (esphomeChanges.length === 1) {
-                    commentBody = generateExternalComponentInstructions(prNumber, componentChanges, owner, repo);
+                    commentBody = generateExternalComponentInstructions(prNumber, componentChanges, owner, repo, docUrl);
                 } else {
                     commentBody = generateRepoInstructions(prNumber, owner, repo, context.payload.pull_request.head.ref);
                 }
@@ -161,6 +179,7 @@ jobs:
             const {owner, repo} = context.repo;
 
             const {esphomeChanges, componentChanges} = await getEsphomeAndComponentChanges(github, owner, repo, prNumber);
+            const docUrl = extractDocsPrUrl(context.payload.pull_request.body);
             if (componentChanges.length !== 0) {
-                await createComment(github, owner, repo, prNumber, esphomeChanges, componentChanges);
+                await createComment(github, owner, repo, prNumber, esphomeChanges, componentChanges, docUrl);
             }

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -113,9 +113,10 @@ def _process_single_config(config: dict[str, Any]) -> None:
         for name in names:
             loader.register_external_component_doc_url(name, base_url)
         _LOGGER.info(
-            "External component source '%s' provides documentation at %s",
+            "External component source '%s' provides documentation at %s for components: %s",
             conf.get(CONF_URL) or conf.get(CONF_PATH),
             base_url,
+            ", ".join(names),
         )
 
     loader.install_meta_finder(components_dir, allowed_components=allowed_components)

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -87,8 +87,10 @@ def _process_single_config(config: dict[str, Any]) -> None:
         raise NotImplementedError
 
     if config[CONF_COMPONENTS] == "all":
-        num_components = len(list(components_dir.glob("*/__init__.py")))
-        if num_components > 100:
+        all_component_names = [
+            p.parent.name for p in components_dir.glob("*/__init__.py")
+        ]
+        if len(all_component_names) > 100:
             # Prevent accidentally including all components from an esphome fork/branch
             # In this case force the user to manually specify which components they want to include
             raise cv.Invalid(
@@ -105,11 +107,14 @@ def _process_single_config(config: dict[str, Any]) -> None:
                     [CONF_COMPONENTS, i],
                 )
         allowed_components = config[CONF_COMPONENTS]
+        all_component_names = None
 
     if (base_url := config.get(CONF_DOC_URL)) is not None:
-        names = allowed_components
-        if names is None:
-            names = [p.parent.name for p in components_dir.glob("*/__init__.py")]
+        names = (
+            allowed_components
+            if allowed_components is not None
+            else all_component_names
+        )
         for name in names:
             loader.register_external_component_doc_url(name, base_url)
         _LOGGER.info(

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -20,6 +20,8 @@ from esphome.const import (
 )
 from esphome.core import CORE, TimePeriodSeconds
 
+CONF_DOC_URL = "doc_url"
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = CONF_EXTERNAL_COMPONENTS
@@ -32,6 +34,7 @@ CONFIG_SCHEMA = cv.ensure_list(
         cv.Optional(CONF_COMPONENTS, default="all"): cv.Any(
             "all", cv.ensure_list(cv.string)
         ),
+        cv.Optional(CONF_DOC_URL): cv.url,
     }
 )
 
@@ -102,6 +105,18 @@ def _process_single_config(config: dict[str, Any]) -> None:
                     [CONF_COMPONENTS, i],
                 )
         allowed_components = config[CONF_COMPONENTS]
+
+    if (base_url := config.get(CONF_DOC_URL)) is not None:
+        names = allowed_components
+        if names is None:
+            names = [p.parent.name for p in components_dir.glob("*/__init__.py")]
+        for name in names:
+            loader.register_external_component_doc_url(name, base_url)
+        _LOGGER.info(
+            "External component source '%s' provides documentation at %s",
+            conf.get(CONF_URL) or conf.get(CONF_PATH),
+            base_url,
+        )
 
     loader.install_meta_finder(components_dir, allowed_components=allowed_components)
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1426,6 +1426,15 @@ def _get_parent_name(path, config):
     return path[-1]
 
 
+def _manifest_for_domain(domain: Any) -> ComponentManifest | None:
+    if not isinstance(domain, str) or domain == "<root>":
+        return None
+    if "." in domain:
+        parent, platform = domain.split(".", 1)
+        return get_platform(parent, platform)
+    return get_component(domain)
+
+
 def _format_vol_invalid(ex: vol.Invalid, config: Config) -> str:
     message = ""
 
@@ -1446,6 +1455,9 @@ def _format_vol_invalid(ex: vol.Invalid, config: Config) -> str:
             message += ex.msg
     else:
         message += humanize_error(config, ex)
+
+    if (manifest := _manifest_for_domain(paren)) is not None and manifest.doc_url:
+        message += f" See {manifest.doc_url} for documentation."
 
     return message
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1411,19 +1411,22 @@ def humanize_error(config, validation_error):
     return validation_error
 
 
-def _get_parent_name(path, config):
+def _get_parent_name(path, config) -> tuple[str, bool]:
+    """Return the name of the parent of the given path, and whether that name is a
+    genuine component domain (a registered output path) rather than an arbitrary
+    nested config key (e.g. `filters`, `then`) that a sub-item error fell back to."""
     if not path:
-        return "<root>"
+        return "<root>", False
     for domain_path, domain in config.output_paths:
         if _path_begins_with(path, domain_path):
             if len(path) > len(domain_path):
                 # Sub-item
                 break
-            return domain
+            return domain, True
     # When processing a list, skip back over the index
     while len(path) > 1 and isinstance(path[-1], int):
         path = path[:-1]
-    return path[-1]
+    return path[-1], False
 
 
 def _manifest_for_domain(domain: Any) -> ComponentManifest | None:
@@ -1438,7 +1441,7 @@ def _manifest_for_domain(domain: Any) -> ComponentManifest | None:
 def _format_vol_invalid(ex: vol.Invalid, config: Config) -> str:
     message = ""
 
-    paren = _get_parent_name(ex.path[:-1], config)
+    paren, paren_is_domain = _get_parent_name(ex.path[:-1], config)
 
     if isinstance(ex, ExtraKeysInvalid):
         if ex.candidates:
@@ -1456,7 +1459,11 @@ def _format_vol_invalid(ex: vol.Invalid, config: Config) -> str:
     else:
         message += humanize_error(config, ex)
 
-    if (manifest := _manifest_for_domain(paren)) is not None and manifest.doc_url:
+    if (
+        paren_is_domain
+        and (manifest := _manifest_for_domain(paren)) is not None
+        and manifest.doc_url
+    ):
         message += f" See {manifest.doc_url} for documentation."
 
     return message

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -741,14 +741,18 @@ def docs_url(path: str) -> str:
     return docs_format.format(path=path)
 
 
-def external_component_doc_url(base_url: str, module_name: str) -> str:
+def external_component_doc_url(base_url: str, module_name: str) -> str | None:
     """Build a documentation link for a component loaded via `external_components:`.
 
     Mirrors ESPHome's own docs layout convention (see `docs_url` above):
     platform components (`esphome.components.<name>.<platform>`) link to
     `components/<platform>/<name>/`; plain components link to `components/<name>/`.
+    Returns None if `module_name` is not a component or platform module name
+    (i.e. has fewer than 3 dotted parts, like `esphome` or `esphome.core`).
     """
     parts = module_name.split(".")
+    if len(parts) < 3:
+        return None
     base = base_url.rstrip("/")
     if len(parts) >= 4:
         component_name, platform_name = parts[2], parts[3]

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -739,3 +739,18 @@ def docs_url(path: str) -> str:
 
     path = path.removeprefix("/")
     return docs_format.format(path=path)
+
+
+def external_component_doc_url(base_url: str, module_name: str) -> str:
+    """Build a documentation link for a component loaded via `external_components:`.
+
+    Mirrors ESPHome's own docs layout convention (see `docs_url` above):
+    platform components (`esphome.components.<name>.<platform>`) link to
+    `components/<platform>/<name>/`; plain components link to `components/<name>/`.
+    """
+    parts = module_name.split(".")
+    base = base_url.rstrip("/")
+    if len(parts) >= 4:
+        component_name, platform_name = parts[2], parts[3]
+        return f"{base}/components/{platform_name}/{component_name}/"
+    return f"{base}/components/{parts[2]}/"

--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterable
 from contextlib import AbstractContextManager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import importlib
 import importlib.abc
 import importlib.resources
@@ -38,6 +38,27 @@ class FileResource:
         return importlib.resources.as_file(
             importlib.resources.files(self.package) / self.resource
         )
+
+
+@dataclass
+class _ExternalDocURLs:
+    urls: dict[str, str] = field(default_factory=dict)
+
+
+_EXTERNAL_DOC_URLS_KEY = "loader_external_doc_urls"
+
+
+def register_external_component_doc_url(component_name: str, base_url: str) -> None:
+    """Record the documentation base URL for a component loaded from an
+    `external_components:` source. Called by
+    `external_components.do_external_components_pass` once per resolved
+    component name. Read later via `ComponentManifest.doc_url`.
+    """
+    # Local import: loader.py avoids eager esphome.core imports (see module docstring above).
+    from esphome.core import CORE
+
+    data = CORE.data.setdefault(_EXTERNAL_DOC_URLS_KEY, _ExternalDocURLs())
+    data.urls[component_name] = base_url
 
 
 class ComponentManifest:
@@ -101,6 +122,31 @@ class ComponentManifest:
     @property
     def codeowners(self) -> list[str]:
         return getattr(self.module, "CODEOWNERS", [])
+
+    @property
+    def doc_url(self) -> str | None:
+        """Documentation URL for this component, if known.
+
+        Checks for a component-declared `DOC_URL` override first (unused
+        today, reserved for a future per-component override), then falls
+        back to the base URL registered by an `external_components:` source,
+        if any.
+        """
+        if override := getattr(self.module, "DOC_URL", None):
+            return override
+        from esphome.core import CORE
+
+        data: _ExternalDocURLs | None = CORE.data.get(_EXTERNAL_DOC_URLS_KEY)
+        if data is None:
+            return None
+        parts = self.module.__name__.split(".")
+        if len(parts) < 3:
+            return None
+        if (base_url := data.urls.get(parts[2])) is None:
+            return None
+        from esphome.helpers import external_component_doc_url
+
+        return external_component_doc_url(base_url, self.module.__name__)
 
     @property
     def aliases(self) -> list[str]:

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -4,7 +4,10 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-from esphome.components.external_components import do_external_components_pass
+from esphome.components.external_components import (
+    CONF_DOC_URL,
+    do_external_components_pass,
+)
 from esphome.const import (
     CONF_EXTERNAL_COMPONENTS,
     CONF_REFRESH,
@@ -13,6 +16,7 @@ from esphome.const import (
     TYPE_GIT,
 )
 from esphome.core import CORE, TimePeriodSeconds
+from esphome.loader import _EXTERNAL_DOC_URLS_KEY
 
 
 def _make_config(tmp_path: Path) -> dict[str, Any]:
@@ -34,6 +38,34 @@ def _make_config(tmp_path: Path) -> dict[str, Any]:
             }
         ]
     }
+
+
+def _make_doc_url_config(
+    tmp_path: Path,
+    component_names: list[str],
+    *,
+    components: Any = "all",
+    doc_url: str | None = "https://example.com/docs",
+) -> dict[str, Any]:
+    components_dir = tmp_path / "components"
+    components_dir.mkdir()
+    for name in component_names:
+        component_dir = components_dir / name
+        component_dir.mkdir()
+        (component_dir / "__init__.py").write_text("# Test component")
+
+    source: dict[str, Any] = {
+        CONF_SOURCE: {
+            "type": TYPE_GIT,
+            CONF_URL: "https://github.com/test/components",
+        },
+        CONF_REFRESH: "1d",
+        "components": components,
+    }
+    if doc_url is not None:
+        source[CONF_DOC_URL] = doc_url
+
+    return {CONF_EXTERNAL_COMPONENTS: [source]}
 
 
 def test_external_components_skip_update_via_core_flag(
@@ -69,3 +101,50 @@ def test_external_components_normal_refresh(
     mock_clone_or_update.assert_called_once()
     call_args = mock_clone_or_update.call_args
     assert call_args.kwargs["refresh"] == TimePeriodSeconds(days=1)
+
+
+def test_external_components_doc_url_populates_core_data(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+) -> None:
+    """`doc_url` with `components: all` registers a doc URL for every discovered component."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_doc_url_config(tmp_path, ["foo", "bar"])
+
+    do_external_components_pass(config)
+
+    data = CORE.data[_EXTERNAL_DOC_URLS_KEY]
+    assert data.urls == {
+        "foo": "https://example.com/docs",
+        "bar": "https://example.com/docs",
+    }
+
+
+def test_external_components_doc_url_absent_by_default(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+) -> None:
+    """Without `doc_url`, nothing is registered and the feature is fully opt-in."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_doc_url_config(tmp_path, ["foo"], doc_url=None)
+
+    do_external_components_pass(config)
+
+    assert _EXTERNAL_DOC_URLS_KEY not in CORE.data
+
+
+def test_external_components_doc_url_explicit_components_list(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+) -> None:
+    """With an explicit `components` list, only those names are registered."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_doc_url_config(tmp_path, ["foo", "bar"], components=["foo"])
+
+    do_external_components_pass(config)
+
+    data = CORE.data[_EXTERNAL_DOC_URLS_KEY]
+    assert data.urls == {"foo": "https://example.com/docs"}

--- a/tests/components/external_components/common.yaml
+++ b/tests/components/external_components/common.yaml
@@ -3,6 +3,7 @@ external_components:
     source: github://esphome/esphome@dev
     refresh: 1d
     components: [bh1750]
+    doc_url: https://esphome.io
   - id: my_local
     source: ../../../esphome/components
     components: [sntp]

--- a/tests/unit_tests/test_config_error_doc_links.py
+++ b/tests/unit_tests/test_config_error_doc_links.py
@@ -1,0 +1,30 @@
+"""Unit tests for doc-link surfacing in esphome.config's validation error formatting."""
+
+import voluptuous as vol
+
+from esphome.config import Config, _format_vol_invalid
+from esphome.loader import register_external_component_doc_url
+
+
+def test_format_vol_invalid_appends_doc_link_when_known() -> None:
+    """A component with a registered doc URL gets a doc link appended to its error message."""
+    register_external_component_doc_url("wifi", "https://example.com/docs")
+
+    config = Config()
+    config.add_output_path(["wifi"], "wifi")
+    err = vol.RequiredFieldInvalid("required key not provided", path=["wifi", "ssid"])
+
+    message = _format_vol_invalid(err, config)
+
+    assert "See https://example.com/docs/components/wifi/ for documentation." in message
+
+
+def test_format_vol_invalid_no_link_when_doc_url_unknown() -> None:
+    """Built-in components without a registered doc URL get no link appended (no regression)."""
+    config = Config()
+    config.add_output_path(["wifi"], "wifi")
+    err = vol.RequiredFieldInvalid("required key not provided", path=["wifi", "ssid"])
+
+    message = _format_vol_invalid(err, config)
+
+    assert "See " not in message

--- a/tests/unit_tests/test_config_error_doc_links.py
+++ b/tests/unit_tests/test_config_error_doc_links.py
@@ -1,5 +1,7 @@
 """Unit tests for doc-link surfacing in esphome.config's validation error formatting."""
 
+from unittest.mock import patch
+
 import voluptuous as vol
 
 from esphome.config import Config, _format_vol_invalid, _manifest_for_domain
@@ -41,4 +43,26 @@ def test_format_vol_invalid_no_link_when_doc_url_unknown() -> None:
 
     message = _format_vol_invalid(err, config)
 
+    assert "See " not in message
+
+
+def test_format_vol_invalid_skips_lookup_for_sub_item_error() -> None:
+    """A sub-item error (path deeper than any registered output path) falls back to an
+    arbitrary nested config key, not a component domain. That key must never be looked
+    up as a component: it isn't one, and doing so would both spam an "Unable to import
+    component" log line for every such error and, if the key happens to collide with a
+    real component name (e.g. `button`, `light`, `sensor`), attach an unrelated doc link."""
+    register_external_component_doc_url("button", "https://example.com/docs")
+
+    config = Config()
+    config.add_output_path(["lvgl", 0], "lvgl")
+    err = vol.Invalid(
+        "extra keys not allowed",
+        path=["lvgl", 0, "widgets", 0, "button", "bad_key"],
+    )
+
+    with patch("esphome.config.get_component") as mock_get_component:
+        message = _format_vol_invalid(err, config)
+
+    mock_get_component.assert_not_called()
     assert "See " not in message

--- a/tests/unit_tests/test_config_error_doc_links.py
+++ b/tests/unit_tests/test_config_error_doc_links.py
@@ -2,8 +2,22 @@
 
 import voluptuous as vol
 
-from esphome.config import Config, _format_vol_invalid
+from esphome.config import Config, _format_vol_invalid, _manifest_for_domain
 from esphome.loader import register_external_component_doc_url
+
+
+def test_manifest_for_domain_rejects_non_string_and_root() -> None:
+    """Non-string and "<root>" domains have no meaningful component to link to -> None."""
+    assert _manifest_for_domain(3) is None
+    assert _manifest_for_domain("<root>") is None
+
+
+def test_manifest_for_domain_resolves_platform_domain() -> None:
+    """A "<platform>.<component>" domain (e.g. a config error inside a sensor platform)
+    resolves to that platform's own manifest, not the parent domain's."""
+    manifest = _manifest_for_domain("sensor.dht")
+    assert manifest is not None
+    assert manifest.module.__name__ == "esphome.components.dht.sensor"
 
 
 def test_format_vol_invalid_appends_doc_link_when_known() -> None:

--- a/tests/unit_tests/test_config_error_doc_links.py
+++ b/tests/unit_tests/test_config_error_doc_links.py
@@ -4,8 +4,19 @@ from unittest.mock import patch
 
 import voluptuous as vol
 
-from esphome.config import Config, _format_vol_invalid, _manifest_for_domain
+from esphome.config import (
+    Config,
+    _format_vol_invalid,
+    _get_parent_name,
+    _manifest_for_domain,
+)
 from esphome.loader import register_external_component_doc_url
+
+
+def test_get_parent_name_empty_path_is_root_not_domain() -> None:
+    """An empty path (e.g. an error on an entirely unknown top-level key) reports
+    "<root>", which is never a real domain -- doc-link lookup must not be attempted."""
+    assert _get_parent_name([], Config()) == ("<root>", False)
 
 
 def test_manifest_for_domain_rejects_non_string_and_root() -> None:

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -14,7 +14,7 @@ import pytest
 from esphome import helpers
 from esphome.address_cache import AddressCache
 from esphome.core import CORE, EsphomeError
-from esphome.helpers import ProgressBar, format_ip_url
+from esphome.helpers import ProgressBar, external_component_doc_url, format_ip_url
 
 
 @pytest.mark.parametrize(
@@ -221,6 +221,32 @@ def test_add_git_ceiling_directory_skips_duplicate():
     env = {"GIT_CEILING_DIRECTORIES": str(directory)}
     helpers.add_git_ceiling_directory(env, directory)
     assert env["GIT_CEILING_DIRECTORIES"] == str(directory)
+
+
+def test_external_component_doc_url_plain_component():
+    """A plain (non-platform) component links to components/<name>/."""
+    url = external_component_doc_url(
+        "https://example.com/docs", "esphome.components.foo"
+    )
+    assert url == "https://example.com/docs/components/foo/"
+
+
+def test_external_component_doc_url_platform_component():
+    """A platform component links to components/<platform>/<name>/, mirroring
+    esphome.io's own doc layout."""
+    url = external_component_doc_url(
+        "https://example.com/docs", "esphome.components.foo.switch"
+    )
+    assert url == "https://example.com/docs/components/switch/foo/"
+
+
+def test_external_component_doc_url_none_for_shallow_module_name():
+    """A module name with fewer than 3 dotted parts isn't a component -> None,
+    rather than raising IndexError."""
+    assert external_component_doc_url("https://example.com/docs", "esphome") is None
+    assert (
+        external_component_doc_url("https://example.com/docs", "esphome.core") is None
+    )
 
 
 def test_walk_files(fixture_path):

--- a/tests/unit_tests/test_loader.py
+++ b/tests/unit_tests/test_loader.py
@@ -75,6 +75,21 @@ def test_doc_url_module_override_takes_precedence() -> None:
     assert manifest.doc_url == "https://custom.example/foo"
 
 
+def test_doc_url_none_for_shallow_module_name() -> None:
+    """A module name with fewer than 3 dotted parts (e.g. the "esphome" pseudo-component)
+    can't be resolved back to a component name -> None, even with a source registered."""
+    register_external_component_doc_url("foo", "https://example.com/docs")
+    manifest = _make_named_manifest("esphome.core")
+    assert manifest.doc_url is None
+
+
+def test_doc_url_none_when_component_not_in_registered_source() -> None:
+    """A source was registered, but for a different component name -> None."""
+    register_external_component_doc_url("bar", "https://example.com/docs")
+    manifest = _make_named_manifest("esphome.components.foo")
+    assert manifest.doc_url is None
+
+
 def test_testing_manifest_delegates_to_wrapped() -> None:
     """Unoverridden attributes fall through to the wrapped manifest."""
     inner = _make_manifest(dependencies=["wifi"])

--- a/tests/unit_tests/test_loader.py
+++ b/tests/unit_tests/test_loader.py
@@ -18,6 +18,7 @@ from esphome.loader import (
     _replace_component_manifest,
     get_alias_metadata,
     get_component,
+    register_external_component_doc_url,
 )
 from tests.testing_helpers import ComponentManifestOverride
 
@@ -32,6 +33,46 @@ def _make_manifest(*, to_code=None, dependencies=None) -> ComponentManifest:
     mod.to_code = to_code
     mod.DEPENDENCIES = dependencies or []
     return ComponentManifest(mod)
+
+
+def _make_named_manifest(
+    module_name: str, *, doc_url_override=None
+) -> ComponentManifest:
+    """Return a ComponentManifest backed by a mock module with a real `__name__`."""
+    mod = MagicMock()
+    mod.__name__ = module_name
+    mod.DOC_URL = doc_url_override
+    return ComponentManifest(mod)
+
+
+def test_doc_url_none_when_not_registered() -> None:
+    """No `external_components:` source registered a doc URL -> None."""
+    manifest = _make_named_manifest("esphome.components.foo")
+    assert manifest.doc_url is None
+
+
+def test_doc_url_plain_component() -> None:
+    """A plain (non-platform) component links to components/<name>/."""
+    register_external_component_doc_url("foo", "https://example.com/docs")
+    manifest = _make_named_manifest("esphome.components.foo")
+    assert manifest.doc_url == "https://example.com/docs/components/foo/"
+
+
+def test_doc_url_platform_component() -> None:
+    """A platform component (esphome.components.<name>.<platform>) links to
+    components/<platform>/<name>/, mirroring esphome.io's own doc layout."""
+    register_external_component_doc_url("foo", "https://example.com/docs")
+    manifest = _make_named_manifest("esphome.components.foo.switch")
+    assert manifest.doc_url == "https://example.com/docs/components/switch/foo/"
+
+
+def test_doc_url_module_override_takes_precedence() -> None:
+    """A component-declared DOC_URL wins over the source-level computed URL."""
+    register_external_component_doc_url("foo", "https://example.com/docs")
+    manifest = _make_named_manifest(
+        "esphome.components.foo", doc_url_override="https://custom.example/foo"
+    )
+    assert manifest.doc_url == "https://custom.example/foo"
 
 
 def test_testing_manifest_delegates_to_wrapped() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional `doc_url` key to `external_components:` source entries. Components pulled in this way aren't on esphome.io, so there's currently no way for ESPHome to point users at their docs. Setting `doc_url` lets ESPHome build that link itself, following the same URL pattern esphome.io already uses (`components/<name>/`, or `components/<platform>/<name>/` for platform components).

The link shows up in two places:
- Appended to validation error messages for that component (this reaches the CLI, `esphome vscode`, and the external device-builder tool's `--ace` mode, since they all share the same error formatting code).
- As an info log line when a source with `doc_url` is loaded.

Also updated the `external-component-bot` GitHub Action: if a PR's description links a companion esphome.io documentation PR (using the format the PR template already asks for), the bot's example `external_components:` snippet now includes that link automatically.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7192

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#171

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
external_components:
  - source: github://pr#17883
    components: [lvgl]
    doc_url: https://deploy-preview-7058--esphome.netlify.app/
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
