### PR TITLE
[core] Add portable strcasestr implementation named str_contains_ignore_case

### DIFF
--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -86,7 +86,7 @@ AudioFileType detect_audio_file_type(const char *content_type, const char *url) 
     // Match "audio/ogg" with a codecs parameter containing "opus"
     // Valid forms: audio/ogg;codecs=opus, audio/ogg; codecs="opus", etc.
     // Plain "audio/ogg" without opus is not matched (almost always Ogg Vorbis)
-    if (strncasecmp(content_type, "audio/ogg", 9) == 0 && strcasestr(content_type + 9, "opus") != nullptr) {
+    if (strncasecmp(content_type, "audio/ogg", 9) == 0 && esphome_strcasestr(content_type + 9, "opus") != nullptr) {
       return AudioFileType::OPUS;
     }
 #endif

--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -86,7 +86,7 @@ AudioFileType detect_audio_file_type(const char *content_type, const char *url) 
     // Match "audio/ogg" with a codecs parameter containing "opus"
     // Valid forms: audio/ogg;codecs=opus, audio/ogg; codecs="opus", etc.
     // Plain "audio/ogg" without opus is not matched (almost always Ogg Vorbis)
-    if (strncasecmp(content_type, "audio/ogg", 9) == 0 && esphome_strcasestr(content_type + 9, "opus") != nullptr) {
+    if (strncasecmp(content_type, "audio/ogg", 9) == 0 && str_contains_ignore_case(content_type + 9, "opus")) {
       return AudioFileType::OPUS;
     }
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -221,7 +221,10 @@ bool str_endswith_ignore_case(const char *str, size_t str_len, const char *suffi
 }
 
 bool str_contains_ignore_case_fallback(const char *haystack, const char *needle) {
-  const size_t needle_len = strlen(needle) if (needle_len == 0) { return true; }
+  const size_t needle_len = strlen(needle);
+  if (needle_len == 0) {
+    return true;
+  }
   for (const char *p = haystack; *p != '\0'; p++) {
     if (strncasecmp(p, needle, needle_len) == 0) {
       return true;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -220,6 +220,16 @@ bool str_endswith_ignore_case(const char *str, size_t str_len, const char *suffi
   return strncasecmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
 }
 
+bool str_contains_ignore_case_fallback(const char *haystack, const char *needle) {
+  const size_t needle_len = strlen(needle) if (needle_len == 0) { return true; }
+  for (const char *p = haystack; *p != '\0'; p++) {
+    if (strncasecmp(p, needle, needle_len) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // str_truncate, str_until, str_lower_case, str_upper_case, str_snake_case moved to alloc_helpers.cpp
 char *str_sanitize_to(char *buffer, size_t buffer_size, const char *str) {
   if (buffer_size == 0) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -981,6 +981,33 @@ inline bool str_endswith_ignore_case(const std::string &str, const char *suffix)
   return str_endswith_ignore_case(str.c_str(), str.size(), suffix, strlen(suffix));
 }
 
+inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
+  if (!needle || !haystack) {
+    return false;
+  }
+// There is no strcasestr equivalent on the
+// RP2/Arduino platform, so it needs to be
+// implemented by hand.
+#if defined(USE_RP2) || defined(USE_ARDUINO)
+  if (needle[0] == '\0') {
+    return true;
+  }
+  for (const char *p = haystack; *p != '\0'; p++) {
+    size_t i = 0;
+    while (needle[i] != '\0' &&
+           tolower(static_cast<unsigned char>(p[i])) == tolower(static_cast<unsigned char>(needle[i]))) {
+      i++;
+    }
+    if (needle[i] == '\0') {
+      return true;
+    }
+  }
+  return false;
+#else   // defined(USE_RP2) || defined(USE_ARDUINO)
+  return strcasestr(haystack, needle) != nullptr;
+#endif  // defined(USE_RP2) || defined(USE_ARDUINO)
+}
+
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0
 
 // str_until, str_lower_case, str_upper_case moved to alloc_helpers.h - remove this comment before 2026.11.0

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -988,13 +988,13 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
     return false;
   }
 // There is no strcasestr equivalent on the
-// RP2 or Zephyr platforms, so it needs to be
+// LibreTiny, RP2 or Zephyr platforms, so it needs to be
 // implemented by hand.
-#if defined(USE_RP2) || defined(USE_ZEPHYR)
+#if defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
   return str_contains_ignore_case_fallback(haystack, needle);
-#else   // defined(USE_RP2) || defined(USE_ZEPHYR)
+#else   // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
   return strcasestr(haystack, needle) != nullptr;
-#endif  // defined(USE_RP2) || defined(USE_ZEPHYR)
+#endif  // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
 }
 
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -981,8 +981,10 @@ inline bool str_endswith_ignore_case(const std::string &str, const char *suffix)
   return str_endswith_ignore_case(str.c_str(), str.size(), suffix, strlen(suffix));
 }
 
+/// Fallback implementation for case insensitive substring comparison.
 bool str_contains_ignore_case_fallback(const char *haystack, const char *needle);
 
+/// Case-insensitive check if needle string is contained in haystack (no heap allocation).
 inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
   if (!needle || !haystack) {
     return false;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -981,31 +981,20 @@ inline bool str_endswith_ignore_case(const std::string &str, const char *suffix)
   return str_endswith_ignore_case(str.c_str(), str.size(), suffix, strlen(suffix));
 }
 
+bool str_contains_ignore_case_fallback(const char *haystack, const char *needle);
+
 inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
   if (!needle || !haystack) {
     return false;
   }
 // There is no strcasestr equivalent on the
-// RP2/Arduino platform, so it needs to be
+// RP2 or Zephyr platforms, so it needs to be
 // implemented by hand.
-#if defined(USE_RP2) || defined(USE_ARDUINO) || defined(USE_NRF52)
-  if (needle[0] == '\0') {
-    return true;
-  }
-  for (const char *p = haystack; *p != '\0'; p++) {
-    size_t i = 0;
-    while (needle[i] != '\0' &&
-           tolower(static_cast<unsigned char>(p[i])) == tolower(static_cast<unsigned char>(needle[i]))) {
-      i++;
-    }
-    if (needle[i] == '\0') {
-      return true;
-    }
-  }
-  return false;
-#else   // defined(USE_RP2) || defined(USE_ARDUINO) || defined(USE_NRF52)
+#if defined(USE_RP2) || defined(USE_ZEPHYR)
+  return str_contains_ignore_case_fallback(haystack, needle);
+#else   // defined(USE_RP2) || defined(USE_ZEPHYR)
   return strcasestr(haystack, needle) != nullptr;
-#endif  // defined(USE_RP2) || defined(USE_ARDUINO) || defined(USE_NRF52)
+#endif  // defined(USE_RP2) || defined(USE_ZEPHYR)
 }
 
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -988,7 +988,7 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
 // There is no strcasestr equivalent on the
 // RP2/Arduino platform, so it needs to be
 // implemented by hand.
-#if defined(USE_RP2) || defined(USE_ARDUINO)
+#if defined(USE_RP2) || defined(USE_ARDUINO) || defined(USE_NRF52)
   if (needle[0] == '\0') {
     return true;
   }
@@ -1003,9 +1003,9 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
     }
   }
   return false;
-#else   // defined(USE_RP2) || defined(USE_ARDUINO)
+#else   // defined(USE_RP2) || defined(USE_ARDUINO) || defined(USE_NRF52)
   return strcasestr(haystack, needle) != nullptr;
-#endif  // defined(USE_RP2) || defined(USE_ARDUINO)
+#endif  // defined(USE_RP2) || defined(USE_ARDUINO) || defined(USE_NRF52)
 }
 
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -989,9 +989,10 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
   if (!needle || !haystack) {
     return false;
   }
