### PR TITLE
[sensor] Pass NaN through the delta filter again

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -283,11 +283,11 @@ DeltaFilter::DeltaFilter(float min_a0, float min_a1, float max_a0, float max_a1)
 void DeltaFilter::set_baseline(float (*fn)(float)) { this->baseline_ = fn; }
 
 optional<float> DeltaFilter::new_value(float value) {
-  const bool value_nan = std::isnan(value);
+  const bool no_value = std::isnan(value);
   const bool no_reference = std::isnan(this->last_value_);
-  if (value_nan && no_reference)
+  if (no_value && no_reference)
     return {};
-  if (value_nan || no_reference) {
+  if (no_value || no_reference) {
     this->last_value_ = value;
     return value;
   }

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -283,8 +283,11 @@ DeltaFilter::DeltaFilter(float min_a0, float min_a1, float max_a0, float max_a1)
 void DeltaFilter::set_baseline(float (*fn)(float)) { this->baseline_ = fn; }
 
 optional<float> DeltaFilter::new_value(float value) {
-  // Always yield the first value.
-  if (std::isnan(this->last_value_)) {
+  const bool value_nan = std::isnan(value);
+  const bool no_reference = std::isnan(this->last_value_);
+  if (value_nan && no_reference)
+    return {};
+  if (value_nan || no_reference) {
     this->last_value_ = value;
     return value;
   }
@@ -293,8 +296,7 @@ optional<float> DeltaFilter::new_value(float value) {
   float min = fabsf(this->min_a0_ + ref * this->min_a1_);
   float max = fabsf(this->max_a0_ + ref * this->max_a1_);
   float delta = fabsf(value - ref);
-  // if there is no reference, e.g. for the first value, just accept this one,
-  // otherwise accept only if within range.
+  // accept only if within range
   if (delta > min && delta <= max) {
     this->last_value_ = value;
     return value;

--- a/tests/integration/fixtures/sensor_filters_delta.yaml
+++ b/tests/integration/fixtures/sensor_filters_delta.yaml
@@ -33,6 +33,11 @@ sensor:
     id: source_sensor_5
     accuracy_decimals: 1
 
+  - platform: template
+    name: "Source Sensor 6"
+    id: source_sensor_6
+    accuracy_decimals: 1
+
   - platform: copy
     source_id: source_sensor_1
     name: "Filter Min"
@@ -80,6 +85,13 @@ sensor:
     id: filter_percentage
     filters:
       - delta: 50%
+
+  - platform: copy
+    source_id: source_sensor_6
+    name: "Filter NaN"
+    id: filter_nan
+    filters:
+      - delta: 0
 
 script:
   - id: test_filter_min
@@ -188,6 +200,24 @@ script:
           id: source_sensor_5
           state: 250.0  # Passes (delta=90 > 80)
 
+  - id: test_filter_nan
+    then:
+      - sensor.template.publish:
+          id: source_sensor_6
+          state: 1.0
+      - delay: 20ms
+      - sensor.template.publish:
+          id: source_sensor_6
+          state: !lambda "return NAN;"
+      - delay: 20ms
+      - sensor.template.publish:
+          id: source_sensor_6
+          state: !lambda "return NAN;"  # Filtered out
+      - delay: 20ms
+      - sensor.template.publish:
+          id: source_sensor_6
+          state: 2.0
+
 button:
   - platform: template
     name: "Test Filter Min"
@@ -218,3 +248,9 @@ button:
     id: btn_filter_percentage
     on_press:
       - script.execute: test_filter_percentage
+
+  - platform: template
+    name: "Test Filter NaN"
+    id: btn_filter_nan
+    on_press:
+      - script.execute: test_filter_nan

--- a/tests/integration/test_sensor_filters_delta.py
+++ b/tests/integration/test_sensor_filters_delta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 
 from aioesphomeapi import ButtonInfo, EntityState, SensorState
 import pytest
@@ -25,6 +26,7 @@ async def test_sensor_filters_delta(
         "filter_baseline_max": [],
         "filter_zero_delta": [],
         "filter_percentage": [],
+        "filter_nan": [],
     }
 
     filter_min_done = loop.create_future()
@@ -32,16 +34,23 @@ async def test_sensor_filters_delta(
     filter_baseline_max_done = loop.create_future()
     filter_zero_delta_done = loop.create_future()
     filter_percentage_done = loop.create_future()
+    filter_nan_done = loop.create_future()
 
     def on_state(state: EntityState) -> None:
-        if not isinstance(state, SensorState) or state.missing_state:
+        if not isinstance(state, SensorState):
             return
 
         sensor_name = key_to_sensor.get(state.key)
         if sensor_name not in sensor_values:
             return
 
-        sensor_values[sensor_name].append(state.state)
+        if state.missing_state:
+            # Only the NaN test is interested in unavailable states
+            if sensor_name != "filter_nan":
+                return
+            sensor_values[sensor_name].append(math.nan)
+        else:
+            sensor_values[sensor_name].append(state.state)
 
         # Check completion conditions
         if (
@@ -74,6 +83,12 @@ async def test_sensor_filters_delta(
             and not filter_percentage_done.done()
         ):
             filter_percentage_done.set_result(True)
+        elif (
+            sensor_name == "filter_nan"
+            and len(sensor_values[sensor_name]) == 3
+            and not filter_nan_done.done()
+        ):
+            filter_nan_done.set_result(True)
 
     async with (
         run_compiled(yaml_config),
@@ -89,6 +104,7 @@ async def test_sensor_filters_delta(
                 "filter_baseline_max": "Filter Baseline Max",
                 "filter_zero_delta": "Filter Zero Delta",
                 "filter_percentage": "Filter Percentage",
+                "filter_nan": "Filter NaN",
             },
         )
 
@@ -108,13 +124,14 @@ async def test_sensor_filters_delta(
             "Test Filter Baseline Max": "filter_baseline_max",
             "Test Filter Zero Delta": "filter_zero_delta",
             "Test Filter Percentage": "filter_percentage",
+            "Test Filter NaN": "filter_nan",
         }
         buttons = {}
         for entity in entities:
             if isinstance(entity, ButtonInfo) and entity.name in button_name_map:
                 buttons[button_name_map[entity.name]] = entity.key
 
-        assert len(buttons) == 5, f"Expected 5 buttons, found {len(buttons)}"
+        assert len(buttons) == 6, f"Expected 6 buttons, found {len(buttons)}"
 
         # Test 1: Min
         sensor_values["filter_min"].clear()
@@ -186,3 +203,18 @@ async def test_sensor_filters_delta(
         assert sensor_values["filter_percentage"] == pytest.approx(expected), (
             f"Test 5 failed: expected {expected}, got {sensor_values['filter_percentage']}"
         )
+
+        # Test 6: NaN passes through once, then is suppressed
+        sensor_values["filter_nan"].clear()
+        client.button_command(buttons["filter_nan"])
+        try:
+            await asyncio.wait_for(filter_nan_done, timeout=2.0)
+        except TimeoutError:
+            pytest.fail(f"Test 6 timed out. Values: {sensor_values['filter_nan']}")
+
+        values = sensor_values["filter_nan"]
+        assert values[0] == pytest.approx(1.0), f"Test 6 failed: got {values}"
+        assert math.isnan(values[1]), (
+            f"Test 6 failed: NaN not passed through, got {values}"
+        )
+        assert values[2] == pytest.approx(2.0), f"Test 6 failed: got {values}"


### PR DESCRIPTION
# What does this implement/fix?

The delta filter dropped NaN whenever it already had a reference value. Comparisons against NaN are always false, so `delta > min && delta <= max` never matched and the value was discarded — the frontend kept showing the last valid reading instead of learning the sensor had become unavailable.

This matters most behind a `timeout:` filter, whose whole job is to emit NaN when a sensor stops updating:

```yaml
filters:
  - timeout: 10s
  - delta: 0.0
```

NaN handling was added in #3610 and lost in #12605, which rewrote the body around the min/max linear equations without carrying the branch across. Releases from **2026.2.0** onwards are affected — verified against the tags, `2026.1.5` still has it.

The restored branch is merged into the existing no-reference case, since both simply yield the value and store it:

```cpp
const bool value_nan = std::isnan(value);
const bool no_reference = std::isnan(this->last_value_);
if (value_nan && no_reference)
  return {};
if (value_nan || no_reference) {
  this->last_value_ = value;
  return value;
}
```

| `value` | `last_value_` | result |
| --- | --- | --- |
| NaN | NaN | dropped |
| NaN | valid | NaN yielded, reference cleared |
| valid | NaN | yielded (first value, or after a gap) |
| valid | valid | range check as before |

So NaN passes through once and clears the reference, meaning the next real reading is yielded too; a second NaN in a row is still dropped. This is the behaviour #3610 established.

Two comments are also dropped: `Always yield the first value.` no longer described its branch, and the `if there is no reference, e.g. for the first value` comment on the range check described a case that is returned on above it — stale since #12605, not because of this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18398

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: template
    name: "Delta NaN Test"
    id: delta_nan_test
    filters:
      - timeout: 1s
      - delta: 0.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
