### PR TITLE
[bluetooth_connection] Shorten platform TAG strings

### DIFF
--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -20,7 +20,7 @@
 
 namespace esphome::bluetooth_connection {
 
-static const char *const TAG = "bluetooth_connection.bluedroid";
+static const char *const TAG = "bluetooth_connection";
 
 using ble_device_base::FAST_CONN_TIMEOUT;
 using ble_device_base::FAST_MAX_CONN_INTERVAL;

--- a/esphome/components/bluetooth_connection/bluetooth_connection_rp2.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_rp2.cpp
@@ -15,7 +15,7 @@
 
 namespace esphome::bluetooth_connection {
 
-static const char *const TAG = "bluetooth_connection.rp2";
+static const char *const TAG = "bluetooth_connection";
 
 using ble_device_base::ESPBTUUID;
 using ble_device_base::GATT_ERR_NOT_CONNECTED;


### PR DESCRIPTION
# What does this implement/fix?

Shortens the bluedroid and rp2 TAGs to `bluetooth_connection`, matching the base and hub files. Only one platform implementation is compiled into a build, so the suffix is redundant and the literal merges with the existing one. Same reasoning as #15004 and #18438.

Note for users: if your `logger: logs:` config filters on one of the old tags (`bluetooth_connection.bluedroid`, `bluetooth_connection.rp2`), update the entry to `bluetooth_connection`; the old key still validates but no longer matches any log line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).