### PR TITLE
[ble_midi] Add BLE MIDI component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -77,6 +77,7 @@ esphome/components/bl0940/* @dan-s-github @tobias-
 esphome/components/bl0942/* @dbuezas @dwmw2
 esphome/components/ble_client/* @buxtronix @clydebarrow
 esphome/components/ble_device_base/* @Bl00d-B0b
+esphome/components/ble_midi/* @bogdanr
 esphome/components/ble_nus/* @tomaszduda23
 esphome/components/bluetooth_connection/* @bdraco @jesserockz
 esphome/components/bluetooth_proxy/* @bdraco @jesserockz

--- a/esphome/components/ble_midi/__init__.py
+++ b/esphome/components/ble_midi/__init__.py
@@ -1,0 +1,315 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import ble_client
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CHANNEL,
+    CONF_DATA,
+    CONF_ID,
+    CONF_ON_CONNECT,
+    CONF_ON_DISCONNECT,
+    CONF_ON_MESSAGE,
+    CONF_PAYLOAD,
+    CONF_TRIGGER_ID,
+    CONF_VALUE,
+)
+
+CODEOWNERS = ["@bogdanr"]
+DEPENDENCIES = ["ble_client"]
+MULTI_CONF = True
+
+CONF_CONTROL_NUMBER = "control_number"
+CONF_MAX_SYSEX_SIZE = "max_sysex_size"
+CONF_NOTE = "note"
+CONF_ON_CONTROL_CHANGE = "on_control_change"
+CONF_ON_NOTE_OFF = "on_note_off"
+CONF_ON_NOTE_ON = "on_note_on"
+CONF_ON_PITCH_BEND = "on_pitch_bend"
+CONF_ON_PROGRAM_CHANGE = "on_program_change"
+CONF_ON_SYSEX = "on_sysex"
+CONF_PAIR = "pair"
+CONF_PROGRAM = "program"
+CONF_VELOCITY = "velocity"
+
+ble_midi_ns = cg.esphome_ns.namespace("ble_midi")
+BLEMidi = ble_midi_ns.class_("BLEMidi", cg.Component, ble_client.BLEClientNode)
+
+ConnectTrigger = ble_midi_ns.class_("ConnectTrigger", automation.Trigger.template())
+DisconnectTrigger = ble_midi_ns.class_(
+    "DisconnectTrigger", automation.Trigger.template()
+)
+NoteOnTrigger = ble_midi_ns.class_(
+    "NoteOnTrigger", automation.Trigger.template(cg.uint8, cg.uint8, cg.uint8)
+)
+NoteOffTrigger = ble_midi_ns.class_(
+    "NoteOffTrigger", automation.Trigger.template(cg.uint8, cg.uint8, cg.uint8)
+)
+ControlChangeTrigger = ble_midi_ns.class_(
+    "ControlChangeTrigger", automation.Trigger.template(cg.uint8, cg.uint8, cg.uint8)
+)
+ProgramChangeTrigger = ble_midi_ns.class_(
+    "ProgramChangeTrigger", automation.Trigger.template(cg.uint8, cg.uint8)
+)
+PitchBendTrigger = ble_midi_ns.class_(
+    "PitchBendTrigger", automation.Trigger.template(cg.int16, cg.uint8)
+)
+SysexTrigger = ble_midi_ns.class_(
+    "SysexTrigger", automation.Trigger.template(cg.std_vector.template(cg.uint8))
+)
+MessageTrigger = ble_midi_ns.class_(
+    "MessageTrigger", automation.Trigger.template(cg.std_vector.template(cg.uint8))
+)
+
+NoteOnAction = ble_midi_ns.class_("NoteOnAction", automation.Action)
+NoteOffAction = ble_midi_ns.class_("NoteOffAction", automation.Action)
+ControlChangeAction = ble_midi_ns.class_("ControlChangeAction", automation.Action)
+ProgramChangeAction = ble_midi_ns.class_("ProgramChangeAction", automation.Action)
+PitchBendAction = ble_midi_ns.class_("PitchBendAction", automation.Action)
+SysexAction = ble_midi_ns.class_("SysexAction", automation.Action)
+RawAction = ble_midi_ns.class_("RawAction", automation.Action)
+BLEMidiConnectedCondition = ble_midi_ns.class_(
+    "BLEMidiConnectedCondition", automation.Condition
+)
+
+# MIDI data bytes are 7-bit and channels are 4-bit, matching what goes on the wire and what the triggers report.
+# Channel 0 is the channel that MIDI hardware usually labels "1".
+midi_data_byte = cv.int_range(min=0, max=127)
+midi_channel = cv.int_range(min=0, max=15)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(BLEMidi),
+            cv.Optional(CONF_MAX_SYSEX_SIZE, default=256): cv.int_range(
+                min=8, max=2048
+            ),
+            cv.Optional(CONF_PAIR, default=False): cv.boolean,
+            cv.Optional(CONF_ON_CONNECT): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ConnectTrigger)}
+            ),
+            cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DisconnectTrigger)}
+            ),
+            cv.Optional(CONF_ON_NOTE_ON): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(NoteOnTrigger)}
+            ),
+            cv.Optional(CONF_ON_NOTE_OFF): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(NoteOffTrigger)}
+            ),
+            cv.Optional(CONF_ON_CONTROL_CHANGE): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ControlChangeTrigger)}
+            ),
+            cv.Optional(CONF_ON_PROGRAM_CHANGE): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ProgramChangeTrigger)}
+            ),
+            cv.Optional(CONF_ON_PITCH_BEND): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PitchBendTrigger)}
+            ),
+            cv.Optional(CONF_ON_SYSEX): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SysexTrigger)}
+            ),
+            cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger)}
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(ble_client.BLE_CLIENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await ble_client.register_ble_node(var, config)
+
+    cg.add(var.set_max_sysex_size(config[CONF_MAX_SYSEX_SIZE]))
+    cg.add(var.set_pair(config[CONF_PAIR]))
+
+    note_args = [
+        (cg.uint8, CONF_NOTE),
+        (cg.uint8, CONF_VELOCITY),
+        (cg.uint8, CONF_CHANNEL),
+    ]
+    bytes_args = [(cg.std_vector.template(cg.uint8), CONF_DATA)]
+    triggers = (
+        (CONF_ON_CONNECT, []),
+        (CONF_ON_DISCONNECT, []),
+        (CONF_ON_NOTE_ON, note_args),
+        (CONF_ON_NOTE_OFF, note_args),
+        (
+            CONF_ON_CONTROL_CHANGE,
+            [
+                (cg.uint8, CONF_CONTROL_NUMBER),
+                (cg.uint8, CONF_VALUE),
+                (cg.uint8, CONF_CHANNEL),
+            ],
+        ),
+        (CONF_ON_PROGRAM_CHANGE, [(cg.uint8, CONF_PROGRAM), (cg.uint8, CONF_CHANNEL)]),
+        (CONF_ON_PITCH_BEND, [(cg.int16, CONF_VALUE), (cg.uint8, CONF_CHANNEL)]),
+        (CONF_ON_SYSEX, bytes_args),
+        (CONF_ON_MESSAGE, bytes_args),
+    )
+    for key, args in triggers:
+        for conf in config.get(key, []):
+            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+            await automation.build_automation(trigger, args, conf)
+
+
+def _action_schema(keys: dict) -> cv.Schema:
+    return cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(BLEMidi),
+            **keys,
+            cv.Optional(CONF_CHANNEL, default=0): cv.templatable(midi_channel),
+        }
+    )
+
+
+async def _build_action(config, action_id, template_arg, args, keys):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, parent)
+    for key, type_ in {**keys, CONF_CHANNEL: cg.uint8}.items():
+        template_ = await cg.templatable(config[key], args, type_)
+        cg.add(getattr(var, f"set_{key}")(template_))
+    return var
+
+
+NOTE_ACTION_SCHEMA = _action_schema(
+    {
+        cv.Required(CONF_NOTE): cv.templatable(midi_data_byte),
+        cv.Optional(CONF_VELOCITY, default=64): cv.templatable(midi_data_byte),
+    }
+)
+
+
+@automation.register_action(
+    "ble_midi.send_note_on", NoteOnAction, NOTE_ACTION_SCHEMA, synchronous=True
+)
+async def send_note_on_to_code(config, action_id, template_arg, args):
+    return await _build_action(
+        config,
+        action_id,
+        template_arg,
+        args,
+        {CONF_NOTE: cg.uint8, CONF_VELOCITY: cg.uint8},
+    )
+
+
+@automation.register_action(
+    "ble_midi.send_note_off", NoteOffAction, NOTE_ACTION_SCHEMA, synchronous=True
+)
+async def send_note_off_to_code(config, action_id, template_arg, args):
+    return await _build_action(
+        config,
+        action_id,
+        template_arg,
+        args,
+        {CONF_NOTE: cg.uint8, CONF_VELOCITY: cg.uint8},
+    )
+
+
+@automation.register_action(
+    "ble_midi.send_control_change",
+    ControlChangeAction,
+    _action_schema(
+        {
+            cv.Required(CONF_CONTROL_NUMBER): cv.templatable(midi_data_byte),
+            cv.Required(CONF_VALUE): cv.templatable(midi_data_byte),
+        }
+    ),
+    synchronous=True,
+)
+async def send_control_change_to_code(config, action_id, template_arg, args):
+    return await _build_action(
+        config,
+        action_id,
+        template_arg,
+        args,
+        {CONF_CONTROL_NUMBER: cg.uint8, CONF_VALUE: cg.uint8},
+    )
+
+
+@automation.register_action(
+    "ble_midi.send_program_change",
+    ProgramChangeAction,
+    _action_schema({cv.Required(CONF_PROGRAM): cv.templatable(midi_data_byte)}),
+    synchronous=True,
+)
+async def send_program_change_to_code(config, action_id, template_arg, args):
+    return await _build_action(
+        config, action_id, template_arg, args, {CONF_PROGRAM: cg.uint8}
+    )
+
+
+@automation.register_action(
+    "ble_midi.send_pitch_bend",
+    PitchBendAction,
+    _action_schema(
+        {
+            cv.Required(CONF_VALUE): cv.templatable(cv.int_range(min=-8192, max=8191)),
+        }
+    ),
+    synchronous=True,
+)
+async def send_pitch_bend_to_code(config, action_id, template_arg, args):
+    return await _build_action(
+        config, action_id, template_arg, args, {CONF_VALUE: cg.int16}
+    )
+
+
+@automation.register_action(
+    "ble_midi.send_sysex",
+    SysexAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(BLEMidi),
+            cv.Required(CONF_PAYLOAD): cv.templatable(cv.ensure_list(cv.hex_uint8_t)),
+        }
+    ),
+    synchronous=True,
+)
+async def send_sysex_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, parent)
+    payload = await cg.templatable(
+        config[CONF_PAYLOAD], args, cg.std_vector.template(cg.uint8)
+    )
+    cg.add(var.set_payload(payload))
+    return var
+
+
+@automation.register_action(
+    "ble_midi.send_raw",
+    RawAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(BLEMidi),
+            cv.Required(CONF_DATA): cv.templatable(cv.ensure_list(cv.hex_uint8_t)),
+        }
+    ),
+    synchronous=True,
+)
+async def send_raw_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, parent)
+    data = await cg.templatable(
+        config[CONF_DATA], args, cg.std_vector.template(cg.uint8)
+    )
+    cg.add(var.set_data(data))
+    return var
+
+
+@automation.register_condition(
+    "ble_midi.connected",
+    BLEMidiConnectedCondition,
+    cv.Schema({cv.GenerateID(): cv.use_id(BLEMidi)}),
+)
+async def connected_to_code(config, condition_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(condition_id, template_arg)
+    await cg.register_parented(var, parent)
+    return var

--- a/esphome/components/ble_midi/automation.h
+++ b/esphome/components/ble_midi/automation.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/automation.h"
+
+#include "ble_midi.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace esphome::ble_midi {
+
+class ConnectTrigger final : public Trigger<> {
+ public:
+  explicit ConnectTrigger(BLEMidi *parent) { parent->add_on_connect_trigger(this); }
+};
+
+class DisconnectTrigger final : public Trigger<> {
+ public:
+  explicit DisconnectTrigger(BLEMidi *parent) { parent->add_on_disconnect_trigger(this); }
+};
+
+/// Triggered with (note, velocity, channel).
+class NoteOnTrigger final : public Trigger<uint8_t, uint8_t, uint8_t> {
+ public:
+  explicit NoteOnTrigger(BLEMidi *parent) { parent->add_on_note_on_trigger(this); }
+};
+
+/// Triggered with (note, velocity, channel). Note On with velocity zero is
+/// reported here as well.
+class NoteOffTrigger final : public Trigger<uint8_t, uint8_t, uint8_t> {
+ public:
+  explicit NoteOffTrigger(BLEMidi *parent) { parent->add_on_note_off_trigger(this); }
+};
+
+/// Triggered with (control_number, value, channel).
+class ControlChangeTrigger final : public Trigger<uint8_t, uint8_t, uint8_t> {
+ public:
+  explicit ControlChangeTrigger(BLEMidi *parent) { parent->add_on_control_change_trigger(this); }
+};
+
+/// Triggered with (program, channel).
+class ProgramChangeTrigger final : public Trigger<uint8_t, uint8_t> {
+ public:
+  explicit ProgramChangeTrigger(BLEMidi *parent) { parent->add_on_program_change_trigger(this); }
+};
+
+/// Triggered with (value, channel), value being -8192 to 8191.
+class PitchBendTrigger final : public Trigger<int16_t, uint8_t> {
+ public:
+  explicit PitchBendTrigger(BLEMidi *parent) { parent->add_on_pitch_bend_trigger(this); }
+};
+
+/// Triggered with the SysEx payload, without the 0xF0/0xF7 wrappers.
+class SysexTrigger final : public Trigger<std::vector<uint8_t>> {
+ public:
+  explicit SysexTrigger(BLEMidi *parent) { parent->add_on_sysex_trigger(this); }
+};
+
+/// Triggered with the raw bytes of every decoded message.
+class MessageTrigger final : public Trigger<std::vector<uint8_t>> {
+ public:
+  explicit MessageTrigger(BLEMidi *parent) { parent->add_on_message_trigger(this); }
+};
+
+template<typename... Ts> class NoteOnAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(uint8_t, note)
+  TEMPLATABLE_VALUE(uint8_t, velocity)
+  TEMPLATABLE_VALUE(uint8_t, channel)
+
+  void play(Ts... x) override {
+    this->parent_->send_note_on(this->note_.value(x...), this->velocity_.value(x...), this->channel_.value(x...));
+  }
+};
+
+template<typename... Ts> class NoteOffAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(uint8_t, note)
+  TEMPLATABLE_VALUE(uint8_t, velocity)
+  TEMPLATABLE_VALUE(uint8_t, channel)
+
+  void play(Ts... x) override {
+    this->parent_->send_note_off(this->note_.value(x...), this->velocity_.value(x...), this->channel_.value(x...));
+  }
+};
+
+template<typename... Ts> class ControlChangeAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(uint8_t, control_number)
+  TEMPLATABLE_VALUE(uint8_t, value)
+  TEMPLATABLE_VALUE(uint8_t, channel)
+
+  void play(Ts... x) override {
+    this->parent_->send_control_change(this->control_number_.value(x...), this->value_.value(x...),
+                                       this->channel_.value(x...));
+  }
+};
+
+template<typename... Ts> class ProgramChangeAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(uint8_t, program)
+  TEMPLATABLE_VALUE(uint8_t, channel)
+
+  void play(Ts... x) override {
+    this->parent_->send_program_change(this->program_.value(x...), this->channel_.value(x...));
+  }
+};
+
+template<typename... Ts> class PitchBendAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(int16_t, value)
+  TEMPLATABLE_VALUE(uint8_t, channel)
+
+  void play(Ts... x) override { this->parent_->send_pitch_bend(this->value_.value(x...), this->channel_.value(x...)); }
+};
+
+template<typename... Ts> class SysexAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, payload)
+
+  void play(Ts... x) override { this->parent_->send_sysex(this->payload_.value(x...)); }
+};
+
+template<typename... Ts> class RawAction final : public Action<Ts...>, public Parented<BLEMidi> {
+ public:
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+
+  void play(Ts... x) override { this->parent_->send_raw(this->data_.value(x...)); }
+};
+
+template<typename... Ts> class BLEMidiConnectedCondition final : public Condition<Ts...>, public Parented<BLEMidi> {
+ public:
+  bool check(Ts... x) override { return this->parent_->is_ready(); }
+};
+
+}  // namespace esphome::ble_midi
+
+#endif  // USE_ESP32

--- a/esphome/components/ble_midi/automation.h
+++ b/esphome/components/ble_midi/automation.h
@@ -13,11 +13,14 @@
 
 namespace esphome::ble_midi {
 
+/// Triggered once the MIDI characteristic is found and notifications are
+/// enabled, which is also when the device can be sent to.
 class ConnectTrigger final : public Trigger<> {
  public:
   explicit ConnectTrigger(BLEMidi *parent) { parent->add_on_connect_trigger(this); }
 };
 
+/// Triggered when an established MIDI connection is lost.
 class DisconnectTrigger final : public Trigger<> {
  public:
   explicit DisconnectTrigger(BLEMidi *parent) { parent->add_on_disconnect_trigger(this); }

--- a/esphome/components/ble_midi/ble_midi.cpp
+++ b/esphome/components/ble_midi/ble_midi.cpp
@@ -1,0 +1,266 @@
+#include "ble_midi.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include <cstring>
+
+namespace esphome::ble_midi {
+
+static const char *const TAG = "ble_midi";
+
+// Standard BLE-MIDI service and characteristic, as defined by the BLE-MIDI
+// specification.
+static const char *const SERVICE_UUID = "03B80E5A-EDE8-4B33-A751-6CE34EC4C700";
+static const char *const CHARACTERISTIC_UUID = "7772E5DB-3868-4112-A1A9-F2669D106BF3";
+
+// A BLE-MIDI packet starts with a header byte and a timestamp byte, both of
+// which have bit 7 set. The remaining timestamp bits are used for jitter
+// reconstruction only and are left at zero when transmitting.
+static const uint8_t PACKET_HEADER = 0x80;
+static const uint8_t PACKET_TIMESTAMP = 0x80;
+
+// MIDI status bytes for the messages this component can transmit.
+static const uint8_t STATUS_NOTE_OFF = 0x80;
+static const uint8_t STATUS_NOTE_ON = 0x90;
+static const uint8_t STATUS_CONTROL_CHANGE = 0xB0;
+static const uint8_t STATUS_PROGRAM_CHANGE = 0xC0;
+static const uint8_t STATUS_PITCH_BEND = 0xE0;
+static const uint8_t STATUS_SYSEX_START = 0xF0;
+static const uint8_t STATUS_SYSEX_END = 0xF7;
+
+// Number of received bytes included in verbose packet logs.
+static const size_t LOG_MAX_BYTES = 32;
+
+template<typename... Ts> static void fire_triggers(const std::vector<Trigger<Ts...> *> &triggers, const Ts &...args) {
+  for (auto *trigger : triggers)
+    trigger->trigger(args...);
+}
+
+void BLEMidi::setup() { this->parser_.init_sysex_buffer(this->max_sysex_size_); }
+
+void BLEMidi::loop() {
+  // Messages arrive through gattc_event_handler() and are dispatched from
+  // there, so this component does not need to run on every loop iteration.
+  this->disable_loop();
+}
+
+void BLEMidi::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "BLE MIDI:\n"
+                "  MAC address: %s\n"
+                "  Maximum SysEx size: %u\n"
+                "  Pair on connect: %s",
+                this->parent()->address_str(), static_cast<unsigned>(this->max_sysex_size_), YESNO(this->pair_));
+}
+
+void BLEMidi::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
+  switch (event) {
+    case ESP_GATTC_OPEN_EVT: {
+      if (param->open.status != ESP_GATT_OK)
+        break;
+      this->parser_.reset();
+      if (this->pair_) {
+        esp_err_t err = this->parent()->pair();
+        if (err != ESP_OK) {
+          ESP_LOGW(TAG, "Pairing failed, error=%d", err);
+        }
+      }
+      for (auto *trigger : this->connect_triggers_)
+        trigger->trigger();
+      break;
+    }
+    case ESP_GATTC_DISCONNECT_EVT:
+    case ESP_GATTC_CLOSE_EVT: {
+      this->parser_.reset();
+      this->characteristic_handle_ = 0;
+      this->notify_registered_ = false;
+      this->node_state = espbt::ClientState::IDLE;
+      for (auto *trigger : this->disconnect_triggers_)
+        trigger->trigger();
+      break;
+    }
+    case ESP_GATTC_SEARCH_CMPL_EVT: {
+      auto *characteristic = this->parent()->get_characteristic(espbt::ESPBTUUID::from_raw(SERVICE_UUID),
+                                                                espbt::ESPBTUUID::from_raw(CHARACTERISTIC_UUID));
+      if (characteristic == nullptr) {
+        ESP_LOGW(TAG, "No BLE MIDI characteristic found on this device");
+        break;
+      }
+      this->characteristic_handle_ = characteristic->handle;
+      this->write_without_response_ = (characteristic->properties & ESP_GATT_CHAR_PROP_BIT_WRITE_NR) != 0;
+      esp_err_t err = this->parent()->register_for_notify(characteristic->handle);
+      if (err != ESP_OK) {
+        ESP_LOGW(TAG, "register_for_notify failed, error=%d", err);
+      }
+      break;
+    }
+    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
+      if (param->reg_for_notify.handle != this->characteristic_handle_)
+        break;
+      if (param->reg_for_notify.status != ESP_GATT_OK) {
+        ESP_LOGW(TAG, "Enabling notifications failed, status=%d", param->reg_for_notify.status);
+        break;
+      }
+      this->notify_registered_ = true;
+      this->node_state = espbt::ClientState::ESTABLISHED;
+      ESP_LOGI(TAG, "MIDI notifications enabled");
+      break;
+    }
+    case ESP_GATTC_NOTIFY_EVT: {
+      if (param->notify.handle != this->characteristic_handle_ || param->notify.value_len == 0)
+        break;
+      // format_hex_to() truncates to the buffer size, so long packets are logged
+      // only in part.
+      char hex[format_hex_size(LOG_MAX_BYTES)];
+      ESP_LOGV(TAG, "Received %u bytes: %s", param->notify.value_len,
+               format_hex_to(hex, param->notify.value, param->notify.value_len));
+      this->parser_.feed(param->notify.value, param->notify.value_len,
+                         [this](const MidiMessage &message) { this->handle_message_(message); });
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void BLEMidi::handle_message_(const MidiMessage &message) {
+  ESP_LOGV(TAG, "Decoded %s", message_type_name(message.type));
+
+  if (!this->message_triggers_.empty()) {
+    std::vector<uint8_t> bytes(message.data, message.data + message.length);
+    fire_triggers(this->message_triggers_, bytes);
+  }
+
+  switch (message.type) {
+    case MessageType::NOTE_ON:
+      fire_triggers(this->note_on_triggers_, message.note(), message.velocity(), message.channel());
+      break;
+    case MessageType::NOTE_OFF:
+      fire_triggers(this->note_off_triggers_, message.note(), message.velocity(), message.channel());
+      break;
+    case MessageType::CONTROL_CHANGE:
+      fire_triggers(this->control_change_triggers_, message.control_number(), message.control_value(),
+                    message.channel());
+      break;
+    case MessageType::PROGRAM_CHANGE:
+      fire_triggers(this->program_change_triggers_, message.program(), message.channel());
+      break;
+    case MessageType::PITCH_BEND:
+      fire_triggers(this->pitch_bend_triggers_, message.pitch_bend(), message.channel());
+      break;
+    case MessageType::SYSEX: {
+      if (this->sysex_triggers_.empty())
+        break;
+      // Hand the payload to the automation without the 0xF0/0xF7 wrappers.
+      std::vector<uint8_t> payload;
+      if (message.length > 2)
+        payload.assign(message.data + 1, message.data + message.length - 1);
+      fire_triggers(this->sysex_triggers_, payload);
+      break;
+    }
+    case MessageType::UNKNOWN:
+      ESP_LOGW(TAG, "Undecodable MIDI byte 0x%02X", message.status());
+      break;
+    default:
+      // Polyphonic and channel aftertouch, system common and real-time messages
+      // are only reported through on_message.
+      break;
+  }
+}
+
+bool BLEMidi::write_midi_(const uint8_t *midi_bytes, size_t length) {
+  if (length == 0)
+    return false;
+  if (!this->is_ready() || this->characteristic_handle_ == 0) {
+    ESP_LOGW(TAG, "Cannot send: not connected");
+    return false;
+  }
+  if (length > MAX_TX_MIDI_BYTES) {
+    ESP_LOGW(TAG, "Cannot send: message of %u bytes exceeds the %u byte limit", static_cast<unsigned>(length),
+             static_cast<unsigned>(MAX_TX_MIDI_BYTES));
+    return false;
+  }
+
+  uint8_t packet[MAX_TX_MIDI_BYTES + 2];
+  packet[0] = PACKET_HEADER;
+  packet[1] = PACKET_TIMESTAMP;
+  std::memcpy(packet + 2, midi_bytes, length);
+  size_t packet_length = length + 2;
+
+  esp_err_t err = esp_ble_gattc_write_char(
+      this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->characteristic_handle_, packet_length,
+      packet, this->write_without_response_ ? ESP_GATT_WRITE_TYPE_NO_RSP : ESP_GATT_WRITE_TYPE_RSP,
+      ESP_GATT_AUTH_REQ_NONE);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Write failed, error=%d", err);
+    return false;
+  }
+
+  char hex[format_hex_size(LOG_MAX_BYTES)];
+  ESP_LOGV(TAG, "Sent %u bytes: %s", static_cast<unsigned>(packet_length), format_hex_to(hex, packet, packet_length));
+  return true;
+}
+
+void BLEMidi::send_note_on(uint8_t note, uint8_t velocity, uint8_t channel) {
+  const uint8_t bytes[3] = {static_cast<uint8_t>(STATUS_NOTE_ON | (channel & 0x0F)), static_cast<uint8_t>(note & 0x7F),
+                            static_cast<uint8_t>(velocity & 0x7F)};
+  this->write_midi_(bytes, sizeof(bytes));
+}
+
+void BLEMidi::send_note_off(uint8_t note, uint8_t velocity, uint8_t channel) {
+  const uint8_t bytes[3] = {static_cast<uint8_t>(STATUS_NOTE_OFF | (channel & 0x0F)), static_cast<uint8_t>(note & 0x7F),
+                            static_cast<uint8_t>(velocity & 0x7F)};
+  this->write_midi_(bytes, sizeof(bytes));
+}
+
+void BLEMidi::send_control_change(uint8_t control_number, uint8_t value, uint8_t channel) {
+  const uint8_t bytes[3] = {static_cast<uint8_t>(STATUS_CONTROL_CHANGE | (channel & 0x0F)),
+                            static_cast<uint8_t>(control_number & 0x7F), static_cast<uint8_t>(value & 0x7F)};
+  this->write_midi_(bytes, sizeof(bytes));
+}
+
+void BLEMidi::send_program_change(uint8_t program, uint8_t channel) {
+  const uint8_t bytes[2] = {static_cast<uint8_t>(STATUS_PROGRAM_CHANGE | (channel & 0x0F)),
+                            static_cast<uint8_t>(program & 0x7F)};
+  this->write_midi_(bytes, sizeof(bytes));
+}
+
+void BLEMidi::send_pitch_bend(int16_t value, uint8_t channel) {
+  uint16_t unsigned_value = static_cast<uint16_t>(clamp<int32_t>(value, -8192, 8191) + 8192);
+  const uint8_t bytes[3] = {static_cast<uint8_t>(STATUS_PITCH_BEND | (channel & 0x0F)),
+                            static_cast<uint8_t>(unsigned_value & 0x7F),
+                            static_cast<uint8_t>((unsigned_value >> 7) & 0x7F)};
+  this->write_midi_(bytes, sizeof(bytes));
+}
+
+void BLEMidi::send_sysex(const std::vector<uint8_t> &payload) {
+  if (payload.empty())
+    return;
+  bool has_start = payload.front() == STATUS_SYSEX_START;
+  bool has_end = payload.back() == STATUS_SYSEX_END;
+  size_t length = payload.size() + (has_start ? 0 : 1) + (has_end ? 0 : 1);
+  if (length > MAX_TX_MIDI_BYTES) {
+    ESP_LOGW(TAG, "Cannot send: SysEx of %u bytes exceeds the %u byte limit", static_cast<unsigned>(length),
+             static_cast<unsigned>(MAX_TX_MIDI_BYTES));
+    return;
+  }
+
+  uint8_t bytes[MAX_TX_MIDI_BYTES];
+  size_t offset = 0;
+  if (!has_start)
+    bytes[offset++] = STATUS_SYSEX_START;
+  std::memcpy(bytes + offset, payload.data(), payload.size());
+  offset += payload.size();
+  if (!has_end)
+    bytes[offset++] = STATUS_SYSEX_END;
+  this->write_midi_(bytes, offset);
+}
+
+void BLEMidi::send_raw(const std::vector<uint8_t> &bytes) { this->write_midi_(bytes.data(), bytes.size()); }
+
+}  // namespace esphome::ble_midi
+
+#endif  // USE_ESP32

--- a/esphome/components/ble_midi/ble_midi.cpp
+++ b/esphome/components/ble_midi/ble_midi.cpp
@@ -68,18 +68,21 @@ void BLEMidi::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gatt
           ESP_LOGW(TAG, "Pairing failed, error=%d", err);
         }
       }
-      for (auto *trigger : this->connect_triggers_)
-        trigger->trigger();
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT:
     case ESP_GATTC_CLOSE_EVT: {
       this->parser_.reset();
       this->characteristic_handle_ = 0;
+      // Both events can arrive for the same disconnect, so the triggers are
+      // fired only for the one that follows an established MIDI connection.
+      bool was_ready = this->notify_registered_;
       this->notify_registered_ = false;
       this->node_state = espbt::ClientState::IDLE;
-      for (auto *trigger : this->disconnect_triggers_)
-        trigger->trigger();
+      if (was_ready) {
+        for (auto *trigger : this->disconnect_triggers_)
+          trigger->trigger();
+      }
       break;
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
@@ -107,6 +110,10 @@ void BLEMidi::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gatt
       this->notify_registered_ = true;
       this->node_state = espbt::ClientState::ESTABLISHED;
       ESP_LOGI(TAG, "MIDI notifications enabled");
+      // The device can only be sent to once notifications are enabled, so this
+      // is the point where on_connect is useful.
+      for (auto *trigger : this->connect_triggers_)
+        trigger->trigger();
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {

--- a/esphome/components/ble_midi/ble_midi.h
+++ b/esphome/components/ble_midi/ble_midi.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+
+#include "midi_parser.h"
+
+#include <esp_gattc_api.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace esphome::ble_midi {
+
+namespace espbt = esphome::esp32_ble_tracker;
+
+/// Client for devices implementing the standard BLE-MIDI service, e.g. wireless
+/// MIDI keyboards and pad controllers. Incoming messages are exposed as
+/// automation triggers; outgoing messages are sent with the ble_midi.send_*
+/// actions.
+///
+/// Specification: "Specification for MIDI over Bluetooth Low Energy
+/// (BLE-MIDI)", MIDI Association, document M1-2017-11-01.
+class BLEMidi final : public Component, public ble_client::BLEClientNode {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
+
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
+
+  void set_max_sysex_size(size_t size) { this->max_sysex_size_ = size; }
+  void set_pair(bool pair) { this->pair_ = pair; }
+
+  /// True once the MIDI characteristic has been discovered and notifications
+  /// are enabled.
+  bool is_ready() const { return this->notify_registered_; }
+
+  // Channel is 0-15, note/velocity/controller/value/program are 0-127.
+  void send_note_on(uint8_t note, uint8_t velocity, uint8_t channel);
+  void send_note_off(uint8_t note, uint8_t velocity, uint8_t channel);
+  void send_control_change(uint8_t control_number, uint8_t value, uint8_t channel);
+  void send_program_change(uint8_t program, uint8_t channel);
+  /// Pitch bend value is -8192 to 8191, centered on zero.
+  void send_pitch_bend(int16_t value, uint8_t channel);
+  /// Send a System Exclusive message. The 0xF0/0xF7 wrappers are added if the
+  /// payload does not already carry them.
+  void send_sysex(const std::vector<uint8_t> &payload);
+  /// Send raw MIDI bytes (status byte followed by its data bytes).
+  void send_raw(const std::vector<uint8_t> &bytes);
+
+  void add_on_connect_trigger(Trigger<> *trigger) { this->connect_triggers_.push_back(trigger); }
+  void add_on_disconnect_trigger(Trigger<> *trigger) { this->disconnect_triggers_.push_back(trigger); }
+  void add_on_note_on_trigger(Trigger<uint8_t, uint8_t, uint8_t> *trigger) {
+    this->note_on_triggers_.push_back(trigger);
+  }
+  void add_on_note_off_trigger(Trigger<uint8_t, uint8_t, uint8_t> *trigger) {
+    this->note_off_triggers_.push_back(trigger);
+  }
+  void add_on_control_change_trigger(Trigger<uint8_t, uint8_t, uint8_t> *trigger) {
+    this->control_change_triggers_.push_back(trigger);
+  }
+  void add_on_program_change_trigger(Trigger<uint8_t, uint8_t> *trigger) {
+    this->program_change_triggers_.push_back(trigger);
+  }
+  void add_on_pitch_bend_trigger(Trigger<int16_t, uint8_t> *trigger) { this->pitch_bend_triggers_.push_back(trigger); }
+  void add_on_sysex_trigger(Trigger<std::vector<uint8_t>> *trigger) { this->sysex_triggers_.push_back(trigger); }
+  void add_on_message_trigger(Trigger<std::vector<uint8_t>> *trigger) { this->message_triggers_.push_back(trigger); }
+
+ protected:
+  void handle_message_(const MidiMessage &message);
+  /// Wrap MIDI bytes in a BLE-MIDI packet and write them to the MIDI
+  /// characteristic.
+  bool write_midi_(const uint8_t *midi_bytes, size_t length);
+
+  // Longest MIDI message that can be transmitted in a single BLE-MIDI packet,
+  // header and timestamp excluded.
+  static constexpr size_t MAX_TX_MIDI_BYTES = 128;
+
+  MidiParser parser_;
+  size_t max_sysex_size_{256};
+  uint16_t characteristic_handle_{0};
+  bool notify_registered_{false};
+  // Write without response has lower latency and is preferred when the
+  // characteristic supports it.
+  bool write_without_response_{false};
+  bool pair_{false};
+
+  std::vector<Trigger<> *> connect_triggers_;
+  std::vector<Trigger<> *> disconnect_triggers_;
+  std::vector<Trigger<uint8_t, uint8_t, uint8_t> *> note_on_triggers_;
+  std::vector<Trigger<uint8_t, uint8_t, uint8_t> *> note_off_triggers_;
+  std::vector<Trigger<uint8_t, uint8_t, uint8_t> *> control_change_triggers_;
+  std::vector<Trigger<uint8_t, uint8_t> *> program_change_triggers_;
+  std::vector<Trigger<int16_t, uint8_t> *> pitch_bend_triggers_;
+  std::vector<Trigger<std::vector<uint8_t>> *> sysex_triggers_;
+  std::vector<Trigger<std::vector<uint8_t>> *> message_triggers_;
+};
+
+}  // namespace esphome::ble_midi
+
+#endif  // USE_ESP32

--- a/esphome/components/ble_midi/midi_parser.cpp
+++ b/esphome/components/ble_midi/midi_parser.cpp
@@ -1,0 +1,295 @@
+#include "midi_parser.h"
+
+namespace esphome::ble_midi {
+
+const char *message_type_name(MessageType type) {
+  switch (type) {
+    case MessageType::NOTE_OFF:
+      return "NOTE_OFF";
+    case MessageType::NOTE_ON:
+      return "NOTE_ON";
+    case MessageType::POLY_AFTERTOUCH:
+      return "POLY_AFTERTOUCH";
+    case MessageType::CONTROL_CHANGE:
+      return "CONTROL_CHANGE";
+    case MessageType::PROGRAM_CHANGE:
+      return "PROGRAM_CHANGE";
+    case MessageType::CHANNEL_AFTERTOUCH:
+      return "CHANNEL_AFTERTOUCH";
+    case MessageType::PITCH_BEND:
+      return "PITCH_BEND";
+    case MessageType::SYSEX:
+      return "SYSEX";
+    case MessageType::SYSTEM_COMMON:
+      return "SYSTEM_COMMON";
+    case MessageType::SYSTEM_REAL_TIME:
+      return "SYSTEM_REAL_TIME";
+    case MessageType::UNKNOWN:
+    default:
+      return "UNKNOWN";
+  }
+}
+
+static MessageType type_for_status(uint8_t status) {
+  if (status >= 0xF8)
+    return MessageType::SYSTEM_REAL_TIME;
+  if (status >= 0xF1 && status <= 0xF6)
+    return MessageType::SYSTEM_COMMON;
+  switch (status & 0xF0) {
+    case 0x80:
+      return MessageType::NOTE_OFF;
+    case 0x90:
+      return MessageType::NOTE_ON;
+    case 0xA0:
+      return MessageType::POLY_AFTERTOUCH;
+    case 0xB0:
+      return MessageType::CONTROL_CHANGE;
+    case 0xC0:
+      return MessageType::PROGRAM_CHANGE;
+    case 0xD0:
+      return MessageType::CHANNEL_AFTERTOUCH;
+    case 0xE0:
+      return MessageType::PITCH_BEND;
+    default:
+      return MessageType::UNKNOWN;
+  }
+}
+
+void MidiParser::init_sysex_buffer(size_t size) {
+  this->sysex_buffer_ = std::make_unique<uint8_t[]>(size);
+  this->sysex_capacity_ = size;
+  this->sysex_length_ = 0;
+}
+
+void MidiParser::reset() {
+  this->running_status_ = 0;
+  this->sysex_active_ = false;
+  this->sysex_length_ = 0;
+  this->reset_current_();
+}
+
+void MidiParser::reset_current_() {
+  this->current_message_[0] = 0;
+  this->current_length_ = 0;
+  this->current_expected_ = 0;
+}
+
+uint8_t MidiParser::expected_data_bytes(uint8_t status) {
+  switch (status & 0xF0) {
+    case 0x80:  // Note Off
+    case 0x90:  // Note On
+    case 0xA0:  // Polyphonic Aftertouch
+    case 0xB0:  // Control Change
+    case 0xE0:  // Pitch Bend
+      return 2;
+    case 0xC0:  // Program Change
+    case 0xD0:  // Channel Aftertouch
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+uint8_t MidiParser::expected_system_common_data_bytes(uint8_t status) {
+  switch (status) {
+    case 0xF1:  // MIDI Time Code Quarter Frame
+    case 0xF3:  // Song Select
+      return 1;
+    case 0xF2:  // Song Position Pointer
+      return 2;
+    default:  // 0xF4, 0xF5 undefined, 0xF6 Tune Request
+      return 0;
+  }
+}
+
+void MidiParser::sysex_push_(uint8_t byte) {
+  if (this->sysex_length_ < this->sysex_capacity_)
+    this->sysex_buffer_[this->sysex_length_++] = byte;
+}
+
+void MidiParser::emit_sysex_(const std::function<void(const MidiMessage &)> &callback) {
+  MidiMessage message;
+  message.type = MessageType::SYSEX;
+  message.data = this->sysex_buffer_.get();
+  message.length = this->sysex_length_;
+  this->sysex_active_ = false;
+  this->sysex_length_ = 0;
+  this->running_status_ = 0;
+  callback(message);
+}
+
+void MidiParser::emit_current_(const std::function<void(const MidiMessage &)> &callback) {
+  if (this->current_message_[0] == 0)
+    return;
+  uint8_t status = this->current_message_[0];
+  MidiMessage message;
+  message.type = type_for_status(status);
+  // A Note On with velocity zero is canonically a Note Off.
+  if (message.type == MessageType::NOTE_ON && this->current_length_ >= 3 && this->current_message_[2] == 0)
+    message.type = MessageType::NOTE_OFF;
+  message.data = this->current_message_;
+  message.length = this->current_length_;
+  // System Common clears running status; channel-voice messages set it.
+  this->running_status_ = (status >= 0xF0 && status <= 0xF7) ? 0 : status;
+  this->current_length_ = 0;
+  this->current_expected_ = 0;
+  callback(message);
+  // The message bytes must stay valid for the duration of the callback, so the
+  // status byte is cleared afterwards.
+  this->current_message_[0] = 0;
+}
+
+void MidiParser::emit_single_(MessageType type, uint8_t byte,
+                              const std::function<void(const MidiMessage &)> &callback) {
+  this->single_byte_ = byte;
+  MidiMessage message;
+  message.type = type;
+  message.data = &this->single_byte_;
+  message.length = 1;
+  callback(message);
+}
+
+void MidiParser::feed(const uint8_t *data, size_t length, const std::function<void(const MidiMessage &)> &callback) {
+  // A BLE-MIDI packet is at least a header byte plus one timestamp or SysEx
+  // continuation byte, and the header byte always has bit 7 set. Anything else
+  // is malformed.
+  if (length < 2 || (data[0] & 0x80) == 0) {
+    for (size_t i = 0; i < length; i++)
+      this->emit_single_(MessageType::UNKNOWN, data[i], callback);
+    return;
+  }
+
+  size_t i = 1;
+  bool expect_timestamp = true;
+
+  while (i < length) {
+    uint8_t byte = data[i];
+
+    if (expect_timestamp) {
+      // Either a timestamp byte introducing a new status byte, or a data byte
+      // continuing a SysEx or running status.
+      if ((byte & 0x80) == 0) {
+        if (this->sysex_active_) {
+          this->sysex_push_(byte);
+          i++;
+          continue;
+        }
+        // Running-status data byte: reprocess it below.
+        expect_timestamp = false;
+        continue;
+      }
+      i++;
+      expect_timestamp = false;
+      continue;
+    }
+
+    if ((byte & 0x80) == 0) {
+      // Data byte belonging to the message being assembled, or to a
+      // running-status message.
+      if (this->current_message_[0] == 0) {
+        if (this->running_status_ == 0) {
+          // Data byte without any status context.
+          this->emit_single_(MessageType::UNKNOWN, byte, callback);
+          i++;
+          continue;
+        }
+        this->current_message_[0] = this->running_status_;
+        this->current_length_ = 1;
+        this->current_expected_ = expected_data_bytes(this->running_status_);
+      }
+      if (this->current_length_ < sizeof(this->current_message_))
+        this->current_message_[this->current_length_++] = byte;
+      if (this->current_length_ >= this->current_expected_ + 1u) {
+        this->emit_current_(callback);
+        expect_timestamp = true;
+      }
+      i++;
+      continue;
+    }
+
+    // Status byte.
+    if (byte == 0xF0) {
+      // Start of SysEx; the rest of the packet is SysEx data until 0xF7 or the
+      // end of the packet.
+      this->sysex_active_ = true;
+      this->sysex_length_ = 0;
+      this->sysex_push_(0xF0);
+      i++;
+      while (i < length) {
+        uint8_t sysex_byte = data[i];
+        if ((sysex_byte & 0x80) == 0) {
+          this->sysex_push_(sysex_byte);
+          i++;
+          continue;
+        }
+        // A byte with bit 7 set inside SysEx is a timestamp; what follows
+        // decides its meaning.
+        if (i + 1 >= length) {
+          // Dangling timestamp at the end of the packet.
+          i++;
+          break;
+        }
+        uint8_t next = data[i + 1];
+        if (next == 0xF7) {
+          this->sysex_push_(0xF7);
+          this->emit_sysex_(callback);
+          i += 2;
+          break;
+        }
+        if (next >= 0xF8) {
+          // Real-time message interrupting the SysEx; SysEx resumes afterwards.
+          this->emit_single_(MessageType::SYSTEM_REAL_TIME, next, callback);
+          i += 2;
+          continue;
+        }
+        // Any other status byte ends the SysEx without an end-of-exclusive
+        // byte: malformed, but recoverable. Skip the timestamp and let the
+        // outer loop process the status byte.
+        this->emit_sysex_(callback);
+        i++;
+        break;
+      }
+      expect_timestamp = true;
+      continue;
+    }
+
+    if (byte == 0xF7) {
+      // End of SysEx without a preceding timestamp byte.
+      if (this->sysex_active_) {
+        this->sysex_push_(0xF7);
+        this->emit_sysex_(callback);
+      } else {
+        this->emit_single_(MessageType::UNKNOWN, byte, callback);
+      }
+      i++;
+      expect_timestamp = true;
+      continue;
+    }
+
+    if (byte >= 0xF8) {
+      // Real-time message: a single byte that does not affect running status.
+      this->emit_single_(MessageType::SYSTEM_REAL_TIME, byte, callback);
+      i++;
+      expect_timestamp = true;
+      continue;
+    }
+
+    // Any other status byte starts a new message and discards an incomplete
+    // one.
+    this->reset_current_();
+    this->current_message_[0] = byte;
+    this->current_length_ = 1;
+    this->current_expected_ =
+        (byte >= 0xF1 && byte <= 0xF6) ? expected_system_common_data_bytes(byte) : expected_data_bytes(byte);
+    if (this->current_expected_ == 0) {
+      // The status byte is a complete message on its own, e.g. Tune Request.
+      this->emit_current_(callback);
+      expect_timestamp = true;
+    } else {
+      expect_timestamp = false;
+    }
+    i++;
+  }
+}
+
+}  // namespace esphome::ble_midi

--- a/esphome/components/ble_midi/midi_parser.h
+++ b/esphome/components/ble_midi/midi_parser.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace esphome::ble_midi {
+
+// Decoded MIDI message types emitted by MidiParser.
+// Status bytes in MIDI have the high bit set; the low nibble encodes the
+// channel for channel-voice messages (0x80-0xEF), while system messages
+// (0xF0-0xFF) are channel-less.
+enum class MessageType : uint8_t {
+  NOTE_OFF,            // 0x80
+  NOTE_ON,             // 0x90
+  POLY_AFTERTOUCH,     // 0xA0
+  CONTROL_CHANGE,      // 0xB0
+  PROGRAM_CHANGE,      // 0xC0
+  CHANNEL_AFTERTOUCH,  // 0xD0
+  PITCH_BEND,          // 0xE0
+  SYSEX,               // 0xF0 ... 0xF7, possibly fragmented across BLE packets
+  SYSTEM_COMMON,       // 0xF1-0xF6, e.g. quarter frame, song position
+  SYSTEM_REAL_TIME,    // 0xF8-0xFF, e.g. clock, start, stop
+  UNKNOWN,             // malformed/undecodable byte
+};
+
+/// Short human-readable name of a message type, for logging.
+const char *message_type_name(MessageType type);
+
+/// A decoded MIDI message.
+///
+/// `data` points into storage owned by the MidiParser and is only valid for the
+/// duration of the parser callback; consumers that need to keep the bytes must
+/// copy them.
+struct MidiMessage {
+  MessageType type{MessageType::UNKNOWN};
+  // Full message bytes: status byte followed by its data bytes. For SysEx this
+  // includes the 0xF0/0xF7 wrappers.
+  const uint8_t *data{nullptr};
+  size_t length{0};
+
+  // Accessors below are only meaningful for the matching message type.
+  uint8_t status() const { return this->length > 0 ? this->data[0] : 0; }
+  uint8_t channel() const { return this->length > 0 ? (this->data[0] & 0x0F) : 0; }
+
+  // NOTE_ON / NOTE_OFF / POLY_AFTERTOUCH
+  uint8_t note() const { return this->length > 1 ? this->data[1] : 0; }
+  uint8_t velocity() const { return this->length > 2 ? this->data[2] : 0; }
+
+  // CONTROL_CHANGE
+  uint8_t control_number() const { return this->length > 1 ? this->data[1] : 0; }
+  uint8_t control_value() const { return this->length > 2 ? this->data[2] : 0; }
+
+  // PROGRAM_CHANGE / CHANNEL_AFTERTOUCH
+  uint8_t program() const { return this->length > 1 ? this->data[1] : 0; }
+
+  // PITCH_BEND: 14-bit value re-centered on zero (-8192..8191).
+  int16_t pitch_bend() const {
+    if (this->length < 3)
+      return 0;
+    uint16_t raw = (static_cast<uint16_t>(this->data[2]) << 7) | this->data[1];
+    return static_cast<int16_t>(raw) - 8192;
+  }
+};
+
+/// Decoder for the BLE-MIDI packet format (Apple/MMA "Bluetooth Low Energy
+/// MIDI" specification, section 3).
+///
+/// Packet layout:
+///   [header] [timestamp] [MIDI 0] ... ([timestamp] [MIDI n])*
+///
+/// - header    : 0b10hhhhhh, bit 7 set, bits 5-0 hold the high bits of the
+/// timestamp
+/// - timestamp : 0b1lllllll, bit 7 set, bits 6-0 hold the low bits of the
+/// timestamp
+///
+/// A timestamp byte precedes every new status byte, except where running status
+/// applies. SysEx messages may span several BLE packets and may be interrupted
+/// by real-time messages (0xF8-0xFF).
+///
+/// Timestamps are used for jitter reconstruction by MIDI hosts and are ignored
+/// here.
+///
+/// This class holds no BLE or ESPHome state so that it can be exercised in
+/// isolation.
+class MidiParser final {
+ public:
+  /// Allocate the buffer that reassembles SysEx messages. Must be called once
+  /// before feed(); SysEx payloads longer than `size` bytes are truncated.
+  void init_sysex_buffer(size_t size);
+
+  /// Drop all parser state. Call on disconnect so running status and partial
+  /// messages do not leak into the next session.
+  void reset();
+
+  /// Feed one BLE notification payload, invoking `callback` once per decoded
+  /// message. Undecodable bytes are reported as MessageType::UNKNOWN so the
+  /// caller can log them.
+  void feed(const uint8_t *data, size_t length, const std::function<void(const MidiMessage &)> &callback);
+
+ protected:
+  // Number of data bytes that follow a channel-voice status byte.
+  static uint8_t expected_data_bytes(uint8_t status);
+  // Number of data bytes that follow a system-common status byte.
+  static uint8_t expected_system_common_data_bytes(uint8_t status);
+
+  void emit_current_(const std::function<void(const MidiMessage &)> &callback);
+  void emit_single_(MessageType type, uint8_t byte, const std::function<void(const MidiMessage &)> &callback);
+  void emit_sysex_(const std::function<void(const MidiMessage &)> &callback);
+  void sysex_push_(uint8_t byte);
+  void reset_current_();
+
+  // Last channel-voice status byte, sticky across bytes and packets until a new
+  // status byte or a system-common message clears it (MIDI running status).
+  uint8_t running_status_{0};
+
+  // SysEx reassembly across packets.
+  std::unique_ptr<uint8_t[]> sysex_buffer_;
+  size_t sysex_capacity_{0};
+  size_t sysex_length_{0};
+  bool sysex_active_{false};
+
+  // Message currently being assembled: status byte plus up to two data bytes.
+  uint8_t current_message_[3]{};
+  uint8_t current_length_{0};
+  uint8_t current_expected_{0};
+
+  // Scratch storage for single-byte messages (real-time, undecodable bytes).
+  uint8_t single_byte_{0};
+};
+
+}  // namespace esphome::ble_midi

--- a/tests/components/ble_midi/common.yaml
+++ b/tests/components/ble_midi/common.yaml
@@ -1,0 +1,83 @@
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: 01:02:03:04:05:06
+    id: test_midi_client
+
+ble_midi:
+  id: test_midi
+  ble_client_id: test_midi_client
+  max_sysex_size: 64
+  pair: false
+  on_connect:
+    - logger.log: "MIDI device connected"
+    - ble_midi.send_program_change:
+        id: test_midi
+        program: 0
+  on_disconnect:
+    - logger.log: "MIDI device disconnected"
+  on_note_on:
+    - logger.log:
+        format: "Note on %u velocity %u channel %u"
+        args: [note, velocity, channel]
+  on_note_off:
+    - logger.log:
+        format: "Note off %u channel %u"
+        args: [note, channel]
+  on_control_change:
+    - logger.log:
+        format: "CC %u = %u on channel %u"
+        args: [control_number, value, channel]
+  on_program_change:
+    - logger.log:
+        format: "Program %u on channel %u"
+        args: [program, channel]
+  on_pitch_bend:
+    - logger.log:
+        format: "Pitch bend %d on channel %u"
+        args: [value, channel]
+  on_sysex:
+    - logger.log:
+        format: "SysEx of %u bytes"
+        args: ["data.size()"]
+  on_message:
+    - logger.log:
+        format: "Raw message of %u bytes"
+        args: ["data.size()"]
+
+button:
+  - platform: template
+    name: "MIDI send tests"
+    on_press:
+      - ble_midi.send_note_on:
+          id: test_midi
+          note: 60
+      - ble_midi.send_note_on:
+          id: test_midi
+          note: !lambda "return 60;"
+          velocity: !lambda "return 100;"
+          channel: !lambda "return 1;"
+      - ble_midi.send_note_off:
+          id: test_midi
+          note: 60
+          velocity: 0
+          channel: 1
+      - ble_midi.send_control_change:
+          id: test_midi
+          control_number: 7
+          value: 64
+      - ble_midi.send_pitch_bend:
+          id: test_midi
+          value: -8192
+      - ble_midi.send_sysex:
+          id: test_midi
+          payload: [0x7E, 0x7F, 0x06, 0x01]
+      - ble_midi.send_raw:
+          id: test_midi
+          data: !lambda "return std::vector<uint8_t>{0x90, 0x3C, 0x40};"
+      - if:
+          condition:
+            ble_midi.connected:
+              id: test_midi
+          then:
+            - logger.log: "Still connected"

--- a/tests/components/ble_midi/midi_parser_test.cpp
+++ b/tests/components/ble_midi/midi_parser_test.cpp
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "esphome/components/ble_midi/midi_parser.h"
+
+namespace esphome::ble_midi::testing {
+
+// A BLE-MIDI packet is a header byte, then timestamp/MIDI byte pairs. Both
+// header and timestamp have bit 7 set; their remaining bits carry a timestamp
+// that this component ignores.
+static constexpr uint8_t HDR = 0x80;
+static constexpr uint8_t TS = 0x80;
+
+struct Decoded {
+  MessageType type;
+  std::vector<uint8_t> bytes;
+};
+
+class MidiParserTest : public ::testing::Test {
+ protected:
+  void SetUp() override { this->parser_.init_sysex_buffer(64); }
+
+  void feed_(const std::vector<uint8_t> &packet) {
+    this->parser_.feed(packet.data(), packet.size(), [this](const MidiMessage &message) {
+      this->messages_.push_back({message.type, std::vector<uint8_t>(message.data, message.data + message.length)});
+    });
+  }
+
+  MidiParser parser_;
+  std::vector<Decoded> messages_;
+};
+
+TEST_F(MidiParserTest, NoteOn) {
+  this->feed_({HDR, TS, 0x90, 0x3C, 0x40});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::NOTE_ON);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0x90, 0x3C, 0x40}));
+}
+
+TEST_F(MidiParserTest, ChannelIsTakenFromTheStatusByte) {
+  this->feed_({HDR, TS, 0x95, 0x3C, 0x40});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  MidiMessage message{this->messages_[0].type, this->messages_[0].bytes.data(), this->messages_[0].bytes.size()};
+  EXPECT_EQ(message.channel(), 5);
+  EXPECT_EQ(message.note(), 60);
+  EXPECT_EQ(message.velocity(), 64);
+}
+
+TEST_F(MidiParserTest, RunningStatusReusesThePreviousStatusByte) {
+  this->feed_({HDR, TS, 0x90, 0x3C, 0x40, 0x3E, 0x41});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[1].type, MessageType::NOTE_ON);
+  EXPECT_EQ(this->messages_[1].bytes, std::vector<uint8_t>({0x90, 0x3E, 0x41}));
+}
+
+TEST_F(MidiParserTest, RunningStatusSurvivesAcrossPackets) {
+  this->feed_({HDR, TS, 0xB0, 0x07, 0x10});
+  this->feed_({HDR, 0x07, 0x20});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[1].type, MessageType::CONTROL_CHANGE);
+  EXPECT_EQ(this->messages_[1].bytes, std::vector<uint8_t>({0xB0, 0x07, 0x20}));
+}
+
+TEST_F(MidiParserTest, ResetClearsRunningStatus) {
+  this->feed_({HDR, TS, 0x90, 0x3C, 0x40});
+  this->parser_.reset();
+  this->messages_.clear();
+  this->feed_({HDR, TS, 0x3E, 0x41});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::UNKNOWN);
+  EXPECT_EQ(this->messages_[1].type, MessageType::UNKNOWN);
+}
+
+TEST_F(MidiParserTest, NoteOnWithZeroVelocityIsANoteOff) {
+  this->feed_({HDR, TS, 0x90, 0x3C, 0x00});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::NOTE_OFF);
+}
+
+TEST_F(MidiParserTest, ControlChange) {
+  this->feed_({HDR, TS, 0xB2, 0x07, 0x64});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  MidiMessage message{this->messages_[0].type, this->messages_[0].bytes.data(), this->messages_[0].bytes.size()};
+  EXPECT_EQ(message.type, MessageType::CONTROL_CHANGE);
+  EXPECT_EQ(message.channel(), 2);
+  EXPECT_EQ(message.control_number(), 7);
+  EXPECT_EQ(message.control_value(), 100);
+}
+
+TEST_F(MidiParserTest, ProgramChangeHasASingleDataByte) {
+  this->feed_({HDR, TS, 0xC0, 0x05, TS, 0xC0, 0x06});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::PROGRAM_CHANGE);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0xC0, 0x05}));
+  EXPECT_EQ(this->messages_[1].bytes, std::vector<uint8_t>({0xC0, 0x06}));
+}
+
+TEST_F(MidiParserTest, PitchBendIsCenteredOnZero) {
+  this->feed_({HDR, TS, 0xE0, 0x00, 0x40, TS, 0xE0, 0x00, 0x00, TS, 0xE0, 0x7F, 0x7F});
+  ASSERT_EQ(this->messages_.size(), 3u);
+  auto bend = [this](size_t index) {
+    MidiMessage message{this->messages_[index].type, this->messages_[index].bytes.data(),
+                        this->messages_[index].bytes.size()};
+    return message.pitch_bend();
+  };
+  EXPECT_EQ(this->messages_[0].type, MessageType::PITCH_BEND);
+  EXPECT_EQ(bend(0), 0);
+  EXPECT_EQ(bend(1), -8192);
+  EXPECT_EQ(bend(2), 8191);
+}
+
+TEST_F(MidiParserTest, RealTimeMessageIsASingleByte) {
+  this->feed_({HDR, TS, 0xF8});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::SYSTEM_REAL_TIME);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0xF8}));
+}
+
+TEST_F(MidiParserTest, SystemCommonMessageWithTwoDataBytes) {
+  this->feed_({HDR, TS, 0xF2, 0x01, 0x02});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::SYSTEM_COMMON);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0xF2, 0x01, 0x02}));
+}
+
+TEST_F(MidiParserTest, SystemCommonClearsRunningStatus) {
+  this->feed_({HDR, TS, 0x90, 0x3C, 0x40, TS, 0xF6});
+  this->messages_.clear();
+  this->feed_({HDR, 0x3E, 0x41});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::UNKNOWN);
+}
+
+TEST_F(MidiParserTest, SysexInASinglePacket) {
+  this->feed_({HDR, TS, 0xF0, 0x7E, 0x7F, 0x06, 0x01, TS, 0xF7});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::SYSEX);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7}));
+}
+
+TEST_F(MidiParserTest, SysexReassembledAcrossPackets) {
+  this->feed_({HDR, TS, 0xF0, 0x7E, 0x7F});
+  EXPECT_TRUE(this->messages_.empty());
+  this->feed_({HDR, 0x06, 0x01, TS, 0xF7});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7}));
+}
+
+TEST_F(MidiParserTest, RealTimeMessageInterruptsSysex) {
+  this->feed_({HDR, TS, 0xF0, 0x7E, TS, 0xF8, 0x7F, TS, 0xF7});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::SYSTEM_REAL_TIME);
+  EXPECT_EQ(this->messages_[1].type, MessageType::SYSEX);
+  EXPECT_EQ(this->messages_[1].bytes, std::vector<uint8_t>({0xF0, 0x7E, 0x7F, 0xF7}));
+}
+
+TEST_F(MidiParserTest, SysexLongerThanTheBufferIsTruncatedAndDoesNotOverflow) {
+  MidiParser small_parser;
+  small_parser.init_sysex_buffer(8);
+  std::vector<uint8_t> packet{HDR, TS, 0xF0};
+  for (uint8_t i = 0; i < 64; i++)
+    packet.push_back(i & 0x7F);
+  packet.push_back(TS);
+  packet.push_back(0xF7);
+
+  std::vector<size_t> lengths;
+  small_parser.feed(packet.data(), packet.size(),
+                    [&lengths](const MidiMessage &message) { lengths.push_back(message.length); });
+  ASSERT_EQ(lengths.size(), 1u);
+  EXPECT_EQ(lengths[0], 8u);
+}
+
+TEST_F(MidiParserTest, DataByteWithoutStatusContextIsReportedAsUnknown) {
+  this->feed_({HDR, TS, 0x3C});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::UNKNOWN);
+  EXPECT_EQ(this->messages_[0].bytes, std::vector<uint8_t>({0x3C}));
+}
+
+TEST_F(MidiParserTest, PacketWithoutAHeaderByteIsRejected) {
+  this->feed_({0x3C, 0x40});
+  ASSERT_EQ(this->messages_.size(), 2u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::UNKNOWN);
+  EXPECT_EQ(this->messages_[1].type, MessageType::UNKNOWN);
+}
+
+TEST_F(MidiParserTest, EmptyAndSingleByteInputAreHandled) {
+  this->feed_({});
+  this->feed_({HDR});
+  EXPECT_EQ(this->messages_.size(), 1u);
+}
+
+TEST_F(MidiParserTest, IncompleteMessageIsDiscardedWhenANewStatusByteArrives) {
+  this->feed_({HDR, TS, 0x90, 0x3C, TS, 0xB0, 0x07, 0x10});
+  ASSERT_EQ(this->messages_.size(), 1u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::CONTROL_CHANGE);
+}
+
+TEST_F(MidiParserTest, MultipleMessagesInOnePacket) {
+  this->feed_({HDR, TS, 0x90, 0x3C, 0x40, TS, 0x80, 0x3C, 0x00, TS, 0xB0, 0x07, 0x7F});
+  ASSERT_EQ(this->messages_.size(), 3u);
+  EXPECT_EQ(this->messages_[0].type, MessageType::NOTE_ON);
+  EXPECT_EQ(this->messages_[1].type, MessageType::NOTE_OFF);
+  EXPECT_EQ(this->messages_[2].type, MessageType::CONTROL_CHANGE);
+}
+
+}  // namespace esphome::ble_midi::testing

--- a/tests/components/ble_midi/test.esp32-c3-idf.yaml
+++ b/tests/components/ble_midi/test.esp32-c3-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  ble: !include ../../test_build_components/common/ble/esp32-c3-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/ble_midi/test.esp32-idf.yaml
+++ b/tests/components/ble_midi/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  ble: !include ../../test_build_components/common/ble/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

This adds a `ble_midi` component: it connects to a BLE MIDI device (a keyboard, a pad
controller, a foot switch) as a GATT client and turns the incoming MIDI into
automations. It can also send MIDI back to the device.

I have been running this on real hardware for the past four months, in an external
component of my own (https://github.com/bogdanr/esphome-ble-midi), on an M-Vave SMC-PAD
and a Korg microKEY Air. This PR is that code, reduced to the generic part and reworked
to fit the core guidelines: no auto-created entities, no AUTO_LOAD of platform
components, no device-specific mapping and no reaching into other components. The
opinionated bits (per-device profiles, mapping notes to lights) stay in my repo, on top
of the triggers this PR provides.

What is in scope here is only the hub:

- Triggers: `on_note_on`, `on_note_off`, `on_control_change`, `on_program_change`,
  `on_pitch_bend`, `on_sysex`, `on_message`, `on_connect`, `on_disconnect`
- Actions: `ble_midi.send_note_on`, `send_note_off`, `send_control_change`,
  `send_program_change`, `send_pitch_bend`, `send_sysex`, `send_raw`
- Condition: `ble_midi.connected`

A few things to mention:

- Channels are 0-15 in both triggers and actions, matching the wire format. I did not
  add a 1-16 translation because it cannot be applied to a `!lambda` channel, and having
  the read and write paths disagree would be worse than exposing the raw value.
- `on_sysex` gives the payload without the `0xF0`/`0xF7` wrappers; `send_sysex` adds them
  if they are missing.
- `on_message` exposes the raw bytes of every message, including aftertouch and system
  messages that have no dedicated trigger, so nothing is unreachable.
- `max_sysex_size` is the only allocation and it happens once in `setup()`. A larger
  SysEx is truncated rather than growing the buffer.
- The parser (`midi_parser.h`/`.cpp`) has no ESPHome or BLE dependency on purpose, so it
  can be unit tested on the host. `loop()` disables itself immediately; everything is
  driven from the GATT event handler.

Happy to change the naming or the surface if you would rather see this as one transport
under a generic `midi` core later on. The parser and the automation layer are already
separate for that reason.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7219

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble_tracker:

ble_client:
  - mac_address: 01:02:03:04:05:06
    id: pad_client

ble_midi:
  id: pad
  ble_client_id: pad_client
  on_note_on:
    - logger.log:
        format: "Note %u on, velocity %u, channel %u"
        args: [note, velocity, channel]
  on_control_change:
    - logger.log:
        format: "CC %u = %u"
        args: [control_number, value]

button:
  - platform: template
    name: "Send a note"
    on_press:
      - ble_midi.send_note_on:
          id: pad
          note: 60
          velocity: 100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
