### PR TITLE
[ota] Skip partition-access OTA sources when the feature is disabled

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -182,4 +182,11 @@ def FILTER_SOURCE_FILES() -> list[str]:
         for define in CORE.defines
     ):
         files.append("ota_signature_esp_idf.cpp")
+    # ota_bootloader_esp_idf.cpp and ota_partitions_esp_idf.cpp are fully
+    # #ifdef'd on USE_OTA_PARTITIONS (set by the esphome OTA platform when
+    # allow_partition_access is enabled). Filter them out otherwise for the
+    # same reason as above.
+    if not any(define.name == "USE_OTA_PARTITIONS" for define in CORE.defines):
+        files.append("ota_bootloader_esp_idf.cpp")
+        files.append("ota_partitions_esp_idf.cpp")
     return files


### PR DESCRIPTION
# What does this implement/fix?

`ota_bootloader_esp_idf.cpp` and `ota_partitions_esp_idf.cpp` are fully wrapped in `#ifdef USE_OTA_PARTITIONS`, which is only set when the esphome OTA platform has `allow_partition_access` enabled; for every other build they are copied and compiled into empty objects. They are also among the slower files to parse since they pull in the OTA backend headers.

This filters both files out of the source copy when the define is absent, the same way `ota_signature_esp_idf.cpp` is already handled a few lines above. Builds with `allow_partition_access: true` still compile them.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ota:
  - platform: esphome
    password: !secret ota_password

# files are compiled again when partition access is enabled:
# ota:
#   - platform: esphome
#     allow_partition_access: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