-// There is no strcasestr equivalent on the
-// LibreTiny, RP2 or Zephyr platforms, so it needs to be
-// implemented by hand.
+
+// strcasestr is a GNU extension: newlib only declares it when _GNU_SOURCE is set.
+// ESP32/ESP8266/host builds get it from their framework or from g++ on Linux;
+// LibreTiny, RP2 and Zephyr do not, so they use the hand-rolled fallback.
 #if defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
   return str_contains_ignore_case_fallback(haystack, needle);
 #else   // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -131,23 +131,30 @@ struct LogString;
 
 // This is an ugly implementation, but there is no strcasestr equivalent
 // on the RP2/Arduino platform
-#if defined(USE_RP2) || defined(USE_ARDUINO)
+//#if defined(USE_RP2) || defined(USE_ARDUINO)
 #include <algorithm>
 inline const char *esphome_strcasestr(const char *haystack, const char *needle) {
-  std::string haystack_lower = haystack;
-  std::transform(haystack_lower.begin(), haystack_lower.end(), haystack_lower.begin(), tolower);
-  std::string needle_lower = needle;
-  std::transform(needle_lower.begin(), needle_lower.end(), needle_lower.begin(), tolower);
-
-  auto pos = haystack_lower.find(needle_lower);
-  if (pos == std::string::npos) {
+  if (!needle || !haystack) {
     return nullptr;
   }
-  return haystack + pos;
+  if (needle[0] == '\0') {
+    return haystack;
+  }
+  for (const char *p = haystack; *p != '\0'; p++) {
+    size_t i = 0;
+    while (needle[i] != '\0' &&
+           tolower(static_cast<unsigned char>(p[i])) == tolower(static_cast<unsigned char>(needle[i]))) {
+      i++;
+    }
+    if (needle[i] == '\0') {
+      return p;
+    }
+  }
+  return nullptr;
 }
 #define ESPHOME_strcasestr esphome_strcasestr
-#else  // defined(USE_RP2) || defined(USE_ARDUINO)
-#define ESPHOME_strcasestr strcasestr
-#endif  // defined(USE_RP2) || defined(USE_ARDUINO)
+//#else  // defined(USE_RP2) || defined(USE_ARDUINO)
+//#define ESPHOME_strcasestr strcasestr
+//#endif  // defined(USE_RP2) || defined(USE_ARDUINO)
 
 }  // namespace esphome

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -129,32 +129,4 @@ struct LogString;
     } \
   }
 
