### PR TITLE
[ci] Stop jobs hanging on apt by restoring the cached apt action and bounding raw apt calls

### DIFF
--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -52,12 +52,19 @@ jobs:
         # timeout-minutes.
         timeout-minutes: 15
         run: |
+          # The runners' primary mirror (azure.archive.ubuntu.com) can
+          # black-hole; apt's default per-fetch timeout then burns most of
+          # a bound before the mirrorlist falls back to archive.ubuntu.com.
+          # Short per-fetch timeouts make apt give up on the dead mirror in
+          # seconds so the bound is spent on the working fallback.
+          APT_OPTS=(-o Acquire::Retries=1 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
           attempt=0
           for bound in 45 90 180; do
             attempt=$((attempt + 1))
-            if sudo timeout -k 15 "$bound" apt-get update \
+            if sudo timeout -k 15 "$bound" \
+                apt-get "${APT_OPTS[@]}" update \
               && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \
-                apt-get install -y protobuf-compiler
+                apt-get "${APT_OPTS[@]}" install -y protobuf-compiler
             then
               protoc --version
               exit 0

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -41,17 +41,12 @@ jobs:
           version: "0.11.15"
 
       - name: Install apt dependencies
-        # Pull-request-only workflow, so nothing on dev could seed a shared
-        # apt cache entry and the cached apt action would write one copy per
-        # pull request. Plain apt stays, but every call is bounded so a
-        # slow mirror fails the step instead of hanging it.
-        # Short per-fetch timeouts in apt.conf.d make apt abandon a
-        # black-holing mirror in seconds, so the outer bounds are spent on
-        # the working fallback; timeout runs under sudo so it can kill
-        # apt-get itself. The install is tried without ``apt-get update``
-        # first: the runner image ships with fresh package lists, so the
-        # common path avoids the index download that a congested fallback
-        # mirror makes slow.
+        # PR-only workflow, so nothing on dev could seed a shared apt cache
+        # entry; the cached apt action would save one copy per PR. Plain apt
+        # with every call bounded: the apt.conf.d timeouts make a dead
+        # mirror fail over in seconds, and timeout runs under sudo so it can
+        # kill apt-get itself. Install without update first: image lists are
+        # fresh, and the index refresh is what a congested mirror makes slow.
         timeout-minutes: 15
         run: |
           sudo tee /etc/apt/apt.conf.d/99ci-acquire-timeouts >/dev/null <<'EOF'
@@ -65,10 +60,8 @@ jobs:
             protoc --version
             exit 0
           fi
-          # Rescue path: refresh the lists once, with a generous bound.
-          # The apt config above already converts a stalled mirror into a
-          # fast per-fetch failure and a fallback, so one bounded attempt
-          # is enough; the outer timeout is only a backstop.
+          # Rescue path: refresh the lists once with a generous bound; the
+          # apt config already fails a stalled mirror over quickly.
           sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
             dpkg --configure -a || true
           sudo timeout -k 15 300 apt-get update

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -45,11 +45,14 @@ jobs:
         # apt cache entry and the cached apt action would write one copy per
         # pull request. Plain apt stays, but every call is bounded and
         # retried so a slow mirror fails the step instead of hanging it.
+        # timeout runs under sudo so it can kill apt-get itself; the
+        # per-call bounds are sized so all three attempts fit inside
+        # timeout-minutes (3 x (75 + 75 + 10) s).
         timeout-minutes: 10
         run: |
           for attempt in 1 2 3; do
-            if timeout 300 sudo apt-get update \
-              && timeout 300 sudo DEBIAN_FRONTEND=noninteractive \
+            if sudo timeout -k 15 60 apt-get update \
+              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 60 \
                 apt-get install -y protobuf-compiler
             then
               protoc --version

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -43,38 +43,38 @@ jobs:
       - name: Install apt dependencies
         # Pull-request-only workflow, so nothing on dev could seed a shared
         # apt cache entry and the cached apt action would write one copy per
-        # pull request. Plain apt stays, but every call is bounded and
-        # retried so a slow mirror fails the step instead of hanging it.
-        # timeout runs under sudo so it can kill apt-get itself. The
-        # per-call bound escalates per attempt so a congested but working
-        # mirror still gets a generous last try; with the kill grace, the
-        # dpkg recovery call and the sleeps, all three attempts stay inside
-        # timeout-minutes.
+        # pull request. Plain apt stays, but every call is bounded so a
+        # slow mirror fails the step instead of hanging it.
+        # Short per-fetch timeouts in apt.conf.d make apt abandon a
+        # black-holing mirror in seconds, so the outer bounds are spent on
+        # the working fallback; timeout runs under sudo so it can kill
+        # apt-get itself. The install is tried without ``apt-get update``
+        # first: the runner image ships with fresh package lists, so the
+        # common path avoids the index download that a congested fallback
+        # mirror makes slow.
         timeout-minutes: 15
         run: |
-          # The runners' primary mirror (azure.archive.ubuntu.com) can
-          # black-hole; apt's default per-fetch timeout then burns most of
-          # a bound before the mirrorlist falls back to archive.ubuntu.com.
-          # Short per-fetch timeouts make apt give up on the dead mirror in
-          # seconds so the bound is spent on the working fallback.
-          APT_OPTS=(-o Acquire::Retries=1 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
-          attempt=0
-          for bound in 45 90 180; do
-            attempt=$((attempt + 1))
-            if sudo timeout -k 15 "$bound" \
-                apt-get "${APT_OPTS[@]}" update \
-              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \
-                apt-get "${APT_OPTS[@]}" install -y protobuf-compiler
-            then
-              protoc --version
-              exit 0
-            fi
-            echo "apt-get attempt ${attempt} (${bound}s per call) failed, retrying"
-            sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
-              dpkg --configure -a || true
-            sleep 10
-          done
-          exit 1
+          sudo tee /etc/apt/apt.conf.d/99ci-acquire-timeouts >/dev/null <<'EOF'
+          Acquire::Retries "1";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          EOF
+          # Common path: the image's package lists are fresh enough.
+          if sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 90 \
+              apt-get install -y protobuf-compiler; then
+            protoc --version
+            exit 0
+          fi
+          # Rescue path: refresh the lists once, with a generous bound.
+          # The apt config above already converts a stalled mirror into a
+          # fast per-fetch failure and a fallback, so one bounded attempt
+          # is enough; the outer timeout is only a backstop.
+          sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
+            dpkg --configure -a || true
+          sudo timeout -k 15 300 apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 300 \
+            apt-get install -y protobuf-compiler
+          protoc --version
       - name: Install python dependencies
         run: uv pip install --system aioesphomeapi -c requirements.txt -r requirements_dev.txt
       - name: Generate files

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -41,11 +41,25 @@ jobs:
           version: "0.11.15"
 
       - name: Install apt dependencies
+        # Pull-request-only workflow, so nothing on dev could seed a shared
+        # apt cache entry and the cached apt action would write one copy per
+        # pull request. Plain apt stays, but every call is bounded and
+        # retried so a slow mirror fails the step instead of hanging it.
+        timeout-minutes: 10
         run: |
-          sudo apt update
-          sudo apt-cache show protobuf-compiler
-          sudo apt install -y protobuf-compiler
-          protoc --version
+          for attempt in 1 2 3; do
+            if timeout 300 sudo apt-get update \
+              && timeout 300 sudo DEBIAN_FRONTEND=noninteractive \
+                apt-get install -y protobuf-compiler
+            then
+              protoc --version
+              exit 0
+            fi
+            echo "apt-get attempt ${attempt} failed, retrying"
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          exit 1
       - name: Install python dependencies
         run: uv pip install --system aioesphomeapi -c requirements.txt -r requirements_dev.txt
       - name: Generate files

--- a/.github/workflows/ci-api-proto.yml
+++ b/.github/workflows/ci-api-proto.yml
@@ -45,21 +45,26 @@ jobs:
         # apt cache entry and the cached apt action would write one copy per
         # pull request. Plain apt stays, but every call is bounded and
         # retried so a slow mirror fails the step instead of hanging it.
-        # timeout runs under sudo so it can kill apt-get itself; the
-        # per-call bounds are sized so all three attempts fit inside
-        # timeout-minutes (3 x (75 + 75 + 10) s).
-        timeout-minutes: 10
+        # timeout runs under sudo so it can kill apt-get itself. The
+        # per-call bound escalates per attempt so a congested but working
+        # mirror still gets a generous last try; with the kill grace, the
+        # dpkg recovery call and the sleeps, all three attempts stay inside
+        # timeout-minutes.
+        timeout-minutes: 15
         run: |
-          for attempt in 1 2 3; do
-            if sudo timeout -k 15 60 apt-get update \
-              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 60 \
+          attempt=0
+          for bound in 45 90 180; do
+            attempt=$((attempt + 1))
+            if sudo timeout -k 15 "$bound" apt-get update \
+              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \
                 apt-get install -y protobuf-compiler
             then
               protoc --version
               exit 0
             fi
-            echo "apt-get attempt ${attempt} failed, retrying"
-            sudo dpkg --configure -a || true
+            echo "apt-get attempt ${attempt} (${bound}s per call) failed, retrying"
+            sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
+              dpkg --configure -a || true
             sleep 10
           done
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,12 +517,19 @@ jobs:
             echo "libc6-dbg already installed"
             exit 0
           fi
+          # The runners' primary mirror (azure.archive.ubuntu.com) can
+          # black-hole; apt's default per-fetch timeout then burns most of
+          # a bound before the mirrorlist falls back to archive.ubuntu.com.
+          # Short per-fetch timeouts make apt give up on the dead mirror in
+          # seconds so the bound is spent on the working fallback.
+          APT_OPTS=(-o Acquire::Retries=1 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
           attempt=0
           for bound in 30 60 120; do
             attempt=$((attempt + 1))
-            if sudo timeout -k 15 "$bound" apt-get update \
+            if sudo timeout -k 15 "$bound" \
+                apt-get "${APT_OPTS[@]}" update \
               && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \
-                apt-get install -y libc6-dbg
+                apt-get "${APT_OPTS[@]}" install -y libc6-dbg
             then
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,12 @@ jobs:
     # Pull request jobs restore the apt packages below through the cache
     # action, and a cache written on a pull request branch is only visible
     # to that one pull request. Pushes to dev/beta/release seed and refresh
-    # the single shared entry instead, so pull request jobs always hit it
-    # and never write a copy of their own. The package list and version
-    # must stay identical to the steps that restore it; the cache key is
-    # derived from them alone.
+    # the single shared entry instead, so pull request jobs hit it and never
+    # write a copy of their own for as long as that entry exists. The package
+    # list and version must stay identical to the steps that restore it; the
+    # cache key is derived from them alone. Listed in ci-status so a broken
+    # seed shows up on dev instead of quietly bringing per-pull-request
+    # copies back.
     if: github.event_name == 'push'
     timeout-minutes: 10
     steps:
@@ -491,17 +493,23 @@ jobs:
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
       - name: Install libc6-dbg
-        # The CodSpeed runner installs this itself with a plain apt-get call
-        # that has no timeout, so a slow apt mirror hangs the job until
-        # timeout-minutes kills it. Installing it here with a bounded retry
-        # also lets the runner find it already present after restoring
-        # valgrind from its cache and skip apt entirely. The cached apt
-        # action cannot be used for this: it restores files without
-        # registering them with dpkg, so the runner would still call apt.
+        # The CodSpeed runner (CodSpeedHQ/codspeed, executor/valgrind/setup.rs)
+        # skips its own install only when valgrind is present and
+        # ``dpkg -s libc6-dbg`` succeeds; otherwise helpers/apt.rs runs
+        # ``apt-get update`` with no timeout, so a slow apt mirror hangs the
+        # job until timeout-minutes kills it. Installing libc6-dbg here with
+        # a bounded retry lets the runner skip apt once valgrind is restored
+        # from its cache. The cached apt action cannot be used for this: it
+        # restores files without registering them with dpkg. Best effort
+        # only; a failure here just hands the install back to the runner,
+        # with the job timeout as the backstop. Per-call bounds are sized so
+        # all three attempts fit inside timeout-minutes (3 x (75 + 75 + 10) s).
+        timeout-minutes: 10
+        continue-on-error: true
         run: |
           for attempt in 1 2 3; do
-            if timeout 300 sudo apt-get update \
-              && timeout 300 sudo DEBIAN_FRONTEND=noninteractive \
+            if sudo timeout -k 15 60 apt-get update \
+              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 60 \
                 apt-get install -y libc6-dbg
             then
               exit 0
@@ -940,7 +948,10 @@ jobs:
         # pull-request-only job hits and never saves a copy of its own. A
         # cache hit never touches apt, so a slow mirror cannot hang the job,
         # and the timeout bounds the cold path. Package list and version
-        # must match seed-apt-cache exactly.
+        # must match seed-apt-cache exactly. The action has no
+        # --no-install-recommends, so the recommended packages of libsdl2-dev
+        # come along; this is the same package set this job used before
+        # #17463.
         timeout-minutes: 10
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
@@ -1480,6 +1491,7 @@ jobs:
     # this check.
     needs:
       - common
+      - seed-apt-cache
       - determine-jobs
       - ci-custom
       - pylint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,12 +506,19 @@ jobs:
         # with the job timeout as the backstop. The per-call bound escalates
         # per attempt so a congested but working mirror still gets a generous
         # last try; with the kill grace, the dpkg recovery call and the
-        # sleeps, all three attempts stay inside timeout-minutes.
-        timeout-minutes: 15
+        # sleeps, all three attempts stay inside timeout-minutes. The ladder
+        # is tighter than the one in ci-api-proto.yml on purpose: this step
+        # is optional, so most of the 30 minute job budget stays reserved
+        # for the benchmark run itself.
+        timeout-minutes: 10
         continue-on-error: true
         run: |
+          if dpkg -s libc6-dbg >/dev/null 2>&1; then
+            echo "libc6-dbg already installed"
+            exit 0
+          fi
           attempt=0
-          for bound in 45 90 180; do
+          for bound in 30 60 120; do
             attempt=$((attempt + 1))
             if sudo timeout -k 15 "$bound" apt-get update \
               && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,52 +493,51 @@ jobs:
           fi
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
-      - name: Install libc6-dbg
-        # The CodSpeed runner (CodSpeedHQ/codspeed, executor/valgrind/setup.rs)
-        # skips its own install only when valgrind is present and
-        # ``dpkg -s libc6-dbg`` succeeds; otherwise helpers/apt.rs runs
-        # ``apt-get update`` with no timeout, so a slow apt mirror hangs the
-        # job until timeout-minutes kills it. Installing libc6-dbg here with
-        # a bounded retry lets the runner skip apt once valgrind is restored
-        # from its cache. The cached apt action cannot be used for this: it
-        # restores files without registering them with dpkg. Best effort
-        # only; a failure here just hands the install back to the runner,
-        # with the job timeout as the backstop. The per-call bound escalates
-        # per attempt so a congested but working mirror still gets a generous
-        # last try; with the kill grace, the dpkg recovery call and the
-        # sleeps, all three attempts stay inside timeout-minutes. The ladder
-        # is tighter than the one in ci-api-proto.yml on purpose: this step
-        # is optional, so most of the 30 minute job budget stays reserved
-        # for the benchmark run itself.
-        timeout-minutes: 10
+      - name: Bound apt fetches and pre-install libc6-dbg
+        # Two protections for the CodSpeed step below. First, a persistent
+        # apt config: the CodSpeed runner (CodSpeedHQ/codspeed,
+        # executor/valgrind/setup.rs) installs valgrind and libc6-dbg with
+        # its own ``apt-get update`` that has no timeout, and per-invocation
+        # options cannot reach it. With short per-fetch timeouts in
+        # apt.conf.d, any stalled mirror connection dies in seconds for
+        # every later apt call in this job, the runner's included, so a
+        # black-holing mirror can no longer hang the job. Second, a
+        # best-effort libc6-dbg pre-install so the runner can skip apt
+        # entirely once its valgrind cache is restored (it skips only when
+        # valgrind is present and ``dpkg -s libc6-dbg`` succeeds). The
+        # install is tried without ``apt-get update`` first: the runner
+        # image ships with fresh package lists, so the common path avoids
+        # the index download that a congested fallback mirror makes slow.
+        # The cached apt action cannot be used for this: it restores files
+        # without registering them with dpkg. A failure here just hands the
+        # install back to the runner, now itself bounded by the apt config,
+        # with the job timeout as the last backstop.
+        timeout-minutes: 15
         continue-on-error: true
         run: |
+          sudo tee /etc/apt/apt.conf.d/99ci-acquire-timeouts >/dev/null <<'EOF'
+          Acquire::Retries "1";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          EOF
           if dpkg -s libc6-dbg >/dev/null 2>&1; then
             echo "libc6-dbg already installed"
             exit 0
           fi
-          # The runners' primary mirror (azure.archive.ubuntu.com) can
-          # black-hole; apt's default per-fetch timeout then burns most of
-          # a bound before the mirrorlist falls back to archive.ubuntu.com.
-          # Short per-fetch timeouts make apt give up on the dead mirror in
-          # seconds so the bound is spent on the working fallback.
-          APT_OPTS=(-o Acquire::Retries=1 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15)
-          attempt=0
-          for bound in 30 60 120; do
-            attempt=$((attempt + 1))
-            if sudo timeout -k 15 "$bound" \
-                apt-get "${APT_OPTS[@]}" update \
-              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \
-                apt-get "${APT_OPTS[@]}" install -y libc6-dbg
-            then
-              exit 0
-            fi
-            echo "apt-get attempt ${attempt} (${bound}s per call) failed, retrying"
-            sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
-              dpkg --configure -a || true
-            sleep 10
-          done
-          exit 1
+          # Common path: the image's package lists are fresh enough.
+          if sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 90 \
+              apt-get install -y libc6-dbg; then
+            exit 0
+          fi
+          # Rescue path: refresh the lists once, with a generous bound.
+          # The apt config above already converts a stalled mirror into a
+          # fast per-fetch failure and a fallback, so one bounded attempt
+          # is enough; the outer timeout is only a backstop.
+          sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
+            dpkg --configure -a || true
+          sudo timeout -k 15 300 apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 300 \
+            apt-get install -y libc6-dbg
 
       - name: Run CodSpeed benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,13 +359,14 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install ccache (cached)
-        # Speeds up the host compiles: tests in a bucket compile overlapping
-        # component sets, so later tests reuse earlier tests' objects.
-        # Restored from the entry seed-apt-cache writes on dev; a cache hit
-        # never touches apt, so a slow mirror cannot hang the job, and the
-        # timeout bounds the cold path. Package list and version must match
-        # seed-apt-cache exactly.
+      - name: Install apt packages (cached)
+        # ccache speeds up the host compiles: tests in a bucket compile
+        # overlapping component sets, so later tests reuse earlier tests'
+        # objects. Restored from the entry seed-apt-cache writes on dev; a
+        # cache hit never touches apt, so a slow mirror cannot hang the job,
+        # and the timeout bounds the cold path. Package list and version must
+        # match seed-apt-cache exactly: libsdl2-dev is not used here and is
+        # carried only so this step shares the seed job's cache key.
         timeout-minutes: 10
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
@@ -502,20 +503,25 @@ jobs:
         # from its cache. The cached apt action cannot be used for this: it
         # restores files without registering them with dpkg. Best effort
         # only; a failure here just hands the install back to the runner,
-        # with the job timeout as the backstop. Per-call bounds are sized so
-        # all three attempts fit inside timeout-minutes (3 x (75 + 75 + 10) s).
-        timeout-minutes: 10
+        # with the job timeout as the backstop. The per-call bound escalates
+        # per attempt so a congested but working mirror still gets a generous
+        # last try; with the kill grace, the dpkg recovery call and the
+        # sleeps, all three attempts stay inside timeout-minutes.
+        timeout-minutes: 15
         continue-on-error: true
         run: |
-          for attempt in 1 2 3; do
-            if sudo timeout -k 15 60 apt-get update \
-              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 60 \
+          attempt=0
+          for bound in 45 90 180; do
+            attempt=$((attempt + 1))
+            if sudo timeout -k 15 "$bound" apt-get update \
+              && sudo DEBIAN_FRONTEND=noninteractive timeout -k 15 "$bound" \
                 apt-get install -y libc6-dbg
             then
               exit 0
             fi
-            echo "apt-get attempt ${attempt} failed, retrying"
-            sudo dpkg --configure -a || true
+            echo "apt-get attempt ${attempt} (${bound}s per call) failed, retrying"
+            sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
+              dpkg --configure -a || true
             sleep 10
           done
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,15 +71,10 @@ jobs:
   seed-apt-cache:
     name: Seed apt package cache
     runs-on: ubuntu-24.04
-    # Pull request jobs restore the apt packages below through the cache
-    # action, and a cache written on a pull request branch is only visible
-    # to that one pull request. Pushes to dev/beta/release seed and refresh
-    # the single shared entry instead, so pull request jobs hit it and never
-    # write a copy of their own for as long as that entry exists. The package
-    # list and version must stay identical to the steps that restore it; the
-    # cache key is derived from them alone. Listed in ci-status so a broken
-    # seed shows up on dev instead of quietly bringing per-pull-request
-    # copies back.
+    # PR-branch cache saves are invisible to other PRs, so dev/beta/release
+    # pushes seed the one shared entry PR jobs restore. The key is derived
+    # only from the package list and version; keep both identical in every
+    # step that restores it. In ci-status needs so a broken seed fails dev.
     if: github.event_name == 'push'
     timeout-minutes: 10
     steps:
@@ -344,9 +339,7 @@ jobs:
 
   integration-tests:
     name: Run integration tests (${{ matrix.bucket.name }})
-    # Pinned to the same image as seed-apt-cache: the apt cache key does
-    # not include the OS, so the restored packages must come from the same
-    # Ubuntu release.
+    # Must match seed-apt-cache's image: the apt cache key has no OS in it.
     runs-on: ubuntu-24.04
     needs:
       - common
@@ -360,13 +353,10 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install apt packages (cached)
-        # ccache speeds up the host compiles: tests in a bucket compile
-        # overlapping component sets, so later tests reuse earlier tests'
-        # objects. Restored from the entry seed-apt-cache writes on dev; a
-        # cache hit never touches apt, so a slow mirror cannot hang the job,
-        # and the timeout bounds the cold path. Package list and version must
-        # match seed-apt-cache exactly: libsdl2-dev is not used here and is
-        # carried only so this step shares the seed job's cache key.
+        # ccache speeds up the host compiles. A cache hit never touches apt
+        # (mirror outages cannot hang the job); the timeout bounds the cold
+        # path. Packages and version must match seed-apt-cache exactly;
+        # libsdl2-dev is unused here and carried only for cache-key parity.
         timeout-minutes: 10
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
@@ -494,24 +484,15 @@ jobs:
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
 
       - name: Bound apt fetches and pre-install libc6-dbg
-        # Two protections for the CodSpeed step below. First, a persistent
-        # apt config: the CodSpeed runner (CodSpeedHQ/codspeed,
-        # executor/valgrind/setup.rs) installs valgrind and libc6-dbg with
-        # its own ``apt-get update`` that has no timeout, and per-invocation
-        # options cannot reach it. With short per-fetch timeouts in
-        # apt.conf.d, any stalled mirror connection dies in seconds for
-        # every later apt call in this job, the runner's included, so a
-        # black-holing mirror can no longer hang the job. Second, a
-        # best-effort libc6-dbg pre-install so the runner can skip apt
-        # entirely once its valgrind cache is restored (it skips only when
-        # valgrind is present and ``dpkg -s libc6-dbg`` succeeds). The
-        # install is tried without ``apt-get update`` first: the runner
-        # image ships with fresh package lists, so the common path avoids
-        # the index download that a congested fallback mirror makes slow.
-        # The cached apt action cannot be used for this: it restores files
-        # without registering them with dpkg. A failure here just hands the
-        # install back to the runner, now itself bounded by the apt config,
-        # with the job timeout as the last backstop.
+        # The CodSpeed runner installs valgrind + libc6-dbg via its own
+        # unbounded apt-get update; per-invocation apt options cannot reach
+        # it. The apt.conf.d timeouts below bound every later apt call in
+        # this job, the runner's included. Pre-installing libc6-dbg lets the
+        # runner skip apt once its valgrind cache is restored (it checks
+        # ``dpkg -s libc6-dbg``, so the cache action's unregistered restores
+        # would not count). Install without update first: image lists are
+        # fresh, and the index refresh is what a congested mirror makes
+        # slow. Best effort; the job timeout is the last backstop.
         timeout-minutes: 15
         continue-on-error: true
         run: |
@@ -529,10 +510,8 @@ jobs:
               apt-get install -y libc6-dbg; then
             exit 0
           fi
-          # Rescue path: refresh the lists once, with a generous bound.
-          # The apt config above already converts a stalled mirror into a
-          # fast per-fetch failure and a fallback, so one bounded attempt
-          # is enough; the outer timeout is only a backstop.
+          # Rescue path: refresh the lists once with a generous bound; the
+          # apt config already fails a stalled mirror over quickly.
           sudo DEBIAN_FRONTEND=noninteractive timeout -k 10 30 \
             dpkg --configure -a || true
           sudo timeout -k 15 300 apt-get update
@@ -963,14 +942,11 @@ jobs:
         run: echo ${{ matrix.batch.components }}
 
       - name: Install apt packages (cached)
-        # Restored from the entry seed-apt-cache writes on dev, so this
-        # pull-request-only job hits and never saves a copy of its own. A
-        # cache hit never touches apt, so a slow mirror cannot hang the job,
-        # and the timeout bounds the cold path. Package list and version
-        # must match seed-apt-cache exactly. The action has no
-        # --no-install-recommends, so the recommended packages of libsdl2-dev
-        # come along; this is the same package set this job used before
-        # #17463.
+        # A cache hit (seeded on dev by seed-apt-cache) never touches apt,
+        # so mirror outages cannot hang this PR-only job; the timeout bounds
+        # the cold path. Packages and version must match seed-apt-cache
+        # exactly. The action has no --no-install-recommends; same package
+        # set this job used before #17463.
         timeout-minutes: 10
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,25 @@ jobs:
           uv pip install -r requirements.txt -r requirements_dev.txt -r requirements_test.txt
           uv pip install -e .
 
+  seed-apt-cache:
+    name: Seed apt package cache
+    runs-on: ubuntu-24.04
+    # Pull request jobs restore the apt packages below through the cache
+    # action, and a cache written on a pull request branch is only visible
+    # to that one pull request. Pushes to dev/beta/release seed and refresh
+    # the single shared entry instead, so pull request jobs always hit it
+    # and never write a copy of their own. The package list and version
+    # must stay identical to the steps that restore it; the cache key is
+    # derived from them alone.
+    if: github.event_name == 'push'
+    timeout-minutes: 10
+    steps:
+      - name: Install apt packages (cached)
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: libsdl2-dev ccache
+          version: 1.1
+
   determine-jobs:
     name: Determine which jobs to run
     runs-on: ubuntu-24.04
@@ -323,7 +342,10 @@ jobs:
 
   integration-tests:
     name: Run integration tests (${{ matrix.bucket.name }})
-    runs-on: ubuntu-latest
+    # Pinned to the same image as seed-apt-cache: the apt cache key does
+    # not include the OS, so the restored packages must come from the same
+    # Ubuntu release.
+    runs-on: ubuntu-24.04
     needs:
       - common
       - determine-jobs
@@ -335,12 +357,18 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install ccache
+      - name: Install ccache (cached)
         # Speeds up the host compiles: tests in a bucket compile overlapping
         # component sets, so later tests reuse earlier tests' objects.
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends ccache
+        # Restored from the entry seed-apt-cache writes on dev; a cache hit
+        # never touches apt, so a slow mirror cannot hang the job, and the
+        # timeout bounds the cold path. Package list and version must match
+        # seed-apt-cache exactly.
+        timeout-minutes: 10
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: libsdl2-dev ccache
+          version: 1.1
       - name: Set up Python 3.13
         id: python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -421,6 +449,7 @@ jobs:
   benchmarks:
     name: Run CodSpeed benchmarks
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     needs:
       - common
       - determine-jobs
@@ -460,6 +489,28 @@ jobs:
             exit 1
           fi
           echo "binary=$BINARY" >> $GITHUB_OUTPUT
+
+      - name: Install libc6-dbg
+        # The CodSpeed runner installs this itself with a plain apt-get call
+        # that has no timeout, so a slow apt mirror hangs the job until
+        # timeout-minutes kills it. Installing it here with a bounded retry
+        # also lets the runner find it already present after restoring
+        # valgrind from its cache and skip apt entirely. The cached apt
+        # action cannot be used for this: it restores files without
+        # registering them with dpkg, so the runner would still call apt.
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 sudo apt-get update \
+              && timeout 300 sudo DEBIAN_FRONTEND=noninteractive \
+                apt-get install -y libc6-dbg
+            then
+              exit 0
+            fi
+            echo "apt-get attempt ${attempt} failed, retrying"
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          exit 1
 
       - name: Run CodSpeed benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
@@ -884,12 +935,17 @@ jobs:
       - name: List components
         run: echo ${{ matrix.batch.components }}
 
-      - name: Install apt packages
-        # Not cached: this job is pull-request-only, so a cache save could
-        # never be shared and would only consume quota.
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libsdl2-dev ccache
+      - name: Install apt packages (cached)
+        # Restored from the entry seed-apt-cache writes on dev, so this
+        # pull-request-only job hits and never saves a copy of its own. A
+        # cache hit never touches apt, so a slow mirror cannot hang the job,
+        # and the timeout bounds the cold path. Package list and version
+        # must match seed-apt-cache exactly.
+        timeout-minutes: 10
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
+        with:
+          packages: libsdl2-dev ccache
+          version: 1.1
 
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
# What does this implement/fix?

Jobs that run plain `apt-get update` on the runner are hanging on a slow apt mirror; on #18513 the component batch job is stuck in its apt step and the CodSpeed job is stuck inside the CodSpeed action, which installs libc6-dbg with its own unbounded apt call. Steps that go through `awalsh128/cache-apt-pkgs-action` are fine, a cache hit never touches apt.

This brings the cached apt action back for `integration-tests` and `test-build-components-split` (removed in #17463 because pull request runs each wrote their own cache copy) and adds a `seed-apt-cache` job that runs only on pushes with the same package list and version, so the single shared entry is written on dev and pull request jobs always hit it and never save. The benchmarks job gets a 30 minute timeout and pre-installs libc6-dbg with a bounded retry loop so the CodSpeed runner skips apt; `ci-api-proto.yml` is pull request only so nothing could seed it, it keeps plain apt wrapped in the same bounded retry loop. The cached apt action has no `--no-install-recommends`, so the component batch job goes back to the package set it had before #17463 with the recommended packages of libsdl2-dev included; `seed-apt-cache` is listed in `ci-status` so a broken seed is visible on dev instead of quietly bringing per pull request cache copies back.

Same fixes as esphome/esphome-device-builder#2586 and esphome/esphome-device-builder#2603.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
