### PR TITLE
[core] Add add_cmake_arg

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -7,6 +7,7 @@ from esphome.components.esp32 import get_esp32_variant, idf_version
 import esphome.config_validation as cv
 from esphome.core import CORE
 from esphome.framework_helpers import (
+    get_project_cmake_args,
     get_project_compile_flags,
     get_project_cxx_compile_flags,
     get_project_link_flags,
@@ -109,6 +110,11 @@ def get_project_cmakelists(minimal: bool = False) -> str:
         else ""
     )
 
+    cmake_args = "\n".join(
+        f'set({name} "{value.replace("\\", "\\\\").replace('"', '\\"')}")'
+        for name, value in get_project_cmake_args()
+    )
+
     # Per-project list exposed as a CMake variable so converted PIO libs
     # can reference ${ESPHOME_PROJECT_MANAGED_COMPONENTS} without baking
     # project-specific names into their cached CMakeLists.
@@ -162,6 +168,8 @@ set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1)
 
 set(IDF_TARGET {idf_target})
 set(EXTRA_COMPONENT_DIRS ${{CMAKE_SOURCE_DIR}}/src)
+
+{cmake_args}
 
 include($ENV{{IDF_PATH}}/tools/cmake/project.cmake)
 

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -72,6 +72,13 @@ def has_discovered_components() -> bool:
     return get_available_components() is not None
 
 
