### PR TITLE
[core] Keep templated !include filenames as strings so Windows path normalization cannot corrupt them

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -363,13 +363,12 @@ def resolve_include(
     an explicit non-goal here.
     """
     original = include.file
-    original_str = str(original)
     filename = str(
         _expand_substitutions(
-            original_str, path + ["file"], context_vars, strict_undefined, errors
+            original, path + ["file"], context_vars, strict_undefined, errors
         )
     )
-    substituted = filename != original_str
+    substituted = filename != original
     if substituted:
         include = include.with_file(filename)
     try:

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -231,7 +231,7 @@ class IncludeFile:
     def __init__(
         self,
         parent_file: Path,
-        file: Path | str,
+        file: str,
         vars: dict[str, Any] | None,
         yaml_loader: Callable[[Path], Any],
     ) -> None:
@@ -240,7 +240,7 @@ class IncludeFile:
         # must never round-trip through Path(): on Windows, WindowsPath str()
         # rewrites "/" to "\", which Jinja then decodes as escapes like
         # "\b" -> backspace (issue #18545).
-        self.file: str = file if isinstance(file, str) else file.as_posix()
+        self.file = file
         self.vars = vars
         self.yaml_loader = yaml_loader
         self._content: Any = _UNSET
@@ -270,7 +270,7 @@ class IncludeFile:
         """Check if the filename contains substitution variables or Jinja expressions."""
         return has_substitution_or_expression(self.file)
 
-    def with_file(self, file: Path | str) -> IncludeFile:
+    def with_file(self, file: str) -> IncludeFile:
         """Clone this include with *file* as the filename."""
         return IncludeFile(self.parent_file, file, self.vars, self.yaml_loader)
 
@@ -366,7 +366,7 @@ def _load_include_candidates(
             continue
         expanded_paths.add(candidate)
         try:
-            loaded = include.with_file(candidate).load()
+            loaded = include.with_file(candidate.as_posix()).load()
         except (EsphomeError, Invalid) as err:
             # Unlike an unresolved pattern (expected during the discovery
             # re-parse), a matched on-disk candidate that fails to load is a
@@ -798,6 +798,10 @@ class ESPHomeLoaderMixin:
             file = fields.get("file")
             if file is None:
                 raise yaml.MarkedYAMLError("Must include 'file'", node.start_mark)
+            if not isinstance(file, str):
+                raise yaml.MarkedYAMLError(
+                    "Include 'file' must be a string", node.start_mark
+                )
             vars = fields.get(CONF_VARS)
             return file, vars
 

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -236,13 +236,24 @@ class IncludeFile:
         yaml_loader: Callable[[Path], Any],
     ) -> None:
         self.parent_file = parent_file
-        self.file = Path(file)
+        # A templated filename stays a raw string: Path() corrupts the
+        # expression on Windows (WindowsPath str() rewrites "/" to "\",
+        # which Jinja then decodes as escapes like "\b" -> backspace).
+        file_str = file if isinstance(file, str) else file.as_posix()
+        self.file: Path | str = (
+            file_str if has_substitution_or_expression(file_str) else Path(file)
+        )
         self.vars = vars
         self.yaml_loader = yaml_loader
         self._content: Any = _UNSET
 
+    @property
+    def posix_file(self) -> str:
+        """Include target as text: the raw expression, or the path in POSIX form."""
+        return self.file if isinstance(self.file, str) else self.file.as_posix()
+
     def __repr__(self) -> str:
-        return f"IncludeFile({self.file.as_posix()})"
+        return f"IncludeFile({self.posix_file})"
 
     def load(self) -> Any:
         """Load and cache the included file content.
@@ -264,7 +275,8 @@ class IncludeFile:
 
     def has_unresolved_expressions(self) -> bool:
         """Check if the filename contains substitution variables or Jinja expressions."""
-        return has_substitution_or_expression(str(self.file))
+        # The constructor keeps the filename a str exactly when it is templated.
+        return isinstance(self.file, str)
 
     def with_file(self, file: Path | str) -> IncludeFile:
         """Clone this include with *file* as the filename."""
@@ -1333,11 +1345,11 @@ class ESPHomeDumper(yaml.SafeDumper):
 
     def represent_include_file(self, value):
         if value.vars:
-            mapping = {"file": value.file.as_posix(), "vars": value.vars}
+            mapping = {"file": value.posix_file, "vars": value.vars}
             return self.represent_mapping(
                 tag="!include", mapping=mapping, flow_style=False
             )
-        return self.represent_scalar(tag="!include", value=value.file.as_posix())
+        return self.represent_scalar(tag="!include", value=value.posix_file)
 
     def represent_id(self, value):
         if is_secret(value.id):

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -236,24 +236,17 @@ class IncludeFile:
         yaml_loader: Callable[[Path], Any],
     ) -> None:
         self.parent_file = parent_file
