### PR TITLE
[adc] Shorten platform TAG strings

### DIFF
--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::adc {
 
-static const char *const TAG = "adc.common";
+static const char *const TAG = "adc";
 
 const LogString *sampling_mode_to_str(SamplingMode mode) {
   switch (mode) {

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -6,7 +6,7 @@
 
 namespace esphome::adc {
 
-static const char *const TAG = "adc.esp32";
+static const char *const TAG = "adc";
 
 adc_oneshot_unit_handle_t ADCSensor::shared_adc_handles[2] = {nullptr, nullptr};
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -13,7 +13,7 @@ ADC_MODE(ADC_VCC)
 
 namespace esphome::adc {
 
-static const char *const TAG = "adc.esp8266";
+static const char *const TAG = "adc";
 
 void ADCSensor::setup() {
 #ifndef USE_ADC_SENSOR_VCC

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -5,7 +5,7 @@
 
 namespace esphome::adc {
 
-static const char *const TAG = "adc.libretiny";
+static const char *const TAG = "adc";
 
 void ADCSensor::setup() {
 #ifndef USE_ADC_SENSOR_VCC

--- a/esphome/components/adc/adc_sensor_rp2.cpp
+++ b/esphome/components/adc/adc_sensor_rp2.cpp
@@ -17,7 +17,7 @@
 
 namespace esphome::adc {
 
-static const char *const TAG = "adc.rp2";
+static const char *const TAG = "adc";
 
 // The on-die temperature sensor sits on the last ADC channel: input 4 on RP2040
 // and RP2350A, but input 8 on RP2350B, which has eight external channels rather

--- a/esphome/components/adc/adc_sensor_zephyr.cpp
+++ b/esphome/components/adc/adc_sensor_zephyr.cpp
@@ -7,7 +7,7 @@
 
 namespace esphome::adc {
 
-static const char *const TAG = "adc.zephyr";
+static const char *const TAG = "adc";
 
 void ADCSensor::setup() {
   if (!adc_is_ready_dt(this->channel_)) {


### PR DESCRIPTION
# What does this implement/fix?

Shortens the log TAG in the adc platform implementations to just `adc`. Only one platform file is compiled into a build, so the suffix is redundant; the common file merges into the same literal, and on ESP8266 these tag strings live in RAM. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`adc.common`, `adc.esp32`, `adc.esp8266`, `adc.rp2`, `adc.libretiny`, `adc.zephyr`), update the entry to `adc`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).