### PR TITLE
[nextion] Shorten upload TAG strings

### DIFF
--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -13,7 +13,7 @@
 
 namespace esphome::nextion {
 
-static const char *const TAG = "nextion.upload.arduino";
+static const char *const TAG = "nextion.upload";
 static constexpr size_t NEXTION_MAX_RESPONSE_LOG_BYTES = 16;
 
 // Timeout for display acknowledgment during TFT upload (ms).

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -16,7 +16,7 @@
 
 namespace esphome::nextion {
 
-static const char *const TAG = "nextion.upload.esp32";
+static const char *const TAG = "nextion.upload";
 static constexpr size_t NEXTION_MAX_RESPONSE_LOG_BYTES = 16;
 
 // Timeout for display acknowledgment during TFT upload (ms).


### PR DESCRIPTION
# What does this implement/fix?

Shortens the upload TAGs to `nextion.upload`, matching the shared upload file. Only one upload implementation is compiled into a build, so the platform suffix is redundant and the literal merges with the existing one. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`nextion.upload.esp32`, `nextion.upload.arduino`), update the entry to `nextion.upload`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).