### PR TITLE
[bmi270] Add optional BMM150 magnetometer support via aux interface

### DIFF
--- a/esphome/components/bmi270/bmi270.cpp
+++ b/esphome/components/bmi270/bmi270.cpp
@@ -5,6 +5,8 @@
 
 namespace esphome::bmi270 {
 
+using namespace bmm150;  // NOLINT - sole consumer of the BMM150 aux-device definitions
+
 static const char *const TAG = "bmi270";
 
 #if defined(USE_ARDUINO) && !defined(USE_ESP32)
@@ -137,7 +139,99 @@ void BMI270Component::setup() {
     return;
   }
 
+  // 9. Optionally bring up whatever is wired to the aux interface.
+  // This is entirely additive: it is off by default, and failure only disables
+  // magnetometer reporting rather than the whole component.
+  if (this->aux_device_ == BMI270_AUX_DEVICE_BMM150) {
+    this->magnetometer_ready_ = this->setup_magnetometer_();
+    if (!this->magnetometer_ready_) {
+      ESP_LOGW(TAG, "BMM150 magnetometer setup failed; continuing without it");
+    }
+  }
+
   ESP_LOGCONFIG(TAG, "BMI270 initialised successfully");
+}
+
+bool BMI270Component::wait_for_aux_idle_(uint32_t timeout_ms) {
+  // STATUS bit 2 (0x04) is set while an aux transaction is in flight. Aux transaction
+  // duration depends on the attached device's own timing, so poll with a bounded
+  // timeout instead of guessing a fixed delay.
+  uint32_t start = millis();
+  while (true) {
+    uint8_t status = 0;
+    if (!this->read_byte(BMI270_REG_STATUS, &status))
+      return false;
+    if ((status & 0x04) == 0)
+      return true;
+    if (millis() - start >= timeout_ms)
+      return false;
+    delay(1);
+  }
+}
+
+bool BMI270Component::setup_magnetometer_() {
+  // Sequence adapted from the Bosch BMI270 aux-interface protocol: enable the
+  // secondary I2C master, point it at the BMM150's address, soft-reset + power-on
+  // the BMM150 through the aux write path, verify its chip ID via an aux read,
+  // put it in normal/30Hz mode, then switch the aux interface to auto-burst mode
+  // so BMI270 keeps AUX_X/Y/Z_LSB refreshed from the BMM150's data registers.
+  ESP_LOGD(TAG, "Setting up BMM150 magnetometer via BMI270 aux interface...");
+
+  if (!this->write_byte(BMI270_REG_IF_CONF, 0x20))  // aux_if_en
+    return false;
+  if (!this->write_byte(BMI270_REG_PWR_CTRL, 0x0E))  // temp+gyr+acc on, aux still off
+    return false;
+  if (!this->write_byte(BMI270_REG_AUX_IF_CONF, 0x80))  // manual mode, burst length 1
+    return false;
+  if (!this->write_byte(BMI270_REG_AUX_DEV_ID, (uint8_t) (this->aux_device_address_ << 1)))
+    return false;
+
+  // Soft-reset + power on the BMM150 (write 0x83 to its POWER_CONTROL register 0x4B).
+  if (!this->write_byte(BMI270_REG_AUX_WR_DATA, BMM150_CMD_POWER_ON_RESET))
+    return false;
+  if (!this->write_byte(BMI270_REG_AUX_WR_ADDR, BMM150_REG_POWER_CONTROL))
+    return false;
+  if (!this->wait_for_aux_idle_(20)) {
+    ESP_LOGW(TAG, "BMM150 power-on write timed out");
+    return false;
+  }
+
+  // Point the aux read address at the BMM150's chip-ID register and verify it.
+  if (!this->write_byte(BMI270_REG_AUX_IF_CONF, 0x80))  // enable read, burst length 1
+    return false;
+  if (!this->write_byte(BMI270_REG_AUX_RD_ADDR, BMM150_REG_CHIP_ID))
+    return false;
+  if (!this->wait_for_aux_idle_(20)) {
+    ESP_LOGW(TAG, "BMM150 chip-ID read timed out");
+    return false;
+  }
+  uint8_t chip_id = 0;
+  if (!this->read_byte(BMI270_REG_AUX_X_LSB, &chip_id) || chip_id != BMM150_CHIP_ID_VALUE) {
+    ESP_LOGW(TAG, "BMM150 not detected (chip ID 0x%02X, expected 0x%02X)", chip_id, BMM150_CHIP_ID_VALUE);
+    return false;
+  }
+
+  // Put the BMM150 in normal power mode, ODR 30 Hz (write 0x38 to OP_MODE register 0x4C).
+  if (!this->write_byte(BMI270_REG_AUX_WR_DATA, BMM150_CMD_NORMAL_MODE_ODR_30HZ))
+    return false;
+  if (!this->write_byte(BMI270_REG_AUX_WR_ADDR, BMM150_REG_OP_MODE))
+    return false;
+  if (!this->wait_for_aux_idle_(20)) {
+    ESP_LOGW(TAG, "BMM150 mode write timed out");
+    return false;
+  }
+
+  // Switch to auto-burst mode: BMI270 will keep polling 8 bytes from the BMM150's
+  // data registers (0x42) into its own AUX_X/Y/Z/R registers automatically.
+  if (!this->write_byte(BMI270_REG_AUX_IF_CONF, 0x4F))  // fcu_write_en, burst length 8
+    return false;
+  if (!this->write_byte(BMI270_REG_AUX_RD_ADDR, BMM150_REG_DATA_X_LSB))
+    return false;
+  if (!this->write_byte(BMI270_REG_PWR_CTRL, 0x0F))  // temp+gyr+acc+aux all on
+    return false;
+
+  ESP_LOGD(TAG, "BMM150 magnetometer ready");
+  return true;
 }
 
 void BMI270Component::dump_config() {
@@ -153,6 +247,10 @@ void BMI270Component::dump_config() {
 
   ESP_LOGCONFIG(TAG, "  Accel range : %s", ACCEL_RANGE_STRS[accel_range_]);
   ESP_LOGCONFIG(TAG, "  Gyro  range : %s", GYRO_RANGE_STRS[gyro_range_]);
+  if (this->aux_device_ == BMI270_AUX_DEVICE_BMM150) {
+    ESP_LOGCONFIG(TAG, "  Aux device  : BMM150 magnetometer (%s)",
+                  this->magnetometer_ready_ ? "ready" : "NOT DETECTED");
+  }
   MotionComponent::dump_config();
 }
 
@@ -195,14 +293,30 @@ bool BMI270Component::update_data(motion::MotionData &data) {
   data.angular_rate[motion::Y_AXIS] = (int16_t) ((raw_data[GYR_OFFS + 3] << 8) | raw_data[GYR_OFFS + 2]) * scale;
   data.angular_rate[motion::Z_AXIS] = (int16_t) ((raw_data[GYR_OFFS + 5] << 8) | raw_data[GYR_OFFS + 4]) * scale;
 
-  if (this->temperature_callback_.empty())
-    return true;
-  //  Temperature: registers 0x22–0x23
-  // Formula from datasheet: T[°C] = raw / 512 + 23
-  static constexpr uint8_t TEMP_OFFS = BMI270_REG_TEMP_0 - BMI270_REG_DATA_8;
-  int16_t raw_t = (int16_t) ((raw_data[TEMP_OFFS + 1] << 8) | raw_data[TEMP_OFFS + 0]);
-  float temperature = (raw_t / 512.0f) + 23.0f;
-  this->temperature_callback_.call(temperature);
+  if (!this->temperature_callback_.empty()) {
+    //  Temperature: registers 0x22–0x23
+    // Formula from datasheet: T[°C] = raw / 512 + 23
+    static constexpr uint8_t TEMP_OFFS = BMI270_REG_TEMP_0 - BMI270_REG_DATA_8;
+    int16_t raw_t = (int16_t) ((raw_data[TEMP_OFFS + 1] << 8) | raw_data[TEMP_OFFS + 0]);
+    float temperature = (raw_t / 512.0f) + 23.0f;
+    this->temperature_callback_.call(temperature);
+  }
+
+  // Magnetometer: separate read, since AUX_X/Y/Z live at 0x04-0x09, well before the
+  // accel/gyro/temp block read above. Only touched when the BMM150 aux setup succeeded.
+  if (this->magnetometer_ready_ && !this->magnetometer_callback_.empty()) {
+    uint8_t mag_raw[6];
+    if (this->read_bytes(BMI270_REG_AUX_X_LSB, mag_raw, sizeof(mag_raw))) {
+      BMM150Data mag_data{
+          .x = (int16_t) ((mag_raw[1] << 8) | mag_raw[0]) * BMM150_MICROTESLA_PER_LSB,
+          .y = (int16_t) ((mag_raw[3] << 8) | mag_raw[2]) * BMM150_MICROTESLA_PER_LSB,
+          .z = (int16_t) ((mag_raw[5] << 8) | mag_raw[4]) * BMM150_MICROTESLA_PER_LSB,
+      };
+      this->magnetometer_callback_.call(mag_data);
+    } else {
+      ESP_LOGW(TAG, "Failed to read magnetometer data");
+    }
+  }
   return true;
 }
 

--- a/esphome/components/bmi270/bmi270.h
+++ b/esphome/components/bmi270/bmi270.h
@@ -4,6 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/components/i2c/i2c.h"
+#include "bmm150_aux.h"
 #include <functional>
 
 namespace esphome::bmi270 {
@@ -33,6 +34,17 @@ static const uint8_t BMI270_REG_GYR_CONF = 0x42;
 static const uint8_t BMI270_REG_GYR_RANGE = 0x43;
 
 static const uint8_t BMI270_CHIP_ID_VALUE = 0x24;
+
+//  Auxiliary (secondary I2C master) interface registers.
+//  Used to optionally drive a BMM150 magnetometer wired to the BMI270's AUX pins
+//  instead of the main I2C bus - the BMM150 has no address of its own on that bus.
+static const uint8_t BMI270_REG_AUX_X_LSB = 0x04;  // start of aux data: X,Y,Z,R (8 bytes)
+static const uint8_t BMI270_REG_AUX_DEV_ID = 0x4B;
+static const uint8_t BMI270_REG_AUX_IF_CONF = 0x4C;
+static const uint8_t BMI270_REG_AUX_RD_ADDR = 0x4D;
+static const uint8_t BMI270_REG_AUX_WR_ADDR = 0x4E;
+static const uint8_t BMI270_REG_AUX_WR_DATA = 0x4F;
+static const uint8_t BMI270_REG_IF_CONF = 0x6B;
 
 //  Accelerometer range options
 enum BMI270AccelRange : uint8_t {
@@ -75,7 +87,12 @@ enum BMI270GyroODR : uint8_t {
   BMI270_GYRO_ODR_3200 = 0x0D,
 };
 
-// ---Data class
+// What, if anything, is wired to the BMI270's auxiliary (secondary I2C master) interface.
+// Only one aux device can be attached at a time - it's a single secondary bus, not a mux.
+enum BMI270AuxDevice : uint8_t {
+  BMI270_AUX_DEVICE_NONE = 0,
+  BMI270_AUX_DEVICE_BMM150 = 1,
+};
 
 // Main component class
 class BMI270Component final : public motion::MotionComponent, public i2c::I2CDevice {
@@ -90,19 +107,32 @@ class BMI270Component final : public motion::MotionComponent, public i2c::I2CDev
   void set_accel_odr(BMI270AccelODR o) { this->accel_odr_ = o; }
   void set_gyro_range(BMI270GyroRange r) { this->gyro_range_ = r; }
   void set_gyro_odr(BMI270GyroODR o) { this->gyro_odr_ = o; }
+  void set_aux_device(BMI270AuxDevice device) { this->aux_device_ = device; }
+  void set_aux_device_address(uint8_t address) { this->aux_device_address_ = address; }
   template<typename F> void add_temperature_listener(F &&cb) { this->temperature_callback_.add(std::forward<F>(cb)); }
+  template<typename F> void add_magnetometer_listener(F &&cb) { this->magnetometer_callback_.add(std::forward<F>(cb)); }
 
  protected:
   bool update_data(motion::MotionData &data) override;
   bool load_config_file_();
+  // Brings up the BMM150 over the BMI270's aux interface. Optional: on failure this only
+  // disables magnetometer reporting, it does not fail the whole component (accel/gyro still work).
+  bool setup_magnetometer_();
+  // Blocking poll of the aux-transaction-busy bit; aux transaction time depends on the
+  // attached device, so this is bounded by retries/timeout rather than a fixed delay.
+  bool wait_for_aux_idle_(uint32_t timeout_ms);
 
   // Config
   BMI270AccelRange accel_range_{BMI270_ACCEL_RANGE_4G};
   BMI270AccelODR accel_odr_{BMI270_ACCEL_ODR_100};
   BMI270GyroRange gyro_range_{BMI270_GYRO_RANGE_2000};
   BMI270GyroODR gyro_odr_{BMI270_GYRO_ODR_200};
+  BMI270AuxDevice aux_device_{BMI270_AUX_DEVICE_NONE};
+  uint8_t aux_device_address_{bmm150::BMM150_DEFAULT_I2C_ADDRESS};
+  bool magnetometer_ready_{false};
 
   LazyCallbackManager<void(float)> temperature_callback_{};
+  LazyCallbackManager<void(bmm150::BMM150Data &)> magnetometer_callback_{};
 };
 
 }  // namespace esphome::bmi270

--- a/esphome/components/bmi270/bmm150_aux.h
+++ b/esphome/components/bmi270/bmm150_aux.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+
+// BMM150 magnetometer definitions - the chip that can optionally be wired to the BMI270's
+// auxiliary (secondary I2C master) interface. Lives in its own header/namespace because this
+// is BMM150-specific driver knowledge, not BMI270 knowledge - it just can't be a standalone
+// ESPHome component, since the BMM150 has no address of its own on the main I2C bus and is only
+// reachable by having the BMI270 proxy register reads/writes through its aux interface.
+namespace esphome::bmi270::bmm150 {
+
+static const uint8_t BMM150_DEFAULT_I2C_ADDRESS = 0x10;
+static const uint8_t BMM150_REG_CHIP_ID = 0x40;
+static const uint8_t BMM150_REG_DATA_X_LSB = 0x42;
+static const uint8_t BMM150_REG_POWER_CONTROL = 0x4B;
+static const uint8_t BMM150_REG_OP_MODE = 0x4C;
+static const uint8_t BMM150_CHIP_ID_VALUE = 0x32;
+static const uint8_t BMM150_CMD_POWER_ON_RESET = 0x83;
+static const uint8_t BMM150_CMD_NORMAL_MODE_ODR_30HZ = 0x38;
+// µT per LSB, per BMM150 datasheet (13-bit data, ±1300µT full scale in x/y).
+static constexpr float BMM150_MICROTESLA_PER_LSB = 10.0f * 4912.0f / 32768.0f;
+
+// Result of a BMM150 magnetometer reading, in µT.
+struct BMM150Data {
+  float x;
+  float y;
+  float z;
+};
+
+}  // namespace esphome::bmi270::bmm150

--- a/esphome/components/bmi270/motion.py
+++ b/esphome/components/bmi270/motion.py
@@ -13,6 +13,17 @@ from . import BMI270Component, bmi270_ns
 
 DEPENDENCIES = ["i2c"]
 
+CONF_AUX_DEVICE = "aux_device"
+CONF_AUX_ADDRESS = "aux_address"
+
+# What's wired to the BMI270's auxiliary (secondary I2C master) interface, if anything.
+# It's a single secondary bus, not a mux, so only one aux device can be attached at a time.
+BMI270AuxDevice = bmi270_ns.enum("BMI270AuxDevice")
+AUX_DEVICE_OPTIONS = {
+    "NONE": BMI270AuxDevice.BMI270_AUX_DEVICE_NONE,
+    "BMM150": BMI270AuxDevice.BMI270_AUX_DEVICE_BMM150,
+}
+
 #  Enum proxies (must match the C++ enum values exactly)
 BMI270AccelRange = bmi270_ns.enum("BMI270AccelRange")
 ACCEL_RANGE_OPTIONS = {
@@ -72,6 +83,13 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_GYROSCOPE_ODR, default="200HZ"): cv.enum(
                 GYRO_ODR_OPTIONS, upper=True
             ),
+            # Optional device wired to the BMI270's aux interface (not the main I2C bus).
+            # Defaults to NONE so existing configs/boards are unaffected.
+            cv.Optional(CONF_AUX_DEVICE, default="NONE"): cv.enum(
+                AUX_DEVICE_OPTIONS, upper=True
+            ),
+            # Default matches the BMM150's fixed I2C address; irrelevant when aux_device is NONE.
+            cv.Optional(CONF_AUX_ADDRESS, default=0x10): cv.i2c_address,
         }
     )
     .extend(i2c.i2c_device_schema(0x68))
