### PR TITLE
[lvgl] Restore long_press_repeat_time functionality

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -444,7 +444,7 @@ LVTouchListener::LVTouchListener(uint16_t long_press_time, uint16_t long_press_r
   lv_indev_set_type(this->drv_, LV_INDEV_TYPE_POINTER);
   lv_indev_set_disp(this->drv_, parent->get_disp());
   lv_indev_set_long_press_time(this->drv_, long_press_time);
-  // long press repeat time TBD
+  lv_indev_set_long_press_repeat_time(this->drv_, long_press_repeat_time);
   lv_indev_set_user_data(this->drv_, this);
   lv_indev_set_read_cb(this->drv_, [](lv_indev_t *d, lv_indev_data_t *data) {
     auto *l = static_cast<LVTouchListener *>(lv_indev_get_user_data(d));


### PR DESCRIPTION
During the migration to LVGL9's indev API, long_press_repeat_time was accepted from the config but never applied to the indev. A "// long press repeat time TBD" comment was left in its place instead.

This patch restores the missing lv_indev_set_long_press_repeat_time() call so the option takes effect again, matching the encoder/keypad listener which already sets it correctly.

# What does this implement/fix?
Fixes the configurable repeat rate for touch-screens using LVGL.
(configuration comes from `long_press_repeat_time` in yaml)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18388

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
lvgl:
  displays:
    - my_display
  rotation: 90
  touchscreens:
    touchscreen_id: my_touch
    long_press_repeat_time: 1000ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
