### PR TITLE
[ota] Shorten platform backend TAG strings

### DIFF
--- a/esphome/components/ota/ota_backend_arduino_libretiny.cpp
+++ b/esphome/components/ota/ota_backend_arduino_libretiny.cpp
@@ -9,7 +9,7 @@
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.arduino_libretiny";
+static const char *const TAG = "ota";
 
 std::unique_ptr<ArduinoLibreTinyOTABackend> make_ota_backend() { return make_unique<ArduinoLibreTinyOTABackend>(); }
 

--- a/esphome/components/ota/ota_backend_arduino_rp2.cpp
+++ b/esphome/components/ota/ota_backend_arduino_rp2.cpp
@@ -11,7 +11,7 @@
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.arduino_rp2";
+static const char *const TAG = "ota";
 
 std::unique_ptr<ArduinoRP2OTABackend> make_ota_backend() { return make_unique<ArduinoRP2OTABackend>(); }
 

--- a/esphome/components/ota/ota_backend_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_esp8266.cpp
@@ -46,7 +46,7 @@ static constexpr size_t MIN_BUFFER_SIZE = 256;
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.esp8266";
+static const char *const TAG = "ota";
 
 std::unique_ptr<ESP8266OTABackend> make_ota_backend() { return make_unique<ESP8266OTABackend>(); }
 

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -15,7 +15,7 @@
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.idf";
+static const char *const TAG = "ota";
 
 std::unique_ptr<IDFOTABackend> make_ota_backend() { return make_unique<IDFOTABackend>(); }
 

--- a/esphome/components/ota/ota_backend_host.cpp
+++ b/esphome/components/ota/ota_backend_host.cpp
@@ -27,7 +27,7 @@ namespace esphome::ota {
 
 namespace {
 
-const char *const TAG = "ota.host";
+const char *const TAG = "ota";
 
 constexpr size_t MAX_OTA_SIZE = 256u * 1024u * 1024u;  // 256 MiB
 constexpr size_t HEADER_PEEK_SIZE = 64;

--- a/esphome/components/ota/ota_bootloader_esp_idf.cpp
+++ b/esphome/components/ota/ota_bootloader_esp_idf.cpp
@@ -11,7 +11,7 @@
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.idf";
+static const char *const TAG = "ota";
 
 OTAResponseTypes IDFOTABackend::register_and_validate_bootloader_part_() {
   // Register the bootloader partition

--- a/esphome/components/ota/ota_partitions_esp_idf.cpp
+++ b/esphome/components/ota/ota_partitions_esp_idf.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.idf";
+static const char *const TAG = "ota";
 
 static inline bool check_overlap(uint32_t a_offset, size_t a_size, uint32_t b_offset, size_t b_size) {
   return (a_offset + a_size > b_offset && b_offset + b_size > a_offset);

--- a/esphome/components/ota/ota_signature_esp_idf.cpp
+++ b/esphome/components/ota/ota_signature_esp_idf.cpp
@@ -31,7 +31,7 @@
 
 namespace esphome::ota {
 
-static const char *const TAG = "ota.idf";
+static const char *const TAG = "ota";
 
 // Route the "Signature check: " prefix (and its per-block form) through one
 // shared format string each, so the prefix is pooled once by the linker instead


### PR DESCRIPTION
# What does this implement/fix?

Shortens the log TAG in the OTA platform backends to just `ota`. Only one backend is ever compiled into a build, so the platform suffix is redundant; on ESP8266 these strings live in RAM, so `ota.esp8266` wastes 8 bytes there. Same reasoning as the preferences tags in #15004.

Note for users: if your `logger: logs:` config filters on one of the old tags (`ota.esp8266`, `ota.idf`, `ota.arduino_rp2`, `ota.arduino_libretiny`, `ota.host`), update the entry to `ota`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).