### PR TITLE
[core] Update paho-mqtt to v2.1.0

### DIFF
--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -63,15 +63,15 @@ def initialize(
 def prepare(
     config, subscriptions, on_message, on_connect, username, password, client_id
 ):
-    def on_connect_(client, userdata, flags, return_code):
+    def on_connect_(client, userdata, flags, reason_code, properties):
         _LOGGER.info("Connected to MQTT broker!")
         for topic in subscriptions:
             client.subscribe(topic)
         if on_connect is not None:
-            on_connect(client, userdata, flags, return_code)
+            on_connect(client, userdata, flags, reason_code, properties)
 
-    def on_disconnect(client, userdata, result_code):
-        if result_code == 0:
+    def on_disconnect(client, userdata, flags, reason_code, properties):
+        if reason_code == 0:
             return
 
         tries = 0
@@ -86,13 +86,13 @@ def prepare(
             wait_time = min(2**tries, 300)
             _LOGGER.warning(
                 "Disconnected from MQTT (%s). Trying to reconnect in %s s",
-                result_code,
+                reason_code,
                 wait_time,
             )
             time.sleep(wait_time)
             tries += 1
 
-    client = mqtt.Client(client_id or "")
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id or "")
     client.on_connect = on_connect_
     client.on_message = on_message
     client.on_disconnect = on_disconnect
@@ -153,7 +153,7 @@ def show_discover(config, username=None, password=None, client_id=None):
             message = time_ + " " + payload
             safe_print(message)
 
-    def on_connect(client, userdata, flags, return_code):
+    def on_connect(client, userdata, flags, reason_code, properties):
         _LOGGER.info("Send discover via MQTT broker")
         client.publish("esphome/discover", None, retain=False)
 
@@ -241,7 +241,7 @@ def get_esphome_device_ip(
             failed = False  # a complete answer wins over an earlier empty one
             client.disconnect()
 
-    def on_connect(client, userdata, flags, return_code):
+    def on_connect(client, userdata, flags, reason_code, properties):
         topic = "esphome/ping/" + dev_name
         _LOGGER.info("Send discover via MQTT broker topic: %s", topic)
         client.publish(topic, None, retain=False)
@@ -250,10 +250,10 @@ def get_esphome_device_ip(
         # Teardown already started; don't open a broker connection at all
         return []
 
-    def on_disconnect(client, userdata, result_code):
+    def on_disconnect(client, userdata, flags, reason_code, properties):
         nonlocal failed
-        if result_code != 0:
-            _LOGGER.warning("Disconnected from MQTT broker (%s)", result_code)
+        if reason_code != 0:
+            _LOGGER.warning("Disconnected from MQTT broker (%s)", reason_code)
             failed = True
 
     mqtt_client = prepare(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cryptography==50.0.0; platform_system != "Darwin" or platform_machine != "x86_64
 cryptography==48.0.1; platform_system == "Darwin" and platform_machine == "x86_64"
 voluptuous==0.16.0
 PyYAML==6.0.3
-paho-mqtt==1.6.1
+paho-mqtt==2.1.0
 colorama==0.4.6
 tzlocal==5.4.4    # from time
 tzdata>=2026.3  # from time

--- a/tests/unit_tests/test_mqtt.py
+++ b/tests/unit_tests/test_mqtt.py
@@ -217,9 +217,9 @@ def test_get_esphome_device_ip_replaces_reconnect_handler(
         get_esphome_device_ip(_discovery_config(), timeout=0.25)
 
     assert client.on_disconnect is not prepare_handler
-    client.on_disconnect(client, None, 0)
+    client.on_disconnect(client, None, 0, 0, None)
     assert "Disconnected from MQTT broker" not in caplog.text
-    client.on_disconnect(client, None, 5)
+    client.on_disconnect(client, None, 0, 5, None)
     assert "Disconnected from MQTT broker (5)" in caplog.text
 
 
@@ -268,7 +268,7 @@ def test_get_esphome_device_ip_broker_disconnect_fails_fast(
     with patch("esphome.mqtt.prepare", return_value=client):
 
         def drop_connection(*args, **kwargs):
-            client.on_disconnect(client, None, 5)
+            client.on_disconnect(client, None, 0, 5, None)
 
         client.loop_start.side_effect = drop_connection
 
@@ -288,7 +288,7 @@ def test_get_esphome_device_ip_sends_discovery_ping() -> None:
 
         def connect_then_answer(*args, **kwargs):
             on_connect = mock_prepare.call_args.args[3]
-            on_connect(client, None, None, 0)
+            on_connect(client, None, None, 0, None)
             msg = MagicMock()
             msg.payload = json.dumps({"name": "test-device", "ip": "10.0.0.5"}).encode()
             mock_prepare.call_args.args[2](client, None, msg)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This updates the paho-mqtt dependency to v2, which has a couple of breaking changes. I tested this by running `logs`, `discover` and `clean-mqtt`.

I used https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html as reference. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

<!--
**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```
-->

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
