### PR TITLE
[ci] Fail the benchmark job when the C++ benchmark build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,10 +464,19 @@ jobs:
       - name: Build benchmarks
         id: build
         run: |
+          # pipefail: without it a failed build is masked by the grep/cut
+          # pipeline below, leaving BINARY empty and silently dropping every
+          # C++ benchmark from the run while the job still reports success.
+          set -o pipefail
           . venv/bin/activate
-          export BENCHMARK_LIB_CONFIG=$(python script/setup_codspeed_lib.py)
+          BENCHMARK_LIB_CONFIG=$(python script/setup_codspeed_lib.py)
+          export BENCHMARK_LIB_CONFIG
           # --build-only prints BUILD_BINARY=<path> to stdout
           BINARY=$(script/cpp_benchmark.py --all --build-only | grep '^BUILD_BINARY=' | tail -1 | cut -d= -f2-)
+          if [ -z "$BINARY" ]; then
+            echo "::error::Benchmark build did not report a binary path"
+            exit 1
+          fi
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
       - name: Run CodSpeed benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,8 +471,10 @@ jobs:
           . venv/bin/activate
           BENCHMARK_LIB_CONFIG=$(python script/setup_codspeed_lib.py)
           export BENCHMARK_LIB_CONFIG
-          # --build-only prints BUILD_BINARY=<path> to stdout
-          BINARY=$(script/cpp_benchmark.py --all --build-only | grep '^BUILD_BINARY=' | tail -1 | cut -d= -f2-)
+          # --build-only prints BUILD_BINARY=<path> to stdout; the grep is
+          # non-fatal so a missing marker reaches the check below instead of
+          # tripping errexit at this assignment
+          BINARY=$(script/cpp_benchmark.py --all --build-only | { grep '^BUILD_BINARY=' || true; } | tail -1 | cut -d= -f2-)
           if [ -z "$BINARY" ]; then
             echo "::error::Benchmark build did not report a binary path"
             exit 1

--- a/tests/benchmarks/components/api/__init__.py
+++ b/tests/benchmarks/components/api/__init__.py
@@ -15,6 +15,7 @@ def override_manifest(manifest: ComponentManifestOverride) -> None:
         # components have hardware dependencies (BLE/UART/RMT); lightweight
         # stub headers in tests/benchmarks/stubs/ satisfy the includes.
         cg.add_define("USE_BLUETOOTH_PROXY")
+        cg.add_define("USE_BLUETOOTH_PROXY_CONNECTIONS")
         cg.add_define("BLUETOOTH_PROXY_MAX_CONNECTIONS", 3)
         cg.add_define("BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE", 16)
         cg.add_define("USE_ZWAVE_PROXY")


### PR DESCRIPTION
> [!IMPORTANT]
> The benchmarks stopped running, this PR fixes them. https://github.com/esphome/esphome/pull/18482 fixes the perf regression. They can merge in any order

# What does this implement/fix?

The Build benchmarks step in CI could not fail. If the C++ benchmark build broke, the failure was masked by the `grep | tail | cut` pipeline, `BINARY` came back empty, and the CodSpeed step just ran the python benchmarks; the job still reported success while every C++ benchmark silently dropped out of the run.

This adds `set -o pipefail` to the step, splits the `export BENCHMARK_LIB_CONFIG=$(...)` assignment so the setup script's exit code is not masked either, and fails the job with a clear error when no binary path is reported. Split out of #18312 since it is independent of that change.

The masking is not hypothetical; the C++ benchmark build has been broken on dev since #18281 gated the bluetooth connection messages behind `USE_BLUETOOTH_PROXY_CONNECTIONS`, which the benchmark api component never defines, so the `bluetooth_proxy` stub fails to compile while the job stays green (see the build error buried in the passing job on #18482). This PR adds the missing define as well, so the gate lands together with the fix instead of failing every PR the moment it merges. Verified locally, the benchmark build fails without the define and compiles and links with it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# Not applicable, CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
