### PR TITLE
[core] Make FINAL_VALIDATE_SCHEMA functions return None

### DIFF
--- a/esphome/components/bk72xx_ble/__init__.py
+++ b/esphome/components/bk72xx_ble/__init__.py
@@ -68,12 +68,11 @@ def _unsupported_family_message(family: str) -> str | None:
     return None
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     # Warn only: a hard error here would break the validate-only CI fixtures,
     # which run on a BLE 4.2 board. The hard error is raised at codegen.
     if msg := _unsupported_family_message(libretiny.get_libretiny_family()):
         _LOGGER.warning("%s (this configuration cannot compile)", msg)
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -61,7 +61,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     full_config = fv.full_config.get()
     wifi_conf = full_config.get("wifi")
 
@@ -87,8 +87,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
 
     socket.consume_sockets(3, "captive_portal")(config)
     socket.consume_sockets(1, "captive_portal", socket.SocketType.UDP)(config)
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -88,7 +88,7 @@ async def to_code(config):
     cg.add_library("esphome/dsmr_parser", "1.9.0")
 
 
-def final_validate(config: ConfigType) -> ConfigType:
+def final_validate(config: ConfigType) -> None:
     full_config = fv.full_config.get()
 
     for uart_conf in full_config["uart"]:
@@ -101,8 +101,6 @@ def final_validate(config: ConfigType) -> ConfigType:
                     rx_buffer_size,
                 )
             break
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = final_validate

--- a/esphome/components/emontx/__init__.py
+++ b/esphome/components/emontx/__init__.py
@@ -59,7 +59,7 @@ CONFIG_SCHEMA = (
 )
 
 
-def final_validate(config: ConfigType) -> ConfigType:
+def final_validate(config: ConfigType) -> None:
     full_config = fv.full_config.get()
 
     # Count sensors registered to this hub (IDs are resolved at final_validate stage)
@@ -95,7 +95,7 @@ def final_validate(config: ConfigType) -> ConfigType:
         parity="NONE",
         stop_bits=1,
     )
-    return schema(config)
+    schema(config)
 
 
 FINAL_VALIDATE_SCHEMA = final_validate

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -153,7 +153,7 @@ def customise_schema(config):
 CONFIG_SCHEMA = customise_schema
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     spi.final_validate_device_schema(
         "epaper_spi", require_miso=False, require_mosi=True
     )(config)
@@ -170,7 +170,6 @@ def _final_validate(config):
             config[CONF_SHOW_TEST_CARD] = True
     elif CONF_UPDATE_INTERVAL not in config:
         config[CONF_UPDATE_INTERVAL] = update_interval("1min")
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1368,7 +1368,7 @@ def _validate_signed_ota_keys(config: ConfigType) -> ConfigType:
     return config
 
 
-def final_validate(config):
+def final_validate(config) -> None:
     # Imported locally to avoid circular import issues
     from esphome.components.psram import DOMAIN as PSRAM_DOMAIN
 
@@ -1628,8 +1628,6 @@ def final_validate(config):
         )
     if errs:
         raise cv.MultipleInvalid(errs)
-
-    return config
 
 
 CONF_SDKCONFIG_OPTIONS = "sdkconfig_options"

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -443,7 +443,7 @@ def validate_connection_slots(max_connections: int) -> None:
     )
 
 
-def final_validation(config):
+def final_validation(config) -> None:
     validate_variant(config)
     if (name := config.get(CONF_NAME)) is not None:
         full_config = fv.full_config.get()
@@ -513,8 +513,6 @@ def final_validation(config):
     # CONFIG_BTDM_CTRL_BLE_MAX_CONN is ESP32-specific controller limit (just connections, not ADV/SCAN)
     # For newer chips (C3/S3/etc), different configs are used automatically
     add_idf_sdkconfig_option("CONFIG_BTDM_CTRL_BLE_MAX_CONN", max_connections)
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = final_validation

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -307,7 +307,7 @@ def create_device_information_service(config):
     return config
 
 
-def final_validate_config(config):
+def final_validate_config(config) -> None:
     # Validate max_clients does not exceed esp32_ble max_connections
     max_clients = config[CONF_MAX_CLIENTS]
     if max_clients > 1:
