### PR TITLE
[esp32] Grow the default IDF component exclusion list

### DIFF
--- a/esphome/components/ac_dimmer/output.py
+++ b/esphome/components/ac_dimmer/output.py
@@ -49,6 +49,12 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    if CORE.is_esp32:
+        from esphome.components.esp32 import include_builtin_idf_component
+
+        # Re-enable the gptimer driver (excluded by default to save compile time)
+        include_builtin_idf_component("esp_driver_gptimer")
+
     if CORE.is_esp8266:
         # ac_dimmer uses setTimer1Callback which requires the waveform generator
         from esphome.components.esp8266.const import require_waveform

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -219,8 +219,8 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "esp_adc",  # ADC driver - only needed by adc component
     "esp_driver_cam",  # Camera driver - the esp32-camera managed component pulls it back
     "esp_driver_dac",  # DAC driver - only needed by esp32_dac component
-    "esp_driver_gptimer",  # General purpose timer - only needed by ac_dimmer, opentherm
-    "esp_driver_i2c",  # I2C driver - only needed by i2c component
+    "esp_driver_gptimer",  # General purpose timer - re-included by ac_dimmer, opentherm, Arduino BLE libs
+    "esp_driver_i2c",  # I2C driver - re-included by i2c; esp32-camera pulls it back itself
     "esp_driver_i2s",  # I2S driver - only needed by i2s_audio component
     "esp_driver_ledc",  # LEDC PWM driver - re-included by ledc; esp32-camera pulls it back itself
     "esp_driver_mcpwm",  # MCPWM driver - ESPHome doesn't use motor control PWM

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -204,18 +204,32 @@ COMPILER_OPTIMIZATIONS = {
 # ESP-IDF components excluded by default to reduce compile time.
 # Components can be re-enabled by calling include_builtin_idf_component() in to_code().
 #
-# Cannot be excluded (dependencies of required components):
-# - "console": espressif/mdns unconditionally depends on it
-# - "sdmmc": driver -> esp_driver_sdmmc -> sdmmc dependency chain
+# Note: excluding a component only removes it from the initial build set.
+# ESP-IDF's requirement expansion adds an excluded component back when any
+# component still in the build REQUIRES it (e.g. espressif/mdns pulls
+# "console" back in, esp_http_client pulls "tcp_transport" back in), so
+# exclusions here are safe for such components and simply become no-ops in
+# builds that need them.
 DEFAULT_EXCLUDED_IDF_COMPONENTS = (
+    "app_trace",  # CPU trace/SystemView support - unused by ESPHome
     "cmock",  # Unit testing mock framework - ESPHome doesn't use IDF's testing
+    "console",  # Console REPL - unused by ESPHome; espressif/mdns pulls it back when configured
     "driver",  # Legacy driver shim - only needed by esp32_touch, esp32_can for legacy headers
+    "esp-tls",  # TLS wrapper - only needed by http_request (re-included there)
     "esp_adc",  # ADC driver - only needed by adc component
+    "esp_driver_cam",  # Camera driver - the esp32-camera managed component pulls it back
     "esp_driver_dac",  # DAC driver - only needed by esp32_dac component
+    "esp_driver_gptimer",  # General purpose timer - only needed by ac_dimmer, opentherm
+    "esp_driver_i2c",  # I2C driver - only needed by i2c component
     "esp_driver_i2s",  # I2S driver - only needed by i2s_audio component
+    "esp_driver_ledc",  # LEDC PWM driver - only needed by ledc component
     "esp_driver_mcpwm",  # MCPWM driver - ESPHome doesn't use motor control PWM
     "esp_driver_pcnt",  # PCNT driver - only needed by pulse_counter, hlw8012 components
     "esp_driver_rmt",  # RMT driver - only needed by remote_transmitter/receiver, neopixelbus
+    "esp_driver_sdio",  # SDIO device-mode driver - unused by ESPHome
+    "esp_driver_sdm",  # Sigma-delta modulation driver - unused by ESPHome
+    "esp_driver_sdmmc",  # SD/MMC host driver - unused by ESPHome
+    "esp_driver_sdspi",  # SD-over-SPI driver - unused by ESPHome
     "esp_driver_touch_sens",  # Touch sensor driver - only needed by esp32_touch
     "esp_driver_twai",  # TWAI/CAN driver - only needed by esp32_can component
     "esp_eth",  # Ethernet driver - only needed by ethernet component
@@ -227,11 +241,16 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "esp_local_ctrl",  # Local control over HTTPS/BLE - ESPHome has native API
     "espcoredump",  # Core dump support - ESPHome has its own debug component
     "fatfs",  # FAT filesystem - ESPHome doesn't use filesystem storage
+    "json",  # cJSON library - ESPHome uses ArduinoJson instead
     "mqtt",  # ESP-IDF MQTT library - ESPHome has its own MQTT implementation
     "openthread",  # Thread protocol - only needed by openthread component
     "perfmon",  # Xtensa performance monitor - ESPHome has its own debug component
+    "protobuf-c",  # Protobuf runtime - only used by provisioning components (also excluded)
     "protocomm",  # Protocol communication for provisioning - unused by ESPHome
+    "rt",  # POSIX realtime extensions - unused by ESPHome
+    "sdmmc",  # SD/MMC protocol layer - only used by SD drivers and fatfs (also excluded)
     "spiffs",  # SPIFFS filesystem - ESPHome doesn't use filesystem storage (IDF only)
+    "tcp_transport",  # Transport layer - esp_http_client/mqtt pull it back when re-included
     "ulp",  # ULP coprocessor - not currently used by any ESPHome component
     "unity",  # Unit testing framework - ESPHome doesn't use IDF's testing
     "wear_levelling",  # Flash wear levelling for fatfs - unused since fatfs unused

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -215,14 +215,14 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "cmock",  # Unit testing mock framework - ESPHome doesn't use IDF's testing
     "console",  # Console REPL - unused by ESPHome; espressif/mdns pulls it back when configured
     "driver",  # Legacy driver shim - only needed by esp32_touch, esp32_can for legacy headers
-    "esp-tls",  # TLS wrapper - only needed by http_request (re-included there)
+    "esp-tls",  # TLS wrapper - re-included by http_request, mqtt, web_server_idf
     "esp_adc",  # ADC driver - only needed by adc component
     "esp_driver_cam",  # Camera driver - the esp32-camera managed component pulls it back
     "esp_driver_dac",  # DAC driver - only needed by esp32_dac component
     "esp_driver_gptimer",  # General purpose timer - only needed by ac_dimmer, opentherm
     "esp_driver_i2c",  # I2C driver - only needed by i2c component
     "esp_driver_i2s",  # I2S driver - only needed by i2s_audio component
-    "esp_driver_ledc",  # LEDC PWM driver - only needed by ledc component
+    "esp_driver_ledc",  # LEDC PWM driver - re-included by ledc; esp32-camera pulls it back itself
     "esp_driver_mcpwm",  # MCPWM driver - ESPHome doesn't use motor control PWM
     "esp_driver_pcnt",  # PCNT driver - only needed by pulse_counter, hlw8012 components
     "esp_driver_rmt",  # RMT driver - only needed by remote_transmitter/receiver, neopixelbus

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -170,8 +170,11 @@ async def to_code(config: ConfigType) -> None:
         cg.add(var.set_watchdog_timeout(timeout_ms))
 
     if CORE.is_esp32:
-        # Re-enable ESP-IDF's HTTP client (excluded by default to save compile time)
+        # Re-enable ESP-IDF's HTTP client (excluded by default to save compile time).
+        # esp-tls is re-enabled too because http_request includes <esp_tls.h>
+        # directly and esp_http_client only pulls it in as a private dependency.
         esp32.include_builtin_idf_component("esp_http_client")
+        esp32.include_builtin_idf_component("esp-tls")
 
         cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
         cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -284,6 +284,11 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 async def to_code(config):
     cg.add_global(i2c_ns.using)
     cg.add_define("USE_I2C")
+    if CORE.is_esp32:
+        from esphome.components.esp32 import include_builtin_idf_component
+
+        # Re-enable the I2C driver (excluded by default to save compile time)
+        include_builtin_idf_component("esp_driver_i2c")
     if CORE.is_host:
         var = cg.new_Pvariable(config[CONF_ID])
         await cg.register_component(var, config)

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -3,6 +3,7 @@ from typing import Any
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import output
+from esphome.components.esp32 import include_builtin_idf_component
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CHANNEL,
@@ -62,6 +63,9 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 
 
 async def to_code(config: ConfigType) -> None:
+    # Re-enable the LEDC driver (excluded by default to save compile time)
+    include_builtin_idf_component("esp_driver_ledc")
+
     gpio = await cg.gpio_pin_expression(config[CONF_PIN])
     var = cg.new_Pvariable(config[CONF_ID], gpio)
     await cg.register_component(var, config)

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -361,6 +361,8 @@ async def to_code(config):
             add_idf_component(name="espressif/mqtt", ref="1.0.0")
         else:
             include_builtin_idf_component("mqtt")
+        # mqtt_client.h drags in esp_tls types; esp-tls is excluded by default
+        include_builtin_idf_component("esp-tls")
 
     cg.add_define("USE_MQTT")
     cg.add_global(mqtt_ns.using)

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -290,7 +290,9 @@ async def to_code(config):
 
         if CORE.is_esp32:
             # Re-enable ESP-IDF's HTTP client (excluded by default to save compile time)
+            # and esp-tls, whose sdkconfig options below need the component present
             esp32.include_builtin_idf_component("esp_http_client")
+            esp32.include_builtin_idf_component("esp-tls")
             esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_INSECURE", True)
             esp32.add_idf_sdkconfig_option(
                 "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True

--- a/esphome/components/web_server_idf/__init__.py
+++ b/esphome/components/web_server_idf/__init__.py
@@ -1,4 +1,7 @@
-from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components.esp32 import (
+    add_idf_sdkconfig_option,
+    include_builtin_idf_component,
+)
 import esphome.config_validation as cv
 
 CODEOWNERS = ["@dentra"]
@@ -12,3 +15,6 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     # Increase the maximum supported size of headers section in HTTP request packet to be processed by the server
     add_idf_sdkconfig_option("CONFIG_HTTPD_MAX_REQ_HDR_LEN", 1024)
+    # Re-enable esp-tls (excluded by default to save compile time);
+    # web_server_idf.cpp includes <esp_tls_crypto.h> for digest auth
+    include_builtin_idf_component("esp-tls")

--- a/tests/component_tests/esp32/config/exclusion_reincludes.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes.yaml
@@ -1,0 +1,33 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+i2c:
+  sda: 21
+  scl: 22
+
+output:
+  - platform: ledc
+    id: ledc_out
+    pin: 25
+  - platform: ac_dimmer
+    id: dimmer_out
+    gate_pin: 26
+    zero_cross_pin: 27
+
+mqtt:
+  broker: "10.0.0.1"
+
+http_request:
+  verify_ssl: false
+
+web_server:
+  version: 3

--- a/tests/component_tests/esp32/config/exclusion_reincludes.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes.yaml
@@ -6,10 +6,6 @@ esp32:
   framework:
     type: esp-idf
 
-wifi:
-  ssid: "test_ssid"
-  password: "test_password"
-
 i2c:
   sda: 21
   scl: 22
@@ -22,12 +18,3 @@ output:
     id: dimmer_out
     gate_pin: 26
     zero_cross_pin: 27
-
-mqtt:
-  broker: "10.0.0.1"
-
-http_request:
-  verify_ssl: false
-
-web_server:
-  version: 3

--- a/tests/component_tests/esp32/config/exclusion_reincludes_http_request.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes_http_request.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+http_request:
+  verify_ssl: false

--- a/tests/component_tests/esp32/config/exclusion_reincludes_mqtt.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes_mqtt.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+mqtt:
+  broker: "10.0.0.1"

--- a/tests/component_tests/esp32/config/exclusion_reincludes_nextion.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes_nextion.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+uart:
+  tx_pin: 17
+  rx_pin: 16
+  baud_rate: 115200
+
+display:
+  - platform: nextion
+    tft_url: "http://10.0.0.1/display.tft"

--- a/tests/component_tests/esp32/config/exclusion_reincludes_web_server.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes_web_server.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+web_server:
+  version: 3

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -236,6 +236,33 @@ def test_esp32_configuration_errors(
         FINAL_VALIDATE_SCHEMA(CONFIG_SCHEMA(config))
 
 
+def test_default_exclusions_reincluded_by_owning_components(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Components whose IDF driver is excluded by default must re-include it
+    during codegen; a dropped include_builtin_idf_component() call would only
+    surface as a missing-header failure in a full compile job."""
+    from esphome.components.esp32.const import KEY_EXCLUDE_COMPONENTS
+
+    generate_main(component_config_path("exclusion_reincludes.yaml"))
+    excluded = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
+
+    for name in (
+        "esp_driver_i2c",  # i2c
+        "esp_driver_ledc",  # ledc
+        "esp_driver_gptimer",  # ac_dimmer
+        "esp-tls",  # http_request, mqtt, web_server_idf
+        "esp_http_client",  # http_request
+        "mqtt",  # mqtt
+    ):
+        assert name not in excluded, f"{name} should have been re-included"
+
+    # Components no part of this config touches stay excluded.
+    assert "unity" in excluded
+    assert "fatfs" in excluded
+
+
 def test_execute_from_psram_s3_sdkconfig(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -236,26 +236,48 @@ def test_esp32_configuration_errors(
         FINAL_VALIDATE_SCHEMA(CONFIG_SCHEMA(config))
 
 
+@pytest.mark.parametrize(
+    ("config_file", "reincluded"),
+    [
+        pytest.param(
+            "exclusion_reincludes.yaml",
+            ("esp_driver_i2c", "esp_driver_ledc", "esp_driver_gptimer"),
+            id="i2c_ledc_ac_dimmer",
+        ),
+        # esp-tls has three owners; a per-owner config makes a dropped
+        # re-include from any single one fail the test.
+        pytest.param(
+            "exclusion_reincludes_http_request.yaml",
+            ("esp-tls", "esp_http_client"),
+            id="http_request",
+        ),
+        pytest.param(
+            "exclusion_reincludes_mqtt.yaml",
+            ("esp-tls", "mqtt"),
+            id="mqtt",
+        ),
+        pytest.param(
+            "exclusion_reincludes_web_server.yaml",
+            ("esp-tls",),
+            id="web_server_idf",
+        ),
+    ],
+)
 def test_default_exclusions_reincluded_by_owning_components(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
+    config_file: str,
+    reincluded: tuple[str, ...],
 ) -> None:
     """Components whose IDF driver is excluded by default must re-include it
     during codegen; a dropped include_builtin_idf_component() call would only
     surface as a missing-header failure in a full compile job."""
     from esphome.components.esp32.const import KEY_EXCLUDE_COMPONENTS
 
-    generate_main(component_config_path("exclusion_reincludes.yaml"))
+    generate_main(component_config_path(config_file))
     excluded = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
 
-    for name in (
-        "esp_driver_i2c",  # i2c
-        "esp_driver_ledc",  # ledc
-        "esp_driver_gptimer",  # ac_dimmer
-        "esp-tls",  # http_request, mqtt, web_server_idf
-        "esp_http_client",  # http_request
-        "mqtt",  # mqtt
-    ):
+    for name in reincluded:
         assert name not in excluded, f"{name} should have been re-included"
 
     # Components no part of this config touches stay excluded.

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -252,14 +252,21 @@ def test_esp32_configuration_errors(
             id="http_request",
         ),
         pytest.param(
+            # "mqtt" itself is deliberately not asserted: on IDF >= 6.0 it
+            # is a managed component and never leaves the exclusion set.
             "exclusion_reincludes_mqtt.yaml",
-            ("esp-tls", "mqtt"),
+            ("esp-tls",),
             id="mqtt",
         ),
         pytest.param(
             "exclusion_reincludes_web_server.yaml",
             ("esp-tls",),
             id="web_server_idf",
+        ),
+        pytest.param(
+            "exclusion_reincludes_nextion.yaml",
+            ("esp-tls", "esp_http_client"),
+            id="nextion",
         ),
     ],
 )


### PR DESCRIPTION
# What does this implement/fix?

Adds 16 more IDF components to the default exclusion list (app_trace, console, esp-tls, esp_driver_cam, esp_driver_gptimer, esp_driver_i2c, esp_driver_ledc, esp_driver_sdio, esp_driver_sdm, esp_driver_sdmmc, esp_driver_sdspi, json, protobuf-c, rt, sdmmc, tcp_transport); none of them contribute any code to a firmware that does not use them.

In tree components that include their headers re-include them: i2c, ledc and ac_dimmer re-enable their drivers, http_request, web_server_idf and mqtt re-enable esp-tls. Everything else returns automatically because IDF requirement expansion adds an excluded component back when something still in the build REQUIRES it; that covers tcp_transport, esp_driver_cam via the esp32-camera managed component, and console via mdns. All 16 components' public headers were swept against every in tree source file to find the re-include sites, since previous growths of this list (#13664) missed opentherm and pulse_counter and needed follow up fixes (#13732, #13747).

**This is a developer breaking change for external components**, same as #13610 and #13664 were in practice. An external component that includes headers from one of the newly excluded IDF components without declaring the dependency will fail to compile. Migration: call `esp32.include_builtin_idf_component("<idf component>")` in the component's `to_code`, or as a user level workaround add it under `esp32: framework: advanced: include_builtin_idf_components:`.

Stacked on #18531 so CI exercises the exclusions on native builds; applies to PlatformIO builds independently. Tested with native, `toolchain: platformio` and Arduino builds covering i2c, ledc, ac_dimmer, mqtt, http_request, esp32_camera, ethernet and web_server; a basic ethernet config drops from 1032 to 996 objects with identical firmware.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #13610 and #18531

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed; external components using an excluded IDF
# component can re-enable it:
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      include_builtin_idf_components:
        - esp_driver_sdmmc
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

