### PR TITLE
[vscode] Report the origin of an unexpected exception during validation

### DIFF
--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from io import StringIO
 import json
 from pathlib import Path
+import traceback
 from typing import Any
 
 from esphome.config import Config, _format_vol_invalid, validate_config
 import esphome.config_validation as cv
 from esphome.const import __version__ as ESPHOME_VERSION
-from esphome.core import CORE, DocumentRange
+from esphome.core import CORE, DocumentRange, EsphomeError
 from esphome.yaml_util import parse_yaml
 
 
@@ -97,6 +98,15 @@ def _ace_loader(fname: Path) -> dict[str, Any]:
     return parse_yaml(fname, raw_yaml_stream)
 
 
+def _format_unexpected_error(err: Exception) -> str:
+    """Describe a crash inside validation with the frame it came from."""
+    frame = traceback.extract_tb(err.__traceback__)[-1]
+    return (
+        f"Unexpected error while validating: {type(err).__name__}: {err} "
+        f"({frame.filename}:{frame.lineno} in {frame.name})"
+    )
+
+
 def _print_version():
     """Print ESPHome version."""
     print(
@@ -134,8 +144,10 @@ def read_config(args):
         try:
             config = loader(file_name)
             res = validate_config(config, command_line_substitutions)
-        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
+        except (EsphomeError, cv.Invalid) as err:
             vs.add_yaml_error(str(err))
+        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
+            vs.add_yaml_error(_format_unexpected_error(err))
         else:
             for err in res.errors:
                 try:

--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from io import StringIO
 import json
 from pathlib import Path
+import sys
 import traceback
 from typing import Any
 
@@ -100,11 +101,12 @@ def _ace_loader(fname: Path) -> dict[str, Any]:
 
 def _format_unexpected_error(err: Exception) -> str:
     """Describe a crash inside validation with the frame it came from."""
-    frame = traceback.extract_tb(err.__traceback__)[-1]
-    return (
-        f"Unexpected error while validating: {type(err).__name__}: {err} "
-        f"({frame.filename}:{frame.lineno} in {frame.name})"
-    )
+    message = f"Unexpected error while validating: {type(err).__name__}: {err}"
+    frames = traceback.extract_tb(err.__traceback__)
+    if not frames:
+        return message
+    frame = frames[-1]
+    return f"{message} ({frame.filename}:{frame.lineno} in {frame.name})"
 
 
 def _print_version():
@@ -147,6 +149,8 @@ def read_config(args):
         except (EsphomeError, cv.Invalid) as err:
             vs.add_yaml_error(str(err))
         except Exception as err:  # noqa: BLE001  # pylint: disable=broad-except
+            # stdout carries the JSON protocol; the full chain goes to stderr.
+            traceback.print_exc(file=sys.stderr)
             vs.add_yaml_error(_format_unexpected_error(err))
         else:
             for err in res.errors:

--- a/tests/unit_tests/test_vscode.py
+++ b/tests/unit_tests/test_vscode.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from esphome import vscode
+import esphome.config_validation as cv
 from esphome.core import EsphomeError
 
 
@@ -170,3 +171,24 @@ def test_esphome_error_stays_plain() -> None:
 
     result = json.loads(output_lines[-1])
     assert result["yaml_errors"] == [{"message": "boom"}]
+
+
+def test_invalid_stays_plain() -> None:
+    source_path = str(Path("dir_path", "x.yaml"))
+    with patch("esphome.vscode.validate_config", side_effect=cv.Invalid("bad value")):
+        output_lines = _run_repl_test(
+            [
+                _validate(source_path),
+                _file_response("""esphome:
+  name: test1
+"""),
+            ]
+        )
+
+    result = json.loads(output_lines[-1])
+    assert result["yaml_errors"] == [{"message": "bad value"}]
+
+
+def test_format_unexpected_error_without_traceback() -> None:
+    message = vscode._format_unexpected_error(ValueError("boom"))
+    assert message == "Unexpected error while validating: ValueError: boom"

--- a/tests/unit_tests/test_vscode.py
+++ b/tests/unit_tests/test_vscode.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from esphome import vscode
+from esphome.core import EsphomeError
 
 
 def _run_repl_test(input_data):
@@ -126,3 +127,46 @@ packages:
     assert range["start_col"] == 2
     assert range["end_line"] == 1
     assert range["end_col"] == 7
+
+
+def _explode(*_args, **_kwargs):
+    raise AttributeError("'NoneType' object has no attribute 'get'")
+
+
+def test_unexpected_error_reports_origin():
+    source_path = str(Path("dir_path", "x.yaml"))
+    with patch("esphome.vscode.validate_config", _explode):
+        output_lines = _run_repl_test(
+            [
+                _validate(source_path),
+                _file_response("""esphome:
+  name: test1
+"""),
+            ]
+        )
+
+    result = json.loads(output_lines[-1])
+    assert result["validation_errors"] == []
+    (error,) = result["yaml_errors"]
+    assert error["message"].startswith(
+        "Unexpected error while validating: AttributeError: "
+        "'NoneType' object has no attribute 'get' ("
+    )
+    assert "test_vscode.py" in error["message"]
+    assert error["message"].endswith(" in _explode)")
+
+
+def test_esphome_error_stays_plain():
+    source_path = str(Path("dir_path", "x.yaml"))
+    with patch("esphome.vscode.validate_config", side_effect=EsphomeError("boom")):
+        output_lines = _run_repl_test(
+            [
+                _validate(source_path),
+                _file_response("""esphome:
+  name: test1
+"""),
+            ]
+        )
+
+    result = json.loads(output_lines[-1])
+    assert result["yaml_errors"] == [{"message": "boom"}]

--- a/tests/unit_tests/test_vscode.py
+++ b/tests/unit_tests/test_vscode.py
@@ -129,11 +129,11 @@ packages:
     assert range["end_col"] == 7
 
 
-def _explode(*_args, **_kwargs):
+def _explode(*_args: object, **_kwargs: object) -> None:
     raise AttributeError("'NoneType' object has no attribute 'get'")
 
 
-def test_unexpected_error_reports_origin():
+def test_unexpected_error_reports_origin() -> None:
     source_path = str(Path("dir_path", "x.yaml"))
     with patch("esphome.vscode.validate_config", _explode):
         output_lines = _run_repl_test(
@@ -156,7 +156,7 @@ def test_unexpected_error_reports_origin():
     assert error["message"].endswith(" in _explode)")
 
 
-def test_esphome_error_stays_plain():
+def test_esphome_error_stays_plain() -> None:
     source_path = str(Path("dir_path", "x.yaml"))
     with patch("esphome.vscode.validate_config", side_effect=EsphomeError("boom")):
         output_lines = _run_repl_test(


### PR DESCRIPTION
# What does this implement/fix?

When something inside `validate_config` raises a plain Python exception (not an `EsphomeError` or `cv.Invalid`), `esphome vscode` reported only `str(err)`; the dashboard then showed a bare `'NoneType' object has no attribute 'get'` banner with no hint of where it came from. This keeps the message for real config errors unchanged and, for an unexpected exception, prefixes the exception type and appends the file, line and function it was raised from.

Example from a broken external component: `Unexpected error while validating: AttributeError: 'NoneType' object has no attribute 'get' (.../external_components/bc1d6748/components/web_server/__init__.py:315 in _final_validate_file_explorer)`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/device-builder#2587 (reported there; the actual crash was in an external component fork)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
