### PR TITLE
[api] Widen message type storage to uint16_t

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1790,8 +1790,10 @@ void APIConnection::complete_authentication_() {
 bool APIConnection::send_hello_response_(const HelloRequest &msg) {
   // Copy client name with truncation if needed (set_client_name handles truncation)
   this->helper_->set_client_name(msg.client_info.c_str(), msg.client_info.size());
-  this->client_api_version_major_ = static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_major, 255));
-  this->client_api_version_minor_ = static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_minor, 255));
+  this->client_api_version_major_ =
+      static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_major, std::numeric_limits<uint8_t>::max()));
+  this->client_api_version_minor_ =
+      static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_minor, std::numeric_limits<uint8_t>::max()));
   char peername[socket::SOCKADDR_STR_LEN];
   ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %u.%u", this->helper_->get_client_name(),
            this->helper_->get_peername_to(peername), this->client_api_version_major_, this->client_api_version_minor_);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1790,10 +1790,10 @@ void APIConnection::complete_authentication_() {
 bool APIConnection::send_hello_response_(const HelloRequest &msg) {
   // Copy client name with truncation if needed (set_client_name handles truncation)
   this->helper_->set_client_name(msg.client_info.c_str(), msg.client_info.size());
-  this->client_api_version_major_ = msg.api_version_major;
-  this->client_api_version_minor_ = msg.api_version_minor;
+  this->client_api_version_major_ = static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_major, 255));
+  this->client_api_version_minor_ = static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_minor, 255));
   char peername[socket::SOCKADDR_STR_LEN];
-  ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %" PRIu16 ".%" PRIu16, this->helper_->get_client_name(),
+  ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %u.%u", this->helper_->get_client_name(),
            this->helper_->get_peername_to(peername), this->client_api_version_major_, this->client_api_version_minor_);
 
   HelloResponse resp;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2224,7 +2224,7 @@ bool APIConnection::try_to_clear_buffer_slow_(bool log_out_of_space) {
   }
   return false;
 }
-bool APIConnection::send_message_(uint32_t payload_size, uint8_t message_type, MessageEncodeFn encode_fn,
+bool APIConnection::send_message_(uint32_t payload_size, uint16_t message_type, MessageEncodeFn encode_fn,
                                   const void *msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // Skip dump for log messages (recursive logging risk) and camera frames (high-frequency noise)
@@ -2253,7 +2253,7 @@ uint16_t APIConnection::encode_to_buffer_slow(uint32_t calculated_size, MessageE
                                               APIConnection *conn, uint32_t remaining_size) {
   return encode_to_buffer(calculated_size, encode_fn, msg, conn, remaining_size);
 }
-bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
+bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint16_t message_type) {
   const bool is_log_message = (message_type == SubscribeLogsResponse::MESSAGE_TYPE);
 
   if (!this->try_to_clear_buffer(!is_log_message)) {
@@ -2283,12 +2283,12 @@ void APIConnection::on_fatal_error() {
   this->flags_.remove = true;
 }
 
-bool APIConnection::schedule_message_front_(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
+bool APIConnection::schedule_message_front_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size) {
   this->deferred_batch_.add_item_front(entity, message_type, estimated_size);
   return this->schedule_batch_();
 }
 
-bool APIConnection::send_message_smart_(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
+bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                                         uint8_t aux_data_index) {
   if (this->should_send_immediately_(message_type) && this->helper_->can_write_without_blocking()) {
     auto &shared_buf = this->parent_->get_shared_buffer_ref();

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1796,7 +1796,8 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
       static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_minor, std::numeric_limits<uint8_t>::max()));
   char peername[socket::SOCKADDR_STR_LEN];
   ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %u.%u", this->helper_->get_client_name(),
-           this->helper_->get_peername_to(peername), this->client_api_version_major_, this->client_api_version_minor_);
+           this->helper_->get_peername_to(peername), static_cast<unsigned>(this->client_api_version_major_),
+           static_cast<unsigned>(this->client_api_version_minor_));
 
   HelloResponse resp;
   resp.api_version_major = 1;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1796,8 +1796,7 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
       static_cast<uint8_t>(std::min<uint32_t>(msg.api_version_minor, std::numeric_limits<uint8_t>::max()));
   char peername[socket::SOCKADDR_STR_LEN];
   ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %u.%u", this->helper_->get_client_name(),
-           this->helper_->get_peername_to(peername), static_cast<unsigned>(this->client_api_version_major_),
-           static_cast<unsigned>(this->client_api_version_minor_));
+           this->helper_->get_peername_to(peername), this->client_api_version_major_, this->client_api_version_minor_);
 
   HelloResponse resp;
   resp.api_version_major = 1;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -757,13 +757,15 @@ class APIConnection final : public APIServerConnectionBase {
 #endif
   } flags_{};  // 2 bytes total
 
-  // 2-byte types immediately after flags_ (no padding between them)
-  uint16_t client_api_version_major_{0};
-  uint16_t client_api_version_minor_{0};
+  // 2-byte type immediately after flags_ (no padding between them)
   uint16_t batch_message_type_{0};  // Current message type during batch encoding
   // 1-byte types to fill remaining space before next 4-byte boundary
+  // Client API versions are clamped to 255 on receive (see send_hello_response_)
+  uint8_t client_api_version_major_{0};
+  uint8_t client_api_version_minor_{0};
   ActiveIterator active_iterator_{ActiveIterator::NONE};
