### PR TITLE
[sx127x] Add long packet support, plus payload_length_lambda for unknown-length packets

### DIFF
--- a/esphome/components/sx127x/__init__.py
+++ b/esphome/components/sx127x/__init__.py
@@ -170,6 +170,12 @@ def validate_config(config):
             raise cv.Invalid("Minimum 'preamble_size' is 6 with LORA")
         if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
             raise cv.Invalid("Payload length must be set when spreading factor is 6")
+        if config[CONF_PAYLOAD_LENGTH] > 255:
+            raise cv.Invalid("Payload length must be <= 255 with LORA")
+        if CONF_PAYLOAD_LENGTH_LAMBDA in config:
+            raise cv.Invalid("payload_length_lambda is not available with LORA")
+        if CONF_DIO1_PIN in config:
+            raise cv.Invalid("dio1_pin is not available with LORA")
     else:
         if config[CONF_BANDWIDTH] == "500_0kHz":
             raise cv.Invalid(f"{config[CONF_BANDWIDTH]} is only available with LORA")
@@ -179,6 +185,10 @@ def validate_config(config):
             raise cv.Invalid("Config 'packet_mode' required with FSK/OOK")
         if config[CONF_PACKET_MODE] and CONF_DIO0_PIN not in config:
             raise cv.Invalid("Config 'dio0_pin' required in packet mode")