-// This is an ugly implementation, but there is no strcasestr equivalent
-// on the RP2/Arduino platform
-//#if defined(USE_RP2) || defined(USE_ARDUINO)
-#include <algorithm>
-inline const char *esphome_strcasestr(const char *haystack, const char *needle) {
-  if (!needle || !haystack) {
-    return nullptr;
-  }
-  if (needle[0] == '\0') {
-    return haystack;
-  }
-  for (const char *p = haystack; *p != '\0'; p++) {
-    size_t i = 0;
-    while (needle[i] != '\0' &&
-           tolower(static_cast<unsigned char>(p[i])) == tolower(static_cast<unsigned char>(needle[i]))) {
-      i++;
-    }
-    if (needle[i] == '\0') {
-      return p;
-    }
-  }
-  return nullptr;
-}
-#define ESPHOME_strcasestr esphome_strcasestr
-//#else  // defined(USE_RP2) || defined(USE_ARDUINO)
-//#define ESPHOME_strcasestr strcasestr
-//#endif  // defined(USE_RP2) || defined(USE_ARDUINO)
-
 }  // namespace esphome

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -132,7 +132,8 @@ struct LogString;
 // This is an ugly implementation, but there is no strcasestr equivalent
 // on the RP2/Arduino platform
 #if defined(USE_RP2) || defined(USE_ARDUINO)
-inline const char *esphome_strcasestr_P(const char *haystack, const char *needle) {
+#include <algorithm>
+inline const char *esphome_strcasestr(const char *haystack, const char *needle) {
   std::string haystack_lower = haystack;
   std::transform(haystack_lower.begin(), haystack_lower.end(), haystack_lower.begin(), tolower);
   std::string needle_lower = needle;
@@ -144,9 +145,9 @@ inline const char *esphome_strcasestr_P(const char *haystack, const char *needle
   }
   return haystack + pos;
 }
-#define ESPHOME_strcasestr_P esphome_strcasestr_P
+#define ESPHOME_strcasestr esphome_strcasestr
 #else  // defined(USE_RP2) || defined(USE_ARDUINO)
-#define ESPHOME_strcasestr_P strcasestr
+#define ESPHOME_strcasestr strcasestr
 #endif  // defined(USE_RP2) || defined(USE_ARDUINO)
 
 }  // namespace esphome

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -21,7 +21,6 @@
 #define ESPHOME_snprintf_P snprintf_P
 #define ESPHOME_strcmp_P strcmp_P
 #define ESPHOME_strcasecmp_P strcasecmp_P
-#define ESPHOME_strcasestr_P strcasestr_P
 #define ESPHOME_strncmp_P strncmp_P
 #define ESPHOME_strncasecmp_P strncasecmp_P
 // Type for pointers to PROGMEM strings (for use with ESPHOME_F return values)
