### PR TITLE
[internal_temperature] Shorten platform TAG strings

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
@@ -9,7 +9,7 @@ uint32_t temp_single_get_current_temperature(uint32_t *temp_value);
 
 namespace esphome::internal_temperature {
 
-static const char *const TAG = "internal_temperature.bk72xx";
+static const char *const TAG = "internal_temperature";
 
 void InternalTemperatureSensor::update() {
   float temperature = NAN;

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -16,7 +16,7 @@ uint8_t temprature_sens_read();
 
 namespace esphome::internal_temperature {
 
-static const char *const TAG = "internal_temperature.esp32";
+static const char *const TAG = "internal_temperature";
 
 void InternalTemperatureSensor::update() {
   float temperature = NAN;

--- a/esphome/components/internal_temperature/internal_temperature_rp2.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::internal_temperature {
 
-static const char *const TAG = "internal_temperature.rp2";
+static const char *const TAG = "internal_temperature";
 
 // The on-die temperature sensor sits on the last ADC channel: input 4 on RP2040
 // and RP2350A, but input 8 on RP2350B, which has eight external channels rather

--- a/esphome/components/internal_temperature/internal_temperature_zephyr.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_zephyr.cpp
@@ -8,7 +8,7 @@
 
 namespace esphome::internal_temperature {
 
-static const char *const TAG = "internal_temperature.zephyr";
+static const char *const TAG = "internal_temperature";
 
 static const struct device *const DIE_TEMPERATURE_SENSOR = DEVICE_DT_GET_ONE(nordic_nrf_temp);
 


### PR DESCRIPTION
# What does this implement/fix?

Shortens the platform TAGs to `internal_temperature`, matching the common file. Only one platform file is compiled into a build, so the suffix is redundant and the literal merges with the existing one. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`internal_temperature.esp32`, `internal_temperature.rp2`, `internal_temperature.bk72xx`, `internal_temperature.zephyr`), update the entry to `internal_temperature`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).