### PR TITLE
[uptime] Skip the timestamp sensor source when no time component is configured

### DIFF
--- a/esphome/components/uptime/sensor/__init__.py
+++ b/esphome/components/uptime/sensor/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_SECOND,
 )
+from esphome.core import CORE
 
 uptime_ns = cg.esphome_ns.namespace("uptime")
 UptimeSecondsSensor = uptime_ns.class_(
@@ -59,3 +60,11 @@ async def to_code(config):
     if time_id_config := config.get(CONF_TIME_ID):
         time_id = await cg.get_variable(time_id_config)
         cg.add(var.set_time(time_id))
+
+
+def FILTER_SOURCE_FILES() -> list[str]:
+    # uptime_timestamp_sensor.cpp is fully #ifdef'd on USE_TIME; skip it
+    # when no time component is configured.
+    if not any(define.name == "USE_TIME" for define in CORE.defines):
+        return ["uptime_timestamp_sensor.cpp"]
+    return []


### PR DESCRIPTION
# What does this implement/fix?

`uptime_timestamp_sensor.cpp` is fully wrapped in `#ifdef USE_TIME`, so any config with an uptime sensor but no time component compiles it into an empty object on every build. This adds a `FILTER_SOURCE_FILES` hook to the uptime sensor platform that skips the file when `USE_TIME` is not set, matching how other components filter fully ifdef'd sources. Configs with a time component still compile it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: uptime
    name: Uptime

# the timestamp variant is compiled again when a time source exists:
# time:
#   - platform: sntp
# sensor:
#   - platform: uptime
#     type: timestamp
#     name: Last Boot
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
