### PR TITLE
[api] Bump noise-c to 0.1.19

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -497,7 +497,7 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.18")
+        cg.add_library("esphome/noise-c", "0.1.19")
         # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
         cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
         cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.18                 ; api
+    esphome/noise-c@0.1.19                 ; api
     improv/Improv@1.2.6                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.18                ; api
+    esphome/noise-c@0.1.19                ; api
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.18  ; used by api
+    esphome/noise-c@0.1.19  ; used by api
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}


### PR DESCRIPTION
# What does this implement/fix?

Bumps noise-c from 0.1.18 to 0.1.19, which pulls in libsodium 1.10021.3. That libsodium release adds ESP8266 only yields inside the curve25519 scalar multiplication loops (esphome-libs/libsodium#31); without them the ~280 ms unyielding crypto window during the noise handshake starves the cooperative SYS context, the WiFi RX queue overflows under normal background broadcast traffic, and the connection stalls on TCP retransmission timeouts.

Measured on an esp01_1m against a live network: in conditions where every encrypted API connect stalled (12 of 12 at 2.3 to 3.3 seconds, reproducible at both 80 and 160 MHz), the yields produced 0 stalls in 24 attempts at 326 to 528 ms with a 357 ms median, confirmed with a full A B A B by removing and reapplying the patch. The crypto cost of the ~1 ms yield cadence is modest (base multiply 76 to 86 ms, DH 195 to 206 ms at 80 MHz) and confined to handshakes. Pairs with esphome/esphome#18455 which fixes the same starvation class in the raw TCP socket paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