@@ -89,3 +107,5 @@ async def to_code(config):
     cg.add(var.set_accel_odr(config[CONF_ACCELEROMETER_ODR]))
     cg.add(var.set_gyro_range(config[CONF_GYROSCOPE_RANGE]))
     cg.add(var.set_gyro_odr(config[CONF_GYROSCOPE_ODR]))
+    cg.add(var.set_aux_device(config[CONF_AUX_DEVICE]))
+    cg.add(var.set_aux_device_address(config[CONF_AUX_ADDRESS]))

--- a/esphome/components/bmi270/sensor.py
+++ b/esphome/components/bmi270/sensor.py
@@ -6,36 +6,96 @@ from esphome.const import (
     CONF_TEMPERATURE,
     CONF_TYPE,
     DEVICE_CLASS_TEMPERATURE,
+    ICON_MAGNET,
     ICON_THERMOMETER,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
+    UNIT_MICROTESLA,
 )
 from esphome.cpp_generator import MockObj
+import esphome.final_validate as fv
 
-from . import CONF_BMI270_ID, BMI270Component
+from . import CONF_BMI270_ID, BMI270Component, bmi270_ns
+from .motion import CONF_AUX_DEVICE
 
 AUTO_LOAD = ["bmi270"]
 
-CONFIG_SCHEMA = sensor.sensor_schema(
-    unit_of_measurement=UNIT_CELSIUS,
-    icon=ICON_THERMOMETER,
-    accuracy_decimals=2,
-    state_class=STATE_CLASS_MEASUREMENT,
-    device_class=DEVICE_CLASS_TEMPERATURE,
-).extend(
+CONF_MAGNETIC_FIELD_X = "magnetic_field_x"
+CONF_MAGNETIC_FIELD_Y = "magnetic_field_y"
+CONF_MAGNETIC_FIELD_Z = "magnetic_field_z"
+
+BMM150Data = bmi270_ns.namespace("bmm150").class_("BMM150Data")
+
+_MAGNETIC_FIELDS = (CONF_MAGNETIC_FIELD_X, CONF_MAGNETIC_FIELD_Y, CONF_MAGNETIC_FIELD_Z)
+
+
+def _parent_schema():
+    return cv.Schema({cv.GenerateID(CONF_BMI270_ID): cv.use_id(BMI270Component)})
+
+
+def _temperature_sensor_schema():
+    return sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        icon=ICON_THERMOMETER,
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ).extend(_parent_schema())
+
+
+def _magnetic_field_sensor_schema():
+    return sensor.sensor_schema(
+        unit_of_measurement=UNIT_MICROTESLA,
+        icon=ICON_MAGNET,
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ).extend(_parent_schema())
+
+
+# `type` defaults to temperature so existing configs that omit it keep working unchanged.
+CONFIG_SCHEMA = cv.typed_schema(
     {
-        cv.Optional(CONF_TYPE): cv.one_of(CONF_TEMPERATURE),
-        cv.GenerateID(CONF_BMI270_ID): cv.use_id(BMI270Component),
-    }
+        CONF_TEMPERATURE: _temperature_sensor_schema(),
+        **{x: _magnetic_field_sensor_schema() for x in _MAGNETIC_FIELDS},
+    },
+    default_type=CONF_TEMPERATURE,
 )
 
 
