### PR TITLE
[uart] Shorten platform backend TAG strings

### DIFF
--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -14,7 +14,7 @@
 
 namespace esphome::uart {
 
-static const char *const TAG = "uart.arduino_esp8266";
+static const char *const TAG = "uart";
 bool ESP8266UartComponent::serial0_in_use = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 uint32_t ESP8266UartComponent::get_config() {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -21,7 +21,7 @@
 
 namespace esphome::uart {
 
-static const char *const TAG = "uart.idf";
+static const char *const TAG = "uart";
 
 /// Check if a pin number matches one of the default UART0 GPIO pins.
 /// These pins may have residual IOMUX state from the ROM bootloader that

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -98,7 +98,7 @@ speed_t get_baud(int baud) {
 
 namespace esphome::uart {
 
-static const char *const TAG = "uart.host";
+static const char *const TAG = "uart";
 
 HostUartComponent::~HostUartComponent() {
   if (this->file_descriptor_ != -1) {

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::uart {
 
-static const char *const TAG = "uart.lt";
+static const char *const TAG = "uart";
 
 static const char *const UART_TYPE[] = {
     "hardware",

--- a/esphome/components/uart/uart_component_rp2.cpp
+++ b/esphome/components/uart/uart_component_rp2.cpp
@@ -13,7 +13,7 @@
 
 namespace esphome::uart {
 
-static const char *const TAG = "uart.arduino_rp2";
+static const char *const TAG = "uart";
 
 uint16_t RP2UartComponent::get_config() {
   uint16_t config = 0;


### PR DESCRIPTION
# What does this implement/fix?

Shortens the log TAG in the uart platform backends to just `uart`, matching the base files. Only one backend is compiled into a build, so the platform suffix is redundant; on ESP8266 the tag string lives in RAM, and `uart.arduino_esp8266` is 21 bytes there. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`uart.idf`, `uart.arduino_esp8266`, `uart.lt`, `uart.arduino_rp2`, `uart.host`), update the entry to `uart`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).