+def _cmake_quote(value: str) -> str:
+    """Quote a cmake arg value for a set() line. add_cmake_arg rejects
+    whitespace, quotes, and '$', so only backslashes need escaping."""
+    escaped = value.replace("\\", "\\\\")
+    return f'"{escaped}"'
+
+
 def get_project_cmakelists(minimal: bool = False) -> str:
     """Generate the top-level CMakeLists.txt for ESP-IDF project.
 
@@ -118,10 +125,8 @@ def get_project_cmakelists(minimal: bool = False) -> str:
     # include(project.cmake) so values like EXCLUDE_COMPONENTS are already
     # set when project.cmake seeds the component list, and on minimal
     # (discovery) writes too so excluded components never register.
-    # add_cmake_arg rejects whitespace and quotes, so only backslashes
-    # need escaping here.
     cmake_args = "\n".join(
-        f'set({name} "{value.replace("\\", "\\\\")}")'
+        f"set({name} {_cmake_quote(value)})"
         for name, value in sorted(CORE.cmake_args.items())
     )
 
@@ -149,6 +154,8 @@ def get_project_cmakelists(minimal: bool = False) -> str:
     # project_description.json from a build without exclusions may still
     # list them, and requiring an excluded component pulls it back into
     # the build (IDF requirement expansion overrides EXCLUDE_COMPONENTS).
+    # Derived from the EXCLUDE_COMPONENTS cmake arg emitted above so the
+    # two can never disagree within one generated file.
     builtin_components_property = (
         ""
         if minimal
@@ -156,7 +163,7 @@ def get_project_cmakelists(minimal: bool = False) -> str:
             f"idf_build_set_property(ESPHOME_PROJECT_BUILTIN_COMPONENTS {name} APPEND)"
             for name in sorted(
                 set(get_available_components() or []).difference(
-                    get_excluded_builtin_components()
+                    CORE.cmake_args.get("EXCLUDE_COMPONENTS", "").split(";")
                 )
             )
         )

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -12,7 +12,6 @@ from esphome.components.esp32 import (
 import esphome.config_validation as cv
 from esphome.core import CORE
 from esphome.framework_helpers import (
-    get_project_cmake_args,
     get_project_compile_flags,
     get_project_cxx_compile_flags,
     get_project_link_flags,
@@ -119,9 +118,11 @@ def get_project_cmakelists(minimal: bool = False) -> str:
     # include(project.cmake) so values like EXCLUDE_COMPONENTS are already
     # set when project.cmake seeds the component list, and on minimal
     # (discovery) writes too so excluded components never register.
+    # add_cmake_arg rejects whitespace and quotes, so only backslashes
+    # need escaping here.
     cmake_args = "\n".join(
-        f'set({name} "{value.replace("\\", "\\\\").replace('"', '\\"')}")'
-        for name, value in get_project_cmake_args()
+        f'set({name} "{value.replace("\\", "\\\\")}")'
+        for name, value in sorted(CORE.cmake_args.items())
     )
 
     # Per-project list exposed as a CMake variable so converted PIO libs
@@ -139,13 +140,6 @@ def get_project_cmakelists(minimal: bool = False) -> str:
         for name in get_managed_component_require_names()
     )
 
-    # Components excluded from the build (DEFAULT_EXCLUDED_IDF_COMPONENTS
-    # minus per-component re-includes). The EXCLUDE_COMPONENTS variable
-    # itself is emitted through the cmake_args block above (registered by
-    # esp32 at FINAL priority); the set is still needed here to filter the
-    # built-in component list below.
-    excluded_components = get_excluded_builtin_components()
-
     # Built-in IDF components exposed via our own property (not IDF's
     # __COMPONENT_REQUIRES_COMMON, which would append them to every
     # component's REQUIRES including real IDF components). Referenced by
@@ -161,7 +155,9 @@ def get_project_cmakelists(minimal: bool = False) -> str:
         else "\n".join(
             f"idf_build_set_property(ESPHOME_PROJECT_BUILTIN_COMPONENTS {name} APPEND)"
             for name in sorted(
-                set(get_available_components() or []).difference(excluded_components)
+                set(get_available_components() or []).difference(
+                    get_excluded_builtin_components()
+                )
             )
         )
     )

--- a/esphome/build_gen/platformio.py
+++ b/esphome/build_gen/platformio.py
@@ -63,6 +63,13 @@ def get_ini_content():
     # Add extra script for C++ flags
     CORE.add_platformio_option("extra_scripts", [f"pre:{CXX_FLAGS_FILE_NAME}"])
 
+    # Add CMake args
+    if CORE.cmake_args:
+        cmake_extra_args = " ".join(
+            f"-D{name}={value}" for name, value in sorted(CORE.cmake_args.items())
+        )
+        CORE.add_platformio_option("board_build.cmake_extra_args", cmake_extra_args)
+
     content = "[platformio]\n"
     content += f"description = ESPHome {__version__}\n"
 

--- a/esphome/build_gen/platformio.py
+++ b/esphome/build_gen/platformio.py
@@ -1,5 +1,6 @@
 from esphome.const import __version__
 from esphome.core import CORE
+from esphome.framework_helpers import get_project_cmake_args
 from esphome.helpers import mkdir_p, read_file, write_file_if_changed
 from esphome.writer import find_begin_end
 
@@ -63,12 +64,14 @@ def get_ini_content():
     # Add extra script for C++ flags
     CORE.add_platformio_option("extra_scripts", [f"pre:{CXX_FLAGS_FILE_NAME}"])
 
-    # Add CMake args
-    if CORE.cmake_args:
-        cmake_extra_args = " ".join(
-            f"-D{name}={value}" for name, value in sorted(CORE.cmake_args.items())
+    # Add CMake args. Written directly instead of via add_platformio_option:
+    # a user-supplied value is deliberately overwritten (it always was, at
+    # FINAL priority), and it may be a list, which add_platformio_option
+    # would try to append to and assert on the string value.
+    if cmake_args := get_project_cmake_args():
+        CORE.platformio_options["board_build.cmake_extra_args"] = " ".join(
+            f"-D{name}={value}" for name, value in cmake_args
         )
-        CORE.add_platformio_option("board_build.cmake_extra_args", cmake_extra_args)
 
     content = "[platformio]\n"
     content += f"description = ESPHome {__version__}\n"

--- a/esphome/build_gen/platformio.py
+++ b/esphome/build_gen/platformio.py
@@ -1,6 +1,5 @@
 from esphome.const import __version__
 from esphome.core import CORE
-from esphome.framework_helpers import get_project_cmake_args
 from esphome.helpers import mkdir_p, read_file, write_file_if_changed
 from esphome.writer import find_begin_end
 
@@ -64,13 +63,15 @@ def get_ini_content():
     # Add extra script for C++ flags
     CORE.add_platformio_option("extra_scripts", [f"pre:{CXX_FLAGS_FILE_NAME}"])
 
-    # Add CMake args. Written directly instead of via add_platformio_option:
-    # a user-supplied value is deliberately overwritten (it always was, at
-    # FINAL priority), and it may be a list, which add_platformio_option
-    # would try to append to and assert on the string value.
-    if cmake_args := get_project_cmake_args():
-        CORE.platformio_options["board_build.cmake_extra_args"] = " ".join(
-            f"-D{name}={value}" for name, value in cmake_args
+    # Add CMake args. A user-supplied value (str or list) is deliberately
+    # replaced; this option was always overwritten at FINAL priority.
+    if CORE.cmake_args:
+        CORE.add_platformio_option(
+            "board_build.cmake_extra_args",
+            " ".join(
+                f"-D{name}={value}" for name, value in sorted(CORE.cmake_args.items())
+            ),
+            replace=True,
         )
 
     content = "[platformio]\n"

--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -25,6 +25,7 @@ from esphome.cpp_generator import (  # noqa: F401
     add,
     add_build_flag,
     add_build_unflag,
+    add_cmake_arg,
     add_cxx_build_flag,
     add_define,
     add_global,

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2127,9 +2127,7 @@ async def _write_exclude_components() -> None:
     excluded = CORE.data[KEY_ESP32].get(KEY_EXCLUDE_COMPONENTS)
     if excluded:
         exclude_list = ";".join(sorted(excluded))
-        cg.add_platformio_option(
-            "board_build.cmake_extra_args", f"-DEXCLUDE_COMPONENTS={exclude_list}"
-        )
+        cg.add_cmake_arg("EXCLUDE_COMPONENTS", exclude_list)
 
 
 @coroutine_with_priority(CoroPriority.FINAL)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2130,11 +2130,16 @@ def _configure_lwip_max_sockets(conf: dict) -> None:
     add_idf_sdkconfig_option("CONFIG_LWIP_MAX_SOCKETS", max_sockets)
 
 
+def register_exclude_components_cmake_arg() -> None:
+    """Register the current exclusion set as the EXCLUDE_COMPONENTS cmake arg."""
+    if excluded := get_excluded_builtin_components():
+        cg.add_cmake_arg("EXCLUDE_COMPONENTS", ";".join(excluded))
+
+
 @coroutine_with_priority(CoroPriority.FINAL)
 async def _write_exclude_components() -> None:
     """Write EXCLUDE_COMPONENTS cmake arg after all components have registered exclusions."""
-    if excluded := get_excluded_builtin_components():
-        cg.add_cmake_arg("EXCLUDE_COMPONENTS", ";".join(excluded))
+    register_exclude_components_cmake_arg()
 
 
 @coroutine_with_priority(CoroPriority.FINAL)

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1068,15 +1068,18 @@ class EsphomeCore:
     def add_cmake_arg(self, name: str, value: str) -> None:
         """Register a CMake variable for CMake-based toolchains.
 
