### PR TITLE
[mipi_spi] Toggle D/C only while holding the SPI bus

### DIFF
--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -246,33 +246,36 @@ class MipiSpi : public display::Display,
       this->write_cmd_addr_data(8, 0x02, 24, cmd << 8, bytes, len);
       this->disable();
     } else if constexpr (BUS_TYPE == BUS_TYPE_OCTAL) {
-      this->dc_pin_->digital_write(false);
+      // Toggle D/C only while holding the bus; on boards where D/C doubles as
+      // another bus signal, driving it while another device owns the bus
+      // corrupts that device's transfer.
       this->enable();
+      this->dc_pin_->digital_write(false);
       this->write_cmd_addr_data(0, 0, 0, 0, &cmd, 1, 8);
-      this->disable();
       this->dc_pin_->digital_write(true);
+      this->disable();
       if (len != 0) {
         this->enable();
         this->write_cmd_addr_data(0, 0, 0, 0, bytes, len, 8);
         this->disable();
       }
     } else if constexpr (BUS_TYPE == BUS_TYPE_SINGLE) {
-      this->dc_pin_->digital_write(false);
       this->enable();
+      this->dc_pin_->digital_write(false);
       this->write_byte(cmd);
-      this->disable();
       this->dc_pin_->digital_write(true);
+      this->disable();
       if (len != 0) {
         this->enable();
         this->write_array(bytes, len);
         this->disable();
       }
     } else if constexpr (BUS_TYPE == BUS_TYPE_SINGLE_16) {
-      this->dc_pin_->digital_write(false);
       this->enable();
+      this->dc_pin_->digital_write(false);
       this->write_byte(cmd);
-      this->disable();
       this->dc_pin_->digital_write(true);
+      this->disable();
       for (size_t i = 0; i != len; i++) {
         this->enable();
         this->write_byte(0);


### PR DESCRIPTION
# What does this implement/fix?

The single/octal command paths drove the D/C pin low before acquiring the SPI bus (`enable()`) and raised it again after releasing it (`disable()`). On boards where the D/C line doubles as another bus signal (for example, the M5Stack CoreS3 wires the display D/C and bus MISO to the same GPIO behind a pull-up, with an open-drain D/C), writing the pin while another device owns the bus corrupts that device's in-flight transfer. In the CoreS3 + W5500 (Base LAN PoE) case, an LVGL command issued while the ethernet driver was mid-read clamped MISO low, permanently desynced the W5500 RX path, and ended in a task-watchdog reboot loop.

This moves the D/C writes inside the `enable()`/`disable()` window so the pin only changes while the display owns the bus. Panel-visible timing is unchanged: D/CX is sampled on SCL edges, `write_byte()` is synchronous, and D/C is still stable well before the first clock and changed only after the last one.

Verified on an M5Stack CoreS3 with the display, LVGL, touchscreen, and a W5500 sharing one SPI bus: previously a truncated-frame storm and watchdog reboot within seconds of the first LVGL flush, now stable with clean ethernet traffic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).