### PR TITLE
[homeassistant] Log received sensor states at DEBUG, matching the sibling platforms

### DIFF
--- a/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
+++ b/esphome/components/homeassistant/sensor/homeassistant_sensor.cpp
@@ -17,9 +17,9 @@ void HomeassistantSensor::setup() {
     }
 
     if (this->attribute_ != nullptr) {
-      ESP_LOGV(TAG, "'%s::%s': Got attribute state %.2f", this->entity_id_, this->attribute_, *val);
+      ESP_LOGD(TAG, "'%s::%s': Got attribute state %.2f", this->entity_id_, this->attribute_, *val);
     } else {
-      ESP_LOGV(TAG, "'%s': Got state %.2f", this->entity_id_, *val);
+      ESP_LOGD(TAG, "'%s': Got state %.2f", this->entity_id_, *val);
     }
     this->publish_state(*val);
   });


### PR DESCRIPTION
## What does this implement/fix?

`homeassistant` **sensor** logs received states at `ESP_LOGV`, while every sibling platform — `binary_sensor`, `text_sensor`, `switch`, `number` — logs the same event at `ESP_LOGD`:

| platform | "Got state" level |
|---|---|
| sensor | **VERBOSE** (this PR → DEBUG) |
| binary_sensor | DEBUG |
| text_sensor | DEBUG |
| switch | DEBUG |
| number | DEBUG |

At the default DEBUG log level this asymmetry means numeric imports arrive *invisibly* while text imports log visibly. When debugging an HA connection, that reads exactly like "numeric states are not arriving" — text sensors show `Got state`, numeric sensors show nothing, even though both are working. We lost an evening to this: it survived an HA restart, a direct `aioesphomeapi` push test, and a version downgrade before reading the component source revealed the states had been arriving all along.

Two-line change aligning sensor with the other four platforms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] The code change is tested and works locally (built and flashed on an ESP32-S3, reTerminal E1001).
- [x] The code change follows the existing log-level convention of the sibling platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)