### PR TITLE
[platformio] Give the ccache wrapper a cmd.exe safe path

### DIFF
--- a/esphome/platformio/ccache.py.script
+++ b/esphome/platformio/ccache.py.script
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 # pylint: disable=E0602
 Import("env")  # noqa
@@ -9,15 +8,20 @@ Import("env")  # noqa
 # esphome/platformio/toolchain.py); this script only supplies the SCons-level
 # mechanism.
 #
+# The ccache binary comes pre-resolved in ESPHOME_CCACHE_PATH instead of being
+# looked up here: on Windows shutil.which() can return an extended-length
+# \\?\ path (that is how ESPHome Desktop puts its bundled ccache on PATH),
+# which SCons' cmd.exe based spawn cannot run. _ccache_env() strips the prefix
+# before exporting the path.
+#
 # This is a "pre" script, so the platform's builder (which sets CC/CXX and
 # clones the construction environment for framework and library builds) runs
 # after it. Replacing CC/CXX here would be overwritten, and replacing them in
 # a "post" script would miss the already-cloned library environments. Wrapping
 # SPAWN instead is ordering-proof: clones copy the wrapper, and every compiler
 # invocation from every environment funnels through it at execution time.
-if (
-    os.environ.get("ESPHOME_CCACHE_ENABLE") == "1"
-    and (ccache_path := shutil.which("ccache")) is not None
+if os.environ.get("ESPHOME_CCACHE_ENABLE") == "1" and (
+    ccache_path := os.environ.get("ESPHOME_CCACHE_PATH")
 ):
     original_spawn = env["SPAWN"]
 

--- a/esphome/platformio/ccache.py.script
+++ b/esphome/platformio/ccache.py.script
@@ -8,11 +8,8 @@ Import("env")  # noqa
 # esphome/platformio/toolchain.py); this script only supplies the SCons-level
 # mechanism.
 #
-# The ccache binary comes pre-resolved in ESPHOME_CCACHE_PATH instead of being
-# looked up here: on Windows shutil.which() can return an extended-length
-# \\?\ path (that is how ESPHome Desktop puts its bundled ccache on PATH),
-# which SCons' cmd.exe based spawn cannot run. _ccache_env() strips the prefix
-# before exporting the path.
+# The binary comes pre-resolved in ESPHOME_CCACHE_PATH; _ccache_env() has
+# already stripped the Windows \\?\ prefix that cmd.exe cannot run.
 #
 # This is a "pre" script, so the platform's builder (which sets CC/CXX and
 # clones the construction environment for framework and library builds) runs

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -60,6 +60,12 @@ def _strip_win_long_path_prefix(path: str) -> str:
     "The system cannot find the path specified." Stripping the prefix early
     keeps the path shell-quotable.
 
+    The same applies to tools found on ``PATH``: ESPHome Desktop puts its
+    bundled ``ccache`` on ``PATH`` under a ``\\?\`` directory, so
+    ``shutil.which("ccache")`` returns a path that ``CreateProcess`` accepts
+    but ``cmd.exe`` (which SCons uses to run every compile step) rejects with
+    the same message. See ``_ccache_env()``.
+
     No-op on non-Windows platforms.
     """
     if sys.platform != "win32":
@@ -235,18 +241,18 @@ def _check_platformio_python_stamp(config: "ProjectConfig") -> None:
         _write_pio_stamp_python(stamp_file, current)
 
 
-def _ccache_usable() -> bool:
-    """Return True when the ``ccache`` on PATH actually runs.
+def _find_usable_ccache() -> str | None:
+    """Return the path of the ``ccache`` on PATH when it actually runs.
 
     ``shutil.which`` proves existence, not runnability: on Windows it also
     matches ``.bat``/``.cmd`` wrappers and stale package-manager shims whose
     target is gone. Wrapping compiles around such a find fails every compile
     step with an opaque OS error, so probe once and fall back to compiling
-    without ccache when the probe fails.
+    without ccache (``None``) when the probe fails.
     """
     ccache = shutil.which("ccache")
     if ccache is None:
-        return False
+        return None
     try:
         subprocess.run(
             [ccache, "--version"],
@@ -260,19 +266,28 @@ def _ccache_usable() -> bool:
             "Ignoring ccache at %s because it failed to run; compiling without ccache",
             ccache,
         )
-        return False
-    return True
+        return None
+    return ccache
 
 
 def _ccache_env() -> dict[str, str]:
-    """Return ccache settings for PlatformIO builds.
+    r"""Return ccache settings for PlatformIO builds.
 
     Enabled by default whenever the ``ccache`` binary is on PATH; set
     ``ESPHOME_CCACHE_ENABLE=0`` in the environment to opt out (or ``1`` to
     force it on). The decision is normalized into ``ESPHOME_CCACHE_ENABLE``
-    so platform build scripts (e.g. the esp8266 ``ccache.py`` extra script,
-    which wraps compiler invocations inside SCons) only have to check for
-    ``"1"`` instead of re-implementing the policy.
+    and the binary's location into ``ESPHOME_CCACHE_PATH`` so platform build
+    scripts (the shared ``ccache.py`` extra script, which wraps compiler
+    invocations inside SCons) only have to check for ``"1"`` and use the
+    path as given instead of re-implementing the policy.
+
+    The path is exported rather than looked up again inside SCons because
+    ``shutil.which`` can return a Windows extended-length ``\\?\`` path
+    (ESPHome Desktop puts its bundled ccache on PATH that way). Such a path
+    runs fine through ``CreateProcess``, which is how the probe and ESP-IDF
+    invoke it, but SCons runs every compile through ``cmd.exe``, which fails
+    on it with "The system cannot find the path specified." (#18399), so the
+    prefix is stripped here with ``_strip_win_long_path_prefix()``.
 
     The returned values are merged into the environment of the PlatformIO
     subprocess only, never into ``os.environ``: a long-running process
@@ -293,13 +308,20 @@ def _ccache_env() -> dict[str, str]:
     build dir. The other ``CCACHE_*`` values the user already set in the
     environment are respected.
     """
+    ccache_path: str | None = None
     if "ESPHOME_CCACHE_ENABLE" in os.environ:
         enabled = get_bool_env("ESPHOME_CCACHE_ENABLE")
+        if enabled:
+            # Forced on: honor the choice without probing, as before.
+            ccache_path = shutil.which("ccache")
     else:
-        enabled = _ccache_usable()
+        ccache_path = _find_usable_ccache()
+        enabled = ccache_path is not None
     env = {"ESPHOME_CCACHE_ENABLE": "1" if enabled else "0"}
     if not enabled:
         return env
+    if ccache_path is not None:
+        env["ESPHOME_CCACHE_PATH"] = _strip_win_long_path_prefix(ccache_path)
     # build_path is set during preload for every config-loading command, so it
     # being unset means a caller built the environment too early; fail loudly
     # rather than with an opaque TypeError from Path(None).

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -279,10 +279,12 @@ def _ccache_env() -> dict[str, str]:
     The path is exported rather than looked up again inside SCons because
     ``shutil.which`` can return a Windows extended-length ``\\?\`` path
     (ESPHome Desktop puts its bundled ccache on PATH that way). Such a path
-    runs fine through ``CreateProcess``, which is how the probe and ESP-IDF
-    invoke it, but SCons runs every compile through ``cmd.exe``, which fails
-    on it with "The system cannot find the path specified." (#18399), so the
-    prefix is stripped here with ``_strip_win_long_path_prefix()``.
+    runs fine through ``CreateProcess``, which is how ESP-IDF invokes it,
+    but SCons runs every compile through ``cmd.exe``, which fails on it with
+    "The system cannot find the path specified." (#18399), so the prefix is
+    stripped here with ``_strip_win_long_path_prefix()`` before the
+    runnability probe, which therefore validates the exact string the build
+    will execute.
     ``ESPHOME_CCACHE_PATH`` is an internal channel, not a user setting: the
     script only honours it together with ``ESPHOME_CCACHE_ENABLE=1``, and this
     function always sets both or neither.
@@ -310,12 +312,17 @@ def _ccache_env() -> dict[str, str]:
     if explicit and not get_bool_env("ESPHOME_CCACHE_ENABLE"):
         return {"ESPHOME_CCACHE_ENABLE": "0"}
     ccache_path = shutil.which("ccache")
+    if ccache_path is None:
+        return {"ESPHOME_CCACHE_ENABLE": "0"}
+    # Strip before probing so the probe validates (and the failure warning
+    # names) the exact string the build will execute through cmd.exe.
+    ccache_path = _strip_win_long_path_prefix(ccache_path)
     # An explicit opt-in skips the runnability probe.
-    if ccache_path is None or (not explicit and not _ccache_runs(ccache_path)):
+    if not explicit and not _ccache_runs(ccache_path):
         return {"ESPHOME_CCACHE_ENABLE": "0"}
     env = {
         "ESPHOME_CCACHE_ENABLE": "1",
-        "ESPHOME_CCACHE_PATH": _strip_win_long_path_prefix(ccache_path),
+        "ESPHOME_CCACHE_PATH": ccache_path,
     }
     # build_path is set during preload for every config-loading command, so it
     # being unset means a caller built the environment too early; fail loudly

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -313,6 +313,11 @@ def _ccache_env() -> dict[str, str]:
         return {"ESPHOME_CCACHE_ENABLE": "0"}
     ccache_path = shutil.which("ccache")
     if ccache_path is None:
+        if explicit:
+            _LOGGER.warning(
+                "ESPHOME_CCACHE_ENABLE is set but no ccache binary is on PATH; "
+                "compiling without ccache"
+            )
         return {"ESPHOME_CCACHE_ENABLE": "0"}
     # Strip before probing so the probe validates (and the failure warning
     # names) the exact string the build will execute through cmd.exe.

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -60,11 +60,8 @@ def _strip_win_long_path_prefix(path: str) -> str:
     "The system cannot find the path specified." Stripping the prefix early
     keeps the path shell-quotable.
 
-    The same applies to tools found on ``PATH``: ESPHome Desktop puts its
-    bundled ``ccache`` on ``PATH`` under a ``\\?\`` directory, so
-    ``shutil.which("ccache")`` returns a path that ``CreateProcess`` accepts
-    but ``cmd.exe`` (which SCons uses to run every compile step) rejects with
-    the same message. See ``_ccache_env()``.
+    Also applied to the ccache path exported by ``_ccache_env()``, which
+    ``shutil.which`` can return with the same prefix.
 
     No-op on non-Windows platforms.
     """
@@ -241,18 +238,15 @@ def _check_platformio_python_stamp(config: "ProjectConfig") -> None:
         _write_pio_stamp_python(stamp_file, current)
 
 
-def _find_usable_ccache() -> str | None:
-    """Return the path of the ``ccache`` on PATH when it actually runs.
+def _ccache_runs(ccache: str) -> bool:
+    """Return True when the ``ccache`` found on PATH actually runs.
 
     ``shutil.which`` proves existence, not runnability: on Windows it also
     matches ``.bat``/``.cmd`` wrappers and stale package-manager shims whose
     target is gone. Wrapping compiles around such a find fails every compile
     step with an opaque OS error, so probe once and fall back to compiling
-    without ccache (``None``) when the probe fails.
+    without ccache when the probe fails.
     """
-    ccache = shutil.which("ccache")
-    if ccache is None:
-        return None
     try:
         subprocess.run(
             [ccache, "--version"],
@@ -266,8 +260,8 @@ def _find_usable_ccache() -> str | None:
             "Ignoring ccache at %s because it failed to run; compiling without ccache",
             ccache,
         )
-        return None
-    return ccache
+        return False
+    return True
 
 
 def _ccache_env() -> dict[str, str]:
@@ -275,11 +269,12 @@ def _ccache_env() -> dict[str, str]:
 
     Enabled by default whenever the ``ccache`` binary is on PATH; set
     ``ESPHOME_CCACHE_ENABLE=0`` in the environment to opt out (or ``1`` to
-    force it on). The decision is normalized into ``ESPHOME_CCACHE_ENABLE``
-    and the binary's location into ``ESPHOME_CCACHE_PATH`` so platform build
-    scripts (the shared ``ccache.py`` extra script, which wraps compiler
-    invocations inside SCons) only have to check for ``"1"`` and use the
-    path as given instead of re-implementing the policy.
+    force it on without the runnability probe; a binary is still needed).
+    The decision is normalized into ``ESPHOME_CCACHE_ENABLE`` and the
+    binary's location into ``ESPHOME_CCACHE_PATH`` so platform build scripts
+    (the shared ``ccache.py`` extra script, which wraps compiler invocations
+    inside SCons) only have to check for ``"1"`` and use the path as given
+    instead of re-implementing the policy.
 
     The path is exported rather than looked up again inside SCons because
     ``shutil.which`` can return a Windows extended-length ``\\?\`` path
@@ -288,6 +283,9 @@ def _ccache_env() -> dict[str, str]:
     invoke it, but SCons runs every compile through ``cmd.exe``, which fails
     on it with "The system cannot find the path specified." (#18399), so the
     prefix is stripped here with ``_strip_win_long_path_prefix()``.
+    ``ESPHOME_CCACHE_PATH`` is an internal channel, not a user setting: the
+    script only honours it together with ``ESPHOME_CCACHE_ENABLE=1``, and this
+    function always sets both or neither.
 
     The returned values are merged into the environment of the PlatformIO
     subprocess only, never into ``os.environ``: a long-running process
@@ -308,20 +306,17 @@ def _ccache_env() -> dict[str, str]:
     build dir. The other ``CCACHE_*`` values the user already set in the
     environment are respected.
     """
-    ccache_path: str | None = None
-    if "ESPHOME_CCACHE_ENABLE" in os.environ:
-        enabled = get_bool_env("ESPHOME_CCACHE_ENABLE")
-        if enabled:
-            # Forced on: honor the choice without probing, as before.
-            ccache_path = shutil.which("ccache")
-    else:
-        ccache_path = _find_usable_ccache()
-        enabled = ccache_path is not None
-    env = {"ESPHOME_CCACHE_ENABLE": "1" if enabled else "0"}
-    if not enabled:
-        return env
-    if ccache_path is not None:
-        env["ESPHOME_CCACHE_PATH"] = _strip_win_long_path_prefix(ccache_path)
+    explicit = "ESPHOME_CCACHE_ENABLE" in os.environ
+    if explicit and not get_bool_env("ESPHOME_CCACHE_ENABLE"):
+        return {"ESPHOME_CCACHE_ENABLE": "0"}
+    ccache_path = shutil.which("ccache")
+    # An explicit opt-in skips the runnability probe.
+    if ccache_path is None or (not explicit and not _ccache_runs(ccache_path)):
+        return {"ESPHOME_CCACHE_ENABLE": "0"}
+    env = {
+        "ESPHOME_CCACHE_ENABLE": "1",
+        "ESPHOME_CCACHE_PATH": _strip_win_long_path_prefix(ccache_path),
+    }
     # build_path is set during preload for every config-loading command, so it
     # being unset means a caller built the environment too early; fail loudly
     # rather than with an opaque TypeError from Path(None).

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -448,25 +448,34 @@ def test_ccache_env_enabled_by_default(setup_core: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "env_vars",
+    ("env_vars", "expect_warning"),
     [
-        pytest.param({}, id="default"),
-        pytest.param({"ESPHOME_CCACHE_ENABLE": "1"}, id="forced-on"),
+        pytest.param({}, False, id="default"),
+        pytest.param({"ESPHOME_CCACHE_ENABLE": "1"}, True, id="forced-on"),
     ],
 )
 def test_ccache_env_disabled_without_binary(
-    setup_core: Path, env_vars: dict[str, str]
+    setup_core: Path,
+    caplog: pytest.LogCaptureFixture,
+    env_vars: dict[str, str],
+    expect_warning: bool,
 ) -> None:
-    """Ccache stays off when the binary is not on PATH, even when forced on."""
+    """Ccache stays off when the binary is not on PATH, even when forced on.
+
+    A deliberate opt-in that finds no binary is downgraded with a warning so
+    the user can tell why it had no effect; the default path stays quiet.
+    """
     CORE.build_path = setup_core / "build" / "test"
 
     with (
         patch.dict(os.environ, env_vars, clear=True),
         patch.object(toolchain.shutil, "which", return_value=None),
+        caplog.at_level("WARNING"),
     ):
         env = toolchain._ccache_env()
 
     assert env == {"ESPHOME_CCACHE_ENABLE": "0"}
+    assert ("no ccache binary is on PATH" in caplog.text) is expect_warning
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -748,15 +748,11 @@ def _scons_win32_spawn(
 ) -> int:
     r"""Mirror of ``SCons.Platform.win32.spawn``: every command runs via ``cmd.exe /C``.
 
-    SCons is not importable in the test environment (PlatformIO fetches it as
-    a package at build time), so the few lines that matter are mirrored here;
-    they are what turns a ``\\?\`` program path into a failed compile step.
-    SCons calls ``os.spawnve`` with ``[sh, "/C", escaped]``, which the C
-    runtime joins with spaces into the ``CreateProcess`` command line; the
-    same command line is handed to ``CreateProcess`` here through
-    ``subprocess`` (a string is passed through untouched on Windows), which
-    avoids the C runtime's ``spawnve``, known to be fragile inside a larger
-    process.
+    SCons is not importable in the test environment (PlatformIO fetches it at
+    build time), so the lines that matter are mirrored here. The command line
+    SCons hands ``os.spawnve`` goes to ``CreateProcess`` via ``subprocess``
+    instead (identical on Windows, where a string passes through untouched);
+    ``spawnve`` itself crashes inside pytest.
     """
     return subprocess.run(
         " ".join([sh, "/C", escape(" ".join(args))]), env=env, check=False

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -536,8 +536,8 @@ def test_ccache_env_strips_win_long_path_prefix(setup_core: Path) -> None:
 
     assert env["ESPHOME_CCACHE_ENABLE"] == "1"
     assert env["ESPHOME_CCACHE_PATH"] == stripped
-    # The probe itself may use the path as found; CreateProcess accepts it.
-    assert mock_probe.call_args[0][0] == [prefixed, "--version"]
+    # The probe validates the exact string the build will execute.
+    assert mock_probe.call_args[0][0] == [stripped, "--version"]
 
 
 def test_ccache_env_opt_out(setup_core: Path) -> None:
@@ -782,11 +782,13 @@ _WINDOWS_ONLY = pytest.mark.skipif(
 
 
 @_WINDOWS_ONLY
-def test_ccache_env_probe_accepts_verbatim_path(setup_core: Path) -> None:
-    r"""The real probe runs a ``\\?\`` binary, so it alone cannot catch #18399.
+def test_ccache_env_real_probe_runs_stripped_path(setup_core: Path) -> None:
+    r"""With a ``\\?\`` which result, the real probe runs the stripped binary.
 
-    ``CreateProcess`` accepts extended-length paths; only ``cmd.exe`` rejects
-    them, which is why the exported path must be stripped.
+    The probe therefore validates the exact string the build will execute
+    through ``cmd.exe``; probing the verbatim path instead would pass even
+    when the stripped path is unusable (``CreateProcess`` accepts
+    extended-length paths, ``cmd.exe`` does not).
     """
     CORE.build_path = setup_core / "build" / "test"
     assert not sys.executable.startswith("\\\\?\\")

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -447,12 +447,21 @@ def test_ccache_env_enabled_by_default(setup_core: Path) -> None:
     assert "ESPHOME_CCACHE_ENABLE" not in os.environ
 
 
-def test_ccache_env_disabled_without_binary(setup_core: Path) -> None:
-    """Ccache stays off when the binary is not on PATH."""
+@pytest.mark.parametrize(
+    "env_vars",
+    [
+        pytest.param({}, id="default"),
+        pytest.param({"ESPHOME_CCACHE_ENABLE": "1"}, id="forced-on"),
+    ],
+)
+def test_ccache_env_disabled_without_binary(
+    setup_core: Path, env_vars: dict[str, str]
+) -> None:
+    """Ccache stays off when the binary is not on PATH, even when forced on."""
     CORE.build_path = setup_core / "build" / "test"
 
     with (
-        patch.dict(os.environ, {}, clear=True),
+        patch.dict(os.environ, env_vars, clear=True),
         patch.object(toolchain.shutil, "which", return_value=None),
     ):
         env = toolchain._ccache_env()
@@ -501,30 +510,10 @@ def test_ccache_env_forced_on_skips_probe(setup_core: Path) -> None:
     mock_probe.assert_not_called()
 
 
-def test_ccache_env_forced_on_without_binary_exports_no_path(
-    setup_core: Path,
-) -> None:
-    """Forcing ccache on without a binary keeps the flag but exports no path."""
-    CORE.build_path = setup_core / "build" / "test"
-
-    with (
-        patch.dict(os.environ, {"ESPHOME_CCACHE_ENABLE": "1"}, clear=True),
-        patch.object(toolchain.shutil, "which", return_value=None),
-    ):
-        env = toolchain._ccache_env()
-
-    assert env["ESPHOME_CCACHE_ENABLE"] == "1"
-    assert "ESPHOME_CCACHE_PATH" not in env
-
-
 def test_ccache_env_strips_win_long_path_prefix(setup_core: Path) -> None:
     r"""A ``\\?\`` ccache path from PATH is exported without the prefix.
 
-    ESPHome Desktop puts its bundled ccache on PATH under an extended-length
-    directory, so ``shutil.which`` returns a ``\\?\C:\...`` path. The probe
-    (CreateProcess) runs it fine, but SCons launches every compile through
-    ``cmd.exe``, which cannot run such a path and fails each step with
-    "The system cannot find the path specified." (#18399).
+    That is the shape ESPHome Desktop puts on PATH (#18399); see ``_ccache_env``.
     """
     CORE.build_path = setup_core / "build" / "test"
     prefixed = (
@@ -570,7 +559,7 @@ def test_ccache_env_normalizes_enable_value(setup_core: Path) -> None:
 
     with (
         patch.dict(os.environ, {"ESPHOME_CCACHE_ENABLE": "yes"}, clear=True),
-        patch.object(toolchain.shutil, "which", return_value=None),
+        patch.object(toolchain.shutil, "which", return_value="/usr/bin/ccache"),
     ):
         env = toolchain._ccache_env()
 
@@ -692,8 +681,11 @@ def _load_ccache_script(
     return scons_env, original_spawn
 
 
-def _quote(arg: str) -> str:
-    return f'"{arg}"'
+def _scons_win32_escape(x: str) -> str:
+    """Copy of ``SCons.Platform.win32.escape``: quote, guarding a trailing backslash."""
+    if x[-1] == "\\":
+        x = x + "\\"
+    return '"' + x + '"'
 
 
 def test_ccache_script_wraps_compiles_with_exported_path() -> None:
@@ -708,21 +700,21 @@ def test_ccache_script_wraps_compiles_with_exported_path() -> None:
     # A compile step is routed through ccache, with the same path used for
     # the program and (escaped) as the first argument.
     compile_args = ["xtensa-lx106-elf-g++", "-o", "main.o", "-c", "main.cpp"]
-    spawn("cmd.exe", _quote, "xtensa-lx106-elf-g++", list(compile_args), {})
+    spawn("cmd.exe", _scons_win32_escape, "xtensa-lx106-elf-g++", compile_args, {})
     original_spawn.assert_called_once_with(
         "cmd.exe",
-        _quote,
+        _scons_win32_escape,
         ccache_path,
-        [_quote(ccache_path), *compile_args],
+        [_scons_win32_escape(ccache_path), *compile_args],
         {},
     )
 
     # Link steps pass through untouched.
     original_spawn.reset_mock()
     link_args = ["xtensa-lx106-elf-g++", "-o", "firmware.elf", "main.o"]
-    spawn("cmd.exe", _quote, "xtensa-lx106-elf-g++", list(link_args), {})
+    spawn("cmd.exe", _scons_win32_escape, "xtensa-lx106-elf-g++", link_args, {})
     original_spawn.assert_called_once_with(
-        "cmd.exe", _quote, "xtensa-lx106-elf-g++", link_args, {}
+        "cmd.exe", _scons_win32_escape, "xtensa-lx106-elf-g++", link_args, {}
     )
 
 
@@ -740,13 +732,6 @@ def test_ccache_script_leaves_spawn_alone_without_path(
     """Without both the enable flag and a path, SPAWN is not replaced."""
     scons_env, original_spawn = _load_ccache_script(env_vars)
     assert scons_env["SPAWN"] is original_spawn
-
-
-def _scons_win32_escape(x: str) -> str:
-    """Copy of ``SCons.Platform.win32.escape``: quote, guarding a trailing backslash."""
-    if x[-1] == "\\":
-        x = x + "\\"
-    return '"' + x + '"'
 
 
 def _scons_win32_spawn(
@@ -783,65 +768,64 @@ def _spawn_fake_compile_via_cmd_exe(scons_env: _FakeSConsEnv, marker: Path) -> i
     )
 
 
-@pytest.mark.skipif(
+_WINDOWS_ONLY = pytest.mark.skipif(
     sys.platform != "win32", reason="drives cmd.exe, which SCons uses only on Windows"
 )
-def test_ccache_wrapper_compiles_through_cmd_exe_with_verbatim_ccache_path(
-    setup_core: Path, tmp_path: Path
-) -> None:
-    r"""End to end on Windows: a ``\?\`` ccache on PATH still lets SCons compile.
 
-    Reproduces the shape of #18399: ESPHome Desktop puts its bundled ccache on
-    PATH under an extended-length directory, so ``shutil.which`` hands back a
-    ``\?\C:\...`` path. Only the PATH lookup is simulated (the interpreter
-    stands in for ccache); the runnability probe and the ``cmd.exe`` spawn are
-    real, so this fails if the exported path is not usable from ``cmd.exe``.
+
+@_WINDOWS_ONLY
+def test_ccache_env_probe_accepts_verbatim_path(setup_core: Path) -> None:
+    r"""The real probe runs a ``\\?\`` binary, so it alone cannot catch #18399.
+
+    ``CreateProcess`` accepts extended-length paths; only ``cmd.exe`` rejects
+    them, which is why the exported path must be stripped.
     """
     CORE.build_path = setup_core / "build" / "test"
     assert not sys.executable.startswith("\\\\?\\")
-    verbatim_exe = "\\\\?\\" + sys.executable
-    marker = tmp_path / "compiled.txt"
 
     with (
         patch.dict(os.environ, {}, clear=False),
-        patch.object(toolchain.shutil, "which", return_value=verbatim_exe),
+        patch.object(
+            toolchain.shutil, "which", return_value="\\\\?\\" + sys.executable
+        ),
     ):
         os.environ.pop("ESPHOME_CCACHE_ENABLE", None)
-        # Real probe: CreateProcess accepts the extended-length path, so this
-        # alone would not have caught the bug.
         env = toolchain._ccache_env()
 
     assert env["ESPHOME_CCACHE_ENABLE"] == "1"
     assert env["ESPHOME_CCACHE_PATH"] == sys.executable
 
-    scons_env, _ = _load_ccache_script(env, original_spawn=_scons_win32_spawn)
-    assert scons_env["SPAWN"] is not _scons_win32_spawn
 
-    assert _spawn_fake_compile_via_cmd_exe(scons_env, marker) == 0
-    assert marker.read_text() == "compiled"
-
-
-@pytest.mark.skipif(
-    sys.platform != "win32", reason="drives cmd.exe, which SCons uses only on Windows"
+@_WINDOWS_ONLY
+@pytest.mark.parametrize(
+    ("prefix", "expect_ok"),
+    [
+        pytest.param("", True, id="stripped-path-compiles"),
+        pytest.param("\\\\?\\", False, id="verbatim-path-fails"),
+    ],
 )
-def test_ccache_wrapper_verbatim_path_fails_under_cmd_exe(tmp_path: Path) -> None:
-    r"""Control for the test above: an unstripped ``\?\`` path breaks the compile.
+def test_ccache_wrapper_through_cmd_exe(
+    tmp_path: Path, prefix: str, expect_ok: bool
+) -> None:
+    r"""End to end through ``cmd.exe``: the exported path works, a ``\\?\`` one does not.
 
-    This is the failing mechanism behind #18399 ("The system cannot find the
-    path specified." on every compile step). Should this ever start passing,
+    The interpreter stands in for ccache; the spawn mirrors SCons on Windows.
+    The failing case is the mechanism behind #18399 ("The system cannot find
+    the path specified." on every compile step); should it ever start passing,
     ``cmd.exe`` learned extended-length paths and the strip is no longer needed.
     """
     marker = tmp_path / "compiled.txt"
     scons_env, _ = _load_ccache_script(
-        {
-            "ESPHOME_CCACHE_ENABLE": "1",
-            "ESPHOME_CCACHE_PATH": "\\\\?\\" + sys.executable,
-        },
+        {"ESPHOME_CCACHE_ENABLE": "1", "ESPHOME_CCACHE_PATH": prefix + sys.executable},
         original_spawn=_scons_win32_spawn,
     )
+    assert scons_env["SPAWN"] is not _scons_win32_spawn
 
-    assert _spawn_fake_compile_via_cmd_exe(scons_env, marker) != 0
-    assert not marker.exists()
+    rc = _spawn_fake_compile_via_cmd_exe(scons_env, marker)
+    assert (rc == 0) is expect_ok
+    assert marker.exists() is expect_ok
+    if expect_ok:
+        assert marker.read_text() == "compiled"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -737,13 +737,21 @@ def test_ccache_script_leaves_spawn_alone_without_path(
 def _scons_win32_spawn(
     sh: str, escape: Callable[[str], str], cmd: str, args: list[str], env: dict
 ) -> int:
-    r"""Copy of ``SCons.Platform.win32.spawn``: every command runs via ``cmd.exe /C``.
+    r"""Mirror of ``SCons.Platform.win32.spawn``: every command runs via ``cmd.exe /C``.
 
     SCons is not importable in the test environment (PlatformIO fetches it as
     a package at build time), so the few lines that matter are mirrored here;
     they are what turns a ``\\?\`` program path into a failed compile step.
+    SCons calls ``os.spawnve`` with ``[sh, "/C", escaped]``, which the C
+    runtime joins with spaces into the ``CreateProcess`` command line; the
+    same command line is handed to ``CreateProcess`` here through
+    ``subprocess`` (a string is passed through untouched on Windows), which
+    avoids the C runtime's ``spawnve``, known to be fragile inside a larger
+    process.
     """
-    return os.spawnve(os.P_WAIT, sh, [sh, "/C", escape(" ".join(args))], env)
+    return subprocess.run(
+        " ".join([sh, "/C", escape(" ".join(args))]), env=env, check=False
+    ).returncode
 
 
 _MARKER_ENV = "ESPHOME_TEST_CCACHE_MARKER"

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=protected-access
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
@@ -437,6 +437,7 @@ def test_ccache_env_enabled_by_default(setup_core: Path) -> None:
         env = toolchain._ccache_env()
 
     assert env["ESPHOME_CCACHE_ENABLE"] == "1"
+    assert env["ESPHOME_CCACHE_PATH"] == "/usr/bin/ccache"
     assert env["CCACHE_BASEDIR"] == str((setup_core / "build" / "test").resolve())
     assert env["CCACHE_DIR"].endswith("platformio-ccache")
     assert env["CCACHE_NOHASHDIR"] == "true"
@@ -489,12 +490,65 @@ def test_ccache_env_forced_on_skips_probe(setup_core: Path) -> None:
 
     with (
         patch.dict(os.environ, {"ESPHOME_CCACHE_ENABLE": "1"}, clear=True),
+        patch.object(toolchain.shutil, "which", return_value="/usr/bin/ccache"),
         patch.object(toolchain.subprocess, "run") as mock_probe,
     ):
         env = toolchain._ccache_env()
 
     assert env["ESPHOME_CCACHE_ENABLE"] == "1"
+    # The binary's location is still handed to the build script.
+    assert env["ESPHOME_CCACHE_PATH"] == "/usr/bin/ccache"
     mock_probe.assert_not_called()
+
+
+def test_ccache_env_forced_on_without_binary_exports_no_path(
+    setup_core: Path,
+) -> None:
+    """Forcing ccache on without a binary keeps the flag but exports no path."""
+    CORE.build_path = setup_core / "build" / "test"
+
+    with (
+        patch.dict(os.environ, {"ESPHOME_CCACHE_ENABLE": "1"}, clear=True),
+        patch.object(toolchain.shutil, "which", return_value=None),
+    ):
+        env = toolchain._ccache_env()
+
+    assert env["ESPHOME_CCACHE_ENABLE"] == "1"
+    assert "ESPHOME_CCACHE_PATH" not in env
+
+
+def test_ccache_env_strips_win_long_path_prefix(setup_core: Path) -> None:
+    r"""A ``\\?\`` ccache path from PATH is exported without the prefix.
+
+    ESPHome Desktop puts its bundled ccache on PATH under an extended-length
+    directory, so ``shutil.which`` returns a ``\\?\C:\...`` path. The probe
+    (CreateProcess) runs it fine, but SCons launches every compile through
+    ``cmd.exe``, which cannot run such a path and fails each step with
+    "The system cannot find the path specified." (#18399).
+    """
+    CORE.build_path = setup_core / "build" / "test"
+    prefixed = (
+        "\\\\?\\C:\\Users\\jesse\\AppData\\Local\\ESPHome Device Builder"
+        "\\ccache\\ccache.exe"
+    )
+    stripped = (
+        "C:\\Users\\jesse\\AppData\\Local\\ESPHome Device Builder\\ccache\\ccache.exe"
+    )
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        # shutil.which is patched, so the win32 code path of the real
+        # implementation (which crashes on a POSIX host) is never reached.
+        patch("esphome.platformio.toolchain.sys.platform", "win32"),
+        patch.object(toolchain.shutil, "which", return_value=prefixed),
+        patch.object(toolchain.subprocess, "run") as mock_probe,
+    ):
+        env = toolchain._ccache_env()
+
+    assert env["ESPHOME_CCACHE_ENABLE"] == "1"
+    assert env["ESPHOME_CCACHE_PATH"] == stripped
+    # The probe itself may use the path as found; CreateProcess accepts it.
+    assert mock_probe.call_args[0][0] == [prefixed, "--version"]
 
 
 def test_ccache_env_opt_out(setup_core: Path) -> None:
@@ -563,8 +617,10 @@ def test_run_platformio_cli_passes_ccache_env_to_subprocess_only(
 
         env = mock_run_external_process.call_args[1]["env"]
         assert env["ESPHOME_CCACHE_ENABLE"] == "1"
+        assert env["ESPHOME_CCACHE_PATH"] == "/usr/bin/ccache"
         assert env["CCACHE_BASEDIR"] == str((setup_core / "build" / "test").resolve())
         assert "ESPHOME_CCACHE_ENABLE" not in os.environ
+        assert "ESPHOME_CCACHE_PATH" not in os.environ
         assert "CCACHE_BASEDIR" not in os.environ
 
 
@@ -611,6 +667,181 @@ def test_copy_ccache_script(setup_core: Path) -> None:
     dest = setup_core / "build" / "test" / "ccache.py"
     source = Path(toolchain.__file__).parent / "ccache.py.script"
     assert dest.read_text() == source.read_text()
+
+
+class _FakeSConsEnv(dict):
+    """Just enough of a SCons construction environment for ccache.py."""
+
+    def Replace(self, **kwargs: object) -> None:  # noqa: N802
+        self.update(kwargs)
+
+
+def _load_ccache_script(
+    env_vars: dict[str, str], original_spawn: Callable[..., int] | None = None
+) -> tuple[_FakeSConsEnv, Callable[..., int]]:
+    """Run ccache.py.script against a fake SCons env and return (env, original SPAWN)."""
+    if original_spawn is None:
+        original_spawn = Mock(name="original_spawn", return_value=0)
+    scons_env = _FakeSConsEnv(SPAWN=original_spawn)
+    source = (Path(toolchain.__file__).parent / "ccache.py.script").read_text()
+    with patch.dict(os.environ, env_vars, clear=True):
+        exec(  # noqa: S102
+            compile(source, "ccache.py", "exec"),
+            {"Import": lambda *_names: None, "env": scons_env},
+        )
+    return scons_env, original_spawn
+
+
+def _quote(arg: str) -> str:
+    return f'"{arg}"'
+
+
+def test_ccache_script_wraps_compiles_with_exported_path() -> None:
+    """The SCons script uses ESPHOME_CCACHE_PATH as given, without a PATH lookup."""
+    ccache_path = "C:\\Users\\jesse\\ESPHome Device Builder\\ccache\\ccache.exe"
+    scons_env, original_spawn = _load_ccache_script(
+        {"ESPHOME_CCACHE_ENABLE": "1", "ESPHOME_CCACHE_PATH": ccache_path}
+    )
+    spawn = scons_env["SPAWN"]
+    assert spawn is not original_spawn
+
+    # A compile step is routed through ccache, with the same path used for
+    # the program and (escaped) as the first argument.
+    compile_args = ["xtensa-lx106-elf-g++", "-o", "main.o", "-c", "main.cpp"]
+    spawn("cmd.exe", _quote, "xtensa-lx106-elf-g++", list(compile_args), {})
+    original_spawn.assert_called_once_with(
+        "cmd.exe",
+        _quote,
+        ccache_path,
+        [_quote(ccache_path), *compile_args],
+        {},
+    )
+
+    # Link steps pass through untouched.
+    original_spawn.reset_mock()
+    link_args = ["xtensa-lx106-elf-g++", "-o", "firmware.elf", "main.o"]
+    spawn("cmd.exe", _quote, "xtensa-lx106-elf-g++", list(link_args), {})
+    original_spawn.assert_called_once_with(
+        "cmd.exe", _quote, "xtensa-lx106-elf-g++", link_args, {}
+    )
+
+
+@pytest.mark.parametrize(
+    "env_vars",
+    [
+        pytest.param({"ESPHOME_CCACHE_ENABLE": "0"}, id="disabled"),
+        pytest.param({"ESPHOME_CCACHE_ENABLE": "1"}, id="enabled-without-path"),
+        pytest.param({}, id="unset"),
+    ],
+)
+def test_ccache_script_leaves_spawn_alone_without_path(
+    env_vars: dict[str, str],
+) -> None:
+    """Without both the enable flag and a path, SPAWN is not replaced."""
+    scons_env, original_spawn = _load_ccache_script(env_vars)
+    assert scons_env["SPAWN"] is original_spawn
+
+
+def _scons_win32_escape(x: str) -> str:
+    """Copy of ``SCons.Platform.win32.escape``: quote, guarding a trailing backslash."""
+    if x[-1] == "\\":
+        x = x + "\\"
+    return '"' + x + '"'
+
+
+def _scons_win32_spawn(
+    sh: str, escape: Callable[[str], str], cmd: str, args: list[str], env: dict
+) -> int:
+    r"""Copy of ``SCons.Platform.win32.spawn``: every command runs via ``cmd.exe /C``.
+
+    SCons is not importable in the test environment (PlatformIO fetches it as
+    a package at build time), so the few lines that matter are mirrored here;
+    they are what turns a ``\\?\`` program path into a failed compile step.
+    """
+    return os.spawnve(os.P_WAIT, sh, [sh, "/C", escape(" ".join(args))], env)
+
+
+_MARKER_ENV = "ESPHOME_TEST_CCACHE_MARKER"
+# Stands in for a compile: the "ccache" is really the Python interpreter, and
+# the compile "flags" make it write a marker file so the test can tell whether
+# the wrapped command actually ran to completion.
+_FAKE_COMPILE_ARGS = [
+    "-c",
+    f"import os, pathlib; pathlib.Path(os.environ['{_MARKER_ENV}']).write_text('compiled')",
+]
+
+
+def _spawn_fake_compile_via_cmd_exe(scons_env: _FakeSConsEnv, marker: Path) -> int:
+    """Run one wrapped compile step the way SCons does on Windows."""
+    child_env = {**os.environ, _MARKER_ENV: str(marker)}
+    return scons_env["SPAWN"](
+        os.environ.get("COMSPEC", "cmd.exe"),
+        _scons_win32_escape,
+        "xtensa-lx106-elf-gcc",
+        [_scons_win32_escape(arg) if " " in arg else arg for arg in _FAKE_COMPILE_ARGS],
+        child_env,
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="drives cmd.exe, which SCons uses only on Windows"
+)
+def test_ccache_wrapper_compiles_through_cmd_exe_with_verbatim_ccache_path(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    r"""End to end on Windows: a ``\?\`` ccache on PATH still lets SCons compile.
+
+    Reproduces the shape of #18399: ESPHome Desktop puts its bundled ccache on
+    PATH under an extended-length directory, so ``shutil.which`` hands back a
+    ``\?\C:\...`` path. Only the PATH lookup is simulated (the interpreter
+    stands in for ccache); the runnability probe and the ``cmd.exe`` spawn are
+    real, so this fails if the exported path is not usable from ``cmd.exe``.
+    """
+    CORE.build_path = setup_core / "build" / "test"
+    assert not sys.executable.startswith("\\\\?\\")
+    verbatim_exe = "\\\\?\\" + sys.executable
+    marker = tmp_path / "compiled.txt"
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch.object(toolchain.shutil, "which", return_value=verbatim_exe),
+    ):
+        os.environ.pop("ESPHOME_CCACHE_ENABLE", None)
+        # Real probe: CreateProcess accepts the extended-length path, so this
+        # alone would not have caught the bug.
+        env = toolchain._ccache_env()
+
+    assert env["ESPHOME_CCACHE_ENABLE"] == "1"
+    assert env["ESPHOME_CCACHE_PATH"] == sys.executable
+
+    scons_env, _ = _load_ccache_script(env, original_spawn=_scons_win32_spawn)
+    assert scons_env["SPAWN"] is not _scons_win32_spawn
+
+    assert _spawn_fake_compile_via_cmd_exe(scons_env, marker) == 0
+    assert marker.read_text() == "compiled"
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="drives cmd.exe, which SCons uses only on Windows"
+)
+def test_ccache_wrapper_verbatim_path_fails_under_cmd_exe(tmp_path: Path) -> None:
+    r"""Control for the test above: an unstripped ``\?\`` path breaks the compile.
+
+    This is the failing mechanism behind #18399 ("The system cannot find the
+    path specified." on every compile step). Should this ever start passing,
+    ``cmd.exe`` learned extended-length paths and the strip is no longer needed.
+    """
+    marker = tmp_path / "compiled.txt"
+    scons_env, _ = _load_ccache_script(
+        {
+            "ESPHOME_CCACHE_ENABLE": "1",
+            "ESPHOME_CCACHE_PATH": "\\\\?\\" + sys.executable,
+        },
+        original_spawn=_scons_win32_spawn,
+    )
+
+    assert _spawn_fake_compile_via_cmd_exe(scons_env, marker) != 0
+    assert not marker.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

The ESP8266 (and rp2, libretiny, host) ccache wrapper from #17722 looks up `ccache` with `shutil.which` inside the SCons pre-script and prepends that path to every compile step. On Windows, SCons runs every step through `cmd.exe /C`, and `cmd.exe` cannot run extended-length `\\?\` paths. ESPHome Desktop puts its bundled `ccache.exe` on `PATH` under exactly such a path (Tauri canonicalizes the app's own location), so `which` returns `\\?\C:\...\ESPHome Device Builder\ccache\ccache.exe`, every compile step fails with "The system cannot find the path specified." and the build ends with `Error 1`; that is the log in #18399. The probe added in #18407 did not catch it because it runs the binary through `CreateProcess`, which accepts those paths, and ESP-IDF builds are unaffected for the same reason.

`_ccache_env()` now resolves the binary once, strips the prefix with the existing `_strip_win_long_path_prefix()` (the same fix #16158 applied to `sys.executable`), and exports it as `ESPHOME_CCACHE_PATH`; the SCons script uses that path as given instead of doing its own `PATH` lookup.

Reproduced and validated on windows-latest with a real ccache reached through a `\\?\` `PATH` entry ([run](https://github.com/bdraco/esphome/actions/runs/32181526094)): 2026.8.0b4 fails exactly like the issue, this branch compiles with ccache engaged, and the plain-path control still works. Windows-only pytest tests now drive the real script through the same `cmd.exe /C` command line SCons builds, both with the stripped path (compiles) and the `\\?\` one (fails), so the mechanism stays covered in the Windows pytest job.

This is a 2026.8 beta regression and should be picked into the release branch. ESPHome Desktop is also getting a change to stop producing the prefixed path in the first place.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18399

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp8266:
  board: esp01_1m
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
