### PR TITLE
[ci] Chained test run for the apt changes in #18518, do not merge

### DIFF
--- a/tests/benchmarks/python/test_compiled_config_bench.py
+++ b/tests/benchmarks/python/test_compiled_config_bench.py
@@ -114,3 +114,5 @@ def test_read_config_uncached(primed_yaml: Path, benchmark) -> None:
         rounds=3,
         iterations=1,
     )
+
+# Chained CI test for the apt changes on the parent branch; delete with the branch.

--- a/tests/benchmarks/python/test_compiled_config_bench.py
+++ b/tests/benchmarks/python/test_compiled_config_bench.py
@@ -115,4 +115,5 @@ def test_read_config_uncached(primed_yaml: Path, benchmark) -> None:
         iterations=1,
     )
 
+
 # Chained CI test for the apt changes on the parent branch; delete with the branch.

--- a/tests/components/absolute_humidity/common.yaml
+++ b/tests/components/absolute_humidity/common.yaml
@@ -17,3 +17,5 @@ sensor:
         return 42.0;
       }
       return 0.0;
+
+# Chained CI test for the apt changes on the parent branch; delete with the branch.

--- a/tests/integration/test_host_mode_basic.py
+++ b/tests/integration/test_host_mode_basic.py
@@ -21,4 +21,5 @@ async def test_host_mode_basic(
         assert device_info is not None
         assert device_info.name == "host-test"
 
+
 # Chained CI test for the apt changes on the parent branch; delete with the branch.

--- a/tests/integration/test_host_mode_basic.py
+++ b/tests/integration/test_host_mode_basic.py
@@ -20,3 +20,5 @@ async def test_host_mode_basic(
         device_info = await client.device_info()
         assert device_info is not None
         assert device_info.name == "host-test"
+
+# Chained CI test for the apt changes on the parent branch; delete with the branch.


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18518 to exercise its changed CI paths before it merges; do not merge, this will be closed once the runs are checked. Comment-only touches trigger the component batch job, the integration tests and the CodSpeed benchmarks, and the workflow diff itself triggers `ci-api-proto`, so every new apt step runs at least once.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
