### PR TITLE
[espnow] Fix dump_config crash when enable_on_boot is false

### DIFF
--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -130,12 +130,13 @@ ESPNowComponent::ESPNowComponent() { global_esp_now = this; }
 
 void ESPNowComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "espnow:");
-  if (this->is_disabled()) {
+  // Only report driver details once enabled; with enable_on_boot: false the
+  // Wi-Fi driver is not initialized yet and esp_now_get_version() would crash,
+  // and after a failed enable_() the values would be meaningless.
+  if (this->state_ != ESPNOW_STATE_ENABLED) {
     ESP_LOGCONFIG(TAG, "  Disabled");
     return;
   }
-  // Only query the version once enabled; with enable_on_boot: false the Wi-Fi
-  // driver is not initialized yet and esp_now_get_version() would crash.
   uint32_t version = 0;
   esp_now_get_version(&version);
   char own_addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -134,7 +134,8 @@ void ESPNowComponent::dump_config() {
   // Wi-Fi driver is not initialized yet and esp_now_get_version() would crash,
   // and after a failed enable_() the values would be meaningless.
   if (this->state_ != ESPNOW_STATE_ENABLED) {
-    ESP_LOGCONFIG(TAG, "  Disabled");
+    // OFF here means enable_() failed; the core logs the FAILED marker separately
+    ESP_LOGCONFIG(TAG, "  %s", this->is_disabled() ? LOG_STR_LITERAL("Disabled") : LOG_STR_LITERAL("Not enabled"));
     return;
   }
   uint32_t version = 0;

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -129,14 +129,15 @@ void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int 
 ESPNowComponent::ESPNowComponent() { global_esp_now = this; }
 
 void ESPNowComponent::dump_config() {
-  uint32_t version = 0;
-  esp_now_get_version(&version);
-
   ESP_LOGCONFIG(TAG, "espnow:");
   if (this->is_disabled()) {
     ESP_LOGCONFIG(TAG, "  Disabled");
     return;
   }
+  // Only query the version once enabled; with enable_on_boot: false the Wi-Fi
+  // driver is not initialized yet and esp_now_get_version() would crash.
+  uint32_t version = 0;
+  esp_now_get_version(&version);
   char own_addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   format_mac_addr_upper(this->own_address_, own_addr_buf);
   ESP_LOGCONFIG(TAG,


### PR DESCRIPTION
# What does this implement/fix?

`dump_config()` called `esp_now_get_version()` before the disabled check; with `enable_on_boot: false` and no `wifi:` component the Wi-Fi driver is never initialized, so the call crashes with LoadProhibited on the first loop. Move the version query below the disabled early return, where the driver is guaranteed to be up.

This is a regression from 2026.4.0; the unguarded call existed since the component was added, but it was harmless until #15377 made `enable_on_boot` actually reach the C++ code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18569

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
espnow:
  enable_on_boot: false
  channel: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
