### PR TITLE
[wifi] Take the lwIP core lock around sntp_servermode_dhcp()

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -580,7 +580,14 @@ bool WiFiComponent::wifi_sta_ip_config_(const optional<ManualIP> &manual_ip) {
     // lwIP starts the SNTP client if it gets an SNTP server from DHCP. We don't need the time, and more importantly,
     // the built-in SNTP client has a memory leak in certain situations. Disable this feature.
     // https://github.com/esphome/issues/issues/2299
-    sntp_servermode_dhcp(false);
+    {
+#if SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6
+      // sntp_servermode_dhcp() is an empty macro unless lwIP is built with
+      // DHCP-supplied NTP servers, so only that build needs the core lock.
+      LwIPLock lock;
+#endif
+      sntp_servermode_dhcp(false);
+    }
 
     // No manual IP is set; use DHCP client
     if (dhcp_status != ESP_NETIF_DHCP_STARTED) {


### PR DESCRIPTION
#7997 added a lock around this exact call in the Arduino wifi component, and #9570 introduced LwIPLock and applied it across nine files. The esp-idf wifi component was missed by both, so the call is still unlocked here and lwIP asserts on it as soon as CONFIG_LWIP_DHCP_GET_NTP_SRV is enabled:

  assert failed: sntp_servermode_dhcp
  /IDF/components/lwip/lwip/src/apps/sntp/sntp.c:788
  (Required to lock TCPIP core functionality!)

  sntp_servermode_dhcp at sntp.c:788
  WiFiComponent::wifi_sta_ip_config_ at wifi_component_esp_idf.cpp:583
  WiFiComponent::wifi_sta_connect_ at wifi_component_esp_idf.cpp:452
  WiFiComponent::start_connecting at wifi_component.cpp:1197

The node panics on every wifi connect and never reaches a usable state. 

The call is inert under the default CONFIG_LWIP_DHCP_GET_NTP_SRV=n, which is why this has gone unnoticed; enabling the option turns ESPHome's own opt-out from DHCP-provided SNTP into a boot loop.

Reproduced on ESP32-S3 with ESPHome 2026.7.4, esp-idf framework.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)


**Related issue or feature (if applicable):**

- fixes 
- #7997 
- #9570

## Test Environment

- [x] ESP32 IDF


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
