### PR TITLE
[socket] Fix multi-second TCP stalls on ESP8266 by yielding to the SYS context

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -536,12 +536,16 @@ ssize_t LWIPRawImpl::read_locked_(void *buf, size_t len) {
 
 ssize_t LWIPRawImpl::read(void *buf, size_t len) {
 #ifdef USE_ESP8266
-  // Yield to the SYS context so queued WiFi RX reaches lwip before we read.
+  // No buffered data: yield to the SYS context so queued WiFi RX reaches
+  // lwip, which may let this very read succeed instead of would-blocking.
   // CONT and SYS are cooperative on ESP8266; without this, inbound segments
   // can sit unprocessed for seconds during API connection setup while the
   // main loop polls a socket that lwip has not been given time to fill.
-  // Rate-limited: yields only if 1ms has passed since the last yield.
-  optimistic_yield(1000UL);
+  // Reads with data already buffered skip the yield entirely, and
+  // optimistic_yield itself rate-limits to one yield per millisecond.
+  if (this->rx_buf_ == nullptr) {
+    optimistic_yield(1000UL);
+  }
 #endif
   // See waiting_for_data_() for safety of unlocked reads.
   if (this->recv_timeout_cs_ > 0 && this->waiting_for_data_()) {
@@ -610,12 +614,6 @@ ssize_t LWIPRawImpl::internal_write_(const void *buf, size_t len) {
 }
 
 int LWIPRawImpl::internal_output_() {
-#ifdef USE_ESP8266
-  // Yield to the SYS context so the segments queued by tcp_output actually
-  // reach the WiFi driver; otherwise a written frame can sit untransmitted
-  // until an unrelated SYS slot, delaying the noise handshake by seconds.
-  optimistic_yield(1000UL);
-#endif
   LWIP_LOCK();
   if (this->pcb_ == nullptr) {
     errno = ECONNRESET;
@@ -623,6 +621,14 @@ int LWIPRawImpl::internal_output_() {
   }
   LWIP_LOG("tcp_output(%p)", this->pcb_);
   err_t err = tcp_output(this->pcb_);
+#ifdef USE_ESP8266
+  // Data was written and flushed: yield to the SYS context so the segments
+  // queued by tcp_output actually reach the WiFi driver; otherwise a written
+  // frame can sit untransmitted until an unrelated SYS slot, delaying the
+  // noise handshake by seconds. Callers only invoke this after a successful
+  // tcp_write, so the yield never runs on idle paths.
+  optimistic_yield(1000UL);
+#endif
   if (err == ERR_ABRT) {
     // sometimes lwip returns ERR_ABRT for no apparent reason
     // the connection works fine afterwards, and back with ESPAsyncTCP we

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -535,6 +535,14 @@ ssize_t LWIPRawImpl::read_locked_(void *buf, size_t len) {
 }
 
 ssize_t LWIPRawImpl::read(void *buf, size_t len) {
+#ifdef USE_ESP8266
+  // Yield to the SYS context so queued WiFi RX reaches lwip before we read.
+  // CONT and SYS are cooperative on ESP8266; without this, inbound segments
+  // can sit unprocessed for seconds during API connection setup while the
+  // main loop polls a socket that lwip has not been given time to fill.
+  // Rate-limited: yields only if 1ms has passed since the last yield.
+  optimistic_yield(1000UL);
+#endif
   // See waiting_for_data_() for safety of unlocked reads.
   if (this->recv_timeout_cs_ > 0 && this->waiting_for_data_()) {
     this->wait_for_data_();
@@ -602,6 +610,12 @@ ssize_t LWIPRawImpl::internal_write_(const void *buf, size_t len) {
 }
 
 int LWIPRawImpl::internal_output_() {
+#ifdef USE_ESP8266
+  // Yield to the SYS context so the segments queued by tcp_output actually
+  // reach the WiFi driver; otherwise a written frame can sit untransmitted
+  // until an unrelated SYS slot, delaying the noise handshake by seconds.
+  optimistic_yield(1000UL);
+#endif
   LWIP_LOCK();
   if (this->pcb_ == nullptr) {
     errno = ECONNRESET;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -631,15 +631,18 @@ int LWIPRawImpl::internal_output_() {
   }
   LWIP_LOG("tcp_output(%p)", this->pcb_);
   err_t err = tcp_output(this->pcb_);
-  if (err != ERR_OK && err != ERR_ABRT) {
+  if (err != ERR_OK) {
     LWIP_LOG("  -> err %d", err);
-    errno = ECONNRESET;
-    return -1;
+    // ERR_ABRT: sometimes lwip returns it for no apparent reason; the
+    // connection works fine afterwards, and back with ESPAsyncTCP we
+    // indirectly also ignored this error, so treat it as success for
+    // flush purposes too.
+    // FIXME: figure out where this is returned and what it means in this context
+    if (err != ERR_ABRT) {
+      errno = ECONNRESET;
+      return -1;
+    }
   }
-  // ERR_ABRT: sometimes lwip returns it for no apparent reason; the connection
-  // works fine afterwards, and back with ESPAsyncTCP we indirectly also
-  // ignored this error, so treat it as success for flush purposes too.
-  // FIXME: figure out where this is returned and what it means in this context
 #ifdef USE_ESP8266
   // Data was written and flushed: yield to the SYS context so the segments
   // queued by tcp_output actually reach the WiFi driver; otherwise a written

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -541,9 +541,10 @@ ssize_t LWIPRawImpl::read(void *buf, size_t len) {
   // CONT and SYS are cooperative on ESP8266; without this, inbound segments
   // can sit unprocessed for seconds during API connection setup while the
   // main loop polls a socket that lwip has not been given time to fill.
-  // Reads with data already buffered skip the yield entirely, and
-  // optimistic_yield itself rate-limits to one yield per millisecond.
-  if (this->rx_buf_ == nullptr) {
+  // Reads with data already buffered skip the yield entirely, as do closed
+  // or reset sockets where yielding cannot help; optimistic_yield itself
+  // rate-limits to one yield per millisecond.
+  if (this->waiting_for_data_()) {
     optimistic_yield(1000UL);
   }
 #endif
@@ -557,6 +558,9 @@ ssize_t LWIPRawImpl::read(void *buf, size_t len) {
 }
 
 ssize_t LWIPRawImpl::readv(const struct iovec *iov, int iovcnt) {
+  // No would-block yield here: the ESP8266 SYS yield lives in read() because
+  // that is the only path the API frame helpers use. If a consumer switches
+  // to scatter-gather reads, mirror the waiting_for_data_() yield from read().
   // See waiting_for_data_() for safety of unlocked reads.
   if (this->recv_timeout_cs_ > 0 && this->waiting_for_data_()) {
     this->wait_for_data_();
@@ -621,14 +625,6 @@ int LWIPRawImpl::internal_output_() {
   }
   LWIP_LOG("tcp_output(%p)", this->pcb_);
   err_t err = tcp_output(this->pcb_);
-#ifdef USE_ESP8266
-  // Data was written and flushed: yield to the SYS context so the segments
-  // queued by tcp_output actually reach the WiFi driver; otherwise a written
-  // frame can sit untransmitted until an unrelated SYS slot, delaying the
-  // noise handshake by seconds. Callers only invoke this after a successful
-  // tcp_write, so the yield never runs on idle paths.
-  optimistic_yield(1000UL);
-#endif
   if (err == ERR_ABRT) {
     // sometimes lwip returns ERR_ABRT for no apparent reason
     // the connection works fine afterwards, and back with ESPAsyncTCP we
@@ -642,6 +638,14 @@ int LWIPRawImpl::internal_output_() {
     errno = ECONNRESET;
     return -1;
   }
+#ifdef USE_ESP8266
+  // Data was written and flushed: yield to the SYS context so the segments
+  // queued by tcp_output actually reach the WiFi driver; otherwise a written
+  // frame can sit untransmitted until an unrelated SYS slot, delaying the
+  // noise handshake by seconds. Callers only invoke this after a successful
+  // tcp_write, so the yield never runs on idle or failed paths.
+  optimistic_yield(1000UL);
+#endif
   return 0;
 }
 

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -46,8 +46,7 @@ namespace esphome::socket {
 static const char *const TAG = "socket";
 
 #ifdef USE_ESP8266
-// optimistic_yield() rate-limits itself: it yields at most once per this many
-// microseconds of CONT time, so the call sites below are cheap when hot.
+// optimistic_yield() rate limit in microseconds of CONT time; cheap when hot.
 static constexpr uint32_t ESP8266_YIELD_INTERVAL_US = 1000;
 #endif
 
@@ -542,14 +541,9 @@ ssize_t LWIPRawImpl::read_locked_(void *buf, size_t len) {
 
 ssize_t LWIPRawImpl::read(void *buf, size_t len) {
 #ifdef USE_ESP8266
-  // No buffered data: yield to the SYS context so queued WiFi RX reaches
-  // lwip, which may let this very read succeed instead of would-blocking.
-  // CONT and SYS are cooperative on ESP8266; without this, inbound segments
-  // can sit unprocessed for seconds during API connection setup while the
-  // main loop polls a socket that lwip has not been given time to fill.
-  // Reads with data already buffered skip the yield entirely, as do closed
-  // or reset sockets where yielding cannot help; optimistic_yield itself
-  // rate-limits to one yield per millisecond.
+  // Would block: yield to SYS so queued WiFi RX reaches lwip and this read
+  // may succeed. Without this, inbound segments can sit unprocessed for
+  // seconds while the main loop polls (CONT/SYS are cooperative on ESP8266).
   if (this->waiting_for_data_()) {
     optimistic_yield(ESP8266_YIELD_INTERVAL_US);
   }
@@ -564,9 +558,8 @@ ssize_t LWIPRawImpl::read(void *buf, size_t len) {
 }
 
 ssize_t LWIPRawImpl::readv(const struct iovec *iov, int iovcnt) {
-  // No would-block yield here: the ESP8266 SYS yield lives in read() because
-  // that is the only path the API frame helpers use. If a consumer switches
-  // to scatter-gather reads, mirror the waiting_for_data_() yield from read().
+  // No ESP8266 SYS yield here: only read() needs it today. If a consumer
+  // switches to scatter-gather reads, mirror the yield from read().
   // See waiting_for_data_() for safety of unlocked reads.
   if (this->recv_timeout_cs_ > 0 && this->waiting_for_data_()) {
     this->wait_for_data_();
@@ -644,11 +637,9 @@ int LWIPRawImpl::internal_output_() {
     }
   }
 #ifdef USE_ESP8266
-  // Data was written and flushed: yield to the SYS context so the segments
-  // queued by tcp_output actually reach the WiFi driver; otherwise a written
-  // frame can sit untransmitted until an unrelated SYS slot, delaying the
-  // noise handshake by seconds. Callers only invoke this after a successful
-  // tcp_write, so the yield never runs on idle or failed paths.
+  // Flushed: yield to SYS so the queued segments reach the WiFi driver
+  // instead of waiting seconds for an unrelated SYS slot. Callers only get
+  // here after a successful tcp_write, so idle paths never yield.
   optimistic_yield(ESP8266_YIELD_INTERVAL_US);
 #endif
   return 0;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -45,6 +45,12 @@ namespace esphome::socket {
 
 static const char *const TAG = "socket";
 
+#ifdef USE_ESP8266
+// optimistic_yield() rate-limits itself: it yields at most once per this many
+// microseconds of CONT time, so the call sites below are cheap when hot.
+static constexpr uint32_t ESP8266_YIELD_INTERVAL_US = 1000;
+#endif
+
 // set to 1 to enable verbose lwip logging
 #if 0  // NOLINT(readability-avoid-unconditional-preprocessor-if)
 #define LWIP_LOG(msg, ...) ESP_LOGVV(TAG, "socket %p: " msg, this, ##__VA_ARGS__)
@@ -545,7 +551,7 @@ ssize_t LWIPRawImpl::read(void *buf, size_t len) {
   // or reset sockets where yielding cannot help; optimistic_yield itself
   // rate-limits to one yield per millisecond.
   if (this->waiting_for_data_()) {
-    optimistic_yield(1000UL);
+    optimistic_yield(ESP8266_YIELD_INTERVAL_US);
   }
 #endif
   // See waiting_for_data_() for safety of unlocked reads.
@@ -625,26 +631,22 @@ int LWIPRawImpl::internal_output_() {
   }
   LWIP_LOG("tcp_output(%p)", this->pcb_);
   err_t err = tcp_output(this->pcb_);
-  if (err == ERR_ABRT) {
-    // sometimes lwip returns ERR_ABRT for no apparent reason
-    // the connection works fine afterwards, and back with ESPAsyncTCP we
-    // indirectly also ignored this error
-    // FIXME: figure out where this is returned and what it means in this context
-    LWIP_LOG("  -> err ERR_ABRT");
-    return 0;
-  }
-  if (err != ERR_OK) {
+  if (err != ERR_OK && err != ERR_ABRT) {
     LWIP_LOG("  -> err %d", err);
     errno = ECONNRESET;
     return -1;
   }
+  // ERR_ABRT: sometimes lwip returns it for no apparent reason; the connection
+  // works fine afterwards, and back with ESPAsyncTCP we indirectly also
+  // ignored this error, so treat it as success for flush purposes too.
+  // FIXME: figure out where this is returned and what it means in this context
 #ifdef USE_ESP8266
   // Data was written and flushed: yield to the SYS context so the segments
   // queued by tcp_output actually reach the WiFi driver; otherwise a written
   // frame can sit untransmitted until an unrelated SYS slot, delaying the
   // noise handshake by seconds. Callers only invoke this after a successful
   // tcp_write, so the yield never runs on idle or failed paths.
-  optimistic_yield(1000UL);
+  optimistic_yield(ESP8266_YIELD_INTERVAL_US);
 #endif
   return 0;
 }


### PR DESCRIPTION
# What does this implement/fix?

Encrypted API connections on ESP8266 took 2.5 to 3.3 seconds to establish, while ESP32 takes about 63 ms. The root cause chain, established with packet captures, on device RAM probes, and concurrent high rate pings: WiFi and lwip run in the cooperative SYS context that only executes when the sketch yields; when the main loop blocks during connection setup, the WiFi RX queue overflows under normal background broadcast traffic (pings showed RTTs ramping to 700 ms then six consecutive losses), the dropped frame is whatever TCP needed next (a handshake segment or a pure ACK, one capture showed the device retransmitting an already acknowledged segment because the ACK never survived to lwip), and the stall is ordinary TCP retransmission recovery.

This PR adds a rate limited `optimistic_yield` at the two raw TCP spots where the API polls or flushes: in `read()` only when the socket would block, and after a successful `tcp_output()`. This hands SYS a slot exactly when the loop is busiest with socket work; the Arduino core does the same per character inside `uart_write`, which is how the mechanism was found. It benefits every raw TCP consumer including OTA, which uses the same read and write paths; field tested on a device on a poor network, 10 OTA uploads completed with 0 stalls where previously every upload stalled.

The other blocking window, the ~280 ms unyielding curve25519 scalar multiplication in the noise handshake, is fixed separately in esphome-libs/libsodium#31; with both in place the fix is complete. Measured on an esp01_1m against a live network: baseline stalled on every attempt (12 of 12 at 2.3 to 3.3 s, reproducible at both 80 and 160 MHz); with this PR plus the libsodium yields, 0 stalls in 24 attempts at 326 to 528 ms with a 357 ms median on the final form of both; the libsodium yields alone also measured 0 of 12 at 319 to 678 ms, and removing them again brought back 12 of 12, an A B A B confirmation. This PR alone fixes the common case (314 to 497 ms typical) with residual stalls only under heavy ambient traffic during the crypto window.

On loop time accounting, the handshake crypto already trips the component blocking warning on ESP8266 (api took 309 ms in the serial logs, threshold 300 ms) before this change; the yields can attribute additional SYS time to the calling component, none was observed in the measured runs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