+        if config[CONF_PAYLOAD_LENGTH] > 64 and not config[CONF_PACKET_MODE]:
+            raise cv.Invalid(
+                "payload_length must be <= 64 when packet_mode is disabled"
+            )
         if CONF_PAYLOAD_LENGTH_LAMBDA in config:
             if not config[CONF_PACKET_MODE]:
                 raise cv.Invalid(
@@ -195,6 +205,11 @@ def validate_config(config):
             raise cv.Invalid(
                 "dio1_pin is required when payload_length > 64 or "
                 "payload_length_lambda is set"
+            )
+        if is_long_packet and config[CONF_CRC_ENABLE]:
+            raise cv.Invalid(
+                "crc_enable is not available with payload_length > 64 or "
+                "payload_length_lambda"
             )
     if config[CONF_PA_PIN] == "RFO" and config[CONF_PA_POWER] > 15:
         raise cv.Invalid("PA power must be <= 15 dbm when using the RFO pin")

--- a/esphome/components/sx127x/__init__.py
+++ b/esphome/components/sx127x/__init__.py
@@ -19,12 +19,14 @@ CONF_BITSYNC = "bitsync"
 CONF_CODING_RATE = "coding_rate"
 CONF_DEVIATION = "deviation"
 CONF_DIO0_PIN = "dio0_pin"
+CONF_DIO1_PIN = "dio1_pin"
 CONF_MODULATION = "modulation"
 CONF_PA_PIN = "pa_pin"
 CONF_PA_POWER = "pa_power"
 CONF_PA_RAMP = "pa_ramp"
 CONF_PACKET_MODE = "packet_mode"
 CONF_PAYLOAD_LENGTH = "payload_length"
+CONF_PAYLOAD_LENGTH_LAMBDA = "payload_length_lambda"
 CONF_PREAMBLE_DETECT = "preamble_detect"
 CONF_PREAMBLE_ERRORS = "preamble_errors"
 CONF_PREAMBLE_POLARITY = "preamble_polarity"
@@ -177,8 +179,23 @@ def validate_config(config):
             raise cv.Invalid("Config 'packet_mode' required with FSK/OOK")
         if config[CONF_PACKET_MODE] and CONF_DIO0_PIN not in config:
             raise cv.Invalid("Config 'dio0_pin' required in packet mode")
-        if config[CONF_PAYLOAD_LENGTH] > 64:
-            raise cv.Invalid("Payload length must be <= 64 with FSK/OOK")
+        if CONF_PAYLOAD_LENGTH_LAMBDA in config:
+            if not config[CONF_PACKET_MODE]:
+                raise cv.Invalid(
+                    "packet_mode is required when payload_length_lambda is set"
+                )
+            if config[CONF_PAYLOAD_LENGTH] != 0:
+                raise cv.Invalid(
+                    "payload_length must be 0 when payload_length_lambda is set"
+                )
+        is_long_packet = (
+            config[CONF_PAYLOAD_LENGTH] > 64 or CONF_PAYLOAD_LENGTH_LAMBDA in config
+        )
+        if is_long_packet and CONF_DIO1_PIN not in config:
+            raise cv.Invalid(
+                "dio1_pin is required when payload_length > 64 or "
+                "payload_length_lambda is set"
+            )
     if config[CONF_PA_PIN] == "RFO" and config[CONF_PA_POWER] > 15:
         raise cv.Invalid("PA power must be <= 15 dbm when using the RFO pin")
     if config[CONF_PA_PIN] == "BOOST" and config[CONF_PA_POWER] < 2:
@@ -200,6 +217,7 @@ CONFIG_SCHEMA = (
                 cv.frequency, cv.int_range(min=0, max=100000)
             ),
             cv.Optional(CONF_DIO0_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Optional(CONF_DIO1_PIN): pins.internal_gpio_input_pin_schema,
             cv.Required(CONF_FREQUENCY): cv.All(
                 cv.frequency, cv.int_range(min=int(137e6), max=int(1020e6))
             ),
@@ -209,7 +227,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_PA_POWER, default=17): cv.int_range(min=0, max=17),
             cv.Optional(CONF_PA_RAMP, default="40us"): cv.enum(RAMP),
             cv.Optional(CONF_PACKET_MODE): cv.boolean,
-            cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
+            cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=1024),
+            cv.Optional(CONF_PAYLOAD_LENGTH_LAMBDA): cv.lambda_,
             cv.Optional(CONF_PREAMBLE_DETECT, default=0): cv.int_range(min=0, max=3),
             cv.Optional(CONF_PREAMBLE_ERRORS, default=0): cv.int_range(min=0, max=31),
             cv.Optional(CONF_PREAMBLE_POLARITY, default=0xAA): cv.All(
@@ -247,6 +266,9 @@ async def to_code(config):
     if CONF_DIO0_PIN in config:
         dio0_pin = await cg.gpio_pin_expression(config[CONF_DIO0_PIN])
         cg.add(var.set_dio0_pin(dio0_pin))
+    if CONF_DIO1_PIN in config:
+        dio1_pin = await cg.gpio_pin_expression(config[CONF_DIO1_PIN])
+        cg.add(var.set_dio1_pin(dio1_pin))
     rst_pin = await cg.gpio_pin_expression(config[CONF_RST_PIN])
     cg.add(var.set_rst_pin(rst_pin))
     cg.add(var.set_auto_cal(config[CONF_AUTO_CAL]))
@@ -264,6 +286,13 @@ async def to_code(config):
     cg.add(var.set_shaping(config[CONF_SHAPING]))
     cg.add(var.set_crc_enable(config[CONF_CRC_ENABLE]))
     cg.add(var.set_payload_length(config[CONF_PAYLOAD_LENGTH]))
+    if CONF_PAYLOAD_LENGTH_LAMBDA in config:
+        lambda_ = await cg.process_lambda(
+            config[CONF_PAYLOAD_LENGTH_LAMBDA],
+            [(cg.std_vector.template(cg.uint8).operator("ref").operator("const"), "x")],
+            return_type=cg.int32,
+        )
+        cg.add(var.set_payload_length_lambda(lambda_))
     cg.add(var.set_preamble_detect(config[CONF_PREAMBLE_DETECT]))
     cg.add(var.set_preamble_size(config[CONF_PREAMBLE_SIZE]))
     cg.add(var.set_preamble_polarity(config[CONF_PREAMBLE_POLARITY]))

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -37,14 +37,16 @@ void SX127x::write_register_(uint8_t reg, uint8_t value) {
   this->disable();
 }
 
-void SX127x::read_fifo_(std::vector<uint8_t> &packet) {
+void SX127x::read_fifo_(uint8_t *data, size_t length) {
   this->enable();
   this->write_byte(REG_FIFO & 0x7F);
-  for (auto &byte : packet) {
-    byte = this->transfer_byte(0x00);
+  for (size_t i = 0; i < length; i++) {
+    data[i] = this->transfer_byte(0x00);
   }
   this->disable();
 }
+
+void SX127x::read_fifo_(std::vector<uint8_t> &packet) { this->read_fifo_(packet.data(), packet.size()); }
 
 void SX127x::write_fifo_(const std::vector<uint8_t> &packet) {
   this->enable();
@@ -355,7 +357,9 @@ uint32_t SX127x::packet_idle_timeout_ms_() const {
 
 void SX127x::reset_long_packet_rx_() {
   this->packet_.clear();
-  this->packet_expected_length_ = 0;
+  // When the length is known upfront (not resolved via payload_length_func_), set it immediately so
+  // the reserve() below in handle_long_packet_() can take effect from the very first drain.
+  this->packet_expected_length_ = this->payload_length_func_ ? 0 : this->payload_length_;
   this->packet_last_byte_ms_ = 0;
   this->long_packet_rssi_captured_ = false;
 }
@@ -397,13 +401,13 @@ void SX127x::handle_long_packet_(uint8_t irq2) {
     // least 1 byte (the tail end) is available.
     const size_t to_read = (irq2 & FIFO_LEVEL) ? FIFO_THRESHOLD_HALF + 1 : 1;
 
-    std::vector<uint8_t> chunk(to_read);
-    this->read_fifo_(chunk);
-    this->packet_last_byte_ms_ = millis();
     if (this->packet_expected_length_ > 0 && this->packet_.capacity() < this->packet_expected_length_) {
       this->packet_.reserve(this->packet_expected_length_);
     }
-    this->packet_.insert(this->packet_.end(), chunk.begin(), chunk.end());
+    const size_t old_size = this->packet_.size();
+    this->packet_.resize(old_size + to_read);
+    this->read_fifo_(this->packet_.data() + old_size, to_read);
+    this->packet_last_byte_ms_ = millis();
     ESP_LOGVV(TAG, "Drained RX FIFO: read=%u received=%u expected=%u", (unsigned) to_read,
               (unsigned) this->packet_.size(), (unsigned) this->packet_expected_length_);
 
@@ -414,33 +418,29 @@ void SX127x::handle_long_packet_(uint8_t irq2) {
       return;
     }
 
-    if (this->packet_expected_length_ == 0) {
-      if (this->payload_length_func_) {
-        int32_t expected = this->payload_length_func_(this->packet_);
-        if (expected < 0) {
-          ESP_LOGVV(TAG, "Long packet length lambda discarded packet: received=%u", (unsigned) this->packet_.size());
-          this->restart_long_packet_rx_();
-          return;
-        }
-        if (expected > MAX_PACKET_LENGTH) {
-          ESP_LOGW(TAG, "Packet length exceeds maximum, discarding packet: length=%" PRId32 " max=%u", expected,
-                   MAX_PACKET_LENGTH);
-          this->restart_long_packet_rx_();
-          return;
-        }
-        if (expected > 0 && (size_t) expected < this->packet_.size()) {
-          ESP_LOGW(TAG, "Invalid computed packet length, discarding packet: length=%" PRId32 " received=%u", expected,
-                   (unsigned) this->packet_.size());
-          this->restart_long_packet_rx_();
-          return;
-        }
-        if (expected > 0) {
-          this->packet_expected_length_ = (size_t) expected;
-          ESP_LOGVV(TAG, "Resolved packet length: received=%u expected=%u", (unsigned) this->packet_.size(),
-                    (unsigned) this->packet_expected_length_);
-        }
-      } else {
-        this->packet_expected_length_ = this->payload_length_;
+    if (this->packet_expected_length_ == 0 && this->payload_length_func_) {
+      int32_t expected = this->payload_length_func_(this->packet_);
+      if (expected < 0) {
+        ESP_LOGVV(TAG, "Long packet length lambda discarded packet: received=%u", (unsigned) this->packet_.size());
+        this->restart_long_packet_rx_();
+        return;
+      }
+      if (expected > MAX_PACKET_LENGTH) {
+        ESP_LOGW(TAG, "Packet length exceeds maximum, discarding packet: length=%" PRId32 " max=%u", expected,
+                 MAX_PACKET_LENGTH);
+        this->restart_long_packet_rx_();
+        return;
+      }
+      if (expected > 0 && (size_t) expected + FIFO_THRESHOLD_HALF + 1 < this->packet_.size()) {
+        ESP_LOGW(TAG, "Invalid computed packet length, discarding packet: length=%" PRId32 " received=%u", expected,
+                 (unsigned) this->packet_.size());
+        this->restart_long_packet_rx_();
+        return;
+      }
+      if (expected > 0) {
+        this->packet_expected_length_ = (size_t) expected;
+        ESP_LOGVV(TAG, "Resolved packet length: received=%u expected=%u", (unsigned) this->packet_.size(),
+                  (unsigned) this->packet_expected_length_);
       }
     }
 
@@ -464,12 +464,6 @@ void SX127x::loop() {
       return;
     }
     uint8_t irq2 = this->read_register_(REG_IRQ_FLAGS2);
-    if (irq2 & FIFO_OVERRUN) {
-      ESP_LOGW(TAG, "FIFO overrun during long packet RX, restarting: received=%u expected=%u",
-               (unsigned) this->packet_.size(), (unsigned) this->packet_expected_length_);
-      this->restart_long_packet_rx_();
-      return;
-    }
     if (irq2 & FIFO_EMPTY) {
       if (this->packet_.empty()) {
         this->disable_loop();

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -18,6 +18,9 @@ static const uint8_t BW_FSK_OOK[22] = {RX_BW_2_6,   RX_BW_3_1,   RX_BW_3_9,   RX
                                        RX_BW_166_7, RX_BW_200_0, RX_BW_250_0, RX_BW_250_0};
 static const int32_t RSSI_OFFSET_HF = 157;
 static const int32_t RSSI_OFFSET_LF = 164;
+static constexpr uint16_t MAX_PACKET_LENGTH = 1024;
+static constexpr uint16_t PACKET_IDLE_TIMEOUT_BYTES = 64;
+static constexpr uint32_t PACKET_IDLE_TIMEOUT_MIN_MS = 5;
 
 uint8_t SX127x::read_register_(uint8_t reg) {
   this->enable();
@@ -62,6 +65,12 @@ void SX127x::setup() {
   if (this->dio0_pin_) {
     this->dio0_pin_->setup();
     this->dio0_pin_->attach_interrupt(&SX127x::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
+  }
+
+  // setup dio1 (long-packet RX only, mapped to FifoEmpty falling edge)
+  if (this->dio1_pin_) {
+    this->dio1_pin_->setup();
+    this->dio1_pin_->attach_interrupt(&SX127x::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
   }
 
   // start spi
@@ -124,6 +133,10 @@ void SX127x::configure() {
     this->configure_lora_();
   }
 
+  if (this->is_long_packet_mode_()) {
+    this->reset_long_packet_rx_();
+  }
+
   // switch to rx or sleep
   if (this->rx_start_) {
     this->set_mode_rx();
@@ -158,11 +171,18 @@ void SX127x::configure_fsk_ook_() {
   // configure packet mode
   if (this->packet_mode_) {
     uint8_t crc_mode = (this->crc_enable_) ? CRC_ON : CRC_OFF;
-    this->write_register_(REG_FIFO_THRESH, TX_START_FIFO_EMPTY);
-    if (this->payload_length_ > 0) {
+    if (this->is_long_packet_mode_()) {
+      // Unlimited length format: PacketFormat=fixed, PayloadLength=0. The total length (known
+      // upfront or resolved from a lambda) is tracked entirely in software; see handle_long_packet_().
+      this->write_register_(REG_FIFO_THRESH, TX_START_FIFO_EMPTY | FIFO_THRESHOLD_HALF);
+      this->write_register_(REG_PAYLOAD_LENGTH_LSB, 0);
+      this->write_register_(REG_PACKET_CONFIG_1, crc_mode | FIXED_LENGTH);
+    } else if (this->payload_length_ > 0) {
+      this->write_register_(REG_FIFO_THRESH, TX_START_FIFO_EMPTY);
       this->write_register_(REG_PAYLOAD_LENGTH_LSB, this->payload_length_);
       this->write_register_(REG_PACKET_CONFIG_1, crc_mode | FIXED_LENGTH);
     } else {
+      this->write_register_(REG_FIFO_THRESH, TX_START_FIFO_EMPTY);
       this->write_register_(REG_PAYLOAD_LENGTH_LSB, this->get_max_packet_size() - 1);
       this->write_register_(REG_PACKET_CONFIG_1, crc_mode | VARIABLE_LENGTH);
     }
@@ -170,7 +190,11 @@ void SX127x::configure_fsk_ook_() {
   } else {
     this->write_register_(REG_PACKET_CONFIG_2, CONTINUOUS_MODE);
   }
-  this->write_register_(REG_DIO_MAPPING1, DIO0_MAPPING_00);
+  uint8_t dio_mapping = DIO0_MAPPING_00;
+  if (this->is_long_packet_mode_()) {
+    dio_mapping |= DIO1_MAPPING_FIFO_EMPTY;
+  }
+  this->write_register_(REG_DIO_MAPPING1, dio_mapping);
 
   // config bit synchronizer
   uint8_t polarity = (this->preamble_polarity_ == 0xAA) ? PREAMBLE_AA : PREAMBLE_55;
@@ -257,6 +281,11 @@ size_t SX127x::get_max_packet_size() {
 }
 
 SX127xError SX127x::transmit_packet(const std::vector<uint8_t> &packet) {
+  if (this->is_long_packet_mode_()) {
+    // Long packet TX would need chunked FIFO refills; not implemented, RX-only.
+    ESP_LOGE(TAG, "Long packet TX is not supported");
+    return SX127xError::INVALID_PARAMS;
+  }
   if (this->payload_length_ > 0 && this->payload_length_ != packet.size()) {
     ESP_LOGE(TAG, "Packet size does not match config");
     return SX127xError::INVALID_PARAMS;
@@ -314,7 +343,149 @@ void SX127x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
   this->packet_trigger_.trigger(packet, rssi, snr);
 }
 
+bool SX127x::is_long_packet_mode_() const {
+  return this->packet_mode_ && this->modulation_ != MOD_LORA &&
+         (this->payload_length_ > 64 || this->payload_length_func_);
+}
+
+uint32_t SX127x::packet_idle_timeout_ms_() const {
+  const uint32_t timeout = (8u * PACKET_IDLE_TIMEOUT_BYTES * 1000u) / this->bitrate_;
+  return timeout < PACKET_IDLE_TIMEOUT_MIN_MS ? PACKET_IDLE_TIMEOUT_MIN_MS : timeout;
+}
+
+void SX127x::reset_long_packet_rx_() {
+  this->packet_.clear();
+  this->packet_expected_length_ = 0;
+  this->packet_last_byte_ms_ = 0;
+  this->long_packet_rssi_captured_ = false;
+}
+
+void SX127x::restart_long_packet_rx_() {
+  this->set_mode_standby();
+  // Writing the FifoOverrun bit clears both the flag and the FIFO itself.
+  this->write_register_(REG_IRQ_FLAGS2, FIFO_OVERRUN);
+  this->reset_long_packet_rx_();
+  this->set_mode_rx();
+}
+
+void SX127x::finish_long_packet_() {
+  this->packet_.resize(this->packet_expected_length_);
+  float rssi = this->long_packet_rssi_captured_ ? this->long_packet_rssi_
+                                                : -(float) this->read_register_(REG_RSSI_VALUE_FSK) / 2.0f;
+  this->call_listeners_(this->packet_, rssi, 0.0f);
+  this->restart_long_packet_rx_();
+}
+
+void SX127x::handle_long_packet_(uint8_t irq2) {
+  // Drain everything currently available in one loop() invocation, rather than returning to the
+  // scheduler after each bounded chunk: this chip only exposes FifoLevel/FifoEmpty flags, not an
+  // exact byte count, so leaving gaps between drain attempts risks a FIFO overrun on a short burst
+  // before the next loop() tick catches up. Bail out (return) as soon as FifoEmpty is set again; the
+  // idle timeout in loop() remains the outer safety net for a reception that stalls entirely.
+  while (true) {
+    if (irq2 & FIFO_OVERRUN) {
+      ESP_LOGW(TAG, "FIFO overrun during long packet RX, restarting: received=%u expected=%u",
+               (unsigned) this->packet_.size(), (unsigned) this->packet_expected_length_);
+      this->restart_long_packet_rx_();
+      return;
+    }
+    if (irq2 & FIFO_EMPTY) {
+      return;
+    }
+
+    // FifoLevel guarantees strictly more than FIFO_THRESHOLD_HALF bytes are present, otherwise at
+    // least 1 byte (the tail end) is available.
+    const size_t to_read = (irq2 & FIFO_LEVEL) ? FIFO_THRESHOLD_HALF + 1 : 1;
+
+    std::vector<uint8_t> chunk(to_read);
+    this->read_fifo_(chunk);
+    this->packet_last_byte_ms_ = millis();
+    if (this->packet_expected_length_ > 0 && this->packet_.capacity() < this->packet_expected_length_) {
+      this->packet_.reserve(this->packet_expected_length_);
+    }
+    this->packet_.insert(this->packet_.end(), chunk.begin(), chunk.end());
+    ESP_LOGVV(TAG, "Drained RX FIFO: read=%u received=%u expected=%u", (unsigned) to_read,
+              (unsigned) this->packet_.size(), (unsigned) this->packet_expected_length_);
+
+    if (this->packet_.size() > MAX_PACKET_LENGTH) {
+      ESP_LOGW(TAG, "Packet length exceeds maximum, discarding packet: length=%u max=%u",
+               (unsigned) this->packet_.size(), MAX_PACKET_LENGTH);
+      this->restart_long_packet_rx_();
+      return;
+    }
+
+    if (this->packet_expected_length_ == 0) {
+      if (this->payload_length_func_) {
+        int32_t expected = this->payload_length_func_(this->packet_);
+        if (expected < 0) {
+          ESP_LOGVV(TAG, "Long packet length lambda discarded packet: received=%u", (unsigned) this->packet_.size());
+          this->restart_long_packet_rx_();
+          return;
+        }
+        if (expected > MAX_PACKET_LENGTH) {
+          ESP_LOGW(TAG, "Packet length exceeds maximum, discarding packet: length=%" PRId32 " max=%u", expected,
+                   MAX_PACKET_LENGTH);
+          this->restart_long_packet_rx_();
+          return;
+        }
+        if (expected > 0 && (size_t) expected < this->packet_.size()) {
+          ESP_LOGW(TAG, "Invalid computed packet length, discarding packet: length=%" PRId32 " received=%u", expected,
+                   (unsigned) this->packet_.size());
+          this->restart_long_packet_rx_();
+          return;
+        }
+        if (expected > 0) {
+          this->packet_expected_length_ = (size_t) expected;
+          ESP_LOGVV(TAG, "Resolved packet length: received=%u expected=%u", (unsigned) this->packet_.size(),
+                    (unsigned) this->packet_expected_length_);
+        }
+      } else {
+        this->packet_expected_length_ = this->payload_length_;
+      }
+    }
+
+    if (!this->long_packet_rssi_captured_ && this->packet_expected_length_ > 0) {
+      this->long_packet_rssi_ = -(float) this->read_register_(REG_RSSI_VALUE_FSK) / 2.0f;
+      this->long_packet_rssi_captured_ = true;
+    }
+
+    if (this->packet_expected_length_ > 0 && this->packet_.size() >= this->packet_expected_length_) {
+      this->finish_long_packet_();
+      return;
+    }
+
+    irq2 = this->read_register_(REG_IRQ_FLAGS2);
+  }
+}
+
 void SX127x::loop() {
+  if (this->is_long_packet_mode_()) {
+    if (this->dio1_pin_ == nullptr) {
+      return;
+    }
+    uint8_t irq2 = this->read_register_(REG_IRQ_FLAGS2);
+    if (irq2 & FIFO_OVERRUN) {
+      ESP_LOGW(TAG, "FIFO overrun during long packet RX, restarting: received=%u expected=%u",
+               (unsigned) this->packet_.size(), (unsigned) this->packet_expected_length_);
+      this->restart_long_packet_rx_();
+      return;
+    }
+    if (irq2 & FIFO_EMPTY) {
+      if (this->packet_.empty()) {
+        this->disable_loop();
+        return;
+      }
+      if (millis() - this->packet_last_byte_ms_ > this->packet_idle_timeout_ms_()) {
+        ESP_LOGW(TAG, "Packet receive timeout, discarding packet: received=%u expected=%u",
+                 (unsigned) this->packet_.size(), (unsigned) this->packet_expected_length_);
+        this->restart_long_packet_rx_();
+      }
+      return;  // keep the loop ticking while a reception is in progress, even without a new interrupt
+    }
+    this->handle_long_packet_(irq2);
+    return;
+  }
+
   this->disable_loop();
   if (this->dio0_pin_ == nullptr || !this->dio0_pin_->digital_read()) {
     return;
@@ -344,7 +515,8 @@ void SX127x::loop() {
     }
     this->packet_.resize(payload_length);
     this->read_fifo_(this->packet_);
-    this->call_listeners_(this->packet_, 0.0f, 0.0f);
+    float rssi = -(float) this->read_register_(REG_RSSI_VALUE_FSK) / 2.0f;
+    this->call_listeners_(this->packet_, rssi, 0.0f);
   }
 }
 
@@ -416,6 +588,7 @@ void SX127x::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  RST Pin: ", this->rst_pin_);
   LOG_PIN("  DIO0 Pin: ", this->dio0_pin_);
+  LOG_PIN("  DIO1 Pin: ", this->dio1_pin_);
   const char *pa_pin = "RFO";
   if (this->pa_pin_ == PA_PIN_BOOST) {
     pa_pin = "BOOST";
@@ -481,11 +654,21 @@ void SX127x::dump_config() {
                   "  Packet Mode: %s",
                   shaping, this->modulation_ == MOD_FSK ? "FSK" : "OOK", this->bitrate_, TRUEFALSE(this->bitsync_),
                   TRUEFALSE(this->rx_start_), this->rx_floor_, TRUEFALSE(this->packet_mode_));
-    if (this->packet_mode_) {
+    if (!this->packet_mode_) {
+      ESP_LOGCONFIG(TAG, "  Payload Length: Continuous mode");
+    } else {
       ESP_LOGCONFIG(TAG, "  CRC Enable: %s", TRUEFALSE(this->crc_enable_));
-    }
-    if (this->payload_length_ > 0) {
-      ESP_LOGCONFIG(TAG, "  Payload Length: %" PRIu32, this->payload_length_);
+      if (this->payload_length_func_) {
+        ESP_LOGCONFIG(TAG, "  Payload Length: Dynamic lambda (max=%u), unlimited length format", MAX_PACKET_LENGTH);
+      } else if (this->payload_length_ == 0) {
+        ESP_LOGCONFIG(TAG, "  Payload Length: Variable, length byte after sync (max=%u)",
+                      (unsigned) this->get_max_packet_size() - 1);
+      } else if (this->payload_length_ <= 64) {
+        ESP_LOGCONFIG(TAG, "  Payload Length: Fixed, %u bytes", (unsigned) this->payload_length_);
+      } else {
+        ESP_LOGCONFIG(TAG, "  Payload Length: Long fixed, %u bytes (max=%u), unlimited length format",
+                      (unsigned) this->payload_length_, MAX_PACKET_LENGTH);
+      }
     }
     if (!this->sync_value_.empty()) {
       char hex_buf[17];  // 8 bytes max = 16 hex chars + null

--- a/esphome/components/sx127x/sx127x.h
+++ b/esphome/components/sx127x/sx127x.h
@@ -96,6 +96,7 @@ class SX127x final : public Component,
   void set_mode_(uint8_t modulation, uint8_t mode);
   void write_fifo_(const std::vector<uint8_t> &packet);
   void read_fifo_(std::vector<uint8_t> &packet);
+  void read_fifo_(uint8_t *data, size_t length);
   void write_register_(uint8_t reg, uint8_t value);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   uint8_t read_register_(uint8_t reg);

--- a/esphome/components/sx127x/sx127x.h
+++ b/esphome/components/sx127x/sx127x.h
@@ -5,6 +5,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include <functional>
 #include <vector>
 
 namespace esphome::sx127x {
@@ -35,6 +36,7 @@ enum SX127xBw : uint8_t {
 };
 
 enum class SX127xError { NONE = 0, TIMEOUT, INVALID_PARAMS };
+using payload_length_func_t = std::function<int32_t(const std::vector<uint8_t> &)>;
 
 class SX127xListener {
  public:
@@ -58,6 +60,7 @@ class SX127x final : public Component,
   void set_crc_enable(bool crc_enable) { this->crc_enable_ = crc_enable; }
   void set_deviation(uint32_t deviation) { this->deviation_ = deviation; }
   void set_dio0_pin(InternalGPIOPin *dio0_pin) { this->dio0_pin_ = dio0_pin; }
+  void set_dio1_pin(InternalGPIOPin *dio1_pin) { this->dio1_pin_ = dio1_pin; }
   void set_frequency(uint32_t frequency) { this->frequency_ = frequency; }
   void set_mode_rx();
   void set_mode_tx();
@@ -68,7 +71,8 @@ class SX127x final : public Component,
   void set_pa_power(uint8_t power) { this->pa_power_ = power; }
   void set_pa_ramp(uint8_t ramp) { this->pa_ramp_ = ramp; }
   void set_packet_mode(bool packet_mode) { this->packet_mode_ = packet_mode; }
-  void set_payload_length(uint8_t payload_length) { this->payload_length_ = payload_length; }
+  void set_payload_length(uint32_t payload_length) { this->payload_length_ = payload_length; }
+  void set_payload_length_lambda(payload_length_func_t func) { this->payload_length_func_ = std::move(func); }
   void set_preamble_errors(uint8_t preamble_errors) { this->preamble_errors_ = preamble_errors; }
   void set_preamble_polarity(uint8_t preamble_polarity) { this->preamble_polarity_ = preamble_polarity; }
   void set_preamble_size(uint16_t preamble_size) { this->preamble_size_ = preamble_size; }
@@ -95,17 +99,31 @@ class SX127x final : public Component,
   void write_register_(uint8_t reg, uint8_t value);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   uint8_t read_register_(uint8_t reg);
+
+  // Packet handling
+  bool is_long_packet_mode_() const;
+  void reset_long_packet_rx_();
+  void restart_long_packet_rx_();
+  void handle_long_packet_(uint8_t irq2);
+  void finish_long_packet_();
+  uint32_t packet_idle_timeout_ms_() const;
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX127xListener *> listeners_;
   std::vector<uint8_t> packet_;
   std::vector<uint8_t> sync_value_;
+  payload_length_func_t payload_length_func_{};
   InternalGPIOPin *dio0_pin_{nullptr};
+  InternalGPIOPin *dio1_pin_{nullptr};
   InternalGPIOPin *rst_pin_{nullptr};
   SX127xBw bandwidth_;
   uint32_t bitrate_;
   uint32_t deviation_;
   uint32_t frequency_;
   uint32_t payload_length_;
+  size_t packet_expected_length_{0};
+  uint32_t packet_last_byte_ms_{0};
+  float long_packet_rssi_{0.0f};
+  bool long_packet_rssi_captured_{false};
   uint16_t preamble_size_;
   uint8_t coding_rate_;
   uint8_t modulation_;

--- a/esphome/components/sx127x/sx127x_reg.h
+++ b/esphome/components/sx127x/sx127x_reg.h
@@ -45,6 +45,8 @@ enum SX127xReg : uint8_t {
   REG_PAYLOAD_LENGTH_LSB = 0x32,
   REG_FIFO_THRESH = 0x35,
   REG_IMAGE_CAL = 0x3B,
+  REG_RSSI_VALUE_FSK = 0x11,
+  REG_IRQ_FLAGS2 = 0x3F,
   // LoRa registers
   REG_FIFO_ADDR_PTR = 0x0D,
   REG_FIFO_TX_BASE_ADDR = 0x0E,
@@ -131,6 +133,7 @@ enum SX127xDioMapping1 : uint8_t {
   DIO0_MAPPING_01 = 0x40,
   DIO0_MAPPING_10 = 0x80,
   DIO0_MAPPING_11 = 0xC0,
+  DIO1_MAPPING_FIFO_EMPTY = 0x10,
 };
 
 enum SX127xRxConfig : uint8_t {
@@ -233,6 +236,8 @@ enum SX127xPacketConfig2 : uint8_t {
 enum SX127xFifoThresh : uint8_t {
   TX_START_FIFO_EMPTY = 0x80,
   TX_START_FIFO_LEVEL = 0x00,
+  // Half the 64-byte FIFO; only used to size drain bursts during long-packet RX.
+  FIFO_THRESHOLD_HALF = 0x20,
 };
 
 enum SX127xImageCal : uint8_t {
@@ -257,6 +262,17 @@ enum SX127xIrqFlags : uint8_t {
   CAD_DONE = 0x04,
   FHSS_CHANGE_CHANNEL = 0x02,
   CAD_DETECTED = 0x01,
+};
+
+enum SX127xIrqFlags2 : uint8_t {
+  FIFO_FULL = 0x80,
+  FIFO_EMPTY = 0x40,
+  FIFO_LEVEL = 0x20,
+  FIFO_OVERRUN = 0x10,
+  PACKET_SENT = 0x08,
+  PAYLOAD_READY = 0x04,
+  CRC_OK = 0x02,
+  LOW_BAT = 0x01,
 };
 
 enum SX127xModemCfg1 : uint8_t {

--- a/tests/components/sx127x/test-long-packet.esp32-idf.yaml
+++ b/tests/components/sx127x/test-long-packet.esp32-idf.yaml
@@ -1,0 +1,55 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+
+sx127x:
+  - id: transceiver_long_fixed
+    cs_pin: GPIO5
+    rst_pin: GPIO4
+    dio0_pin: GPIO16
+    dio1_pin: GPIO17
+    frequency: 433920000
+    modulation: FSK
+    bitrate: 4800
+    deviation: 5000
+    bandwidth: 50_0kHz
+    bitsync: true
+    packet_mode: true
+    # Above the 64-byte RX FIFO: exercises the unlimited length packet format
+    # and FifoLevel/FifoEmpty-driven draining (SX1276/77/78 datasheet section
+    # 4.2.13.3, "Unlimited Length Packet Format", and 4.2.13.5, "Handling Large
+    # Packets"). Requires dio1_pin, since FifoLevel/FifoEmpty are only
+    # selectable on DIO1 in packet mode, not on DIO0.
+    payload_length: 1024
+    sync_value: [0x33, 0x33]
+    crc_enable: false
+    on_packet:
+      then:
+        - lambda: |-
+            ESP_LOGD("sx127x", "long fixed packet %u bytes rssi %.1f dBm snr %.1f dB", x.size(), rssi, snr);
+
+  - id: transceiver_long_lambda
+    cs_pin: GPIO25
+    rst_pin: GPIO26
+    dio0_pin: GPIO27
+    dio1_pin: GPIO14
+    frequency: 868950000
+    modulation: FSK
+    bitrate: 4800
+    deviation: 5000
+    bandwidth: 50_0kHz
+    bitsync: true
+    packet_mode: true
+    # payload_length: 0 with payload_length_lambda exercises the arbitrary
+    # length field configuration: the length is not known upfront and is
+    # derived at runtime from the bytes received so far.
+    payload_length: 0
+    payload_length_lambda: |-
+      if (x.size() < 3) return 0;
+      if (x[0] != 0x54) return -1;
+      return x[2] + 12;
+    sync_value: [0x54, 0x3D]
+    crc_enable: false
+    on_packet:
+      then:
+        - lambda: |-
+            ESP_LOGD("sx127x", "long lambda packet %u bytes rssi %.1f dBm snr %.1f dB", x.size(), rssi, snr);


### PR DESCRIPTION
# What does this implement/fix?

For context: this PR is part of a larger project, [esphome-mbus](https://github.com/hn/esphome-mbus), a
generic M-Bus/wM-Bus component that works over `cc1101`, `sx126x`, and `sx127x` (and, architecturally,
wired UART). Long-packet RX is needed there to receive full wM-Bus telegrams. More background in
[this feature request comment](https://github.com/esphome/feature-requests/issues/1646#issuecomment-4989529704).

`packet_mode` previously required `payload_length <= 64` (the sx127x RX FIFO size), since the whole
packet had to fit in the FIFO in a single read after `PayloadReady`. This adds long-packet RX by
draining the FIFO progressively while the packet is still being received:

- `payload_length` above 64 switches to the packet engine's Unlimited Length Packet Format
  (`PacketFormat=fixed`, `PayloadLength=0` — SX1276/77/78 datasheet section 4.2.13.3). The total length
  (known upfront, or resolved from a lambda below) is tracked entirely in software; `PayloadReady`/
  `CrcOk` aren't even available in this mode, so there's no hardware completion signal to rely on either
  way.
- Draining follows the datasheet's own "Handling Large Packets" procedure (section 4.2.13.5), driven by
  the `FifoLevel`/`FifoEmpty` flags in `RegIrqFlags2`, polled from `loop()` once armed. This needs a new
  `dio1_pin` config option, used only in this mode: `FifoLevel` is only selectable on DIO1 in packet mode
  (datasheet Table 30, "DIO Mapping, Packet Mode"), never on DIO0.
- `payload_length: 0` with a new `payload_length_lambda` mirrors the contract of cc1101's
  `packet_length_lambda` (esphome/esphome#17578, a sibling PR to this one, same underlying need): for
  protocols whose length isn't known until a few bytes into the packet (e.g. wM-Bus), the lambda is
  called with the bytes received so far on every drain and returns `0` while the length is still
  unknown, the full expected length once known, or a negative value to discard the current packet and
  restart RX.

Also reads real RSSI for FSK/OOK reception (`RegRssiValue`, `0x11`), previously hardcoded to `0` for
every FSK/OOK packet regardless of length — not specific to long packets, just addressed in the same
pass since it touches the same code path. SNR has no FSK/OOK meaning and stays `0`.

A stalled reception (e.g. interference mid-packet) is discarded via a computed idle timeout, and
`packet_.size()`/the lambda's return value are capped at 1024 bytes — the same two safety nets
`packet_length_lambda` already has in #17578.

Long packets are RX-only: transmitting a payload longer than the TX FIFO (64 bytes) still logs and is
rejected, since that would need separate, not-yet-implemented TX FIFO refilling.

`payload_length`'s YAML validation widens from `cv.int_range(min=0, max=256)` to
`cv.int_range(min=0, max=1024)`, and the C++ setter's parameter widens from `uint8_t` to `uint32_t`
accordingly. No existing call site outside `sx127x/` itself calls `set_payload_length`, and the widening
is source-compatible for any that do.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not yet — a doc PR for this, following the shape of esphome/esphome.io#6993 (the equivalent doc PR for #17578), will follow once there's maintainer acceptance for this PR and its sibling #17578.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sx127x:
  id: transceiver
  cs_pin: GPIO7
  rst_pin: GPIO3
  dio0_pin: GPIO10
  dio1_pin: GPIO1
  # ... other required options ...
  packet_mode: true
  payload_length: 0
  payload_length_lambda: |-
    if (x.size() < 3) return 0;          // not enough bytes yet to know the length
    int32_t length = x[2] + 12;          // protocol-specific length field
    return length;                       // full expected length once known
  on_packet:
    then:
      - lambda: |-
          ESP_LOGD("sx127x", "RX %u bytes  RSSI=%.0f dBm", x.size(), rssi);
```

## Checklist:
  - [x] The code change is tested and works locally. *(hardware-validated on ESP32-C3 + a real SX1276 breakout board, receiving full wM-Bus telegrams (194 bytes) via payload_length: 0 + payload_length_lambda, decrypted successfully and matching a parallel capture of the same meter via cc1101/sx126x)*
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). *(new tests/components/sx127x/test-long-packet.esp32-idf.yaml, covering a fixed payload_length: 1024 and a payload_length: 0 + payload_length_lambda instance)*

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). *(not yet, see above)*