### PR TITLE
[i2c] Shorten platform backend TAG strings

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -9,7 +9,7 @@
 
 namespace esphome::i2c {
 
-static const char *const TAG = "i2c.arduino";
+static const char *const TAG = "i2c";
 
 // Maximum bytes to log in hex format (truncates larger transfers)
 static constexpr size_t I2C_MAX_LOG_BYTES = 32;

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -12,7 +12,7 @@
 
 namespace esphome::i2c {
 
-static const char *const TAG = "i2c.idf";
+static const char *const TAG = "i2c";
 
 // Maximum bytes to log in hex format (truncates larger transfers)
 static constexpr size_t I2C_MAX_LOG_BYTES = 32;

--- a/esphome/components/i2c/i2c_bus_host.cpp
+++ b/esphome/components/i2c/i2c_bus_host.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::i2c {
 
-static const char *const TAG = "i2c.host";
+static const char *const TAG = "i2c";
 
 HostI2CBus::~HostI2CBus() {
   if (this->file_descriptor_ != -1) {

--- a/esphome/components/i2c/i2c_bus_zephyr.cpp
+++ b/esphome/components/i2c/i2c_bus_zephyr.cpp
@@ -6,7 +6,7 @@
 
 namespace esphome::i2c {
 
-static const char *const TAG = "i2c.zephyr";
+static const char *const TAG = "i2c";
 
 static const char *get_speed(uint32_t dev_config) {
   switch (I2C_SPEED_GET(dev_config)) {


### PR DESCRIPTION
# What does this implement/fix?

Shortens the log TAG in the i2c bus backends to just `i2c`, matching `i2c.cpp`. Only one backend is compiled into a build, so the platform suffix is redundant; on ESP8266 the tag string lives in RAM. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`i2c.arduino`, `i2c.idf`, `i2c.host`, `i2c.zephyr`), update the entry to `i2c`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).