@@ -355,7 +355,6 @@ def final_validate_config(config):
             raise cv.Invalid(
                 f"Characteristic {char_config[CONF_UUID]} has both a set_value action and a templated value"
             )
-    return config
 
 
 def validate_value_type(value_config):

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -126,7 +126,7 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     # The esp_hosted releases compatible with older ESP-IDF versions crash at
     # boot with a heap double free in the SDIO RX path (fixed in esp_hosted
     # 2.11.0, which requires ESP-IDF 5.3), so reject them at validation time.
@@ -136,7 +136,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
             "Remove the framework version from your configuration to use the "
             "recommended version, or pin a version at or above 5.3."
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -767,7 +767,7 @@ def _final_validate_rmii_pins(config: ConfigType) -> None:
             raise cv.Invalid(error_msg, path=pin_path)
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     """Final validation for Ethernet component."""
     # Allow ethernet + wifi coexistence only when both are declared in network: priority:.
     if "wifi" in fv.full_config.get():
@@ -787,7 +787,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
 
     _final_validate_spi(config)
     _final_validate_rmii_pins(config)
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/factory_reset/__init__.py
+++ b/esphome/components/factory_reset/__init__.py
@@ -60,14 +60,13 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     if CORE.is_esp8266 and CONF_RESETS_REQUIRED in config:
         fconfig = full_config.get()
         if not fconfig.get_config_for_path([KEY_ESP8266, CONF_RESTORE_FROM_FLASH]):
             raise cv.Invalid(
                 "'resets_required' needs 'restore_from_flash' to be enabled in the  'esp8266' configuration"
             )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/file/image.py
+++ b/esphome/components/file/image.py
@@ -225,7 +225,7 @@ def image_schema(class_: MockObjClass = Image_) -> cv.Schema:
     )
 
 
