### PR TITLE
[uart] Guard ESP-IDF UART operations before the driver is installed

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -301,6 +301,14 @@ void IDFUARTComponent::set_rx_timeout(size_t rx_timeout) {
 }
 
 void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
+  if (!this->is_ready()) {
+    // Another component used the bus before setup() installed the driver, or
+    // after the bus failed. Calling the driver would fail and mark this
+    // component failed, which would then skip the driver installation entirely
+    // and permanently disable the bus, so drop the data instead.
+    ESP_LOGW(TAG, "write_array called while the bus is not ready; dropping %zu bytes", len);
+    return;
+  }
   int32_t write_len = uart_write_bytes(this->uart_num_, data, len);
   if (write_len != (int32_t) len) {
     ESP_LOGW(TAG, "uart_write_bytes failed: %" PRId32 " != %zu", write_len, len);
@@ -314,6 +322,9 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
 }
 
 bool IDFUARTComponent::peek_byte(uint8_t *data) {
+  if (!this->is_ready()) {
+    return false;
+  }
   if (!this->check_read_timeout_())
     return false;
   if (this->has_peek_) {
@@ -331,7 +342,7 @@ bool IDFUARTComponent::peek_byte(uint8_t *data) {
 }
 
 bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
-  if (len == 0) {
+  if (len == 0 || !this->is_ready()) {
     return false;
   }
   size_t length_to_read = len;
@@ -357,6 +368,12 @@ size_t IDFUARTComponent::available() {
   size_t available = 0;
   esp_err_t err;
 
+  if (!this->is_ready()) {
+    // The driver is not installed yet (or the bus failed); asking the driver
+    // would fail and mark the whole bus failed, so report no data instead.
+    return this->has_peek_ ? 1 : 0;
+  }
+
   err = uart_get_buffered_data_len(this->uart_num_, &available);
 
   if (err != ESP_OK) {
@@ -370,6 +387,10 @@ size_t IDFUARTComponent::available() {
 }
 
 UARTFlushResult IDFUARTComponent::flush() {
+  if (!this->is_ready()) {
+    // Nothing can be pending before the driver is installed
+    return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
+  }
   ESP_LOGVV(TAG, "    Flushing");
   TickType_t ticks = this->flush_timeout_ms_ == 0 ? portMAX_DELAY : pdMS_TO_TICKS(this->flush_timeout_ms_);
   esp_err_t err = uart_wait_tx_done(this->uart_num_, ticks);

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -371,7 +371,10 @@ size_t IDFUARTComponent::available() {
   if (!this->is_ready()) {
     // The driver is not installed yet (or the bus failed); asking the driver
     // would fail and mark the whole bus failed, so report no data instead.
-    return this->has_peek_ ? 1 : 0;
+    // A stale peeked byte must not be counted either: the read paths refuse
+    // to deliver it while the bus is not ready, so advertising it would make
+    // the common `while (available()) read()` pattern spin forever.
+    return 0;
   }
 
   err = uart_get_buffered_data_len(this->uart_num_, &available);

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -126,13 +126,15 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   esp_err_t err;
 
   if (uart_is_driver_installed(this->uart_num_)) {
-    this->driver_installed_ = false;
     err = uart_driver_delete(this->uart_num_);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "uart_driver_delete failed: %s", esp_err_to_name(err));
       this->mark_failed();
       return;
     }
+    // Only mark the driver gone once the delete actually succeeded; a failed
+    // delete leaves the old driver installed and working
+    this->driver_installed_ = false;
   }
   err = uart_driver_install(this->uart_num_,        // UART number
                             this->rx_buffer_size_,  // RX ring buffer size

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -126,6 +126,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   esp_err_t err;
 
   if (uart_is_driver_installed(this->uart_num_)) {
+    this->driver_installed_ = false;
     err = uart_driver_delete(this->uart_num_);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "uart_driver_delete failed: %s", esp_err_to_name(err));
@@ -146,6 +147,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  this->driver_installed_ = true;
 
   // uart_param_config must be called after uart_driver_install and before any
   // other uart_set_*() calls. The driver installation resets the UART peripheral
@@ -301,12 +303,19 @@ void IDFUARTComponent::set_rx_timeout(size_t rx_timeout) {
 }
 
 void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
-  if (!this->is_ready()) {
-    // Another component used the bus before setup() installed the driver, or
-    // after the bus failed. Calling the driver would fail and mark this
-    // component failed, which would then skip the driver installation entirely
-    // and permanently disable the bus, so drop the data instead.
-    ESP_LOGW(TAG, "write_array called while the bus is not ready; dropping %zu bytes", len);
+  if (!this->driver_installed_) {
+    // Another component used the bus before setup() installed the driver.
+    // Calling the driver would fail and mark this component failed, which
+    // would then skip the driver installation entirely and permanently
+    // disable the bus, so drop the data instead. Warn only once: consumers
+    // writing from loop() can hit this on every iteration of the setup
+    // phase's wait loops, which would flood the log.
+    if (!this->warned_not_ready_) {
+      this->warned_not_ready_ = true;
+      ESP_LOGW(TAG, "write_array called before the driver was installed; dropping %zu bytes", len);
+    } else {
+      ESP_LOGV(TAG, "write_array called before the driver was installed; dropping %zu bytes", len);
+    }
     return;
   }
   int32_t write_len = uart_write_bytes(this->uart_num_, data, len);
@@ -322,7 +331,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
 }
 
 bool IDFUARTComponent::peek_byte(uint8_t *data) {
-  if (!this->is_ready()) {
+  if (!this->driver_installed_) {
     return false;
   }
   if (!this->check_read_timeout_())
@@ -342,7 +351,7 @@ bool IDFUARTComponent::peek_byte(uint8_t *data) {
 }
 
 bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
-  if (len == 0 || !this->is_ready()) {
+  if (len == 0 || !this->driver_installed_) {
     return false;
   }
   size_t length_to_read = len;
@@ -368,12 +377,12 @@ size_t IDFUARTComponent::available() {
   size_t available = 0;
   esp_err_t err;
 
-  if (!this->is_ready()) {
-    // The driver is not installed yet (or the bus failed); asking the driver
-    // would fail and mark the whole bus failed, so report no data instead.
-    // A stale peeked byte must not be counted either: the read paths refuse
-    // to deliver it while the bus is not ready, so advertising it would make
-    // the common `while (available()) read()` pattern spin forever.
+  if (!this->driver_installed_) {
+    // The driver is not installed yet; asking the driver would fail and mark
+    // the whole bus failed, so report no data instead. A stale peeked byte
+    // must not be counted either: the read paths refuse to deliver it while
+    // the driver is missing, so advertising it would make the common
+    // `while (available()) read()` pattern spin forever.
     return 0;
   }
 
@@ -390,7 +399,7 @@ size_t IDFUARTComponent::available() {
 }
 
 UARTFlushResult IDFUARTComponent::flush() {
-  if (!this->is_ready()) {
+  if (!this->driver_installed_) {
     // Nothing can be pending before the driver is installed
     return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -148,6 +148,9 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
   this->driver_installed_ = true;
+  // Re-arm the dropped-write warning so a later not-installed episode
+  // (a failed reinstall through load_settings) is loud again
+  this->warned_not_ready_ = false;
 
   // uart_param_config must be called after uart_driver_install and before any
   // other uart_set_*() calls. The driver installation resets the UART peripheral
@@ -281,7 +284,7 @@ void IDFUARTComponent::dump_config() {
 }
 
 void IDFUARTComponent::set_rx_full_threshold(size_t rx_full_threshold) {
-  if (this->is_ready()) {
+  if (this->driver_installed_) {
     esp_err_t err = uart_set_rx_full_threshold(this->uart_num_, rx_full_threshold);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "uart_set_rx_full_threshold failed: %s", esp_err_to_name(err));
@@ -292,7 +295,7 @@ void IDFUARTComponent::set_rx_full_threshold(size_t rx_full_threshold) {
 }
 
 void IDFUARTComponent::set_rx_timeout(size_t rx_timeout) {
-  if (this->is_ready()) {
+  if (this->driver_installed_) {
     esp_err_t err = uart_set_rx_timeout(this->uart_num_, rx_timeout);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "uart_set_rx_timeout failed: %s", esp_err_to_name(err));

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -54,9 +54,12 @@ class IDFUARTComponent final : public UARTComponent, public Component {
 
  protected:
   void check_logger_conflict() override;
-  uart_port_t uart_num_;
   uart_config_t get_config_();
 
+  // Members ordered largest to smallest to minimize padding
+  uart_port_t uart_num_;
+  uint32_t flush_timeout_ms_{0};  ///< 0 means wait indefinitely (portMAX_DELAY).
+  uint8_t peek_byte_;
   bool has_peek_{false};
   /// True once uart_driver_install() succeeded for uart_num_. Gates all
   /// driver-touching I/O: before setup uart_num_ is not even assigned, so
@@ -66,8 +69,6 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   /// I/O like it always did, and load_settings() can revive it.
   bool driver_installed_{false};
   bool warned_not_ready_{false};
-  uint8_t peek_byte_;
-  uint32_t flush_timeout_ms_{0};  ///< 0 means wait indefinitely (portMAX_DELAY).
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
   // ISR callback for UART RX data notification — wakes the main loop directly.

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -58,6 +58,14 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   uart_config_t get_config_();
 
   bool has_peek_{false};
+  /// True once uart_driver_install() succeeded for uart_num_. Gates all
+  /// driver-touching I/O: before setup uart_num_ is not even assigned, so
+  /// uart_is_driver_installed() cannot be used as the predicate (it could
+  /// alias another component's port). Deliberately not tied to the component
+  /// state so a bus marked failed after a successful install keeps serving
+  /// I/O like it always did, and load_settings() can revive it.
+  bool driver_installed_{false};
+  bool warned_not_ready_{false};
   uint8_t peek_byte_;
   uint32_t flush_timeout_ms_{0};  ///< 0 means wait indefinitely (portMAX_DELAY).
 


### PR DESCRIPTION
# What does this implement/fix?

Hardening for the ESP-IDF UART against consumers that use the bus before its setup has run. Two distinct problems occur when that happens today.

First, the bus dies for the whole boot. A pre-setup `uart_write_bytes` fails, `write_array` calls `mark_failed()` on the UART component, and `Application::setup()` skips setup of failed components, so `uart_driver_install()` never runs; every consumer of that bus is dead until reboot. This was observed on an ESP32-C3 in #15472, where ld2420 declared `setup_priority::BUS` and won the registration order tie against the bus.

Second, the I/O can land on the wrong port. `uart_num_` is only assigned during setup, so a pre-setup call hands the driver an indeterminate port number, usually 0. If a driver is installed on that port, another `uart:` bus or the logger's UART, the write actually transmits on that unrelated port. This is also why `uart_is_driver_installed(this->uart_num_)` cannot serve as the guard.

The scenario is reachable in more ways than the ld2420 bug (fixed separately in #18428): any component can override its priority into the bus tier, users can do the same with the `setup_priority:` YAML option on any UART consumer, and external components copy this pattern; ld2420 shipped at `BUS` for two years before anyone noticed. At a priority tie the order is registration order, which shifts with config layout, so the misuse appears and disappears between builds.

The fix gates all driver touching operations on a flag that tracks whether `uart_driver_install()` succeeded. Early writes are dropped with a single warning (repeats at verbose so a consumer writing from `loop()` cannot flood the log), reads report no data, flush reports assumed success; the bus then initializes normally when its own setup runs. The flag is deliberately not tied to component state: a bus marked failed after a successful install keeps serving I/O exactly as it does today, and `load_settings()` can still revive it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/15472

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  tx_pin: GPIO20
  rx_pin: GPIO21
  baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).