-        The value must not contain whitespace or quotes: the PlatformIO
+        The value must not contain whitespace or quotes (the PlatformIO
         backend passes all args to CMake as a single space-joined string
-        of ``-DNAME=VALUE`` pairs.
+        of ``-DNAME=VALUE`` pairs) or ``$`` (expanded by CMake on the
+        ESP-IDF path but interpolated differently or passed through by
+        PlatformIO).
         """
         if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
             raise ValueError(f"Invalid CMake arg name: {name!r}")
-        if re.search(r"[\s\"']", value):
+        if re.search(r"[\s\"'$]", value):
             raise ValueError(
-                f"CMake arg {name} value {value!r} must not contain whitespace or quotes"
+                f"CMake arg {name} value {value!r} must not contain "
+                "whitespace, quotes, or '$'"
             )
         old = self.cmake_args.get(name)
         if old is not None and old != value:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1066,7 +1066,24 @@ class EsphomeCore:
         return build_flag
 
     def add_cmake_arg(self, name: str, value: str) -> None:
-        self.cmake_args[name] = str(value)
+        """Register a CMake variable for CMake-based toolchains.
+
+        The value must not contain whitespace or quotes: the PlatformIO
+        backend passes all args to CMake as a single space-joined string
+        of ``-DNAME=VALUE`` pairs.
+        """
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            raise ValueError(f"Invalid CMake arg name: {name!r}")
+        if re.search(r"[\s\"']", value):
+            raise ValueError(
+                f"CMake arg {name} value {value!r} must not contain whitespace or quotes"
+            )
+        old = self.cmake_args.get(name)
+        if old is not None and old != value:
+            _LOGGER.warning(
+                "CMake arg %s already set to %s; overwriting with %s", name, old, value
+            )
+        self.cmake_args[name] = value
         _LOGGER.debug("Adding CMake arg: %s=%s", name, value)
 
     def add_cxx_build_flag(self, build_flag: str) -> str:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1115,10 +1115,14 @@ class EsphomeCore:
         _LOGGER.debug("Adding define: %s", define)
         return define
 
-    def add_platformio_option(self, key: str, value: str | list[str]) -> None:
+    def add_platformio_option(
+        self, key: str, value: str | list[str], *, replace: bool = False
+    ) -> None:
+        """Set a platformio.ini option; list values append to an existing list
+        unless ``replace`` is True, which overwrites any existing value."""
         new_val = value
         old_val = self.platformio_options.get(key)
-        if isinstance(old_val, list):
+        if not replace and isinstance(old_val, list):
             assert isinstance(value, list)
             new_val = old_val + value
         self.platformio_options[key] = new_val

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -641,6 +641,8 @@ class EsphomeCore:
         self.platformio_libraries: dict[str, Library] = {}
         # A set of build flags to set in the platformio project
         self.build_flags: set[str] = set()
+        # A map of CMake args to apply to build systems that use CMake.
+        self.cmake_args: dict[str, str] = {}
         # A set of build flags that apply to C++ compiles only (CXXFLAGS /
         # CXX_COMPILE_OPTIONS), for flags GCC rejects or warns about on C
         self.cxx_build_flags: set[str] = set()
@@ -704,6 +706,7 @@ class EsphomeCore:
         self.global_statements = []
         self.platformio_libraries = {}
         self.build_flags = set()
+        self.cmake_args = {}
         self.cxx_build_flags = set()
         self.build_unflags = set()
         self.cpp_standard = None
@@ -1061,6 +1064,10 @@ class EsphomeCore:
         self.build_flags.add(build_flag)
         _LOGGER.debug("Adding build flag: %s", build_flag)
         return build_flag
+
+    def add_cmake_arg(self, name: str, value: str) -> None:
+        self.cmake_args[name] = str(value)
+        _LOGGER.debug("Adding CMake arg: %s=%s", name, value)
 
     def add_cxx_build_flag(self, build_flag: str) -> str:
         self.cxx_build_flags.add(build_flag)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -699,6 +699,11 @@ def add_build_flag(build_flag: str):
     CORE.add_build_flag(build_flag)
 
 
+def add_cmake_arg(name: str, value: str) -> None:
+    """Add a CMake arg for CMake-based toolchains."""
+    CORE.add_cmake_arg(name, value)
+
+
 def add_cxx_build_flag(build_flag: str) -> None:
     """Add a global build flag that applies to C++ compiles only.
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -700,11 +700,7 @@ def add_build_flag(build_flag: str):
 
 
 def add_cmake_arg(name: str, value: str) -> None:
