### PR TITLE
[http_request] Shorten platform backend TAG strings

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::http_request {
 
-static const char *const TAG = "http_request.arduino";
+static const char *const TAG = "http_request";
 #ifdef USE_ESP8266
 // ESP8266 Arduino core (WiFiClientSecureBearSSL.cpp) returns -1000 on OOM
 static constexpr int ESP8266_SSL_ERR_OOM = -1000;

--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -14,7 +14,7 @@
 
 namespace esphome::http_request {
 
-static const char *const TAG = "http_request.host";
+static const char *const TAG = "http_request";
 
 std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, const std::string &method,
                                                         const std::string &body,

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::http_request {
 
-static const char *const TAG = "http_request.idf";
+static const char *const TAG = "http_request";
 static constexpr uint32_t ERROR_DURATION_MS = 1000;
 
 void HttpRequestIDF::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

Shortens the log TAG in the http_request platform backends to just `http_request`, matching the base file. Only one backend is compiled into a build, so the suffix is redundant; on ESP8266 the tag string lives in RAM. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`http_request.arduino`, `http_request.idf`, `http_request.host`), update the entry to `http_request`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).