### PR TITLE
[esp32_hosted] Require ESP-IDF 5.3 or newer

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -19,6 +19,7 @@ from esphome.cpp_generator import add_define
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@swoboda1337"]
+DEPENDENCIES = ["esp32"]
 # esp32_ble raises the task watchdog around the remote BT controller bring-up
 AUTO_LOAD = ["watchdog"]
 

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -252,9 +252,13 @@ async def to_code(config):
         esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_MEMPOOL_PREFER_SPIRAM", True)
 
     # Library versions
+    # The current component set supports ESP-IDF 5.3 and newer. The legacy
+    # fallback (esp_hosted 2.0.11) must not be used on 5.3/5.4: its SDIO RX
+    # path has a double free (crashes with a tlsf_free assert at boot) that
+    # was only fixed in esp_hosted 2.11.0.
     idf_ver = esp32.idf_version()
     os.environ["ESP_IDF_VERSION"] = f"{idf_ver.major}.{idf_ver.minor}"
-    if idf_ver >= cv.Version(5, 5, 0):
+    if idf_ver >= cv.Version(5, 3, 0):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.6.3")
         esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.3")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     CONF_VARIANT,
 )
 from esphome.cpp_generator import add_define
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@swoboda1337"]
 # esp32_ble raises the task watchdog around the remote BT controller bring-up
@@ -122,6 +123,22 @@ CONFIG_SCHEMA = cv.typed_schema(
     },
     default_type="sdio",
 )
+
+
+def _final_validate(config: ConfigType) -> ConfigType:
+    # The esp_hosted releases compatible with older ESP-IDF versions crash at
+    # boot with a heap double free in the SDIO RX path (fixed in esp_hosted
+    # 2.11.0, which requires ESP-IDF 5.3), so reject them at validation time.
+    if (idf_ver := esp32.idf_version()) < cv.Version(5, 3, 0):
+        raise cv.Invalid(
+            f"esp32_hosted requires ESP-IDF 5.3 or newer, got {idf_ver}. "
+            "Remove the framework version from your configuration to use the "
+            "recommended version, or pin a version at or above 5.3."
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 def _configure_sdio(config):
@@ -251,22 +268,14 @@ async def to_code(config):
     if config[CONF_USE_PSRAM]:
         esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_MEMPOOL_PREFER_SPIRAM", True)
 
-    # Library versions
-    # The current component set supports ESP-IDF 5.3 and newer. The legacy
-    # fallback (esp_hosted 2.0.11) must not be used on 5.3/5.4: its SDIO RX
-    # path has a double free (crashes with a tlsf_free assert at boot) that
-    # was only fixed in esp_hosted 2.11.0.
+    # Library versions; this component set requires ESP-IDF 5.3 or newer,
+    # which is enforced at validation time.
     idf_ver = esp32.idf_version()
     os.environ["ESP_IDF_VERSION"] = f"{idf_ver.major}.{idf_ver.minor}"
-    if idf_ver >= cv.Version(5, 3, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.6.3")
-        esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.3")
-        esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.12")
-    else:
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
-        esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.0.11")
+    esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.6.3")
+    esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.3")
+    esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
+    esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.12")
     esp32.add_extra_script(
         "post",
         "esp32_hosted.py",

--- a/tests/component_tests/esp32_hosted/test_init.py
+++ b/tests/component_tests/esp32_hosted/test_init.py
@@ -1,0 +1,35 @@
+"""Tests for the esp32_hosted ESP-IDF version gate."""
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.esp32 import KEY_IDF_VERSION
+from esphome.components.esp32_hosted import _final_validate
+from esphome.const import PlatformFramework
+
+from ..types import SetCoreConfigCallable
+
+
+@pytest.mark.parametrize("idf", ["5.3.0", "5.4.2", "5.5.5"])
+def test_final_validate_accepts_supported_idf(
+    set_core_config: SetCoreConfigCallable, idf: str
+) -> None:
+    """ESP-IDF 5.3 and newer passes validation unchanged."""
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_IDF_VERSION: cv.Version.parse(idf)},
+    )
+    assert _final_validate({}) == {}
+
+
+@pytest.mark.parametrize("idf", ["5.0.0", "5.2.2"])
+def test_final_validate_rejects_old_idf(
+    set_core_config: SetCoreConfigCallable, idf: str
+) -> None:
+    """ESP-IDF older than 5.3 is rejected with a clear error."""
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_IDF_VERSION: cv.Version.parse(idf)},
+    )
+    with pytest.raises(cv.Invalid, match="requires ESP-IDF 5.3 or newer"):
+        _final_validate({})


### PR DESCRIPTION
# What does this implement/fix?

esp32_hosted previously picked its managed components based on the ESP-IDF version: 5.5 and newer got the current stack, anything older silently fell back to esp_hosted 2.0.11 with esp_wifi_remote 0.13.0 and eppp_link 0.2.0. That old esp_hosted release has a known double free in the SDIO RX path, fixed upstream in 2.11.0; on an ESP32-P4 with a C6 coprocessor it crashes at boot with `assert failed: tlsf_free tlsf.c:630 (!block_is_free(block) && "block already marked as free")` and the OTA rolls back.

esp32_hosted now requires ESP-IDF 5.3 or newer; the current component set (esp_hosted 2.12.12, esp_wifi_remote 1.6.3, wifi_remote_over_eppp 0.3.3, eppp_link 1.1.5) is used unconditionally, the legacy fallback is removed, and older ESP-IDF versions fail validation with a clear error instead of producing firmware that is known to crash.

Migration: configs that combine esp32_hosted with a pinned esp-idf version below 5.3 no longer validate; remove the version pin to use the recommended version, or pin 5.3 or newer.

Verified by compiling an ESP32-P4 SDIO config with 5.3.3 and 5.4.2 pinned (esp_wifi_remote selects its matching per-IDF sources) and with the default 5.5.5; a 5.2.2 pin fails validation with a clear error.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18413

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  variant: esp32p4
  flash_size: 16MB
  framework:
    type: esp-idf
    version: "5.4.2"

esp32_hosted:
  variant: ESP32C6
  slot: 1
  active_high: true
  reset_pin: GPIO15
  cmd_pin: GPIO13
  clk_pin: GPIO12
  d0_pin: GPIO11
  d1_pin: GPIO10
  d2_pin: GPIO9
  d3_pin: GPIO8

wifi:
  ssid: MySSID
  password: password1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