-    """Add a CMake arg for CMake-based toolchains.
-
-    The value must not contain whitespace or quotes; see
-    ``EsphomeCore.add_cmake_arg`` for the exact restrictions.
-    """
+    """Add a CMake arg for CMake-based toolchains; see ``EsphomeCore.add_cmake_arg``."""
     CORE.add_cmake_arg(name, value)
 
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -700,7 +700,11 @@ def add_build_flag(build_flag: str):
 
 
 def add_cmake_arg(name: str, value: str) -> None:
-    """Add a CMake arg for CMake-based toolchains."""
+    """Add a CMake arg for CMake-based toolchains.
+
+    The value must not contain whitespace or quotes; see
+    ``EsphomeCore.add_cmake_arg`` for the exact restrictions.
+    """
     CORE.add_cmake_arg(name, value)
 
 

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -40,6 +40,13 @@ def get_project_link_flags() -> list[str]:
     return sorted(flag for flag in CORE.build_flags if flag.startswith("-Wl,"))
 
 
+def get_project_cmake_args() -> list[tuple[str, str]]:
+    """Return sorted CMake args registered by components."""
+    from esphome.core import CORE  # local import to avoid circular dependency
+
+    return sorted(CORE.cmake_args.items())
+
+
 def get_project_compile_flags() -> list[str]:
     """Return the sorted -D and -W (non-linker) flags from the current build."""
     from esphome.core import CORE  # local import to avoid circular dependency

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -40,13 +40,6 @@ def get_project_link_flags() -> list[str]:
     return sorted(flag for flag in CORE.build_flags if flag.startswith("-Wl,"))
 
 