-  // Total: 2 (flags) + 2 + 2 + 2 + 1 = 9 bytes
+  // Total: 2 (flags) + 2 + 1 + 1 + 1 + 1 (batch_header_size_ below) = 8 bytes,
+  // aligned to 4-byte boundary
 
   // Actual header size used by encode_to_buffer for the current message.
   // Read by process_batch_multi_ to pass into MessageInfo.

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -326,8 +326,10 @@ class APIConnection final : public APIServerConnectionBase {
   bool is_marked_for_removal() const { return this->flags_.remove; }
   uint8_t get_log_subscription_level() const { return this->flags_.log_subscription; }
 
-  // Get client API version for feature detection
-  bool client_supports_api_version(uint16_t major, uint16_t minor) const {
+  // Get client API version for feature detection.
+  // Stored versions saturate at 255 (see send_hello_response_), so requesting
+  // a minimum above that can never match.
+  bool client_supports_api_version(uint8_t major, uint8_t minor) const {
     return this->client_api_version_major_ > major ||
            (this->client_api_version_major_ == major && this->client_api_version_minor_ >= minor);
   }

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -374,7 +374,7 @@ class APIConnection final : public APIServerConnectionBase {
       return true;
     return this->try_to_clear_buffer_slow_(log_out_of_space);
   }
-  bool send_buffer(ProtoWriteBuffer buffer, uint8_t message_type);
+  bool send_buffer(ProtoWriteBuffer buffer, uint16_t message_type);
 
   const char *get_name() const { return this->helper_->get_client_name(); }
   /// Get peer name (IP address) into caller-provided buffer, returns buf for convenience
@@ -423,7 +423,7 @@ class APIConnection final : public APIServerConnectionBase {
   }
 
   // Non-template buffer management for send_message
-  bool send_message_(uint32_t payload_size, uint8_t message_type, MessageEncodeFn encode_fn, const void *msg);
+  bool send_message_(uint32_t payload_size, uint16_t message_type, MessageEncodeFn encode_fn, const void *msg);
 
   // Core batch encoding logic. ALWAYS_INLINE so encode_fn devirtualizes at hot call sites.
   // Defined in api_connection_buffer.h (needs APIServer complete).
@@ -664,10 +664,9 @@ class APIConnection final : public APIServerConnectionBase {
 
     struct BatchItem {
       EntityBase *entity;                       // 4 bytes - Entity pointer
-      uint8_t message_type;                     // 1 byte - Message type for protocol and dispatch
+      uint16_t message_type;                    // 2 bytes - Message type for protocol and dispatch
       uint8_t estimated_size;                   // 1 byte - Estimated message size (max 255 bytes)
       uint8_t aux_data_index{AUX_DATA_UNUSED};  // 1 byte - For events: index into entity's event_types
-      // 1 byte padding
     };
 
     std::vector<BatchItem> items;
@@ -677,7 +676,7 @@ class APIConnection final : public APIServerConnectionBase {
     // connections that do, buffers are released after initial sync anyway
 
     // Add item to the batch (with deduplication)
-    void add_item(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
+    void add_item(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                   uint8_t aux_data_index = AUX_DATA_UNUSED) {
       // Dedup: O(n) scan but optimized for RAM over performance
       // Skip deduplication for events - they are edge-triggered, every occurrence matters
@@ -693,7 +692,7 @@ class APIConnection final : public APIServerConnectionBase {
       this->items.push_back({entity, message_type, estimated_size, aux_data_index});
     }
     // Add item to the front of the batch (for high priority messages like ping)
-    void add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
+    void add_item_front(EntityBase *entity, uint16_t message_type, uint8_t estimated_size) {
       // Swap to front avoids expensive vector::insert which shifts all elements
       this->items.push_back({entity, message_type, estimated_size, AUX_DATA_UNUSED});
       if (this->items.size() > 1) {
@@ -761,10 +760,10 @@ class APIConnection final : public APIServerConnectionBase {
   // 2-byte types immediately after flags_ (no padding between them)
   uint16_t client_api_version_major_{0};
   uint16_t client_api_version_minor_{0};
+  uint16_t batch_message_type_{0};  // Current message type during batch encoding
   // 1-byte types to fill remaining space before next 4-byte boundary
   ActiveIterator active_iterator_{ActiveIterator::NONE};
-  uint8_t batch_message_type_{0};  // Current message type during batch encoding
-  // Total: 2 (flags) + 2 + 2 + 1 + 1 = 8 bytes, aligned to 4-byte boundary
+  // Total: 2 (flags) + 2 + 2 + 2 + 1 = 9 bytes
 
   // Actual header size used by encode_to_buffer for the current message.
   // Read by process_batch_multi_ to pass into MessageInfo.
@@ -813,7 +812,7 @@ class APIConnection final : public APIServerConnectionBase {
   // 2. It's an EventResponse (events are edge-triggered - every occurrence matters)
   // 3. OR: User has opted into immediate sending (should_try_send_immediately = true
   //    AND batch_delay = 0)
-  inline bool should_send_immediately_(uint8_t message_type) const {
+  inline bool should_send_immediately_(uint16_t message_type) const {
     return (
 #ifdef USE_UPDATE
         message_type == UpdateStateResponse::MESSAGE_TYPE ||
@@ -827,11 +826,11 @@ class APIConnection final : public APIServerConnectionBase {
   // Helper method to send a message either immediately or via batching
   // Tries immediate send if should_send_immediately_() returns true and buffer has space
   // Falls back to batching if immediate send fails or isn't applicable
-  bool send_message_smart_(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
+  bool send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                            uint8_t aux_data_index = DeferredBatch::AUX_DATA_UNUSED);
 
   // Helper function to schedule a deferred message with known message type
-  bool schedule_message_(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
+  bool schedule_message_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                          uint8_t aux_data_index = DeferredBatch::AUX_DATA_UNUSED) {
     this->deferred_batch_.add_item(entity, message_type, estimated_size, aux_data_index);
     return this->schedule_batch_();
@@ -839,7 +838,7 @@ class APIConnection final : public APIServerConnectionBase {
 
   // Helper function to schedule a high priority message at the front of the batch
   // Out-of-line: callers (on_shutdown, check_keepalive_) are cold paths
-  bool schedule_message_front_(EntityBase *entity, uint8_t message_type, uint8_t estimated_size);
+  bool schedule_message_front_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size);
 
   // Helper function to log client messages with name and peername
   void log_client_(int level, const LogString *message);

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -49,16 +49,16 @@ struct ReadPacketBuffer {
 };
 
 // Packed message info structure to minimize memory usage
-// Note: message_type is uint8_t — all current protobuf message types fit in 8 bits.
-// The noise wire format encodes types as 16-bit, but the high byte is always 0.
-// If message types ever exceed 255, this and encrypt_noise_message_ must be updated.
+// message_type matches the wire formats: noise carries a fixed 16-bit type
+// field, plaintext a type varint. The proto codegen caps message IDs at 16383
+// so the plaintext type varint fits the 2 bytes budgeted in HEADER_PADDING.
 struct MessageInfo {
   uint16_t offset;        // Offset in buffer where message starts
   uint16_t payload_size;  // Size of the message payload
-  uint8_t message_type;   // Message type (0-255)
+  uint16_t message_type;  // Message type (0-16383)
   uint8_t header_size;    // Actual header size used (avoids recomputation in write path)
 
-  MessageInfo(uint8_t type, uint16_t off, uint16_t size, uint8_t hdr)
+  MessageInfo(uint16_t type, uint16_t off, uint16_t size, uint8_t hdr)
       : offset(off), payload_size(size), message_type(type), header_size(hdr) {}
 };
 
@@ -173,7 +173,7 @@ class APIFrameHelper {
   }
   // Write a single protobuf message - the hot path (87-100% of all writes).
   // Caller must ensure state is DATA before calling.
-  virtual APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) = 0;
+  virtual APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) = 0;
   // Write multiple protobuf messages in a single batched operation.
   // Caller must ensure state is DATA and messages is not empty.
   // messages contains (message_type, offset, length) for each message in the buffer.
@@ -187,15 +187,15 @@ class APIFrameHelper {
   // Distinguishes protocols via frame_footer_size_ (noise always has a non-zero MAC
   // footer, plaintext has footer=0). If a protocol with a plaintext footer is ever
   // added, this should become a virtual method.
-  uint8_t frame_header_size(uint16_t payload_size, uint8_t message_type) const {
+  uint8_t frame_header_size(uint16_t payload_size, uint16_t message_type) const {
 #if defined(USE_API_NOISE) && defined(USE_API_PLAINTEXT)
     return this->frame_footer_size_
                ? this->frame_header_padding_
-               : static_cast<uint8_t>(1 + ProtoSize::varint16(payload_size) + ProtoSize::varint8(message_type));
+               : static_cast<uint8_t>(1 + ProtoSize::varint16(payload_size) + ProtoSize::varint16(message_type));
 #elif defined(USE_API_NOISE)
     return this->frame_header_padding_;
 #else  // USE_API_PLAINTEXT only
-    return static_cast<uint8_t>(1 + ProtoSize::varint16(payload_size) + ProtoSize::varint8(message_type));
+    return static_cast<uint8_t>(1 + ProtoSize::varint16(payload_size) + ProtoSize::varint16(message_type));
 #endif
   }
   // Get the frame footer size required by this protocol

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -442,7 +442,7 @@ APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
 }
 // Encrypt a single noise message in place and return the encrypted frame length.
 // Returns APIError::OK on success.
-APIError APINoiseFrameHelper::encrypt_noise_message_(uint8_t *buf_start, uint16_t payload_size, uint8_t message_type,
+APIError APINoiseFrameHelper::encrypt_noise_message_(uint8_t *buf_start, uint16_t payload_size, uint16_t message_type,
                                                      uint16_t &encrypted_len_out) {
   // The noise frame header is written after encryption, when the size is known
 
@@ -472,7 +472,7 @@ APIError APINoiseFrameHelper::encrypt_noise_message_(uint8_t *buf_start, uint16_
   return APIError::OK;
 }
 
-APIError APINoiseFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
+APIError APINoiseFrameHelper::write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) {
 #ifdef ESPHOME_DEBUG_API
   assert(this->state_ == State::DATA);
 #endif

--- a/esphome/components/api/api_frame_helper_noise.h
+++ b/esphome/components/api/api_frame_helper_noise.h
@@ -31,7 +31,7 @@ class APINoiseFrameHelper final : public APIFrameHelper {
 #endif
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
-  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) override;
+  APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
   APIError write_protobuf_messages(ProtoWriteBuffer buffer, std::span<const MessageInfo> messages) override;
 
  protected:
@@ -44,7 +44,7 @@ class APINoiseFrameHelper final : public APIFrameHelper {
   APIError state_action_handshake_write_();
   APIError try_read_frame_();
   APIError write_frame_(const uint8_t *data, uint16_t len);
-  APIError encrypt_noise_message_(uint8_t *buf_start, uint16_t payload_size, uint8_t message_type,
+  APIError encrypt_noise_message_(uint8_t *buf_start, uint16_t payload_size, uint16_t message_type,
                                   uint16_t &encrypted_len_out);
   APIError init_handshake_();
   APIError check_handshake_finished_();

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -252,24 +252,14 @@ ESPHOME_ALWAYS_INLINE static inline void encode_varint_16(uint16_t value, uint8_
   *p = static_cast<uint8_t>(value);
 }
 
-// Encode an 8-bit varint (1-2 bytes) using pre-computed length.
-ESPHOME_ALWAYS_INLINE static inline void encode_varint_8(uint8_t value, uint8_t varint_len, uint8_t *p) {
-  if (varint_len == 2) {
-    *p++ = static_cast<uint8_t>(value | 0x80);
-    *p = static_cast<uint8_t>(value >> 7);
-  } else {
-    *p = value;
-  }
-}
-
 // Write plaintext header into pre-allocated padding before payload.
 // padding_size: bytes reserved before payload (HEADER_PADDING for first/single msg,
 //               actual header size for contiguous batch messages).
 // Returns the total header length (indicator + varints).
 ESPHOME_ALWAYS_INLINE static inline uint8_t write_plaintext_header(uint8_t *buf_start, uint16_t payload_size,
-                                                                   uint8_t message_type, uint8_t padding_size) {
+                                                                   uint16_t message_type, uint8_t padding_size) {
   uint8_t size_varint_len = ProtoSize::varint16(payload_size);
-  uint8_t type_varint_len = ProtoSize::varint8(message_type);
+  uint8_t type_varint_len = ProtoSize::varint16(message_type);
   uint8_t total_header_len = 1 + size_varint_len + type_varint_len;
 
   // The header is right-justified within the padding so it sits immediately before payload.
@@ -292,12 +282,12 @@ ESPHOME_ALWAYS_INLINE static inline uint8_t write_plaintext_header(uint8_t *buf_
 
   // Encode varints directly into buffer using pre-computed lengths
   encode_varint_16(payload_size, size_varint_len, buf_start + header_offset + 1);
-  encode_varint_8(message_type, type_varint_len, buf_start + header_offset + 1 + size_varint_len);
+  encode_varint_16(message_type, type_varint_len, buf_start + header_offset + 1 + size_varint_len);
 
   return total_header_len;
 }
 
-APIError APIPlaintextFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
+APIError APIPlaintextFrameHelper::write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) {
 #ifdef ESPHOME_DEBUG_API
   assert(this->state_ == State::DATA);
 #endif

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "api_pb2.h"
 #include "proto.h"
 #include <cstring>
 #include <cinttypes>
@@ -251,6 +252,13 @@ ESPHOME_ALWAYS_INLINE static inline void encode_varint_16(uint16_t value, uint8_
   }
   *p = static_cast<uint8_t>(value);
 }
+
+// The generator rejects message IDs above MAX_MESSAGE_TYPE, so the type varint
+// can never outgrow the 2 bytes HEADER_PADDING budgets for it. Without this
+// bound, write_plaintext_header's header_offset would underflow for the first
+// message in a batch and the header write would land outside the buffer.
+static_assert(1 + 3 + ProtoSize::varint16(MAX_MESSAGE_TYPE) <= APIPlaintextFrameHelper::HEADER_PADDING,
+              "HEADER_PADDING cannot fit the type varint of the largest message ID");
 
 // Write plaintext header into pre-allocated padding before payload.
 // padding_size: bytes reserved before payload (HEADER_PADDING for first/single msg,

--- a/esphome/components/api/api_frame_helper_plaintext.h
+++ b/esphome/components/api/api_frame_helper_plaintext.h
@@ -10,7 +10,8 @@ class APIPlaintextFrameHelper final : public APIFrameHelper {
   // Plaintext header structure (worst case):
   // Pos 0: indicator (0x00)
   // Pos 1-3: payload size varint (up to 3 bytes)
-  // Pos 4-5: message type varint (up to 2 bytes)
+  // Pos 4-5: message type varint (up to 2 bytes; covers message IDs up to
+  //          16383, enforced by the proto codegen)
   // Pos 6+: actual payload data
   static constexpr uint8_t HEADER_PADDING = 1 + 3 + 2;  // indicator + size varint + type varint
 
@@ -21,7 +22,7 @@ class APIPlaintextFrameHelper final : public APIFrameHelper {
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
-  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) override;
+  APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
   APIError write_protobuf_messages(ProtoWriteBuffer buffer, std::span<const MessageInfo> messages) override;
 #ifdef USE_API_NOISE
   // After try_read_frame_ returned PROTOCOL_SWITCH_TO_NOISE: copy out the

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -9,6 +9,10 @@
 
 namespace esphome::api {
 
+// Upper bound on message IDs, enforced by the code generator: the plaintext
+// frame header budgets 2 varint bytes for the type (HEADER_PADDING).
+static constexpr uint16_t MAX_MESSAGE_TYPE = 16383;
+
 namespace enums {
 
 enum DisconnectReason : uint32_t {

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -407,7 +407,7 @@ class CommandProtoMessage : public ProtoDecodableMessage {
 };
 class HelloRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 1;
+  static constexpr uint16_t MESSAGE_TYPE = 1;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("hello_request"); }
@@ -425,7 +425,7 @@ class HelloRequest final : public ProtoDecodableMessage {
 };
 class HelloResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 2;
+  static constexpr uint16_t MESSAGE_TYPE = 2;
   static constexpr uint8_t ESTIMATED_SIZE = 26;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("hello_response"); }
@@ -444,7 +444,7 @@ class HelloResponse final : public ProtoMessage {
 };
 class DisconnectRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 5;
+  static constexpr uint16_t MESSAGE_TYPE = 5;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("disconnect_request"); }
@@ -461,7 +461,7 @@ class DisconnectRequest final : public ProtoDecodableMessage {
 };
 class DisconnectResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 6;
+  static constexpr uint16_t MESSAGE_TYPE = 6;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("disconnect_response"); }
@@ -474,7 +474,7 @@ class DisconnectResponse final : public ProtoMessage {
 };
 class PingRequest final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 7;
+  static constexpr uint16_t MESSAGE_TYPE = 7;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("ping_request"); }
@@ -487,7 +487,7 @@ class PingRequest final : public ProtoMessage {
 };
 class PingResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 8;
+  static constexpr uint16_t MESSAGE_TYPE = 8;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("ping_response"); }
@@ -544,7 +544,7 @@ class SerialProxyInfo final : public ProtoMessage {
 #endif
 class DeviceInfoResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 10;
+  static constexpr uint16_t MESSAGE_TYPE = 10;
   static constexpr uint16_t ESTIMATED_SIZE = 312;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("device_info_response"); }
@@ -655,7 +655,7 @@ class ZWaveProxyCapabilities final : public ProtoMessage {
 #endif
 class DeviceCapabilitiesResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 150;
+  static constexpr uint16_t MESSAGE_TYPE = 150;
   static constexpr uint8_t ESTIMATED_SIZE = 102;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("device_capabilities_response"); }
@@ -682,7 +682,7 @@ class DeviceCapabilitiesResponse final : public ProtoMessage {
 };
 class ListEntitiesDoneResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 19;
+  static constexpr uint16_t MESSAGE_TYPE = 19;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_done_response"); }
@@ -696,7 +696,7 @@ class ListEntitiesDoneResponse final : public ProtoMessage {
 #ifdef USE_BINARY_SENSOR
 class ListEntitiesBinarySensorResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 12;
+  static constexpr uint16_t MESSAGE_TYPE = 12;
   static constexpr uint8_t ESTIMATED_SIZE = 51;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_binary_sensor_response"); }
@@ -713,7 +713,7 @@ class ListEntitiesBinarySensorResponse final : public InfoResponseProtoMessage {
 };
 class BinarySensorStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 21;
+  static constexpr uint16_t MESSAGE_TYPE = 21;
   static constexpr uint8_t ESTIMATED_SIZE = 13;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("binary_sensor_state_response"); }
@@ -732,7 +732,7 @@ class BinarySensorStateResponse final : public StateResponseProtoMessage {
 #ifdef USE_COVER
 class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 13;
+  static constexpr uint16_t MESSAGE_TYPE = 13;
   static constexpr uint8_t ESTIMATED_SIZE = 57;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_cover_response"); }
@@ -752,7 +752,7 @@ class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
 };
 class CoverStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 22;
+  static constexpr uint16_t MESSAGE_TYPE = 22;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("cover_state_response"); }
@@ -770,7 +770,7 @@ class CoverStateResponse final : public StateResponseProtoMessage {
 };
 class CoverCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 30;
+  static constexpr uint16_t MESSAGE_TYPE = 30;
   static constexpr uint8_t ESTIMATED_SIZE = 25;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("cover_command_request"); }
@@ -792,7 +792,7 @@ class CoverCommandRequest final : public CommandProtoMessage {
 #ifdef USE_FAN
 class ListEntitiesFanResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 14;
+  static constexpr uint16_t MESSAGE_TYPE = 14;
   static constexpr uint8_t ESTIMATED_SIZE = 68;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_fan_response"); }
@@ -812,7 +812,7 @@ class ListEntitiesFanResponse final : public InfoResponseProtoMessage {
 };
 class FanStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 23;
+  static constexpr uint16_t MESSAGE_TYPE = 23;
   static constexpr uint8_t ESTIMATED_SIZE = 28;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("fan_state_response"); }
@@ -832,7 +832,7 @@ class FanStateResponse final : public StateResponseProtoMessage {
 };
 class FanCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 31;
+  static constexpr uint16_t MESSAGE_TYPE = 31;
   static constexpr uint8_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("fan_command_request"); }
@@ -860,7 +860,7 @@ class FanCommandRequest final : public CommandProtoMessage {
 #ifdef USE_LIGHT
 class ListEntitiesLightResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 15;
+  static constexpr uint16_t MESSAGE_TYPE = 15;
   static constexpr uint8_t ESTIMATED_SIZE = 73;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_light_response"); }
@@ -879,7 +879,7 @@ class ListEntitiesLightResponse final : public InfoResponseProtoMessage {
 };
 class LightStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 24;
+  static constexpr uint16_t MESSAGE_TYPE = 24;
   static constexpr uint8_t ESTIMATED_SIZE = 67;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("light_state_response"); }
@@ -906,7 +906,7 @@ class LightStateResponse final : public StateResponseProtoMessage {
 };
 class LightCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 32;
+  static constexpr uint16_t MESSAGE_TYPE = 32;
   static constexpr uint8_t ESTIMATED_SIZE = 112;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("light_command_request"); }
@@ -950,7 +950,7 @@ class LightCommandRequest final : public CommandProtoMessage {
 #ifdef USE_SENSOR
 class ListEntitiesSensorResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 16;
+  static constexpr uint16_t MESSAGE_TYPE = 16;
   static constexpr uint8_t ESTIMATED_SIZE = 66;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_sensor_response"); }
@@ -970,7 +970,7 @@ class ListEntitiesSensorResponse final : public InfoResponseProtoMessage {
 };
 class SensorStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 25;
+  static constexpr uint16_t MESSAGE_TYPE = 25;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("sensor_state_response"); }
@@ -989,7 +989,7 @@ class SensorStateResponse final : public StateResponseProtoMessage {
 #ifdef USE_SWITCH
 class ListEntitiesSwitchResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 17;
+  static constexpr uint16_t MESSAGE_TYPE = 17;
   static constexpr uint8_t ESTIMATED_SIZE = 51;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_switch_response"); }
@@ -1006,7 +1006,7 @@ class ListEntitiesSwitchResponse final : public InfoResponseProtoMessage {
 };
 class SwitchStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 26;
+  static constexpr uint16_t MESSAGE_TYPE = 26;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("switch_state_response"); }
@@ -1022,7 +1022,7 @@ class SwitchStateResponse final : public StateResponseProtoMessage {
 };
 class SwitchCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 33;
+  static constexpr uint16_t MESSAGE_TYPE = 33;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("switch_command_request"); }
@@ -1040,7 +1040,7 @@ class SwitchCommandRequest final : public CommandProtoMessage {
 #ifdef USE_TEXT_SENSOR
 class ListEntitiesTextSensorResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 18;
+  static constexpr uint16_t MESSAGE_TYPE = 18;
   static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_text_sensor_response"); }
@@ -1056,7 +1056,7 @@ class ListEntitiesTextSensorResponse final : public InfoResponseProtoMessage {
 };
 class TextSensorStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 27;
+  static constexpr uint16_t MESSAGE_TYPE = 27;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("text_sensor_state_response"); }
@@ -1074,7 +1074,7 @@ class TextSensorStateResponse final : public StateResponseProtoMessage {
 #endif
 class SubscribeLogsRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 28;
+  static constexpr uint16_t MESSAGE_TYPE = 28;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("subscribe_logs_request"); }
@@ -1090,7 +1090,7 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
 };
 class SubscribeLogsResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 29;
+  static constexpr uint16_t MESSAGE_TYPE = 29;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("subscribe_logs_response"); }
@@ -1113,7 +1113,7 @@ class SubscribeLogsResponse final : public ProtoMessage {
 #ifdef USE_API_NOISE
 class NoiseEncryptionSetKeyRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 124;
+  static constexpr uint16_t MESSAGE_TYPE = 124;
   static constexpr uint8_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("noise_encryption_set_key_request"); }
@@ -1129,7 +1129,7 @@ class NoiseEncryptionSetKeyRequest final : public ProtoDecodableMessage {
 };
 class NoiseEncryptionSetKeyResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 125;
+  static constexpr uint16_t MESSAGE_TYPE = 125;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("noise_encryption_set_key_response"); }
@@ -1159,7 +1159,7 @@ class HomeassistantServiceMap final : public ProtoMessage {
 };
 class HomeassistantActionRequest final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 35;
+  static constexpr uint16_t MESSAGE_TYPE = 35;
   static constexpr uint8_t ESTIMATED_SIZE = 128;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("homeassistant_action_request"); }
@@ -1190,7 +1190,7 @@ class HomeassistantActionRequest final : public ProtoMessage {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
 class HomeassistantActionResponse final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 130;
+  static constexpr uint16_t MESSAGE_TYPE = 130;
   static constexpr uint8_t ESTIMATED_SIZE = 34;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("homeassistant_action_response"); }
@@ -1214,7 +1214,7 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
 #ifdef USE_API_HOMEASSISTANT_STATES
 class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 39;
+  static constexpr uint16_t MESSAGE_TYPE = 39;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("subscribe_home_assistant_state_response"); }
@@ -1232,7 +1232,7 @@ class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
 };
 class HomeAssistantStateResponse final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 40;
+  static constexpr uint16_t MESSAGE_TYPE = 40;
   static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("home_assistant_state_response"); }
@@ -1250,7 +1250,7 @@ class HomeAssistantStateResponse final : public ProtoDecodableMessage {
 #endif
 class GetTimeRequest final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 36;
+  static constexpr uint16_t MESSAGE_TYPE = 36;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("get_time_request"); }
@@ -1292,7 +1292,7 @@ class ParsedTimezone final : public ProtoDecodableMessage {
 };
 class GetTimeResponse final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 37;
+  static constexpr uint16_t MESSAGE_TYPE = 37;
   static constexpr uint8_t ESTIMATED_SIZE = 22;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("get_time_response"); }
@@ -1323,7 +1323,7 @@ class ListEntitiesServicesArgument final : public ProtoMessage {
 };
 class ListEntitiesServicesResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 41;
+  static constexpr uint16_t MESSAGE_TYPE = 41;
   static constexpr uint8_t ESTIMATED_SIZE = 50;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_services_response"); }
@@ -1363,7 +1363,7 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
 };
 class ExecuteServiceRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 42;
+  static constexpr uint16_t MESSAGE_TYPE = 42;
   static constexpr uint8_t ESTIMATED_SIZE = 45;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("execute_service_request"); }
@@ -1390,7 +1390,7 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
 class ExecuteServiceResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 131;
+  static constexpr uint16_t MESSAGE_TYPE = 131;
   static constexpr uint8_t ESTIMATED_SIZE = 34;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("execute_service_response"); }