-def validate_image_final(config: ConfigType) -> ConfigType:
+def validate_image_final(config: ConfigType) -> None:
     """Per-entry final validation, shared by file-backed image platforms.
 
     For LVGL 9 the default byte order for RGB565 images is little-endian, so
@@ -240,7 +240,6 @@ def validate_image_final(config: ConfigType) -> ConfigType:
             )
     else:
         config[CONF_BYTE_ORDER] = "LITTLE_ENDIAN"
-    return config
 
 
 async def new_image(config: ConfigType) -> MockObj:

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -68,10 +68,10 @@ def _pin_shared_only_with_deep_sleep(pin_num: int) -> bool:
     return any(path and path[0] == "deep_sleep" for path, _, _ in pin_users)
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     use_interrupt = config[CONF_USE_INTERRUPT]
     if not use_interrupt:
-        return config
+        return
 
     # Expander pins (e.g. PCF8574, MCP23017) don't support direct interrupt
     # attachment — only internal/native GPIO pins do.
@@ -82,7 +82,7 @@ def _final_validate(config):
             config.get(CONF_NAME, config[CONF_ID]),
         )
         config[CONF_USE_INTERRUPT] = False
-        return config
+        return
 
     pin_num = config[CONF_PIN][CONF_NUMBER]
 
@@ -96,7 +96,7 @@ def _final_validate(config):
             config.get(CONF_NAME, config[CONF_ID]),
         )
         config[CONF_USE_INTERRUPT] = False
-        return config
+        return
 
     # When a pin is shared, interrupts can interfere with other components
     # (e.g., duty_cycle sensor) that need to monitor the pin's state changes.
@@ -119,8 +119,6 @@ def _final_validate(config):
                 config.get(CONF_NAME, config[CONF_ID]),
                 pin_num,
             )
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/growatt_solar/sensor.py
+++ b/esphome/components/growatt_solar/sensor.py
@@ -163,8 +163,8 @@ CONFIG_SCHEMA = (
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("growatt_solar", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("growatt_solar", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -424,7 +424,7 @@ async def power_action_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     full_config = fv.full_config.get()
     if CONF_LOGGER in full_config:
         _level = "NONE"
@@ -448,7 +448,6 @@ def _final_validate(config):
         raise cv.Invalid(
             f"No WiFi configured, if you want to use haier climate without WiFi add {CONF_WIFI_SIGNAL}: false to climate configuration"
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/haier/switch/__init__.py
+++ b/esphome/components/haier/switch/__init__.py
@@ -60,7 +60,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     full_config = fv.full_config.get()
     for switch_type in [CONF_BEEPER, CONF_QUIET_MODE]:
         # Check switches that are only supported for HonClimate
@@ -72,7 +72,6 @@ def _final_validate(config):
                 raise cv.Invalid(
                     f"{switch_type} switch is only supported for hon climate"
                 )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/havells_solar/sensor.py
+++ b/esphome/components/havells_solar/sensor.py
@@ -217,8 +217,8 @@ CONFIG_SCHEMA = (
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("havells_solar", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("havells_solar", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -315,7 +315,7 @@ def _validate_config(config: ConfigType) -> ConfigType:
     return config
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     """Validate requirements when using HUB75 display."""
     # Local imports to avoid circular dependencies
     from esphome.components.esp32 import get_esp32_variant
@@ -380,8 +380,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
 
     if errs:
         raise cv.MultipleInvalid(errs)
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = cv.Schema(_final_validate)

--- a/esphome/components/improv_serial/__init__.py
+++ b/esphome/components/improv_serial/__init__.py
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = (
 )
 
 
-def validate_logger(config):
+def validate_logger(config) -> None:
     logger_conf = fv.full_config.get()[CONF_LOGGER]
     if logger_conf[CONF_BAUD_RATE] == 0:
         raise cv.Invalid("improv_serial requires the logger baud_rate to be not 0")
@@ -33,7 +33,6 @@ def validate_logger(config):
         raise cv.Invalid(
             "improv_serial does not support the selected logger hardware_uart"
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = validate_logger

--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -146,13 +146,12 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _validate_cpu_frequency(config):
+def _validate_cpu_frequency(config) -> None:
     esp32_config = fv.full_config.get()[PLATFORM_ESP32]
     if esp32_config[CONF_CPU_FREQUENCY] != "240MHZ":
         raise cv.Invalid(
             "Inkplate requires 240MHz CPU frequency (set in esp32 component)"
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _validate_cpu_frequency

--- a/esphome/components/it8951/display.py
+++ b/esphome/components/it8951/display.py
@@ -336,7 +336,7 @@ def _customise_schema(config):
 CONFIG_SCHEMA = _customise_schema
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     # IT8951 reads from SPI (DevInfo, VCOM, register reads) so MISO is required.
     spi.final_validate_device_schema("it8951", require_miso=True, require_mosi=True)(
         config
@@ -351,7 +351,6 @@ def _final_validate(config):
                 config[CONF_UPDATE_INTERVAL] = update_interval("never")
         else:
             config[CONF_SHOW_TEST_CARD] = True
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/kuntze/sensor.py
+++ b/esphome/components/kuntze/sensor.py
@@ -89,8 +89,8 @@ CONFIG_SCHEMA = (
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("kuntze", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("kuntze", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/ld6002b/button/__init__.py
+++ b/esphome/components/ld6002b/button/__init__.py
@@ -84,7 +84,7 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-def final_validate(config: ConfigType) -> ConfigType:
+def final_validate(config: ConfigType) -> None:
     full_config = fv.full_config.get()
     hub_id = config[CONF_LD6002B_ID]
 
@@ -107,8 +107,6 @@ def final_validate(config: ConfigType) -> ConfigType:
                 f"{CONF_WAKE} requires {CONF_WAKEUP_PIN} on the parent ld6002b component",
                 path=[CONF_WAKE],
             )
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = final_validate

--- a/esphome/components/ld6002b/number/__init__.py
+++ b/esphome/components/ld6002b/number/__init__.py
@@ -105,9 +105,9 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-def final_validate(config: ConfigType) -> ConfigType:
+def final_validate(config: ConfigType) -> None:
     if config.get(CONF_AREA_CONFIG) is None:
-        return config
+        return
 
     full_config = fv.full_config.get()
     hub_id = config[CONF_LD6002B_ID]
@@ -131,8 +131,6 @@ def final_validate(config: ConfigType) -> ConfigType:
             f"{CONF_AREA_CONFIG} requires select.area_id for the same ld6002b instance",
             path=[CONF_AREA_CONFIG],
         )
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = final_validate

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -165,7 +165,7 @@ def available_effects_str(effects: list) -> str:
     return ", ".join(f"'{name}'" for name in available) if available else "none"
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     """Validate all recorded effect name references against their target lights.
 
     This runs once per light platform instance. If no light platform is configured,
