### PR TITLE
[api] Move NoiseProtocolId off the connection object

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -591,19 +591,19 @@ APIError APINoiseFrameHelper::write_frame_(const uint8_t *data, uint16_t len) {
  */
 APIError APINoiseFrameHelper::init_handshake_() {
   int err;
-  // Stack local: noise_handshakestate_new_by_id copies the id, so keeping it
-  // as a member would waste 104 bytes for the life of the connection.
-  NoiseProtocolId nid;
-  memset(&nid, 0, sizeof(nid));
-  // const char *proto = "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
-  // err = noise_protocol_name_to_id(&nid, proto, strlen(proto));
-  nid.pattern_id = NOISE_PATTERN_NN;
-  nid.cipher_id = NOISE_CIPHER_CHACHAPOLY;
-  nid.dh_id = NOISE_DH_CURVE25519;
-  nid.prefix_id = NOISE_PREFIX_STANDARD;
-  nid.hybrid_id = NOISE_DH_NONE;
-  nid.hash_id = NOISE_HASH_SHA256;
-  nid.modifier_ids[0] = NOISE_MODIFIER_PSK0;
+  // Noise_NNpsk0_25519_ChaChaPoly_SHA256, built on the stack:
+  // noise_handshakestate_new_by_id copies it, so a member would waste
+  // 104 bytes per connection, and a static const would sit in RAM on
+  // ESP8266 (.rodata is DRAM there).
+  const NoiseProtocolId nid = {
+      .prefix_id = NOISE_PREFIX_STANDARD,
+      .pattern_id = NOISE_PATTERN_NN,
+      .modifier_ids = {NOISE_MODIFIER_PSK0},
+      .dh_id = NOISE_DH_CURVE25519,
+      .cipher_id = NOISE_CIPHER_CHACHAPOLY,
+      .hash_id = NOISE_HASH_SHA256,
+      .hybrid_id = NOISE_DH_NONE,
+  };
 
   err = noise_handshakestate_new_by_id(&handshake_, &nid, NOISE_ROLE_RESPONDER);
   APIError aerr =

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -591,18 +591,21 @@ APIError APINoiseFrameHelper::write_frame_(const uint8_t *data, uint16_t len) {
  */
 APIError APINoiseFrameHelper::init_handshake_() {
   int err;
-  memset(&nid_, 0, sizeof(nid_));
+  // Stack local: noise_handshakestate_new_by_id copies the id, so keeping it
+  // as a member would waste 104 bytes for the life of the connection.
+  NoiseProtocolId nid;
+  memset(&nid, 0, sizeof(nid));
   // const char *proto = "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
-  // err = noise_protocol_name_to_id(&nid_, proto, strlen(proto));
-  nid_.pattern_id = NOISE_PATTERN_NN;
-  nid_.cipher_id = NOISE_CIPHER_CHACHAPOLY;
-  nid_.dh_id = NOISE_DH_CURVE25519;
-  nid_.prefix_id = NOISE_PREFIX_STANDARD;
-  nid_.hybrid_id = NOISE_DH_NONE;
-  nid_.hash_id = NOISE_HASH_SHA256;
-  nid_.modifier_ids[0] = NOISE_MODIFIER_PSK0;
+  // err = noise_protocol_name_to_id(&nid, proto, strlen(proto));
+  nid.pattern_id = NOISE_PATTERN_NN;
+  nid.cipher_id = NOISE_CIPHER_CHACHAPOLY;
+  nid.dh_id = NOISE_DH_CURVE25519;
+  nid.prefix_id = NOISE_PREFIX_STANDARD;
+  nid.hybrid_id = NOISE_DH_NONE;
+  nid.hash_id = NOISE_HASH_SHA256;
+  nid.modifier_ids[0] = NOISE_MODIFIER_PSK0;
 
-  err = noise_handshakestate_new_by_id(&handshake_, &nid_, NOISE_ROLE_RESPONDER);
+  err = noise_handshakestate_new_by_id(&handshake_, &nid, NOISE_ROLE_RESPONDER);
   APIError aerr =
       handle_noise_error_(err, LOG_STR("noise_handshakestate_new_by_id"), APIError::HANDSHAKESTATE_SETUP_FAILED);
   if (aerr != APIError::OK)

--- a/esphome/components/api/api_frame_helper_noise.h
+++ b/esphome/components/api/api_frame_helper_noise.h
@@ -63,9 +63,6 @@ class APINoiseFrameHelper final : public APIFrameHelper {
   // Buffer for noise handshake prologue (released after handshake)
   APIBuffer prologue_;
 
-  // NoiseProtocolId (size depends on implementation)
-  NoiseProtocolId nid_;
-
   // Group small types together
   // Fixed-size header buffer for noise protocol:
   // 1 byte for indicator + 2 bytes for message size (16-bit value, not varint)


### PR DESCRIPTION
# What does this implement/fix?

Reduces the RAM cost of each open encrypted API connection by 104 bytes. The `NoiseProtocolId` struct was stored as a member of `APINoiseFrameHelper`, but it is only used inside `init_handshake_()`; `noise_handshakestate_new_by_id` copies it, so it never needs to outlive that call. It is now a stack local.

Measured with the ESP32 toolchain, `sizeof(APINoiseFrameHelper)` drops from 232 to 128 bytes, so every open Noise connection holds 104 bytes less for its entire lifetime.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