@@ -1414,7 +1414,7 @@ class ExecuteServiceResponse final : public ProtoMessage {
 #ifdef USE_CAMERA
 class ListEntitiesCameraResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 43;
+  static constexpr uint16_t MESSAGE_TYPE = 43;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_camera_response"); }
@@ -1429,7 +1429,7 @@ class ListEntitiesCameraResponse final : public InfoResponseProtoMessage {
 };
 class CameraImageResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 44;
+  static constexpr uint16_t MESSAGE_TYPE = 44;
   static constexpr uint8_t ESTIMATED_SIZE = 30;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("camera_image_response"); }
@@ -1451,7 +1451,7 @@ class CameraImageResponse final : public StateResponseProtoMessage {
 };
 class CameraImageRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 45;
+  static constexpr uint16_t MESSAGE_TYPE = 45;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("camera_image_request"); }
@@ -1469,7 +1469,7 @@ class CameraImageRequest final : public ProtoDecodableMessage {
 #ifdef USE_CLIMATE
 class ListEntitiesClimateResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 46;
+  static constexpr uint16_t MESSAGE_TYPE = 46;
   static constexpr uint8_t ESTIMATED_SIZE = 153;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_climate_response"); }
@@ -1503,7 +1503,7 @@ class ListEntitiesClimateResponse final : public InfoResponseProtoMessage {
 };
 class ClimateStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 47;
+  static constexpr uint16_t MESSAGE_TYPE = 47;
   static constexpr uint8_t ESTIMATED_SIZE = 68;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("climate_state_response"); }
