### PR TITLE
[modbus_controller] Brace single-statement log bodies to fix -Wempty-body

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -200,8 +200,9 @@ void ModbusController::update_range_(ModbusCommandItem &cmd) {
     return;
   }
   // A refusal is already logged by the hub; note the affected range for controller-level diagnostics.
-  if (!cmd.send())
+  if (!cmd.send()) {
     ESP_LOGD(TAG, "Poll refused by hub for range 0x%X", cmd.register_address());
+  }
 }
 
 void ModbusController::update() {
@@ -214,8 +215,9 @@ void ModbusController::update() {
       ESP_LOGV(TAG, "Module offline - retrying");
       this->cmd_non_responses_ = 0;  // allow the probe through can_send()
       for (auto &cmd : this->polling_command_items_) {
-        if (!cmd.send())
+        if (!cmd.send()) {
           ESP_LOGD(TAG, "Probe refused by hub for range 0x%X", cmd.register_address());
+        }
       }
     } else {
       ESP_LOGV(TAG, "Module offline - skipping update");


### PR DESCRIPTION
# What does this implement/fix?

`ModbusController::update_range_()` and `ModbusController::update()` log a refused send
without braces:

```cpp
if (!cmd.send())
  ESP_LOGD(TAG, "Poll refused by hub for range 0x%X", cmd.register_address());
```

At any `logger:` level below `debug`, `ESP_LOGD` expands to nothing, so the statement
collapses to `if (!cmd.send()) ;` and GCC flags it:

```
../src/esphome/components/modbus_controller/modbus_controller.cpp:204:80: warning:
  suggest braces around empty body in an 'if' statement [-Wempty-body]
../src/esphome/components/modbus_controller/modbus_controller.cpp:218:87: warning:
  suggest braces around empty body in an 'if' statement [-Wempty-body]
```

Reproduces on any config that combines `modbus_controller` with `logger: level: info`
(or lower). These were the only two warnings in my entire ESP32/ESP-IDF build.

No behaviour change: `cmd.send()` is in the condition, so the poll/probe still runs either
way. This also brings both sites in line with the already-braced `if (!item->send()) {`
a few lines earlier in the same file.

Worth noting that `.clang-tidy` sets `readability-braces-around-statements.ShortStatementLines: 2`,
which exempts an `if` plus a one-line body — so the linter does not catch this pattern,
only the compiler does.

Heads-up on overlap: #18071 (draft) removes `update_range_()` and moves the first of these
logs into `update()`, carrying the brace-less form across, so the warning would survive
that PR as written. If this one merges first, #18071 needs a trivial rebase that keeps the
braces.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a — no user-facing configuration or API change.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any level below `debug` compiles ESP_LOGD out and triggers the warning.
logger:
  level: info

uart:
  id: uart_rs485
  tx_pin: GPIO16
  rx_pin: GPIO17
  baud_rate: 9600

modbus:
  id: modbus_rs485
  uart_id: uart_rs485

modbus_controller:
  - id: heatpump
    address: 0x01
    modbus_id: modbus_rs485
    update_interval: 30s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
