### PR TITLE
[api] Bump noise-c to 0.1.18

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -497,7 +497,11 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.17")
+        cg.add_library(
+            "noise-c",
+            "0.1.17",
+            "https://github.com/esphome-libs/noise-c.git#v0.1.17",
+        )
         # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
         cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
         cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -497,7 +497,7 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.11")
+        cg.add_library("esphome/noise-c", "0.1.17")
         # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
         cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
         cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -497,11 +497,7 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
-        cg.add_library(
-            "noise-c",
-            "0.1.17",
-            "https://github.com/esphome-libs/noise-c.git#v0.1.17",
-        )
+        cg.add_library("esphome/noise-c", "0.1.17")
         # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
         cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
         cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -497,7 +497,7 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.17")
+        cg.add_library("esphome/noise-c", "0.1.18")
         # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
         cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
         cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    https://github.com/esphome-libs/noise-c.git#v0.1.17                 ; api
+    esphome/noise-c@0.1.17                 ; api
     improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    https://github.com/esphome-libs/noise-c.git#v0.1.17                ; api
+    esphome/noise-c@0.1.17                ; api
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    https://github.com/esphome-libs/noise-c.git#v0.1.17  ; used by api
+    esphome/noise-c@0.1.17  ; used by api
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.11                 ; api
+    esphome/noise-c@0.1.17                 ; api
     improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.11                ; api
+    esphome/noise-c@0.1.17                ; api
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.11  ; used by api
+    esphome/noise-c@0.1.17  ; used by api
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.17                 ; api
+    https://github.com/esphome-libs/noise-c.git#v0.1.17                 ; api
     improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.17                ; api
+    https://github.com/esphome-libs/noise-c.git#v0.1.17                ; api
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.17  ; used by api
+    https://github.com/esphome-libs/noise-c.git#v0.1.17  ; used by api
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.17                 ; api
+    esphome/noise-c@0.1.18                 ; api
     improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.17                ; api
+    esphome/noise-c@0.1.18                ; api
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.17  ; used by api
+    esphome/noise-c@0.1.18  ; used by api
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}


### PR DESCRIPTION
# What does this implement/fix?

Bumps noise-c from 0.1.11 to 0.1.18 from the PlatformIO registry; a git tag pin was tried while the registry ingest lagged, but that silently drops noise-c from the Docker image preinstall (script/platformio_install_deps.py skips entries without @) and a registry version is an immutable pin, so the registry stays the source. The release includes esphome-libs/noise-c#20; the ChaChaPoly cipher state no longer keeps per operation working memory resident, shrinking each state from 416 to 80 bytes. The working memory moves to the stack during each encrypt or decrypt, about 340 bytes per call, far below what the curve25519 handshake steps already require, and the change is performance neutral to slightly faster since the wipe now uses libsodium's optimized memzero. An open encrypted API connection holds two cipher states, so every connection frees 672 bytes of heap.

Measured on ESP8266 hardware (esp01_1m, OTA A/B of the same config), performance is unchanged within noise; cipher state allocation drops 416 to 80 bytes, encrypt at 64/512/1390 byte payloads went from 185.4/965.7/2521.9 us to 183.4/963.8/2519.2 us, and free heap with one encrypted connection rose by 840 bytes. Correctness was verified on host against libsodium's reference ChaCha20 Poly1305 IETF AEAD, byte identical output, plus a full NNpsk0 handshake loopback.

The bump spans six releases. 0.1.12 added the ESP-IDF CMake component and moved libsodium to 1.10021.1; 0.1.13 added the LICENSE file; 0.1.14 merged upstream rweather/noise-c master and added a generic CMake target; 0.1.15 moved the Espressif registry manifest's libsodium to 1.10021.2 while the PlatformIO manifest kept 1.10021.1; 0.1.16 contained the ChaChaPoly change described above but its registry publish failed, 0.1.17 is the same code with the version files corrected, and 0.1.18 aligns the PlatformIO manifest's libsodium to 1.10021.2 so both registries ship the same transitive pin. The libsodium constraint still resolves against esp_wireguard's ^1.10018.1.

The compile test against this library change ran as draft #18425, all platforms green.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