@@ -1531,7 +1531,7 @@ class ClimateStateResponse final : public StateResponseProtoMessage {
 };
 class ClimateCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 48;
+  static constexpr uint16_t MESSAGE_TYPE = 48;
   static constexpr uint8_t ESTIMATED_SIZE = 84;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("climate_command_request"); }
@@ -1569,7 +1569,7 @@ class ClimateCommandRequest final : public CommandProtoMessage {
 #ifdef USE_WATER_HEATER
 class ListEntitiesWaterHeaterResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 132;
+  static constexpr uint16_t MESSAGE_TYPE = 132;
   static constexpr uint8_t ESTIMATED_SIZE = 65;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_water_heater_response"); }
@@ -1590,7 +1590,7 @@ class ListEntitiesWaterHeaterResponse final : public InfoResponseProtoMessage {
 };
 class WaterHeaterStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 133;
+  static constexpr uint16_t MESSAGE_TYPE = 133;
   static constexpr uint8_t ESTIMATED_SIZE = 35;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("water_heater_state_response"); }
@@ -1611,7 +1611,7 @@ class WaterHeaterStateResponse final : public StateResponseProtoMessage {
 };
 class WaterHeaterCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 134;
+  static constexpr uint16_t MESSAGE_TYPE = 134;
   static constexpr uint8_t ESTIMATED_SIZE = 34;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("water_heater_command_request"); }