-def get_project_cmake_args() -> list[tuple[str, str]]:
-    """Return sorted CMake args registered by components."""
-    from esphome.core import CORE  # local import to avoid circular dependency
-
-    return sorted(CORE.cmake_args.items())
-
-
 def get_project_compile_flags() -> list[str]:
     """Return the sorted -D and -W (non-linker) flags from the current build."""
     from esphome.core import CORE  # local import to avoid circular dependency

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -136,6 +136,20 @@ def test_get_project_cmakelists_full_emits_builtin_components_property(
     assert "JPEGDEC APPEND" not in content
 
 
+def test_get_project_cmakelists_emits_cmake_args() -> None:
+    CORE.add_cmake_arg("EXECUTABLE_COMPONENT_NAME", "src")
+
+    with (
+        patch("esphome.build_gen.espidf.get_esp32_variant", return_value="ESP32"),
+        patch.object(CORE, "name", "test"),
+    ):
+        from esphome.build_gen.espidf import get_project_cmakelists
+
+        content = get_project_cmakelists(minimal=True)
+
+    assert 'set(EXECUTABLE_COMPONENT_NAME "src")' in content
+
+
 def test_get_component_cmakelists_no_link_flags() -> None:
     """With no -Wl, flags the target_link_options block is emitted with an empty body."""
     CORE.build_flags = set()

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -148,6 +148,17 @@ def test_get_project_cmakelists_emits_cmake_args() -> None:
     assert 'set(EXECUTABLE_COMPONENT_NAME "src")' in content
 
 
+def test_get_project_cmakelists_escapes_backslashes_in_cmake_args() -> None:
+    """Backslashes (the only character escaping applies to; the rest are
+    rejected at registration) are doubled so CMake reads the value back
+    verbatim."""
+    CORE.add_cmake_arg("MY_PATH", r"C:\esp\idf")
+
+    content = _render(minimal=True)
+
+    assert r'set(MY_PATH "C:\\esp\\idf")' in content
+
+
 def test_get_project_cmakelists_emits_exclude_components(tmp_path: Path) -> None:
     """Excluded components are passed to IDF via EXCLUDE_COMPONENTS and are
     dropped from ESPHOME_PROJECT_BUILTIN_COMPONENTS even when a stale

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -16,6 +16,7 @@ from esphome.components.esp32 import (
     KEY_PATH,
     KEY_REF,
     KEY_REPO,
+    register_exclude_components_cmake_arg,
 )
 import esphome.config_validation as cv
 from esphome.const import KEY_CORE
@@ -147,16 +148,6 @@ def test_get_project_cmakelists_emits_cmake_args() -> None:
     assert 'set(EXECUTABLE_COMPONENT_NAME "src")' in content
 
 
-def _register_exclude_components_arg() -> None:
-    """Register EXCLUDE_COMPONENTS the way esp32's FINAL-priority coroutine
-    does in a real build."""
-    from esphome.components.esp32 import get_excluded_builtin_components
-
-    CORE.add_cmake_arg(
-        "EXCLUDE_COMPONENTS", ";".join(get_excluded_builtin_components())
-    )
-
-
 def test_get_project_cmakelists_emits_exclude_components(tmp_path: Path) -> None:
     """Excluded components are passed to IDF via EXCLUDE_COMPONENTS and are
     dropped from ESPHOME_PROJECT_BUILTIN_COMPONENTS even when a stale
@@ -171,7 +162,7 @@ def test_get_project_cmakelists_emits_exclude_components(tmp_path: Path) -> None
         },
     )
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS] = {"unity", "esp_lcd"}
-    _register_exclude_components_arg()
+    register_exclude_components_cmake_arg()
 
     content = _render()
 
