### PR TITLE
[deep_sleep] Shorten bk72xx TAG string

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
@@ -5,7 +5,7 @@
 
 namespace esphome::deep_sleep {
 
-static const char *const TAG = "deep_sleep.bk72xx";
+static const char *const TAG = "deep_sleep";
 
 #ifdef USE_DEEP_SLEEP_ON_WAKE
 WakeupCause get_wakeup_cause() {


### PR DESCRIPTION
# What does this implement/fix?

Shortens the bk72xx TAG to `deep_sleep`, matching every other platform file in the component. Only one platform file is compiled into a build, so the suffix is redundant. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on the old tag (`deep_sleep.bk72xx`), update the entry to `deep_sleep`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).