### PR TITLE
[esp32] Split crash handler addr2line hint per core

### DIFF
--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -435,14 +435,15 @@ void crash_handler_log() {
   // Build addr2line hints for easy copy-paste. One line per core: the two
   // backtraces are separate stacks, and a combined list decodes as one
   // impossible call chain (and can overflow the buffer, dropping addresses).
+  static const char *const ADDR2LINE_CMD = "addr2line -pfiaC -e firmware.elf";
   char hint[256];
-  int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32, s_raw_crash_data.pc);
+  int pos = snprintf(hint, sizeof(hint), "Use: %s 0x%08" PRIX32, ADDR2LINE_CMD, s_raw_crash_data.pc);
   append_addrs_to_hint(hint, sizeof(hint), pos, s_raw_crash_data.backtrace, s_raw_crash_data.backtrace_count,
                        s_raw_crash_data.reg_frame_count);
   ESP_LOGE(TAG, "%s", hint);
 #if SOC_CPU_CORES_NUM > 1
   if (s_raw_crash_data.other_backtrace_count > 0) {
-    pos = snprintf(hint, sizeof(hint), "Other core: addr2line -pfiaC -e firmware.elf");
+    pos = snprintf(hint, sizeof(hint), "Other core: %s", ADDR2LINE_CMD);
     append_addrs_to_hint(hint, sizeof(hint), pos, s_raw_crash_data.other_backtrace,
                          s_raw_crash_data.other_backtrace_count, s_raw_crash_data.other_reg_frame_count);
     ESP_LOGE(TAG, "%s", hint);

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -360,17 +360,6 @@ static bool has_fault_addr() {
   return s_raw_crash_data.exception == PANIC_EXCEPTION_FAULT && !s_raw_crash_data.pseudo_excause;
 }
 
-// Append both cores' backtrace addresses to buf; returns the new position.
-static int append_all_backtraces(char *buf, int size, int pos) {
-  pos = append_addrs_to_hint(buf, size, pos, s_raw_crash_data.backtrace, s_raw_crash_data.backtrace_count,
-                             s_raw_crash_data.reg_frame_count);
-#if SOC_CPU_CORES_NUM > 1
-  pos = append_addrs_to_hint(buf, size, pos, s_raw_crash_data.other_backtrace, s_raw_crash_data.other_backtrace_count,
-                             s_raw_crash_data.other_reg_frame_count);
-#endif
-  return pos;
-}
-
 // The record was captured by a different firmware build (it survives soft
 // resets, including the OTA reboot), so symbolizing its addresses against the
 // current ELF would produce misleading symbols. Print them with lowercase
@@ -443,11 +432,22 @@ void crash_handler_log() {
   }
 #endif
 
-  // Build addr2line hint with all captured addresses for easy copy-paste
+  // Build addr2line hints for easy copy-paste. One line per core: the two
+  // backtraces are separate stacks, and a combined list decodes as one
+  // impossible call chain (and can overflow the buffer, dropping addresses).
   char hint[256];
   int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32, s_raw_crash_data.pc);
-  append_all_backtraces(hint, sizeof(hint), pos);
+  append_addrs_to_hint(hint, sizeof(hint), pos, s_raw_crash_data.backtrace, s_raw_crash_data.backtrace_count,
+                       s_raw_crash_data.reg_frame_count);
   ESP_LOGE(TAG, "%s", hint);
+#if SOC_CPU_CORES_NUM > 1
+  if (s_raw_crash_data.other_backtrace_count > 0) {
+    pos = snprintf(hint, sizeof(hint), "Other core: addr2line -pfiaC -e firmware.elf");
+    append_addrs_to_hint(hint, sizeof(hint), pos, s_raw_crash_data.other_backtrace,
+                         s_raw_crash_data.other_backtrace_count, s_raw_crash_data.other_reg_frame_count);
+    ESP_LOGE(TAG, "%s", hint);
+  }
+#endif
 }
 
 }  // namespace esphome::esp32


### PR DESCRIPTION
# What does this implement/fix?

The crash handler printed a single addr2line hint line that concatenated the fault PC, the crashed core's backtrace, and the other core's backtrace with nothing separating them. Tools that decode that line present two unrelated stacks as one call chain; this happened in the report below, where the decoded backtrace mixed bluedroid, wifi, api, and loop task frames into an impossible stack. The combined list could also exceed the 256 byte hint buffer and silently drop addresses.

This splits the hint into one line per core; the existing "Use:" line now carries only the crashed core's PC and backtrace, and a new "Other core:" line carries the second core's backtrace on dual core chips. Each line now always fits the buffer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/18394

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
