### PR TITLE
[lp5562] Add LP5562 4-channel I2C LED driver output component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -304,6 +304,7 @@ esphome/components/ln882x/* @lamauny
 esphome/components/lock/* @esphome/core
 esphome/components/logger/* @esphome/core
 esphome/components/logger/select/* @clydebarrow
+esphome/components/lp5562/* @DennisGaida
 esphome/components/lps22/* @nagisa
 esphome/components/lsm6ds/* @clydebarrow
 esphome/components/ltr390/* @latonita @sjtrny

--- a/esphome/components/lp5562/__init__.py
+++ b/esphome/components/lp5562/__init__.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@DennisGaida"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+lp5562_ns = cg.esphome_ns.namespace("lp5562")
+LP5562Output = lp5562_ns.class_("LP5562Output", cg.Component, i2c.I2CDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(LP5562Output),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x30))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/lp5562/lp5562_output.cpp
+++ b/esphome/components/lp5562/lp5562_output.cpp
@@ -1,0 +1,61 @@
+#include "lp5562_output.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome::lp5562 {
+
+static const char *const TAG = "lp5562";
+
+// see table 26 in the datasheet https://web.archive.org/web/20240327023921/https://www.ti.com/lit/ds/symlink/lp5562.pdf
+static const uint8_t LP5562_REG_ENABLE = 0x00;
+static const uint8_t LP5562_REG_CONFIG = 0x08;
+static const uint8_t LP5562_REG_LED_MAP = 0x70;
+
+// PWM duty-cycle registers, indexed the same way as the LP5562_CHANNELS enum in output.py
+static const uint8_t LP5562_REG_PWM[4] = {
+    0x02,  // blue
+    0x03,  // green
+    0x04,  // red
+    0x0e,  // white
+};
+
+void LP5562Output::setup() {
+  // power up the chip and enable the internal 32 kHz oscillator, see
+  // https://github.com/m5stack/M5GFX/blob/b2422cdb4735159209c2097d425c0756505b9a81/src/M5GFX.cpp#L566
+  if (!this->write_byte(LP5562_REG_ENABLE, 0x40)) {
+    this->mark_failed();
+    return;
+  }
+  delay(1);
+  // use the internal clock, and drive every channel directly from its PWM register instead of the
+  // internal blink/fade engines
+  if (!this->write_byte(LP5562_REG_CONFIG, 0x01) || !this->write_byte(LP5562_REG_LED_MAP, 0x00)) {
+    this->mark_failed();
+  }
+}
+
+void LP5562Output::dump_config() {
+  ESP_LOGCONFIG(TAG, "LP5562:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Setting up LP5562 failed!");
+  }
+}
+
+void LP5562Output::set_channel_value_(uint8_t channel, uint8_t value) {
+  if (!this->write_byte(LP5562_REG_PWM[channel], value)) {
+    this->status_set_warning();
+    return;
+  }
+  this->status_clear_warning();
+}
+
+void LP5562Output::register_channel(LP5562Channel *channel) { channel->set_parent(this); }
+
+void LP5562Channel::write_state(float state) {
+  const uint8_t max_duty = 255;
+  const auto duty = static_cast<uint8_t>(roundf(state * max_duty));
+  this->parent_->set_channel_value_(this->channel_, duty);
+}
+
+}  // namespace esphome::lp5562

--- a/esphome/components/lp5562/lp5562_output.h
+++ b/esphome/components/lp5562/lp5562_output.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/output/float_output.h"
+
+namespace esphome::lp5562 {
+
+class LP5562Output;
+
+class LP5562Channel final : public output::FloatOutput, public Parented<LP5562Output> {
+ public:
+  void set_channel(uint8_t channel) { channel_ = channel; }
+
+ protected:
+  friend class LP5562Output;
+
+  void write_state(float state) override;
+
+  uint8_t channel_;
+};
+
+/// LP5562 4-channel (RGBW) I2C LED driver.
+class LP5562Output final : public Component, public i2c::I2CDevice {
+ public:
+  void register_channel(LP5562Channel *channel);
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+ protected:
+  friend class LP5562Channel;
+
+  void set_channel_value_(uint8_t channel, uint8_t value);
+};
+
+}  // namespace esphome::lp5562

--- a/esphome/components/lp5562/output.py
+++ b/esphome/components/lp5562/output.py
@@ -1,0 +1,35 @@
+import esphome.codegen as cg
+from esphome.components import output
+import esphome.config_validation as cv
+from esphome.const import CONF_CHANNEL, CONF_ID
+
+from . import LP5562Output, lp5562_ns
+
+DEPENDENCIES = ["lp5562"]
+
+LP5562Channel = lp5562_ns.class_("LP5562Channel", output.FloatOutput)
+CONF_LP5562_ID = "lp5562_id"
+
+# Indices match the LP5562_REG_PWM lookup table in lp5562_output.cpp
+LP5562_CHANNELS = {
+    "blue": 0,
+    "green": 1,
+    "red": 2,
+    "white": 3,
+}
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(LP5562Channel),
+        cv.GenerateID(CONF_LP5562_ID): cv.use_id(LP5562Output),
+        cv.Required(CONF_CHANNEL): cv.enum(LP5562_CHANNELS, lower=True),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_LP5562_ID])
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_channel(config[CONF_CHANNEL]))
+    cg.add(parent.register_channel(var))
+    await output.register_output(var, config)

--- a/tests/components/lp5562/common.yaml
+++ b/tests/components/lp5562/common.yaml
@@ -1,0 +1,21 @@
+lp5562:
+  - address: 0x30
+    id: lp5562_1
+
+output:
+  - platform: lp5562
+    id: lp5562_red
+    channel: red
+    lp5562_id: lp5562_1
+  - platform: lp5562
+    id: lp5562_green
+    channel: green
+    lp5562_id: lp5562_1
+  - platform: lp5562
+    id: lp5562_blue
+    channel: blue
+    lp5562_id: lp5562_1
+  - platform: lp5562
+    id: lp5562_white
+    channel: white
+    lp5562_id: lp5562_1

--- a/tests/components/lp5562/test.esp32-idf.yaml
+++ b/tests/components/lp5562/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/lp5562/test.esp8266-ard.yaml
+++ b/tests/components/lp5562/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/lp5562/test.rp2040-ard.yaml
+++ b/tests/components/lp5562/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `lp5562` component supporting the TI LP5562 4-channel (RGBW) I2C LED driver as an `output.FloatOutput` platform, following the same hub/channel structure as `tlc59208f` (a parent I2C device plus per-channel child outputs referencing it via `lp5562_id`).

This generalizes a working driver I originally wrote for the M5Stack AtomS3R's display backlight (which drives the LP5562's white channel only - see https://github.com/DennisGaida/m5stack-atoms3r-components) into a reusable component that exposes all four channels (red/green/blue/white), so it can back an `rgbw` light or standalone `output`s.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/7210

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: 45
  scl: 0

lp5562:
  - id: lp5562_1
    address: 0x30

output:
  - platform: lp5562
    id: lp5562_red
    lp5562_id: lp5562_1
    channel: red
  - platform: lp5562
    id: lp5562_green
    lp5562_id: lp5562_1
    channel: green
  - platform: lp5562
    id: lp5562_blue
    lp5562_id: lp5562_1
    channel: blue
  - platform: lp5562
    id: lp5562_white
    lp5562_id: lp5562_1
    channel: white

light:
  - platform: rgbw
    name: LP5562 Light
    red: lp5562_red
    green: lp5562_green
    blue: lp5562_blue
    white: lp5562_white
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).