@@ -45,7 +44,6 @@ using ProgmemStr = const __FlashStringHelper *;
 #define ESPHOME_snprintf_P snprintf
 #define ESPHOME_strcmp_P strcmp
 #define ESPHOME_strcasecmp_P strcasecmp
-#define ESPHOME_strcasestr_P strcasestr
 #define ESPHOME_strncmp_P strncmp
 #define ESPHOME_strncasecmp_P strncasecmp
 // Type for pointers to strings (no PROGMEM on non-ESP8266 platforms)
@@ -130,5 +128,24 @@ struct LogString;
       return reinterpret_cast<const ::esphome::LogString *>(get_(idx, fallback)); \
     } \
   }
+
+// This is an ugly implementation, but there is no strcasestr equivalent
+// on the RP2/Arduino platform
+#if defined(USE_RP2) || defined(USE_ARDUINO)
+inline const char *ESPHOME_strcasestr_P(const std::string haystack, const std::string needle) {
+  std::string haystack_lower = haystack;
+  std::transform(haystack.begin(), haystack.end(), haystack_lower.begin(), tolower);
+  std::string needle_lower = needle;
+  std::transform(needle.begin(), needle.end(), needle_lower.begin(), tolower);
+
+  auto pos = haystack_lower.find(needle_lower);
+  if (pos == std::string::npos) {
+    return nullptr;
+  }
+  return haystack.c_str() + pos;
+}
+#else  // defined(USE_RP2) || defined(USE_ARDUINO)
+#define ESPHOME_strcasestr_P strcasestr
+#endif  // defined(USE_RP2) || defined(USE_ARDUINO)
 
 }  // namespace esphome

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -132,18 +132,19 @@ struct LogString;
 // This is an ugly implementation, but there is no strcasestr equivalent
 // on the RP2/Arduino platform
 #if defined(USE_RP2) || defined(USE_ARDUINO)
-inline const char *ESPHOME_strcasestr_P(const std::string haystack, const std::string needle) {
+inline const char *esphome_strcasestr_P(const char *haystack, const char *needle) {
   std::string haystack_lower = haystack;
-  std::transform(haystack.begin(), haystack.end(), haystack_lower.begin(), tolower);
+  std::transform(haystack_lower.begin(), haystack_lower.end(), haystack_lower.begin(), tolower);
   std::string needle_lower = needle;
-  std::transform(needle.begin(), needle.end(), needle_lower.begin(), tolower);
+  std::transform(needle_lower.begin(), needle_lower.end(), needle_lower.begin(), tolower);
 
   auto pos = haystack_lower.find(needle_lower);
   if (pos == std::string::npos) {
     return nullptr;
   }
-  return haystack.c_str() + pos;
+  return haystack + pos;
 }
+#define ESPHOME_strcasestr_P esphome_strcasestr_P
 #else  // defined(USE_RP2) || defined(USE_ARDUINO)
 #define ESPHOME_strcasestr_P strcasestr
 #endif  // defined(USE_RP2) || defined(USE_ARDUINO)

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -21,6 +21,7 @@
 #define ESPHOME_snprintf_P snprintf_P
 #define ESPHOME_strcmp_P strcmp_P
 #define ESPHOME_strcasecmp_P strcasecmp_P
+#define ESPHOME_strcasestr_P strcasestr_P
 #define ESPHOME_strncmp_P strncmp_P
 #define ESPHOME_strncasecmp_P strncasecmp_P
 // Type for pointers to PROGMEM strings (for use with ESPHOME_F return values)
@@ -44,6 +45,7 @@ using ProgmemStr = const __FlashStringHelper *;
 #define ESPHOME_snprintf_P snprintf
 #define ESPHOME_strcmp_P strcmp
 #define ESPHOME_strcasecmp_P strcasecmp
+#define ESPHOME_strcasestr_P strcasestr
 #define ESPHOME_strncmp_P strncmp
 #define ESPHOME_strncasecmp_P strncasecmp
 // Type for pointers to strings (no PROGMEM on non-ESP8266 platforms)

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -110,7 +110,10 @@ TEST(StringContainsIgnoreCaseTest, MiscCaseMatches) {
 TEST(StringContainsIgnoreCaseTest, MiscNotMatching) {
   const char *haystack = "Hello World";
 
+  // Expected to match
   EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hell"));
+
+  // Expected not to match
   EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Heaven"));
   EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Hello!"));
   EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "world!"));

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -119,4 +119,14 @@ TEST(StringContainsIgnoreCaseTest, MiscNotMatching) {
   EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "world!"));
 }
 
