### PR TITLE
[gree] Keep display light on by default for YAN/YAA/YAC/YAC1FB9

### DIFF
--- a/esphome/components/gree/gree.h
+++ b/esphome/components/gree/gree.h
@@ -76,6 +76,12 @@ static constexpr uint8_t GREE_PRESET_NONE = 0x00;
 static constexpr uint8_t GREE_PRESET_SLEEP = 0x01;
 static constexpr uint8_t GREE_PRESET_SLEEP_BIT = 0x80;
 
+// Mode bits stored in remote_state[2] bits 4..7 for YAN/YAA/YAC/YAC1FB9.
+static constexpr uint8_t GREE_MODE_BIT_TURBO = 0x10;
+static constexpr uint8_t GREE_MODE_BIT_LIGHT = 0x20;
+static constexpr uint8_t GREE_MODE_BIT_HEALTH = 0x40;
+static constexpr uint8_t GREE_MODE_BIT_XFAN = 0x80;
+
 // Model codes
 enum Model { GREE_GENERIC, GREE_YAN, GREE_YAA, GREE_YAC, GREE_YAC1FB9, GREE_YX1FF, GREE_YAG };
 
@@ -104,7 +110,8 @@ class GreeClimate final : public climate_ir::ClimateIR {
   uint8_t preset_();
 
   Model model_{};
-  uint8_t mode_bits_{0};  // Combined mode bits for remote_state[2]
+  // LIGHT on by default to preserve pre-#12160 behavior.
+  uint8_t mode_bits_{GREE_MODE_BIT_LIGHT};
 };
 
 }  // namespace esphome::gree

--- a/esphome/components/gree/switch/__init__.py
+++ b/esphome/components/gree/switch/__init__.py
@@ -19,10 +19,22 @@ CONF_GREE_ID = "gree_id"
 # Switch configurations: (config_key, display_name, bit_mask, icon, default_restore_mode)
 # LIGHT defaults to ON to match pre-#12160 behavior.
 SWITCH_CONFIGS = (
-    (CONF_TURBO, "Gree Turbo Switch", 0x10, "mdi:car-turbocharger", "RESTORE_DEFAULT_OFF"),
+    (
+        CONF_TURBO,
+        "Gree Turbo Switch",
+        0x10,
+        "mdi:car-turbocharger",
+        "RESTORE_DEFAULT_OFF",
+    ),
     (CONF_LIGHT, "Gree Light Switch", 0x20, "mdi:led-outline", "RESTORE_DEFAULT_ON"),
     (CONF_HEALTH, "Gree Health Switch", 0x40, "mdi:pine-tree", "RESTORE_DEFAULT_OFF"),
-    (CONF_XFAN, "Gree X-FAN Switch", 0x80, "mdi:wall-sconce-flat", "RESTORE_DEFAULT_OFF"),
+    (
+        CONF_XFAN,
+        "Gree X-FAN Switch",
+        0x80,
+        "mdi:wall-sconce-flat",
+        "RESTORE_DEFAULT_OFF",
+    ),
 )
 
 SUPPORTED_MODELS = {

--- a/esphome/components/gree/switch/__init__.py
+++ b/esphome/components/gree/switch/__init__.py
@@ -16,12 +16,13 @@ CONF_HEALTH = "health"
 CONF_XFAN = "xfan"
 CONF_GREE_ID = "gree_id"
 
-# Switch configurations: (config_key, display_name, bit_mask, icon)
+# Switch configurations: (config_key, display_name, bit_mask, icon, default_restore_mode)
+# LIGHT defaults to ON to match pre-#12160 behavior.
 SWITCH_CONFIGS = (
-    (CONF_TURBO, "Gree Turbo Switch", 0x10, "mdi:car-turbocharger"),
-    (CONF_LIGHT, "Gree Light Switch", 0x20, "mdi:led-outline"),
-    (CONF_HEALTH, "Gree Health Switch", 0x40, "mdi:pine-tree"),
-    (CONF_XFAN, "Gree X-FAN Switch", 0x80, "mdi:wall-sconce-flat"),
+    (CONF_TURBO, "Gree Turbo Switch", 0x10, "mdi:car-turbocharger", "RESTORE_DEFAULT_OFF"),
+    (CONF_LIGHT, "Gree Light Switch", 0x20, "mdi:led-outline", "RESTORE_DEFAULT_ON"),
+    (CONF_HEALTH, "Gree Health Switch", 0x40, "mdi:pine-tree", "RESTORE_DEFAULT_OFF"),
+    (CONF_XFAN, "Gree X-FAN Switch", 0x80, "mdi:wall-sconce-flat", "RESTORE_DEFAULT_OFF"),
 )
 
 SUPPORTED_MODELS = {
@@ -38,11 +39,11 @@ CONFIG_SCHEMA = cv.Schema(
             cv.Optional(key): switch.switch_schema(
                 GreeModeBitSwitch,
                 icon=icon,
-                default_restore_mode="RESTORE_DEFAULT_OFF",
+                default_restore_mode=restore_mode,
                 device_class=DEVICE_CLASS_SWITCH,
                 entity_category=ENTITY_CATEGORY_CONFIG,
             )
-            for key, _, _, icon in SWITCH_CONFIGS
+            for key, _, _, icon, restore_mode in SWITCH_CONFIGS
         },
     }
 )
@@ -66,7 +67,7 @@ FINAL_VALIDATE_SCHEMA = _validate_model
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_GREE_ID])
 
-    for conf_key, name, bit_mask, _ in SWITCH_CONFIGS:
+    for conf_key, name, bit_mask, _, _ in SWITCH_CONFIGS:
         if switch_conf := config.get(conf_key):
             sw = cg.new_Pvariable(switch_conf[cv.CONF_ID], name, bit_mask)
             await switch.register_switch(sw, switch_conf)


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression introduced by #12160 (merged in 2025.12.0) where the AC display light turns off with every command for users who do not configure the `light` switch.

Before #12160, `remote_state[2]` was hardcoded to `0x20` (LIGHT on) for YAN/YAA/YAC/YAC1FB9 models. #12160 replaced the hardcode with a `mode_bits_` field initialized to `0`, which clears the LIGHT bit on every `transmit_state()` call.

This PR initializes `mode_bits_` to `GREE_MODE_BIT_LIGHT` (0x20), restoring the pre-#12160 behavior. Also changes the `light` switch default `restore_mode` from `RESTORE_DEFAULT_OFF` to `RESTORE_DEFAULT_ON` so users who add the switch block without specifying `restore_mode` keep the light on at boot.

This aligns gree with other climate components that have display switches (haier, ld6002b), which all default the display to ON.

Note: YAN's pre-#12160 default was `0x60` (LIGHT + HEALTH). This fix restores LIGHT only; HEALTH remains off by default as introduced by #12160.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18515

## Test Environment

- [x] BK72xx

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: gree
    name: "AC"
    model: yan
    transmitter_id: ir_tx
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