@@ -173,7 +173,7 @@ def _final_validate(config: ConfigType) -> ConfigType:
     """
     data = _get_data()
     if not data.effect_refs and not data.effect_cycle_refs:
-        return config
+        return
 
     # Drain the lists so we only validate once even though
     # FINAL_VALIDATE_SCHEMA runs for each light platform instance.
@@ -216,8 +216,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
                 f"references it. Add at least one effect to the light.",
                 path=[cv.ROOT_CONFIG_PATH] + ref.component_path,
             )
-
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -34,7 +34,7 @@ CONF_NONVOLATILE_WRITE_DELAY = "nonvolatile_write_delay"
 VOLATILE_CHANNELS = ("A", "B", "C", "D")
 
 
-def _validate_nonvolatile(config):
+def _validate_nonvolatile(config) -> None:
     channel = str(config[CONF_CHANNEL])
 
     # Channels E-H address the nonvolatile registers directly — the mirroring options only
@@ -49,7 +49,7 @@ def _validate_nonvolatile(config):
                 f"enabling '{CONF_NONVOLATILE}' or setting '{CONF_NONVOLATILE_WRITE_DELAY}' is only valid for the "
                 f"volatile channels A-D; channels E-H are the nonvolatile registers themselves"
             )
-        return config
+        return
 
     config.setdefault(CONF_NONVOLATILE, True)
     if config[CONF_NONVOLATILE]:
@@ -62,7 +62,6 @@ def _validate_nonvolatile(config):
         raise cv.Invalid(
             f"'{CONF_NONVOLATILE_WRITE_DELAY}' requires '{CONF_NONVOLATILE}: true'"
         )
-    return config
 
 
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -62,7 +62,7 @@ def _consume_mdns_sockets(config: ConfigType) -> ConfigType:
     return config
 
 
-def _require_network_interface(config: ConfigType) -> ConfigType:
+def _require_network_interface(config: ConfigType) -> None:
     """Require a network interface for mDNS on Arduino/LEAmDNS platforms.
 
     On ESP8266 and RP2040 the C++ implementation needs at least one IP state