@@ -1634,7 +1634,7 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
 #ifdef USE_NUMBER
 class ListEntitiesNumberResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 49;
+  static constexpr uint16_t MESSAGE_TYPE = 49;
   static constexpr uint8_t ESTIMATED_SIZE = 75;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_number_response"); }
@@ -1655,7 +1655,7 @@ class ListEntitiesNumberResponse final : public InfoResponseProtoMessage {
 };
 class NumberStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 50;
+  static constexpr uint16_t MESSAGE_TYPE = 50;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("number_state_response"); }
@@ -1672,7 +1672,7 @@ class NumberStateResponse final : public StateResponseProtoMessage {
 };
 class NumberCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 51;
+  static constexpr uint16_t MESSAGE_TYPE = 51;
   static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("number_command_request"); }
@@ -1690,7 +1690,7 @@ class NumberCommandRequest final : public CommandProtoMessage {
 #ifdef USE_SELECT
 class ListEntitiesSelectResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 52;
+  static constexpr uint16_t MESSAGE_TYPE = 52;
   static constexpr uint8_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_select_response"); }
@@ -1706,7 +1706,7 @@ class ListEntitiesSelectResponse final : public InfoResponseProtoMessage {
 };
 class SelectStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 53;
+  static constexpr uint16_t MESSAGE_TYPE = 53;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("select_state_response"); }
@@ -1723,7 +1723,7 @@ class SelectStateResponse final : public StateResponseProtoMessage {
 };
 class SelectCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 54;
+  static constexpr uint16_t MESSAGE_TYPE = 54;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("select_command_request"); }
@@ -1742,7 +1742,7 @@ class SelectCommandRequest final : public CommandProtoMessage {
 #ifdef USE_SIREN
 class ListEntitiesSirenResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 55;
+  static constexpr uint16_t MESSAGE_TYPE = 55;
   static constexpr uint8_t ESTIMATED_SIZE = 62;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_siren_response"); }
@@ -1760,7 +1760,7 @@ class ListEntitiesSirenResponse final : public InfoResponseProtoMessage {
 };
 class SirenStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 56;
+  static constexpr uint16_t MESSAGE_TYPE = 56;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("siren_state_response"); }
@@ -1776,7 +1776,7 @@ class SirenStateResponse final : public StateResponseProtoMessage {
 };
 class SirenCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 57;
+  static constexpr uint16_t MESSAGE_TYPE = 57;
   static constexpr uint8_t ESTIMATED_SIZE = 37;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("siren_command_request"); }
@@ -1802,7 +1802,7 @@ class SirenCommandRequest final : public CommandProtoMessage {
 #ifdef USE_LOCK
 class ListEntitiesLockResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 58;
+  static constexpr uint16_t MESSAGE_TYPE = 58;
   static constexpr uint8_t ESTIMATED_SIZE = 55;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_lock_response"); }
@@ -1821,7 +1821,7 @@ class ListEntitiesLockResponse final : public InfoResponseProtoMessage {
 };
 class LockStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 59;
+  static constexpr uint16_t MESSAGE_TYPE = 59;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("lock_state_response"); }
@@ -1837,7 +1837,7 @@ class LockStateResponse final : public StateResponseProtoMessage {
 };
 class LockCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 60;
+  static constexpr uint16_t MESSAGE_TYPE = 60;
   static constexpr uint8_t ESTIMATED_SIZE = 22;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("lock_command_request"); }
@@ -1858,7 +1858,7 @@ class LockCommandRequest final : public CommandProtoMessage {
 #ifdef USE_BUTTON
 class ListEntitiesButtonResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 61;
+  static constexpr uint16_t MESSAGE_TYPE = 61;
   static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_button_response"); }
@@ -1874,7 +1874,7 @@ class ListEntitiesButtonResponse final : public InfoResponseProtoMessage {
 };
 class ButtonCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 62;
+  static constexpr uint16_t MESSAGE_TYPE = 62;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("button_command_request"); }
@@ -1906,7 +1906,7 @@ class MediaPlayerSupportedFormat final : public ProtoMessage {
 };
 class ListEntitiesMediaPlayerResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 63;
+  static constexpr uint16_t MESSAGE_TYPE = 63;
   static constexpr uint8_t ESTIMATED_SIZE = 80;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_media_player_response"); }
@@ -1924,7 +1924,7 @@ class ListEntitiesMediaPlayerResponse final : public InfoResponseProtoMessage {
 };
 class MediaPlayerStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 64;
+  static constexpr uint16_t MESSAGE_TYPE = 64;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("media_player_state_response"); }
@@ -1942,7 +1942,7 @@ class MediaPlayerStateResponse final : public StateResponseProtoMessage {
 };
 class MediaPlayerCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 65;
+  static constexpr uint16_t MESSAGE_TYPE = 65;
   static constexpr uint8_t ESTIMATED_SIZE = 35;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("media_player_command_request"); }
@@ -1968,7 +1968,7 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY
 class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 66;
+  static constexpr uint16_t MESSAGE_TYPE = 66;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("subscribe_bluetooth_le_advertisements_request"); }
@@ -1996,7 +1996,7 @@ class BluetoothLERawAdvertisement final : public ProtoMessage {
 };
 class BluetoothLERawAdvertisementsResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 93;
+  static constexpr uint16_t MESSAGE_TYPE = 93;
   static constexpr uint8_t ESTIMATED_SIZE = 136;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_le_raw_advertisements_response"); }
@@ -2015,7 +2015,7 @@ class BluetoothLERawAdvertisementsResponse final : public ProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY_CONNECTIONS
 class BluetoothDeviceRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 68;
