### PR TITLE
[ethernet] Skip the custom W5500 SPI driver for other ethernet types

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -811,6 +811,10 @@ _platform_filter = filter_source_files_from_platform(
             PlatformFramework.ESP32_IDF,
             PlatformFramework.ESP32_ARDUINO,
         },
+        "w5500_custom_spi.cpp": {
+            PlatformFramework.ESP32_IDF,
+            PlatformFramework.ESP32_ARDUINO,
+        },
     }
 )
 

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -834,7 +834,8 @@ def _filter_source_files() -> list[str]:
         # to avoid shadowing. Native IDF builds always need the custom driver.
         if cv.Version(5, 4, 2) <= idf_version() < cv.Version(6, 0, 0):
             excluded.append("esp_eth_phy_jl1101.c")
-    # The custom W5500 SPI driver is fully #ifdef'd on USE_ETHERNET_W5500;
+    # The custom W5500 SPI driver is fully #ifdef'd on USE_ESP32 and
+    # USE_ETHERNET_W5500 (the platform filter map above handles non-ESP32);
     # skip it entirely for the other ethernet types.
     if eth_type != "W5500":
         excluded.append("w5500_custom_spi.cpp")

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -830,6 +830,10 @@ def _filter_source_files() -> list[str]:
         # to avoid shadowing. Native IDF builds always need the custom driver.
         if cv.Version(5, 4, 2) <= idf_version() < cv.Version(6, 0, 0):
             excluded.append("esp_eth_phy_jl1101.c")
+    # The custom W5500 SPI driver is fully #ifdef'd on USE_ETHERNET_W5500;
+    # skip it entirely for the other ethernet types.
+    if eth_type != "W5500":
+        excluded.append("w5500_custom_spi.cpp")
     return excluded
 
 


### PR DESCRIPTION
# What does this implement/fix?

`w5500_custom_spi.cpp` is fully wrapped in `#if defined(USE_ESP32) && defined(USE_ETHERNET_W5500)`, so it compiles into an empty object on each build unless both halves of that guard hold. This filters it out of the source copy when the configured type is not W5500, following the JL1101 handling that already exists in `_filter_source_files()`, and adds it to the platform filter map so non ESP32 targets (W5500 is also an RP2040 type) skip it as well.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk:
    mode: CLK_OUT
    pin: 17
  phy_addr: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