@@ -71,7 +71,7 @@ def _require_network_interface(config: ConfigType) -> ConfigType:
     that never initializes.
     """
     if config.get(CONF_DISABLED) or not (CORE.is_esp8266 or CORE.is_rp2):
-        return config
+        return
     full_config = fv.full_config.get()
     has_wifi = "wifi" in full_config
     has_ethernet = CORE.is_rp2 and "ethernet" in full_config
@@ -81,7 +81,6 @@ def _require_network_interface(config: ConfigType) -> ConfigType:
             "mdns on this platform requires a network interface — "
             f"add a {options} component to your configuration."
         )
-    return config
 
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -175,7 +175,7 @@ def _config_schema(config):
     return config
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     global_config = full_config.get()
 
     from esphome.components.lvgl import DOMAIN as LVGL_DOMAIN
@@ -183,7 +183,6 @@ def _final_validate(config):
     if not requires_buffer(config) and LVGL_DOMAIN not in global_config:
         # If no drawing methods are configured, and LVGL is not enabled, show a test card
         config[CONF_SHOW_TEST_CARD] = True
-    return config
 
 
 CONFIG_SCHEMA = _config_schema

--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -248,7 +248,7 @@ def _config_schema(config):
 CONFIG_SCHEMA = _config_schema
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     global_config = full_config.get()
 
     from esphome.components.lvgl import DOMAIN as LVGL_DOMAIN
@@ -260,7 +260,6 @@ def _final_validate(config):
         config = spi.final_validate_device_schema(
             "mipi_rgb", require_miso=False, require_mosi=True
         )(config)
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/mitsubishi_cn105/climate.py
+++ b/esphome/components/mitsubishi_cn105/climate.py
@@ -143,11 +143,11 @@ def CONFIG_SCHEMA(config: ConfigType) -> ConfigType:
 
 
 # Legacy climate-owned hub compatibility. Remove in 2027.2.0.
-def _legacy_final_validate(config: ConfigType) -> ConfigType:
+def _legacy_final_validate(config: ConfigType) -> None:
     if CONF_MITSUBISHI_CN105_ID in config:
-        return config
+        return
 
-    return uart.final_validate_device_schema(
+    uart.final_validate_device_schema(
         DOMAIN,
         require_rx=True,
         require_tx=True,

--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -135,10 +135,8 @@ def validate_modbus_register(config):
     return config
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("modbus_controller", role="client")(
-        config
-    )
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("modbus_controller", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/modbus_server/__init__.py
+++ b/esphome/components/modbus_server/__init__.py
@@ -144,8 +144,8 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("modbus_server", role="server")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("modbus_server", role="server")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/packet_transport/binary_sensor.py
+++ b/esphome/components/packet_transport/binary_sensor.py
@@ -44,10 +44,10 @@ CONFIG_SCHEMA = cv.typed_schema(
 )
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     if config[CONF_TYPE] != CONF_STATUS:
         # Only run this validation if a status sensor is being configured
-        return config
+        return
     full_config = fv.full_config.get()
     transport_path = full_config.get_path_for_id(config[CONF_TRANSPORT_ID])[:-1]
     transport_config = full_config.get_config_for_path(transport_path)
@@ -56,7 +56,7 @@ def _final_validate(config):
         for p in transport_config[CONF_PROVIDERS]
         if p[CONF_NAME] == config[CONF_PROVIDER]
     ):
-        return config
+        return
     raise cv.Invalid(
         "Status sensor requires ping-pong to be enabled and the nominated provider to use encryption."
     )

--- a/esphome/components/provisioning/__init__.py
+++ b/esphome/components/provisioning/__init__.py
@@ -67,7 +67,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     """Validate the provisioning setup once every component has been processed.
 
     Sources register during their own config validation, so by final validation