+  static constexpr uint16_t MESSAGE_TYPE = 68;
   static constexpr uint8_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_device_request"); }
@@ -2033,7 +2033,7 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
 };
 class BluetoothDeviceConnectionResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 69;
+  static constexpr uint16_t MESSAGE_TYPE = 69;
   static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_device_connection_response"); }
@@ -2052,7 +2052,7 @@ class BluetoothDeviceConnectionResponse final : public ProtoMessage {
 };
 class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 70;
+  static constexpr uint16_t MESSAGE_TYPE = 70;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_get_services_request"); }
@@ -2109,7 +2109,7 @@ class BluetoothGATTService final : public ProtoMessage {
 };
 class BluetoothGATTGetServicesResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 71;
+  static constexpr uint16_t MESSAGE_TYPE = 71;
   static constexpr uint8_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_get_services_response"); }
@@ -2126,7 +2126,7 @@ class BluetoothGATTGetServicesResponse final : public ProtoMessage {
 };
 class BluetoothGATTGetServicesDoneResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 72;
+  static constexpr uint16_t MESSAGE_TYPE = 72;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_get_services_done_response"); }
@@ -2142,7 +2142,7 @@ class BluetoothGATTGetServicesDoneResponse final : public ProtoMessage {
 };
 class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 73;
+  static constexpr uint16_t MESSAGE_TYPE = 73;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_read_request"); }
@@ -2158,7 +2158,7 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
 };
 class BluetoothGATTReadResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 74;
+  static constexpr uint16_t MESSAGE_TYPE = 74;
   static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_read_response"); }
@@ -2181,7 +2181,7 @@ class BluetoothGATTReadResponse final : public ProtoMessage {
 };
 class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 75;
+  static constexpr uint16_t MESSAGE_TYPE = 75;
   static constexpr uint8_t ESTIMATED_SIZE = 29;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_write_request"); }
@@ -2201,7 +2201,7 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
 };
 class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 76;
+  static constexpr uint16_t MESSAGE_TYPE = 76;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_read_descriptor_request"); }
@@ -2217,7 +2217,7 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
 };
 class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 77;
+  static constexpr uint16_t MESSAGE_TYPE = 77;
   static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_write_descriptor_request"); }
@@ -2236,7 +2236,7 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
 };
 class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 78;
+  static constexpr uint16_t MESSAGE_TYPE = 78;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_notify_request"); }
@@ -2253,7 +2253,7 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
 };
 class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 79;
+  static constexpr uint16_t MESSAGE_TYPE = 79;
   static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_notify_data_response"); }
@@ -2276,7 +2276,7 @@ class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
 };
 class BluetoothConnectionsFreeResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 81;
+  static constexpr uint16_t MESSAGE_TYPE = 81;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_connections_free_response"); }
@@ -2294,7 +2294,7 @@ class BluetoothConnectionsFreeResponse final : public ProtoMessage {
 };
 class BluetoothGATTErrorResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 82;
+  static constexpr uint16_t MESSAGE_TYPE = 82;
   static constexpr uint8_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_error_response"); }
@@ -2312,7 +2312,7 @@ class BluetoothGATTErrorResponse final : public ProtoMessage {
 };
 class BluetoothGATTWriteResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 83;
+  static constexpr uint16_t MESSAGE_TYPE = 83;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_write_response"); }
@@ -2329,7 +2329,7 @@ class BluetoothGATTWriteResponse final : public ProtoMessage {
 };
 class BluetoothGATTNotifyResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 84;
+  static constexpr uint16_t MESSAGE_TYPE = 84;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_notify_response"); }
@@ -2346,7 +2346,7 @@ class BluetoothGATTNotifyResponse final : public ProtoMessage {
 };
 class BluetoothDevicePairingResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 85;
+  static constexpr uint16_t MESSAGE_TYPE = 85;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_device_pairing_response"); }
@@ -2364,7 +2364,7 @@ class BluetoothDevicePairingResponse final : public ProtoMessage {
 };
 class BluetoothDeviceUnpairingResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 86;
+  static constexpr uint16_t MESSAGE_TYPE = 86;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_device_unpairing_response"); }
@@ -2382,7 +2382,7 @@ class BluetoothDeviceUnpairingResponse final : public ProtoMessage {
 };
 class BluetoothDeviceClearCacheResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 88;
+  static constexpr uint16_t MESSAGE_TYPE = 88;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_device_clear_cache_response"); }
@@ -2402,7 +2402,7 @@ class BluetoothDeviceClearCacheResponse final : public ProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY
 class BluetoothScannerStateResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 126;
+  static constexpr uint16_t MESSAGE_TYPE = 126;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_scanner_state_response"); }
@@ -2420,7 +2420,7 @@ class BluetoothScannerStateResponse final : public ProtoMessage {
 };
 class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 127;
+  static constexpr uint16_t MESSAGE_TYPE = 127;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_scanner_set_mode_request"); }
@@ -2437,7 +2437,7 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
 #ifdef USE_VOICE_ASSISTANT
 class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 89;
+  static constexpr uint16_t MESSAGE_TYPE = 89;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("subscribe_voice_assistant_request"); }
@@ -2466,7 +2466,7 @@ class VoiceAssistantAudioSettings final : public ProtoMessage {
 };
 class VoiceAssistantRequest final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 90;
+  static constexpr uint16_t MESSAGE_TYPE = 90;
   static constexpr uint8_t ESTIMATED_SIZE = 41;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_request"); }
@@ -2486,7 +2486,7 @@ class VoiceAssistantRequest final : public ProtoMessage {
 };
 class VoiceAssistantResponse final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 91;
+  static constexpr uint16_t MESSAGE_TYPE = 91;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_response"); }
@@ -2513,7 +2513,7 @@ class VoiceAssistantEventData final : public ProtoDecodableMessage {
 };
 class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 92;
+  static constexpr uint16_t MESSAGE_TYPE = 92;
   static constexpr uint8_t ESTIMATED_SIZE = 36;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_event_response"); }
@@ -2530,7 +2530,7 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
 };
 class VoiceAssistantAudio final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 106;
+  static constexpr uint16_t MESSAGE_TYPE = 106;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_audio"); }
@@ -2552,7 +2552,7 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
 };
 class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 115;
+  static constexpr uint16_t MESSAGE_TYPE = 115;
   static constexpr uint8_t ESTIMATED_SIZE = 30;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_timer_event_response"); }
@@ -2573,7 +2573,7 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
 };
 class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 119;
+  static constexpr uint16_t MESSAGE_TYPE = 119;
   static constexpr uint8_t ESTIMATED_SIZE = 29;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_announce_request"); }
@@ -2592,7 +2592,7 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
 };
 class VoiceAssistantAnnounceFinished final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 120;
+  static constexpr uint16_t MESSAGE_TYPE = 120;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_announce_finished"); }
@@ -2638,7 +2638,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
 };
 class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 121;
+  static constexpr uint16_t MESSAGE_TYPE = 121;
   static constexpr uint8_t ESTIMATED_SIZE = 34;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_configuration_request"); }
@@ -2653,7 +2653,7 @@ class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
 };
 class VoiceAssistantConfigurationResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 122;
+  static constexpr uint16_t MESSAGE_TYPE = 122;
   static constexpr uint8_t ESTIMATED_SIZE = 56;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_configuration_response"); }
@@ -2671,7 +2671,7 @@ class VoiceAssistantConfigurationResponse final : public ProtoMessage {
 };
 class VoiceAssistantSetConfiguration final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 123;
+  static constexpr uint16_t MESSAGE_TYPE = 123;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("voice_assistant_set_configuration"); }
@@ -2688,7 +2688,7 @@ class VoiceAssistantSetConfiguration final : public ProtoDecodableMessage {
 #ifdef USE_ALARM_CONTROL_PANEL
 class ListEntitiesAlarmControlPanelResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 94;
+  static constexpr uint16_t MESSAGE_TYPE = 94;
   static constexpr uint8_t ESTIMATED_SIZE = 48;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_alarm_control_panel_response"); }
@@ -2706,7 +2706,7 @@ class ListEntitiesAlarmControlPanelResponse final : public InfoResponseProtoMess
 };
 class AlarmControlPanelStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 95;