@@ -190,7 +181,7 @@ def test_get_project_cmakelists_minimal_emits_exclude_components() -> None:
     """The discovery (minimal) write also excludes components so they never
     register in project_description.json."""
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS] = {"unity"}
-    _register_exclude_components_arg()
+    register_exclude_components_cmake_arg()
 
     content = _render(minimal=True)
 
@@ -199,6 +190,8 @@ def test_get_project_cmakelists_minimal_emits_exclude_components() -> None:
 
 def test_get_project_cmakelists_no_exclude_components_line_when_empty() -> None:
     """No EXCLUDE_COMPONENTS line at all when nothing is excluded."""
+    register_exclude_components_cmake_arg()
+
     content = _render()
 
     assert "EXCLUDE_COMPONENTS" not in content
@@ -218,8 +211,8 @@ def test_include_builtin_idf_component_removes_exclusion() -> None:
     include_builtin_idf_component("esp_eth")
 
     assert get_excluded_builtin_components() == ["unity"]
-    _register_exclude_components_arg()
 
+    register_exclude_components_cmake_arg()
     content = _render()
 
     assert 'set(EXCLUDE_COMPONENTS "unity")' in content

--- a/tests/unit_tests/build_gen/test_platformio.py
+++ b/tests/unit_tests/build_gen/test_platformio.py
@@ -169,6 +169,7 @@ def clean_core(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(CORE, "platformio_libraries", {})
     monkeypatch.setattr(CORE, "build_flags", set())
     monkeypatch.setattr(CORE, "build_unflags", set())
+    monkeypatch.setattr(CORE, "cmake_args", {})
 
 
 def test_get_ini_content_pins_cpp_standard(
@@ -200,6 +201,16 @@ def test_get_ini_content_no_cpp_standard(
     content = platformio.get_ini_content()
 
     assert "-std=" not in content
+
+
+def test_get_ini_content_emits_cmake_args(
+    clean_core: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(CORE, "cmake_args", {"EXECUTABLE_COMPONENT_NAME": "src"})
+
+    content = platformio.get_ini_content()
+
+    assert "-DEXECUTABLE_COMPONENT_NAME=src" in content
 
 
 def test_write_cxx_flags_script_emits_registered_flags(

--- a/tests/unit_tests/build_gen/test_platformio.py
+++ b/tests/unit_tests/build_gen/test_platformio.py
@@ -213,6 +213,31 @@ def test_get_ini_content_emits_cmake_args(
     assert "-DEXECUTABLE_COMPONENT_NAME=src" in content
 
 
+def test_get_ini_content_no_cmake_option_when_no_args(clean_core: None) -> None:
+    """No board_build.cmake_extra_args line at all when nothing registered
+    (ESP8266/RP2040/LibreTiny builds must not get a blank option)."""
+    content = platformio.get_ini_content()
+
+    assert "board_build.cmake_extra_args" not in content
+
+
+def test_get_ini_content_overwrites_list_valued_user_cmake_option(
+    clean_core: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user-supplied board_build.cmake_extra_args may be a list; the
+    registered args must replace it without tripping add_platformio_option's
+    list-append assert."""
+    monkeypatch.setattr(
+        CORE, "platformio_options", {"board_build.cmake_extra_args": ["-DFOO=1"]}
+    )
+    monkeypatch.setattr(CORE, "cmake_args", {"EXECUTABLE_COMPONENT_NAME": "src"})
+
+    content = platformio.get_ini_content()
+
+    assert "board_build.cmake_extra_args = -DEXECUTABLE_COMPONENT_NAME=src" in content
+    assert "-DFOO=1" not in content
+
+
 def test_write_cxx_flags_script_emits_registered_flags(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit_tests/build_gen/test_platformio.py
+++ b/tests/unit_tests/build_gen/test_platformio.py
@@ -206,11 +206,19 @@ def test_get_ini_content_no_cpp_standard(
 def test_get_ini_content_emits_cmake_args(
     clean_core: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(CORE, "cmake_args", {"EXECUTABLE_COMPONENT_NAME": "src"})
+    """Registered args are space-joined into one option, sorted by name."""
+    monkeypatch.setattr(
+        CORE,
+        "cmake_args",
+        {"EXECUTABLE_COMPONENT_NAME": "src", "EXCLUDE_COMPONENTS": "unity"},
+    )
 
     content = platformio.get_ini_content()
 
-    assert "-DEXECUTABLE_COMPONENT_NAME=src" in content
+    assert (
+        "board_build.cmake_extra_args = "
+        "-DEXCLUDE_COMPONENTS=unity -DEXECUTABLE_COMPONENT_NAME=src" in content
+    )
 
 
 def test_get_ini_content_no_cmake_option_when_no_args(clean_core: None) -> None:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -990,3 +990,34 @@ class TestEsphomeCore:
         )
         # The unflag is still recorded either way.
         assert target.build_unflags == {"-fno-rtti", "-fno-exceptions"}
+
+    def test_add_cmake_arg(self, target) -> None:
+        target.add_cmake_arg("EXCLUDE_COMPONENTS", "unity;esp_lcd")
+        assert target.cmake_args == {"EXCLUDE_COMPONENTS": "unity;esp_lcd"}
+
+    @pytest.mark.parametrize("name", ["", "BAD NAME", 'A"B', "A(B)", "1ABC"])
+    def test_add_cmake_arg__rejects_invalid_name(self, target, name: str) -> None:
+        with pytest.raises(ValueError, match="Invalid CMake arg name"):
+            target.add_cmake_arg(name, "value")
+
+    @pytest.mark.parametrize("value", ["a b", "a\tb", 'a"b', "a'b"])
+    def test_add_cmake_arg__rejects_invalid_value(self, target, value: str) -> None:
+        """Whitespace and quotes are rejected: the PlatformIO backend passes
+        args as one space-joined string, which would split such a value."""
+        with pytest.raises(ValueError, match="must not contain"):
+            target.add_cmake_arg("MY_ARG", value)
+
+    def test_add_cmake_arg__warns_on_overwrite(
+        self, target, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Re-registering with a different value is last-writer-wins; warn so
+        the silently dropped value is diagnosable."""
+        target.add_cmake_arg("MY_ARG", "one")
+        target.add_cmake_arg("MY_ARG", "one")
+        assert "overwriting" not in caplog.text
+
+        target.add_cmake_arg("MY_ARG", "two")
+        assert (
+            "CMake arg MY_ARG already set to one; overwriting with two" in caplog.text
+        )
+        assert target.cmake_args == {"MY_ARG": "two"}

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1000,10 +1000,11 @@ class TestEsphomeCore:
         with pytest.raises(ValueError, match="Invalid CMake arg name"):
             target.add_cmake_arg(name, "value")
 
-    @pytest.mark.parametrize("value", ["a b", "a\tb", 'a"b', "a'b"])
+    @pytest.mark.parametrize("value", ["a b", "a\tb", 'a"b', "a'b", "a${FOO}b"])
     def test_add_cmake_arg__rejects_invalid_value(self, target, value: str) -> None:
-        """Whitespace and quotes are rejected: the PlatformIO backend passes
-        args as one space-joined string, which would split such a value."""
+        """Whitespace and quotes are rejected (the PlatformIO backend passes
+        args as one space-joined string, which would split such a value), and
+        so is '$' (expanded differently by CMake and PlatformIO)."""
         with pytest.raises(ValueError, match="must not contain"):
             target.add_cmake_arg("MY_ARG", value)
 


### PR DESCRIPTION
# What does this implement/fix?

Adds `cg.add_cmake_arg()` so a component can register a CMake variable once and have every CMake based build pick it up; the PlatformIO builder passes it as `-DNAME=VALUE` via `board_build.cmake_extra_args`, the native ESP-IDF builder writes a `set()` line into the generated CMakeLists. The esp32 component now registers `EXCLUDE_COMPONENTS` through this mechanism, which keeps the behavior #18531 added for the native toolchain and extends the same path to any future arg. Names and values are validated at registration, values may not contain whitespace or quotes since the PlatformIO backend joins all args into one string, and re-registering an arg with a different value logs a warning instead of silently dropping the old one.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [https://github.com/DavidvtWout/esphome-matter/issues/21](https://github.com/DavidvtWout/esphome-matter/issues/21)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

-

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- https://github.com/esphome/developers.esphome.io/pull/172

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