@@ -89,7 +89,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
             "hardcoding them makes the window pointless.",
             ", ".join(sorted(data.hardcoded_credentials)),
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/pzemac/sensor.py
+++ b/esphome/components/pzemac/sensor.py
@@ -98,8 +98,8 @@ async def reset_energy_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("pzemac", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("pzemac", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/pzemdc/sensor.py
+++ b/esphome/components/pzemdc/sensor.py
@@ -80,8 +80,8 @@ async def reset_energy_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("pzemdc", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("pzemdc", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/router/speaker/__init__.py
+++ b/esphome/components/router/speaker/__init__.py
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     # Validate every configured output speaker can accept the router's format.
     # Switching to an output that can't reproduce the format the producer is
     # already sending would otherwise fail silently at runtime.
@@ -76,7 +76,6 @@ def _final_validate(config: ConfigType) -> ConfigType:
             channels=config[CONF_NUM_CHANNELS],
             sample_rate=config[CONF_SAMPLE_RATE],
         )(proxy)
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/rp2040_ble/__init__.py
+++ b/esphome/components/rp2040_ble/__init__.py
@@ -71,10 +71,9 @@ def validate_connection_slots() -> None:
         )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     _validate_board(config)
     validate_connection_slots()
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/sdm_meter/sensor.py
+++ b/esphome/components/sdm_meter/sensor.py
@@ -148,8 +148,8 @@ CONFIG_SCHEMA = (
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("sdm_meter", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("sdm_meter", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/sds011/sensor.py
+++ b/esphome/components/sds011/sensor.py
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     # In the default mode setup() writes config commands, so tx is required;
     # rx_only mode never writes, so tx is optional.
     uart.final_validate_device_schema(
@@ -75,7 +75,6 @@ def _final_validate(config):
         parity="NONE",
         stop_bits=1,
     )(config)
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/selec_meter/sensor.py
+++ b/esphome/components/selec_meter/sensor.py
@@ -164,8 +164,8 @@ CONFIG_SCHEMA = (
 )
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
-    return modbus.final_validate_modbus_device("selec_meter", role="client")(config)
+def _final_validate(config: ConfigType) -> None:
+    modbus.final_validate_modbus_device("selec_meter", role="client")(config)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config):
+def _final_validate(config) -> None:
     full_config = fv.full_config.get()
     if not any(name in full_config for name in _USB_CLASS_COMPONENTS):
         raise cv.Invalid(
@@ -75,7 +75,6 @@ def _final_validate(config):
             "USB_SERIAL_JTAG on variants that support it "
             "(ESP32-S3, ESP32-S31, ESP32-P4, ESP32-H4)"
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -193,7 +193,7 @@ def _validate_no_sorting_component(
                     )
 
 
-def _final_validate_sorting(config: ConfigType) -> ConfigType:
+def _final_validate_sorting(config: ConfigType) -> None:
     if (webserver_version := config.get(CONF_VERSION)) != 3:
         _validate_no_sorting_component(
             CONF_SORTING_WEIGHT, webserver_version, fv.full_config.get()
@@ -201,7 +201,6 @@ def _final_validate_sorting(config: ConfigType) -> ConfigType:
         _validate_no_sorting_component(
             CONF_SORTING_GROUP_ID, webserver_version, fv.full_config.get()
         )
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate_sorting

--- a/esphome/components/zephyr_pwm/output.py
+++ b/esphome/components/zephyr_pwm/output.py
@@ -102,9 +102,8 @@ def _allocate_blocks() -> None:
     _get_data().pwm_blocks = pwm_blocks
 
 
-def _final_validate(config: ConfigType) -> ConfigType:
+def _final_validate(config: ConfigType) -> None:
     _allocate_blocks()
-    return config
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/zwave_proxy/__init__.py
+++ b/esphome/components/zwave_proxy/__init__.py
@@ -11,7 +11,7 @@ zwave_proxy_ns = cg.esphome_ns.namespace("zwave_proxy")
 ZWaveProxy = zwave_proxy_ns.class_("ZWaveProxy", cg.Component, uart.UARTDevice)
 
 
-def final_validate(config):
+def final_validate(config) -> None:
     full_config = fv.full_config.get()
     if (wifi_conf := full_config.get(CONF_WIFI)) and (
         wifi_conf.get(CONF_POWER_SAVE_MODE).lower() != "none"
@@ -19,8 +19,6 @@ def final_validate(config):
         raise cv.Invalid(
             f"{CONF_WIFI} {CONF_POWER_SAVE_MODE} must be set to 'none' when using Z-Wave proxy"
         )
-
-    return config
 
 
 CONFIG_SCHEMA = (

--- a/tests/component_tests/esp32_hosted/test_init.py
+++ b/tests/component_tests/esp32_hosted/test_init.py
@@ -19,7 +19,7 @@ def test_final_validate_accepts_supported_idf(
         PlatformFramework.ESP32_IDF,
         platform_data={KEY_IDF_VERSION: cv.Version.parse(idf)},
     )
-    assert _final_validate({}) == {}
+    _final_validate({})
 
 
 @pytest.mark.parametrize("idf", ["5.0.0", "5.2.2"])

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -371,27 +371,28 @@ def test_migrate_returns_none_for_invalid_legacy_shapes(
 
 
 def test_validate_image_final_defaults_to_little_endian() -> None:
-    out = validate_image_final({CONF_FILE: "x.png"})
-    assert out[CONF_BYTE_ORDER] == "LITTLE_ENDIAN"
+    config = {CONF_FILE: "x.png"}
+    validate_image_final(config)
+    assert config[CONF_BYTE_ORDER] == "LITTLE_ENDIAN"
 
 
 def test_validate_image_final_keeps_little_endian(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    config = {CONF_FILE: "x.png", CONF_BYTE_ORDER: "LITTLE_ENDIAN"}
     with caplog.at_level(logging.WARNING):
-        out = validate_image_final(
-            {CONF_FILE: "x.png", CONF_BYTE_ORDER: "LITTLE_ENDIAN"}
-        )
-    assert out[CONF_BYTE_ORDER] == "LITTLE_ENDIAN"
+        validate_image_final(config)
+    assert config[CONF_BYTE_ORDER] == "LITTLE_ENDIAN"
     assert "big-endian" not in caplog.text
 
 
 def test_validate_image_final_warns_on_big_endian(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    config = {CONF_FILE: "x.png", CONF_BYTE_ORDER: "BIG_ENDIAN"}
     with caplog.at_level(logging.WARNING):
-        out = validate_image_final({CONF_FILE: "x.png", CONF_BYTE_ORDER: "BIG_ENDIAN"})
-    assert out[CONF_BYTE_ORDER] == "BIG_ENDIAN"
+        validate_image_final(config)
+    assert config[CONF_BYTE_ORDER] == "BIG_ENDIAN"
     assert "big-endian" in caplog.text
 
 

--- a/tests/component_tests/provisioning/test_provisioning.py
+++ b/tests/component_tests/provisioning/test_provisioning.py
@@ -37,7 +37,7 @@ def test_provisioning_accepts_a_registered_source(
     set_core_config(PlatformFramework.ESP32_IDF)
     register_source("network")
     # Should not raise.
-    assert FINAL_VALIDATE_SCHEMA({}) == {}
+    FINAL_VALIDATE_SCHEMA({})
 
 
 def test_provisioning_warns_on_hardcoded_credentials(
@@ -49,7 +49,7 @@ def test_provisioning_warns_on_hardcoded_credentials(
     register_source("network")
     report_hardcoded_credentials("wifi")
     with caplog.at_level(logging.WARNING):
-        assert FINAL_VALIDATE_SCHEMA({}) == {}
+        FINAL_VALIDATE_SCHEMA({})
     assert "wifi" in caplog.text
     assert "credentials" in caplog.text
 
@@ -62,7 +62,7 @@ def test_provisioning_no_warning_without_hardcoded_credentials(
     set_core_config(PlatformFramework.ESP32_IDF)
     register_source("network")
     with caplog.at_level(logging.WARNING):
-        assert FINAL_VALIDATE_SCHEMA({}) == {}
+        FINAL_VALIDATE_SCHEMA({})
     assert "credentials" not in caplog.text
 
 


### PR DESCRIPTION
# What does this implement/fix?

`esphome/loader.py` declares the contract as `final_validate_schema: Callable[[ConfigType], None]`, and the caller in `esphome/config.py` discards the return value entirely (its docstring also says the function must not mutate the config). Despite that, 45 component functions wired to `FINAL_VALIDATE_SCHEMA` were annotated `-> ConfigType` and ended with `return config`, which is misleading because the value goes nowhere. This came out of a repo-wide type-annotation sweep, where a Copilot review on #18342 pointed out the mismatch.

Every function assigned to `FINAL_VALIDATE_SCHEMA`, directly or via `cv.Schema(...)`, now returns nothing and is annotated `-> None`. The edits take three shapes:

- A trailing `return config` is removed entirely.
- An early-exit `return config` becomes a bare `return`.
- A `return <validation call>` keeps the call as a plain statement so no validation step is silently dropped. This covers the nine `modbus.final_validate_modbus_device(...)(config)` calls, `schema(config)` in `emontx`, and `uart.final_validate_device_schema(...)(config)` in `mitsubishi_cn105`.

Some functions were deliberately left returning their value, because the return really is consumed there:

- Members of a `cv.All(...)` chain, where each validator's result feeds the next: `psram`, `zigbee`, `lcd_menu`, `mixer`, `speaker`, `speaker_source` and `wifi`.
- Callables that only resemble final validators by name: the `transform=` callbacks in `integration` and `total_daily_energy`, and the `conflict_filter` predicate in `mqtt`.
- The factory-produced closures in `esphome/core/entity_helpers.py` (`validate_no_object_id_conflicts`) and `esphome/components/image/__init__.py` (`legacy_platform_migration_warning`). Both are shared helpers whose declared type covers more than one closure, so converting them is a wider change than this PR. Happy to fold it in if reviewers prefer.

Three tests asserted on the now-discarded return value; they were updated to assert on the mutated config, or simply that no exception is raised. There is no behaviour change: annotations and return statements only.

One thing worth a reviewer's eye: `file.image.validate_image_final` is the one changed function whose docstring describes it as shared between image platforms, although in-tree it is only ever wired to `FINAL_VALIDATE_SCHEMA`. An external component that chained it through `cv.All` would need to stop relying on its return value.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

This is a Python-only change in the config validation layer, so there is nothing platform-specific to flash. It is covered by the existing unit and component test suites, which exercise these validators across the platforms above.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).