+TEST(StringContainsIgnoreCaseTest, FallbackMatchesLibc) {
+  const char *haystack = "Hello World";
+  for (const char *needle : {"", "Hello", "hELLO", "Hell", "world", "Heaven", "Hello!", "d"}) {
+    EXPECT_EQ(str_contains_ignore_case_fallback(haystack, needle), str_contains_ignore_case(haystack, needle))
+        << "needle: " << needle;
+  }
+  EXPECT_EQ(str_contains_ignore_case_fallback("", ""), str_contains_ignore_case("", ""));
+  EXPECT_EQ(str_contains_ignore_case_fallback("ab", "abc"), str_contains_ignore_case("ab", "abc"));
+}
+
 }  // namespace esphome

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -87,33 +87,33 @@ TEST(StringContainsIgnoreCaseTest, NullPointerAlwaysFalse) {
   const char *haystack = nullptr;
   const char *needle = nullptr;
 
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, needle);
-  EXPECT_FALSE(str_contains_ignore_case_fallback("Hello World", needle);
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "anything");
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, needle));
+  EXPECT_FALSE(str_contains_ignore_case_fallback("Hello World", needle));
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "anything"));
 }
 
 TEST(StringContainsIgnoreCaseTest, EmptySearchMatches) {
   const char *haystack = "Hello World";
 
-  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "");
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, ""));
 }
 
 TEST(StringContainsIgnoreCaseTest, MiscCaseMatches) {
   const char *haystack = "Hello World";
 
-  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hello");
-  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "hello");
-  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "HELLO");
-  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "hELLO");
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hello"));
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "hello"));
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "HELLO"));
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "hELLO"));
 }
 
 TEST(StringContainsIgnoreCaseTest, MiscNotMatching) {
   const char *haystack = "Hello World";
 
-  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hell");
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Heaven");
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Hello!");
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "world!");
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hell"));
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Heaven"));
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Hello!"));
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "world!"));
 }
 
 }  // namespace esphome

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -87,9 +87,9 @@ TEST(StringContainsIgnoreCaseTest, NullPointerAlwaysFalse) {
   const char *haystack = nullptr;
   const char *needle = nullptr;
 
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, needle));
-  EXPECT_FALSE(str_contains_ignore_case_fallback("Hello World", needle));
-  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "anything"));
+  EXPECT_FALSE(str_contains_ignore_case(haystack, needle));
+  EXPECT_FALSE(str_contains_ignore_case("Hello World", needle));
+  EXPECT_FALSE(str_contains_ignore_case(haystack, "anything"));
 }
 
 TEST(StringContainsIgnoreCaseTest, EmptySearchMatches) {

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -83,4 +83,37 @@ TEST(StaticVectorTest, ConvertingConstructorSameSize) {
   EXPECT_EQ(dst[2], 3);
 }
 
+TEST(StringContainsIgnoreCaseTest, NullPointerAlwaysFalse) {
+  const char *haystack = nullptr;
+  const char *needle = nullptr;
+
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, needle);
+  EXPECT_FALSE(str_contains_ignore_case_fallback("Hello World", needle);
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "anything");
+}
+
+TEST(StringContainsIgnoreCaseTest, EmptySearchMatches) {
+  const char *haystack = "Hello World";
+
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "");
+}
+
+TEST(StringContainsIgnoreCaseTest, MiscCaseMatches) {
+  const char *haystack = "Hello World";
+
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hello");
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "hello");
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "HELLO");
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "hELLO");
+}
+
+TEST(StringContainsIgnoreCaseTest, MiscNotMatching) {
+  const char *haystack = "Hello World";
+
+  EXPECT_TRUE(str_contains_ignore_case_fallback(haystack, "Hell");
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Heaven");
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "Hello!");
+  EXPECT_FALSE(str_contains_ignore_case_fallback(haystack, "world!");
+}
+
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Some platforms do not directly support strcasestr; add a direct implementation in helpers.h to allow the functionality to work.
(strcasestr is only available if _GNU_SOURCE is defined)

Adapt the audio component code to use the new method instead (in esp32 it will defer to the library implementation anyway).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes An issue with tests on #16337 

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

Manually tested on the host platform by forcing it to use the new implementation (for the tests).

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
