### PR TITLE
[speaker_source] keep mute when volume changes

### DIFF
--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -829,15 +829,7 @@ void SpeakerSourceMediaPlayer::set_volume_(float volume, bool publish) {
     }
   }
 
-  // Turn on the mute state if the volume is effectively zero, off otherwise.
-  // Pass publish=false to avoid saving twice.
-  if (volume < 0.001f) {
-    this->set_mute_state_(true, false);
-  } else {
-    this->set_mute_state_(false, false);
-  }
-
-  // Save after mute mutation so the restored state has the correct is_muted_ value
+  // Volume and mute are independent (Sendspin: volume must not clear mute).
   if (publish) {
     this->save_volume_restore_state_();
   }


### PR DESCRIPTION
# What does this implement/fix?

Makes volume and mute independent in the `speaker_source` media player. `set_volume_` no longer forces the mute state on when the volume is effectively zero and off otherwise. Mute is only changed by the mute and unmute commands and by the saved state on boot.

This follows the Sendspin spec, which says a volume change must not clear the mute state, and matches the end goal across the audio stack: changing the volume while muted keeps the mute, and a volume of zero is silent without reporting as muted. The speaker side of that goal is in #19305, and the same change for the `speaker` media player is in #19307.

This relies on #19063 so that a requested volume of zero reaches the speaker as zero instead of `volume_min`. Without it, and with a non-zero `volume_min`, a volume of zero would be audible once the automatic mute is gone.

**Breaking change note:** Changing the volume of a muted `speaker_source` media player no longer unmutes it. Setting the volume to zero is silent but no longer reports the player as muted, and `on_mute` / `on_unmute` no longer fire from volume changes. On boot, a saved volume of zero no longer forces mute on.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #18391

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sendspin:

media_source:
  - platform: sendspin
    id: sendpin_source

media_player:
  - platform: speaker_source
    name: Media Player
    volume_min: 0.4
    media_pipeline:
      speaker: speaker_id
      sources:
         - sendspin_source
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).