### PR TITLE
[zigbee] bump esp-zigbee-sdk to 2.0.4

### DIFF
--- a/esphome/components/zigbee/zigbee_esp32.cpp
+++ b/esphome/components/zigbee/zigbee_esp32.cpp
@@ -307,6 +307,11 @@ void ZigbeeComponent::setup() {
     return;
   }
 #endif
+
+#ifdef CONFIG_ZB_ZCZR
+  ezb_bdb_set_router_rejoin_required(true);
+#endif
+
   ezb_aps_secur_enable_distributed_security(false);
   ezb_nwk_set_min_join_lqi(32);
   if (ezb_app_signal_add_handler(ZigbeeComponent::app_signal_handler) != ESP_OK) {

--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -285,7 +285,7 @@ async def attributes_to_code(
 async def esp32_to_code(config: ConfigType) -> "MockObj":
     add_idf_component(
         name="espressif/esp-zigbee-lib",
-        ref="2.0.3",
+        ref="2.0.4",
     )
 
     # add sdkconfigs later so they can overwrite esp32 defaults

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -48,7 +48,7 @@ dependencies:
     rules:
       - if: "target in [esp32, esp32p4]"
   espressif/esp-zigbee-lib:
-    version: 2.0.3
+    version: 2.0.4
     rules:
       - if: "target in [esp32h2, esp32c5, esp32c6]"
   espressif/lan87xx:


### PR DESCRIPTION
# What does this implement/fix?

Bump esp-zigbee-sdk to 2.0.4. 
[Release notes](https://github.com/espressif/esp-zigbee-sdk/blob/main/RELEASE_NOTES.md)

Some bug fixes and new features. Most notably:
* allow the TC (ZHA/Z2M) to remove an end device even if it is not a direct child
* router sends now an explicit rejoin request when rejoining

Note: There is now also an `esp_zigbee_stop()` command, so we could start/stop zigbee on demand.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