+def _final_validate(config: dict) -> None:
+    if config[CONF_TYPE] not in _MAGNETIC_FIELDS:
+        return
+    full_config = fv.full_config.get()
+    bmi270_path = full_config.get_path_for_id(config[CONF_BMI270_ID])[:-1]
+    bmi270_config = full_config.get_config_for_path(bmi270_path)
+    if bmi270_config.get(CONF_AUX_DEVICE) != "BMM150":
+        raise cv.Invalid(
+            "This sensor requires the parent bmi270's 'aux_device' to be set to 'BMM150'",
+            path=[CONF_TYPE],
+        )
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
 async def to_code(config):
+    sensor_type = config[CONF_TYPE]
     var = await sensor.new_sensor(config)
     parent = await cg.get_variable(config[CONF_BMI270_ID])
+
+    if sensor_type == CONF_TEMPERATURE:
+        data = MockObj("data")
+        value_lambda = await cg.process_lambda(
+            var.publish_state(data),
+            [(cg.float_, str(data))],
+        )
+        cg.add(parent.add_temperature_listener(value_lambda))
+        return
+
+    axis = sensor_type[-1:]
     data = MockObj("data")
     value_lambda = await cg.process_lambda(
-        var.publish_state(data),
-        [(cg.float_, str(data))],
+        var.publish_state(getattr(data, axis)),
+        [(BMM150Data.operator("ref"), str(data))],
     )