+  static constexpr uint16_t MESSAGE_TYPE = 95;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("alarm_control_panel_state_response"); }
@@ -2722,7 +2722,7 @@ class AlarmControlPanelStateResponse final : public StateResponseProtoMessage {
 };
 class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 96;
+  static constexpr uint16_t MESSAGE_TYPE = 96;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("alarm_control_panel_command_request"); }
@@ -2742,7 +2742,7 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
 #ifdef USE_TEXT
 class ListEntitiesTextResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 97;
+  static constexpr uint16_t MESSAGE_TYPE = 97;
   static constexpr uint8_t ESTIMATED_SIZE = 59;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_text_response"); }
@@ -2761,7 +2761,7 @@ class ListEntitiesTextResponse final : public InfoResponseProtoMessage {
 };
 class TextStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 98;
+  static constexpr uint16_t MESSAGE_TYPE = 98;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("text_state_response"); }
@@ -2778,7 +2778,7 @@ class TextStateResponse final : public StateResponseProtoMessage {
 };
 class TextCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 99;
+  static constexpr uint16_t MESSAGE_TYPE = 99;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("text_command_request"); }
@@ -2797,7 +2797,7 @@ class TextCommandRequest final : public CommandProtoMessage {
 #ifdef USE_DATETIME_DATE
 class ListEntitiesDateResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 100;
+  static constexpr uint16_t MESSAGE_TYPE = 100;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_date_response"); }
@@ -2812,7 +2812,7 @@ class ListEntitiesDateResponse final : public InfoResponseProtoMessage {
 };
 class DateStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 101;
+  static constexpr uint16_t MESSAGE_TYPE = 101;
   static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("date_state_response"); }
@@ -2831,7 +2831,7 @@ class DateStateResponse final : public StateResponseProtoMessage {
 };
 class DateCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 102;
+  static constexpr uint16_t MESSAGE_TYPE = 102;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("date_command_request"); }
@@ -2851,7 +2851,7 @@ class DateCommandRequest final : public CommandProtoMessage {
 #ifdef USE_DATETIME_TIME
 class ListEntitiesTimeResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 103;
+  static constexpr uint16_t MESSAGE_TYPE = 103;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_time_response"); }
@@ -2866,7 +2866,7 @@ class ListEntitiesTimeResponse final : public InfoResponseProtoMessage {
 };
 class TimeStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 104;
+  static constexpr uint16_t MESSAGE_TYPE = 104;
   static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("time_state_response"); }
@@ -2885,7 +2885,7 @@ class TimeStateResponse final : public StateResponseProtoMessage {
 };
 class TimeCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 105;
+  static constexpr uint16_t MESSAGE_TYPE = 105;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("time_command_request"); }
@@ -2905,7 +2905,7 @@ class TimeCommandRequest final : public CommandProtoMessage {
 #ifdef USE_EVENT
 class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 107;
+  static constexpr uint16_t MESSAGE_TYPE = 107;
   static constexpr uint8_t ESTIMATED_SIZE = 67;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_event_response"); }
@@ -2922,7 +2922,7 @@ class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
 };
 class EventResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 108;
+  static constexpr uint16_t MESSAGE_TYPE = 108;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("event_response"); }
@@ -2940,7 +2940,7 @@ class EventResponse final : public StateResponseProtoMessage {
 #ifdef USE_VALVE
 class ListEntitiesValveResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 109;
+  static constexpr uint16_t MESSAGE_TYPE = 109;
   static constexpr uint8_t ESTIMATED_SIZE = 55;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_valve_response"); }
@@ -2959,7 +2959,7 @@ class ListEntitiesValveResponse final : public InfoResponseProtoMessage {
 };
 class ValveStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 110;
+  static constexpr uint16_t MESSAGE_TYPE = 110;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("valve_state_response"); }
@@ -2976,7 +2976,7 @@ class ValveStateResponse final : public StateResponseProtoMessage {
 };
 class ValveCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 111;
+  static constexpr uint16_t MESSAGE_TYPE = 111;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("valve_command_request"); }
@@ -2996,7 +2996,7 @@ class ValveCommandRequest final : public CommandProtoMessage {
 #ifdef USE_DATETIME_DATETIME
 class ListEntitiesDateTimeResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 112;
+  static constexpr uint16_t MESSAGE_TYPE = 112;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_date_time_response"); }
@@ -3011,7 +3011,7 @@ class ListEntitiesDateTimeResponse final : public InfoResponseProtoMessage {
 };
 class DateTimeStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 113;
+  static constexpr uint16_t MESSAGE_TYPE = 113;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("date_time_state_response"); }
@@ -3028,7 +3028,7 @@ class DateTimeStateResponse final : public StateResponseProtoMessage {
 };
 class DateTimeCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 114;
+  static constexpr uint16_t MESSAGE_TYPE = 114;
   static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("date_time_command_request"); }
@@ -3046,7 +3046,7 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
 #ifdef USE_UPDATE
 class ListEntitiesUpdateResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 116;
+  static constexpr uint16_t MESSAGE_TYPE = 116;
   static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_update_response"); }
@@ -3062,7 +3062,7 @@ class ListEntitiesUpdateResponse final : public InfoResponseProtoMessage {
 };
 class UpdateStateResponse final : public StateResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 117;
+  static constexpr uint16_t MESSAGE_TYPE = 117;
   static constexpr uint8_t ESTIMATED_SIZE = 65;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("update_state_response"); }
@@ -3086,7 +3086,7 @@ class UpdateStateResponse final : public StateResponseProtoMessage {
 };
 class UpdateCommandRequest final : public CommandProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 118;
+  static constexpr uint16_t MESSAGE_TYPE = 118;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("update_command_request"); }
@@ -3104,7 +3104,7 @@ class UpdateCommandRequest final : public CommandProtoMessage {
 #ifdef USE_ZWAVE_PROXY
 class ZWaveProxyFrame final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 128;
+  static constexpr uint16_t MESSAGE_TYPE = 128;
   static constexpr uint8_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("z_wave_proxy_frame"); }
@@ -3122,7 +3122,7 @@ class ZWaveProxyFrame final : public ProtoDecodableMessage {
 };
 class ZWaveProxyRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 129;
+  static constexpr uint16_t MESSAGE_TYPE = 129;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("z_wave_proxy_request"); }
@@ -3142,7 +3142,7 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
 };
 class ZWaveProxyRequestResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 151;
+  static constexpr uint16_t MESSAGE_TYPE = 151;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("z_wave_proxy_request_response"); }
@@ -3161,7 +3161,7 @@ class ZWaveProxyRequestResponse final : public ProtoMessage {
 #ifdef USE_INFRARED
 class ListEntitiesInfraredResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 135;
+  static constexpr uint16_t MESSAGE_TYPE = 135;
   static constexpr uint8_t ESTIMATED_SIZE = 48;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_infrared_response"); }
@@ -3180,7 +3180,7 @@ class ListEntitiesInfraredResponse final : public InfoResponseProtoMessage {
 #if defined(USE_IR_RF) || defined(USE_RADIO_FREQUENCY)
 class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 136;
+  static constexpr uint16_t MESSAGE_TYPE = 136;
   static constexpr uint8_t ESTIMATED_SIZE = 224;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("infrared_rf_transmit_raw_timings_request"); }
@@ -3206,7 +3206,7 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
 };
 class InfraredRFReceiveEvent final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 137;
+  static constexpr uint16_t MESSAGE_TYPE = 137;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("infrared_rf_receive_event"); }
@@ -3228,7 +3228,7 @@ class InfraredRFReceiveEvent final : public ProtoMessage {
 #ifdef USE_RADIO_FREQUENCY
 class ListEntitiesRadioFrequencyResponse final : public InfoResponseProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 148;
+  static constexpr uint16_t MESSAGE_TYPE = 148;
   static constexpr uint8_t ESTIMATED_SIZE = 56;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("list_entities_radio_frequency_response"); }
@@ -3249,7 +3249,7 @@ class ListEntitiesRadioFrequencyResponse final : public InfoResponseProtoMessage
 #ifdef USE_SERIAL_PROXY
 class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 138;
+  static constexpr uint16_t MESSAGE_TYPE = 138;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_configure_request"); }
@@ -3269,7 +3269,7 @@ class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
 };
 class SerialProxyDataReceived final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 139;