-        # A templated filename stays a raw string: Path() corrupts the
-        # expression on Windows (WindowsPath str() rewrites "/" to "\",
-        # which Jinja then decodes as escapes like "\b" -> backspace).
-        file_str = file if isinstance(file, str) else file.as_posix()
-        self.file: Path | str = (
-            file_str if has_substitution_or_expression(file_str) else Path(file)
-        )
+        # The raw include text may be a substitution/Jinja expression, so it
+        # must never round-trip through Path(): on Windows, WindowsPath str()
+        # rewrites "/" to "\", which Jinja then decodes as escapes like
+        # "\b" -> backspace (issue #18545).
+        self.file: str = file if isinstance(file, str) else file.as_posix()
         self.vars = vars
         self.yaml_loader = yaml_loader
         self._content: Any = _UNSET
 
-    @property
-    def posix_file(self) -> str:
-        """Include target as text: the raw expression, or the path in POSIX form."""
-        return self.file if isinstance(self.file, str) else self.file.as_posix()
-
     def __repr__(self) -> str:
-        return f"IncludeFile({self.posix_file})"
+        return f"IncludeFile({self.file})"
 
     def load(self) -> Any:
         """Load and cache the included file content.
@@ -269,14 +262,13 @@ class IncludeFile:
             raise Invalid(
                 f"Cannot load include with unresolved substitutions: {self.file}"
             )
-        self._content = self.yaml_loader(Path(self.parent_file.parent / self.file))
+        self._content = self.yaml_loader(self.parent_file.parent / self.file)
         self._content = add_context(self._content, self.vars)
         return self._content
 
     def has_unresolved_expressions(self) -> bool:
         """Check if the filename contains substitution variables or Jinja expressions."""
-        # The constructor keeps the filename a str exactly when it is templated.
-        return isinstance(self.file, str)
+        return has_substitution_or_expression(self.file)
 
     def with_file(self, file: Path | str) -> IncludeFile:
         """Clone this include with *file* as the filename."""
@@ -325,7 +317,7 @@ def _candidate_include_paths(include: IncludeFile) -> list[Path]:
     parent_dir = include.parent_file.parent
     parent_resolved = include.parent_file.resolve()
     candidates: list[Path] = []
-    for pattern in include_candidate_patterns(str(include.file)):
+    for pattern in include_candidate_patterns(include.file):
         if "*" in pattern:
             matches = sorted(_glob_include_candidates(parent_dir, pattern))
         else:
@@ -1345,11 +1337,11 @@ class ESPHomeDumper(yaml.SafeDumper):
 
     def represent_include_file(self, value):
         if value.vars:
-            mapping = {"file": value.posix_file, "vars": value.vars}
+            mapping = {"file": value.file, "vars": value.vars}
             return self.represent_mapping(
                 tag="!include", mapping=mapping, flow_style=False
             )
-        return self.represent_scalar(tag="!include", value=value.posix_file)
+        return self.represent_scalar(tag="!include", value=value.file)
 
     def represent_id(self, value):
         if is_secret(value.id):

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -29,8 +29,9 @@ from esphome.bundle import (
     read_bundle_manifest,
     remap_bundle_path,
 )
+from esphome.components.substitutions import do_substitution_pass
 from esphome.core import CORE, EsphomeError
-from esphome.yaml_util import force_load_include_files
+from esphome.yaml_util import force_load_include_files, load_yaml
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1275,6 +1276,59 @@ def test_discover_files_bundles_all_include_candidates(tmp_path: Path) -> None:
     assert "includes/keys/device-a.yaml" in paths
     assert "includes/keys/device-b.yaml" in paths
     assert "includes/empty.yaml" in paths
+
+
+@pytest.mark.parametrize("enable_proxy", [True, False])
+def test_bundle_roundtrip_templated_include_with_path_separator(
+    tmp_path: Path, enable_proxy: bool
+) -> None:
+    r"""The issue-18545 flow: a Jinja !include whose branches contain "/" still
+    resolves after the bundle is extracted on the build server.
+
+    Windows is the leg that regresses: the raw expression text must survive
+    verbatim, or its separators get rewritten to "\" and Jinja decodes
+    sequences like "\b" as string escapes.
+    """
+    config_dir = _setup_config_dir(
+        tmp_path,
+        files={
+            "includes/boards/board.yaml": (
+                "packages:\n"
+                '  - !include ${ "bluetooth/bluetooth_proxy_single_core.yaml"'
+                ' if enable_bluetooth_proxy else "../empty.yaml" }\n'
+            ),
+            "includes/boards/bluetooth/bluetooth_proxy_single_core.yaml": (
+                "bluetooth_proxy:\n  active: true\n"
+            ),
+            "includes/empty.yaml": "{}\n",
+        },
+    )
+    (config_dir / "test.yaml").write_text(
+        "substitutions:\n"
+        f"  enable_bluetooth_proxy: {str(enable_proxy).lower()}\n"
+        "esphome:\n  name: test\n"
+        "packages:\n  - !include includes/boards/board.yaml\n"
+    )
+
+    result = ConfigBundleCreator({}).create_bundle()
+    bundle_path = tmp_path / "device.esphomebundle.tar.gz"
+    bundle_path.write_bytes(result.data)
+
+    # Both conditional branches must ship in the bundle.
+    paths = [f.path for f in result.files]
+    assert "includes/boards/bluetooth/bluetooth_proxy_single_core.yaml" in paths
+    assert "includes/empty.yaml" in paths
+
+    # Extract to a fresh directory and resolve the config from there, as a
+    # remote build server would.
+    extracted_config = extract_bundle(bundle_path, tmp_path / "remote")
+    config = do_substitution_pass(load_yaml(extracted_config))
+
+    board_pkg = config["packages"][0]["packages"][0]
+    if enable_proxy:
+        assert board_pkg == {"bluetooth_proxy": {"active": True}}
+    else:
+        assert board_pkg == {}
 
 
 def test_discover_files_candidate_outside_config_dir_skipped(

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -747,11 +747,7 @@ def test_include_filename_substitution_undefined_var(tmp_path: Path) -> None:
 def test_include_filename_jinja_expression_with_path_separator(
     tmp_path: Path,
 ) -> None:
-    """A jinja !include whose string literals contain "/" resolves correctly.
-
-    Guards against the raw expression text being mangled by path
-    normalization before Jinja evaluates it (issue #18545).
-    """
+    """A jinja !include whose string literals contain "/" resolves correctly (issue #18545)."""
     main_file = tmp_path / "main.yaml"
     main_file.write_text(
         "substitutions:\n"

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -744,6 +744,29 @@ def test_include_filename_substitution_undefined_var(tmp_path: Path) -> None:
         substitutions.do_substitution_pass(config)
 
 
+def test_include_filename_jinja_expression_with_path_separator(
+    tmp_path: Path,
+) -> None:
+    """A jinja !include whose string literals contain "/" resolves correctly.
+
+    Guards against the raw expression text being mangled by path
+    normalization before Jinja evaluates it (issue #18545).
+    """
+    main_file = tmp_path / "main.yaml"
+    main_file.write_text(
+        "substitutions:\n"
+        "  enable_bluetooth_proxy: true\n"
+        "result: !include "
+        '${ "bluetooth/proxy.yaml" if enable_bluetooth_proxy else "../empty.yaml" }\n'
+    )
+    (tmp_path / "bluetooth").mkdir()
+    (tmp_path / "bluetooth" / "proxy.yaml").write_text("value: 42\n")
+
+    config = yaml_util.load_yaml(main_file)
+    config = substitutions.do_substitution_pass(config)
+    assert config["result"] == {"value": 42}
+
+
 def test_raise_first_undefined_logs_extras_at_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -702,37 +702,20 @@ def test_include_file_has_unresolved_expressions(
 
 
 def test_include_file_templated_filename_stays_raw_string(tmp_path: Path) -> None:
-    r"""A templated filename is never coerced through Path().
-
-    On Windows, Path() rewrites "/" to "\" inside the expression text and
-    Jinja then decodes sequences like "\b" as string escapes, corrupting
-    the filename (issue #18545).
-    """
+    """A templated filename keeps its verbatim text (issue #18545)."""
     parent = tmp_path / "main.yaml"
     expr = '${ "bluetooth/proxy.yaml" if enable_bluetooth_proxy else "../empty.yaml" }'
     include = yaml_util.IncludeFile(parent, expr, None, lambda _: {})
     assert include.file == expr
-    assert isinstance(include.file, str)
     assert include.has_unresolved_expressions()
     assert repr(include) == f"IncludeFile({expr})"
-
-
-def test_include_file_plain_filename_becomes_path(tmp_path: Path) -> None:
-    """A concrete filename is stored as a Path."""
-    parent = tmp_path / "main.yaml"
-    include = yaml_util.IncludeFile(parent, "path/to/device.yaml", None, lambda _: {})
-    assert isinstance(include.file, Path)
-    assert include.file == Path("path/to/device.yaml")
-    assert not include.has_unresolved_expressions()
 
 
 def test_represent_include_file_templated() -> None:
     """Dumping a templated IncludeFile emits the raw expression unchanged."""
     expr = '${ "a/b.yaml" if flag else "../c.yaml" }'
     include = yaml_util.IncludeFile(Path("/fake/main.yaml"), expr, None, lambda _: {})
-    dumped = yaml_util.dump({"key": include})
-    assert "!include" in dumped
-    assert expr in dumped
+    assert yaml_util.dump({"key": include}) == f"key: !include '{expr}'\n"
 
 
 def test_include_in_list_context() -> None:
@@ -1085,7 +1068,7 @@ class _StubInclude:
     ) -> None:
         # Default parent lives in a nonexistent directory so unresolved
         # stubs never glob real files during candidate expansion.
-        self.file = Path(file)
+        self.file = file
         self.parent_file = parent_file or Path("/nonexistent/parent.yaml")
         self._unresolved = unresolved
         self._load_result = load_result if load_result is not None else {}

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -701,6 +701,40 @@ def test_include_file_has_unresolved_expressions(
     assert include.has_unresolved_expressions() == expected
 
 
+def test_include_file_templated_filename_stays_raw_string(tmp_path: Path) -> None:
+    r"""A templated filename is never coerced through Path().
+
+    On Windows, Path() rewrites "/" to "\" inside the expression text and
+    Jinja then decodes sequences like "\b" as string escapes, corrupting
+    the filename (issue #18545).
+    """
+    parent = tmp_path / "main.yaml"
+    expr = '${ "bluetooth/proxy.yaml" if enable_bluetooth_proxy else "../empty.yaml" }'
+    include = yaml_util.IncludeFile(parent, expr, None, lambda _: {})
+    assert include.file == expr
+    assert isinstance(include.file, str)
+    assert include.has_unresolved_expressions()
+    assert repr(include) == f"IncludeFile({expr})"
+
+
+def test_include_file_plain_filename_becomes_path(tmp_path: Path) -> None:
+    """A concrete filename is stored as a Path."""
+    parent = tmp_path / "main.yaml"
+    include = yaml_util.IncludeFile(parent, "path/to/device.yaml", None, lambda _: {})
+    assert isinstance(include.file, Path)
+    assert include.file == Path("path/to/device.yaml")
+    assert not include.has_unresolved_expressions()
+
+
+def test_represent_include_file_templated() -> None:
+    """Dumping a templated IncludeFile emits the raw expression unchanged."""
+    expr = '${ "a/b.yaml" if flag else "../c.yaml" }'
+    include = yaml_util.IncludeFile(Path("/fake/main.yaml"), expr, None, lambda _: {})
+    dumped = yaml_util.dump({"key": include})
+    assert "!include" in dumped
+    assert expr in dumped
+
+
 def test_include_in_list_context() -> None:
     """!include of a file returning a list is handled correctly,
     including when that list itself contains a nested IncludeFile."""

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -701,6 +701,14 @@ def test_include_file_has_unresolved_expressions(
     assert include.has_unresolved_expressions() == expected
 
 
+def test_mapping_include_non_string_file_rejected(tmp_path: Path) -> None:
+    """The mapping !include form rejects a non-string 'file' with a clear error."""
+    entry = tmp_path / "entry.yaml"
+    entry.write_text("wifi: !include\n  file: [not, a, string]\n")
+    with pytest.raises(EsphomeError, match="Include 'file' must be a string"):
+        yaml_util.load_yaml(entry)
+
+
 def test_include_file_templated_filename_stays_raw_string(tmp_path: Path) -> None:
     """A templated filename keeps its verbatim text (issue #18545)."""
     parent = tmp_path / "main.yaml"


### PR DESCRIPTION
# What does this implement/fix?

`IncludeFile` stored the raw `!include` value as a `Path` even when it is a Jinja expression rather than a filename. On Windows, `str()` of a `WindowsPath` rewrites every `/` to `\`, so an include like `!include ${ "bluetooth/proxy.yaml" if enable_bluetooth_proxy else "../empty.yaml" }` gets its expression text corrupted before Jinja evaluates it; Jinja then decodes `\b` in the string literal as a backspace escape, producing `bluetooth\x08luetooth...` and a failed build. Linux hosts are unaffected, which is why this only shows up on Windows remote build servers.

The fix stores the `IncludeFile` filename as verbatim text and builds a `Path` only at the points that actually touch the filesystem, after substitution has produced a concrete name. Using `as_posix()` at the leak sites would not be enough; `WindowsPath` parsing is lossy for expression text in other ways too, for example it collapses `//`, which is Jinja integer division.

As part of this, the mapping form of `!include` now rejects a non string `file:` value with a clear config error pointing at the source location; previously such input failed with a raw `TypeError` traceback.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18545

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
substitutions:
  enable_bluetooth_proxy: true

packages:
  - !include ${ "bluetooth/bluetooth_proxy_single_core.yaml" if enable_bluetooth_proxy else "../empty.yaml" }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