-    cg.add(parent.add_temperature_listener(value_lambda))
+    cg.add(parent.add_magnetometer_listener(value_lambda))

--- a/tests/components/bmi270/common.yaml
+++ b/tests/components/bmi270/common.yaml
@@ -2,6 +2,16 @@ sensor:
   - platform: bmi270
     name: "BMI270 Temperature"
 
+  - platform: bmi270
+    type: magnetic_field_x
+    name: "BMM150 Magnetic Field X"
+  - platform: bmi270
+    type: magnetic_field_y
+    name: "BMM150 Magnetic Field Y"
+  - platform: bmi270
+    type: magnetic_field_z
+    name: "BMM150 Magnetic Field Z"
+
   - platform: motion
     motion_id: bmi270_motion
     type: acceleration_x
@@ -74,6 +84,7 @@ motion:
     # Gyroscope output data rate: 25HZ | 50HZ | 100HZ | 200HZ |
     #                               400HZ | 800HZ | 1600HZ | 3200HZ
     gyroscope_odr: 200HZ
+    aux_device: BMM150
     axis_map:
       x: y
       y: x


### PR DESCRIPTION
# What does this implement/fix?

Adds support for a BMM150 magnetometer wired to the BMI270's auxiliary (secondary I2C master) interface, since the BMM150 has no address of its own on the main I2C bus. Off by default via a new `aux_device` option (NONE | BMM150), so existing configurations are unaffected.

Exposes magnetic_field_x/y/z sensor types on the existing bmi270 sensor platform, backed by a new add_magnetometer_listener callback. BMM150-specific registers/data live in a separate bmm150_aux.h header rather than being mixed into the BMI270's own definitions.

Have been tinkering with a complete BMI270 / BMM150 integration over here https://github.com/DennisGaida/m5stack-atoms3r-components, but let's have this natively in esphome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/7209

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
motion:
  - platform: bmi270
    id: bmi270_motion
    aux_device: BMM150

sensor:
  - platform: bmi270
    type: magnetic_field_x
    name: "Magnetic Field X"
  - platform: bmi270
    type: magnetic_field_y
    name: "Magnetic Field Y"
  - platform: bmi270
    type: magnetic_field_z
    name: "Magnetic Field Z"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).