### PR TITLE
[core] Skip redundant ESP8266 main loop wake posts from ISR context

### DIFF
--- a/esphome/core/wake/wake_esp8266.h
+++ b/esphome/core/wake/wake_esp8266.h
@@ -15,9 +15,11 @@ inline void ESPHOME_ALWAYS_INLINE wake_loop_impl() {
   // Set the wake-requested flag BEFORE esp_schedule so the consumer is
   // guaranteed to see it on its next gate check.
   wake_request_set();
-  // Skip the post when a wake is already pending: esp_schedule() -> ets_post()
-  // can enter SDK WiFi pm code, which must not be poked per-byte from the
-  // software serial RX ISR (see esphome#18409).
+  // Skip the post when a wake was already signalled and not yet consumed by
+  // wakeable_delay(): esp_schedule() -> ets_post() can enter SDK WiFi pm code,
+  // which must not be poked per-byte from the software serial RX ISR (see
+  // esphome#18409). The flag can stay latched while the loop is awake, which
+  // is intentional; posts are only needed to cut a suspend short.
   if (g_main_loop_woke)
     return;
   g_main_loop_woke = true;

--- a/esphome/core/wake/wake_esp8266.h
+++ b/esphome/core/wake/wake_esp8266.h
@@ -15,6 +15,11 @@ inline void ESPHOME_ALWAYS_INLINE wake_loop_impl() {
   // Set the wake-requested flag BEFORE esp_schedule so the consumer is
   // guaranteed to see it on its next gate check.
   wake_request_set();
+  // Skip the post when a wake is already pending: esp_schedule() -> ets_post()
+  // can enter SDK WiFi pm code, which must not be poked per-byte from the
+  // software serial RX ISR (see esphome#18409).
+  if (g_main_loop_woke)
+    return;
   g_main_loop_woke = true;
   esp_schedule();
 }


### PR DESCRIPTION
# What does this implement/fix?

Since 2026.6.0 (#16562) the ESP8266 software serial RX ISR calls `wake_loop_isrsafe()`, which inlines `esp_schedule()` -> `ets_post()` for every received byte, up to ~960 calls per second at 9600 baud from GPIO ISR context. The crash backtraces in #18409 and #17059 show `ets_post` entering the SDK power management code (`pm_keep_active_enable` -> `pm_send_nullfunc`), which is a long known NONOS SDK fragility; poking it per byte from interrupt context makes the Soft/Hardware WDT resets reported with Midea UART polling more likely.

This change skips the `esp_schedule()` when a wake is already pending. The first byte of a burst still posts, so the latency win from #16562 is kept; later bytes arriving while the loop is already woken only set the wake-requested flag. The invariant that every false to true transition of `g_main_loop_woke` issues a post is preserved, so a suspended loop is always woken; the loop gate consumes `g_wake_requested` separately, so no bytes are lost.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18409

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  tx_pin: GPIO12
  rx_pin: GPIO14
  baud_rate: 9600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
