### PR TITLE
[ld2420] Drop the setup priority override so setup runs after the UART bus

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -184,8 +184,6 @@ static int32_t get_firmware_int(const char *version_string) {
   return result;
 }
 
-float LD2420Component::get_setup_priority() const { return setup_priority::BUS; }
-
 void LD2420Component::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "LD2420:\n"

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -105,7 +105,6 @@ class LD2420Component final : public Component, public uart::UARTDevice {
   void apply_config_action();
   void factory_reset_action();
   void revert_config_action();
-  float get_setup_priority() const override;
   int send_cmd_from_array(CmdFrameT cmd_frame);
   void report_gate_data();
   void handle_cmd_error(uint16_t error);


### PR DESCRIPTION
# What does this implement/fix?

The component declared `setup_priority::BUS`, the same tier as the UART bus itself. At a tie the setup order falls back to registration order, so on ESP-IDF the component could run setup before `uart_driver_install()`; the failed write then marked the UART bus failed and its setup was skipped, leaving the bus dead for the whole boot (seen on an ESP32-C3 in #15472).

The override was never an intentional ordering decision. The component was originally submitted in #4847 with `setup_priority::AFTER_CONNECTION`, which the author explained was a leftover development aid: "It was set to allow me to observe setup log activity wirelessly, we can bump it up to a more resonable one now" (https://github.com/esphome/esphome/pull/4847#discussion_r1199655458). The correction went from far too late to exactly the bus tier, and the tie was never noticed.

Delete the override so the component uses the default DATA priority and always runs after the bus. Neither ld2410 nor ld2450 overrides `get_setup_priority()`; both inherit the DATA default, and ld2420 was the only UART consumer in the tree sitting at the bus tier (modbus deliberately uses `BUS - 1.0f` with a comment saying it must run after the UART bus). Split out of #18423 so it can be backported on its own.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/15472

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  tx_pin: GPIO20
  rx_pin: GPIO21
  baud_rate: 115200

ld2420:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