+  static constexpr uint16_t MESSAGE_TYPE = 139;
   static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_data_received"); }
@@ -3291,7 +3291,7 @@ class SerialProxyDataReceived final : public ProtoMessage {
 };
 class SerialProxyWriteRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 140;
+  static constexpr uint16_t MESSAGE_TYPE = 140;
   static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_write_request"); }
@@ -3309,7 +3309,7 @@ class SerialProxyWriteRequest final : public ProtoDecodableMessage {
 };
 class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 141;
+  static constexpr uint16_t MESSAGE_TYPE = 141;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_set_modem_pins_request"); }
@@ -3325,7 +3325,7 @@ class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
 };
 class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 142;
+  static constexpr uint16_t MESSAGE_TYPE = 142;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_get_modem_pins_request"); }
@@ -3340,7 +3340,7 @@ class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
 };
 class SerialProxyGetModemPinsResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 143;
+  static constexpr uint16_t MESSAGE_TYPE = 143;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_get_modem_pins_response"); }
@@ -3358,7 +3358,7 @@ class SerialProxyGetModemPinsResponse final : public ProtoMessage {
 };
 class SerialProxyRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 144;
+  static constexpr uint16_t MESSAGE_TYPE = 144;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_request"); }
@@ -3374,7 +3374,7 @@ class SerialProxyRequest final : public ProtoDecodableMessage {
 };
 class SerialProxyRequestResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 147;
+  static constexpr uint16_t MESSAGE_TYPE = 147;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("serial_proxy_request_response"); }
@@ -3395,7 +3395,7 @@ class SerialProxyRequestResponse final : public ProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY_CONNECTIONS
 class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 145;
+  static constexpr uint16_t MESSAGE_TYPE = 145;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_set_connection_params_request"); }
@@ -3414,7 +3414,7 @@ class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
 };
 class BluetoothSetConnectionParamsResponse final : public ProtoMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 146;
+  static constexpr uint16_t MESSAGE_TYPE = 146;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("bluetooth_set_connection_params_response"); }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -684,11 +684,6 @@ class ProtoSize {
     return value < VARINT_THRESHOLD_1_BYTE ? 1 : (value < VARINT_THRESHOLD_2_BYTE ? 2 : 3);
   }
 
-  // Varint encoded length for an 8-bit value (1 or 2 bytes).
-  static constexpr inline uint8_t ESPHOME_ALWAYS_INLINE varint8(uint8_t value) {
-    return value < VARINT_THRESHOLD_1_BYTE ? 1 : 2;
-  }
-
   /**
    * @brief Calculates the size in bytes needed to encode a uint32_t value as a varint
    *

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -475,6 +475,19 @@ TYPE_INFO: dict[int, TypeInfo] = {}
 # TYPE_DOUBLE = 1, TYPE_FIXED64 = 6, TYPE_SFIXED64 = 16, TYPE_SINT64 = 18
 UNSUPPORTED_TYPES = {1: "double", 6: "fixed64", 16: "sfixed64", 18: "sint64"}
 
+# The plaintext frame header budgets 2 varint bytes for the message type
+# (APIPlaintextFrameHelper::HEADER_PADDING), which caps message IDs at 16383.
+MAX_MESSAGE_ID = 16383
+
+
+def validate_message_id(message_id: int, message_name: str) -> None:
+    """Reject message IDs whose plaintext type varint would not fit in 2 bytes."""
+    if message_id > MAX_MESSAGE_ID:
+        raise ValueError(
+            f"Message ID {message_id} for {message_name} exceeds the plaintext "
+            f"2-byte type varint maximum ({MAX_MESSAGE_ID})"
+        )
+
 
 def validate_field_type(field_type: int, field_name: str = "") -> None:
     """Validate that the field type is supported by ESPHome API.
@@ -2549,13 +2562,7 @@ def build_message_type(
 
     # Add MESSAGE_TYPE method if this is a service message
     if message_id is not None:
-        # The plaintext frame header budgets 2 varint bytes for the type
-        # (HEADER_PADDING), which caps message IDs at 16383
-        if message_id > 16383:
-            raise ValueError(
-                f"Message ID {message_id} for {desc.name} exceeds the plaintext "
-                "2-byte type varint maximum (16383)"
-            )
+        validate_message_id(message_id, desc.name)
 
         # Add static constexpr for message type
         public_content.append(f"static constexpr uint16_t MESSAGE_TYPE = {message_id};")
@@ -3214,8 +3221,12 @@ def main() -> None:
 #include "api_pb2_includes.h"
 """
 
-    content += """
-namespace esphome::api {
+    content += f"""
+namespace esphome::api {{
+
+// Upper bound on message IDs, enforced by the code generator: the plaintext
+// frame header budgets 2 varint bytes for the type (HEADER_PADDING).
+static constexpr uint16_t MAX_MESSAGE_TYPE = {MAX_MESSAGE_ID};
 
 """
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2549,14 +2549,16 @@ def build_message_type(
 
     # Add MESSAGE_TYPE method if this is a service message
     if message_id is not None:
-        # Validate that message_id fits in uint8_t
-        if message_id > 255:
+        # The plaintext frame header budgets 2 varint bytes for the type
+        # (HEADER_PADDING), which caps message IDs at 16383
+        if message_id > 16383:
             raise ValueError(
-                f"Message ID {message_id} for {desc.name} exceeds uint8_t maximum (255)"
+                f"Message ID {message_id} for {desc.name} exceeds the plaintext "
+                "2-byte type varint maximum (16383)"
             )
 
         # Add static constexpr for message type
-        public_content.append(f"static constexpr uint8_t MESSAGE_TYPE = {message_id};")
+        public_content.append(f"static constexpr uint16_t MESSAGE_TYPE = {message_id};")
 
         # Add estimated size constant
         estimated_size = calculate_message_estimated_size(desc)

--- a/tests/unit_tests/components/api/test_api_protobuf_generator.py
+++ b/tests/unit_tests/components/api/test_api_protobuf_generator.py
@@ -15,7 +15,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parents[4] / "script" / "api_protobuf"))
 
-from api_protobuf import _make_ifdef_line, get_varint64_ifdef  # noqa: E402
+from api_protobuf import (  # noqa: E402
+    MAX_MESSAGE_ID,
+    _make_ifdef_line,
+    get_varint64_ifdef,
+    validate_message_id,
+)
 from google.protobuf import descriptor_pb2  # noqa: E402
 
 
@@ -91,3 +96,14 @@ def test_make_ifdef_line_conjunction_and_negation() -> None:
     assert (
         _make_ifdef_line("USE_X && !USE_Y") == "#if defined(USE_X) && !defined(USE_Y)"
     )
+
+
+def test_message_id_at_maximum_is_accepted() -> None:
+    # 16383 is the largest ID whose plaintext type varint fits the 2 bytes
+    # budgeted in HEADER_PADDING.
+    validate_message_id(MAX_MESSAGE_ID, "MaxMessage")
+
+
+def test_message_id_above_maximum_is_rejected() -> None:
+    with pytest.raises(ValueError, match="exceeds the plaintext"):
+        validate_message_id(MAX_MESSAGE_ID + 1, "TooBigMessage")


### PR DESCRIPTION
# What does this implement/fix?

The native API stores protobuf message types as uint8_t on the send path, which caps message IDs at 255. We are at 149 and new messages keep landing, so this widens the storage to uint16_t now. The wire formats already carry 16 bit types: noise has a fixed two byte type field, plaintext encodes the type as a varint, and the RX path already parses types up to 65535, so nothing changes on the wire or in aioesphomeapi.

There is no per connection RAM cost. The batch queue item had one byte of alignment padding after the entity pointer, so the wider field fills that byte and the struct stays 8 bytes on 32 bit targets. The connection's packed small member group also stays 8 bytes: the client API version fields shrink to uint8_t (we are at protocol version 1.15, and the values are clamped to 255 on receive) to make room for the wider batch message type. The MessageInfo array in the multi message write path grows by two bytes per entry, but that is a transient stack array of at most 34 entries. The proto generator now caps message IDs at 16383 so the plaintext type varint keeps fitting the two bytes budgeted in the frame header padding.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related: https://github.com/esphome/esphome/pull/18220#discussion_r3788615401

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# Not applicable, no configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
