### PR TITLE
[core] Keep str_contains_ignore_case needle literals in flash on ESP8266

### DIFF
--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -1,7 +1,6 @@
 #include "audio.h"
 
 #include "esphome/core/helpers.h"
-#include "esphome/core/progmem.h"
 
 #include <cstring>
 
@@ -87,8 +86,7 @@ AudioFileType detect_audio_file_type(const char *content_type, const char *url) 
     // Match "audio/ogg" with a codecs parameter containing "opus"
     // Valid forms: audio/ogg;codecs=opus, audio/ogg; codecs="opus", etc.
     // Plain "audio/ogg" without opus is not matched (almost always Ogg Vorbis)
-    if (strncasecmp(content_type, "audio/ogg", 9) == 0 &&
-        str_contains_ignore_case_p(content_type + 9, ESPHOME_PSTR("opus"))) {
+    if (strncasecmp(content_type, "audio/ogg", 9) == 0 && str_contains_ignore_case(content_type + 9, "opus")) {
       return AudioFileType::OPUS;
     }
 #endif

--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -1,6 +1,7 @@
 #include "audio.h"
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/progmem.h"
 
 #include <cstring>
 
@@ -86,7 +87,8 @@ AudioFileType detect_audio_file_type(const char *content_type, const char *url) 
     // Match "audio/ogg" with a codecs parameter containing "opus"
     // Valid forms: audio/ogg;codecs=opus, audio/ogg; codecs="opus", etc.
     // Plain "audio/ogg" without opus is not matched (almost always Ogg Vorbis)
-    if (strncasecmp(content_type, "audio/ogg", 9) == 0 && str_contains_ignore_case(content_type + 9, "opus")) {
+    if (strncasecmp(content_type, "audio/ogg", 9) == 0 &&
+        str_contains_ignore_case_p(content_type + 9, ESPHOME_PSTR("opus"))) {
       return AudioFileType::OPUS;
     }
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -234,6 +234,8 @@ bool str_contains_ignore_case_fallback(const char *haystack, const char *needle)
 }
 
 #ifdef USE_ESP8266
+// _P mirror of str_contains_ignore_case_fallback above; host tests cover only the fallback,
+// so keep the two bodies in sync.
 bool str_contains_ignore_case_p(const char *haystack, PGM_P needle) {
   if (haystack == nullptr || needle == nullptr) {
     return false;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -233,27 +233,23 @@ bool str_contains_ignore_case_fallback(const char *haystack, const char *needle)
   return false;
 }
 
-bool str_contains_ignore_case_p(const char *haystack, const char *needle) {
+#ifdef USE_ESP8266
+bool str_contains_ignore_case_p(const char *haystack, PGM_P needle) {
   if (haystack == nullptr || needle == nullptr) {
     return false;
   }
-  const auto *needle_p = reinterpret_cast<const uint8_t *>(needle);
-  if (progmem_read_byte(needle_p) == '\0') {
+  const size_t needle_len = strlen_P(needle);
+  if (needle_len == 0) {
     return true;
   }
   for (const char *p = haystack; *p != '\0'; p++) {
-    size_t i = 0;
-    uint8_t n;
-    // Never reads past the haystack terminator: comparing '\0' against a non-'\0' needle byte fails
-    while ((n = progmem_read_byte(needle_p + i)) != '\0' && ::tolower(static_cast<uint8_t>(p[i])) == ::tolower(n)) {
-      i++;
-    }
-    if (n == '\0') {
+    if (strncasecmp_P(p, needle, needle_len) == 0) {
       return true;
     }
   }
   return false;
 }
+#endif  // USE_ESP8266
 
 // str_truncate, str_until, str_lower_case, str_upper_case, str_snake_case moved to alloc_helpers.cpp
 char *str_sanitize_to(char *buffer, size_t buffer_size, const char *str) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -233,6 +233,28 @@ bool str_contains_ignore_case_fallback(const char *haystack, const char *needle)
   return false;
 }
 
+bool str_contains_ignore_case_p(const char *haystack, const char *needle) {
+  if (haystack == nullptr || needle == nullptr) {
+    return false;
+  }
+  const auto *needle_p = reinterpret_cast<const uint8_t *>(needle);
+  if (progmem_read_byte(needle_p) == '\0') {
+    return true;
+  }
+  for (const char *p = haystack; *p != '\0'; p++) {
+    size_t i = 0;
+    uint8_t n;
+    // Never reads past the haystack terminator: comparing '\0' against a non-'\0' needle byte fails
+    while ((n = progmem_read_byte(needle_p + i)) != '\0' && ::tolower(static_cast<uint8_t>(p[i])) == ::tolower(n)) {
+      i++;
+    }
+    if (n == '\0') {
+      return true;
+    }
+  }
+  return false;
+}
+
 // str_truncate, str_until, str_lower_case, str_upper_case, str_snake_case moved to alloc_helpers.cpp
 char *str_sanitize_to(char *buffer, size_t buffer_size, const char *str) {
   if (buffer_size == 0) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -990,7 +990,7 @@ bool str_contains_ignore_case_fallback(const char *haystack, const char *needle)
 bool str_contains_ignore_case_p(const char *haystack, PGM_P needle);
 /// Case-insensitive check if needle string is contained in haystack (no heap allocation).
 /// On ESP8266 the needle is wrapped with PSTR() so it stays in flash, which requires it to be
-/// a string literal; pass a runtime needle to str_contains_ignore_case_p directly instead.
+/// a string literal; a runtime needle needs str_contains_ignore_case_p behind #ifdef USE_ESP8266.
 #define str_contains_ignore_case(haystack, needle) str_contains_ignore_case_p(haystack, PSTR(needle))
 #else
 /// Case-insensitive check if needle string is contained in haystack (no heap allocation).

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -989,7 +989,8 @@ bool str_contains_ignore_case_fallback(const char *haystack, const char *needle)
 /// `str_contains_ignore_case` macro which wraps needle literals with PSTR() automatically.
 bool str_contains_ignore_case_p(const char *haystack, PGM_P needle);
 /// Case-insensitive check if needle string is contained in haystack (no heap allocation).
-/// On ESP8266 the needle literal is wrapped with PSTR() so it stays in flash.
+/// On ESP8266 the needle is wrapped with PSTR() so it stays in flash, which requires it to be
+/// a string literal; pass a runtime needle to str_contains_ignore_case_p directly instead.
 #define str_contains_ignore_case(haystack, needle) str_contains_ignore_case_p(haystack, PSTR(needle))
 #else
 /// Case-insensitive check if needle string is contained in haystack (no heap allocation).

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1000,6 +1000,11 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
 #endif  // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
 }
 
+/// Case-insensitive check if needle string is contained in haystack (no heap allocation).
+/// The needle may live in flash (PROGMEM) on ESP8266 — wrap literals with PSTR().
+/// On all other platforms PROGMEM reads are plain dereferences, so any string works.
+bool str_contains_ignore_case_p(const char *haystack, const char *needle);
+
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0
 
 // str_until, str_lower_case, str_upper_case moved to alloc_helpers.h - remove this comment before 2026.11.0

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -985,13 +985,24 @@ inline bool str_endswith_ignore_case(const std::string &str, const char *suffix)
 bool str_contains_ignore_case_fallback(const char *haystack, const char *needle);
 
 /// Case-insensitive check if needle string is contained in haystack (no heap allocation).
+/// ESP8266 internal implementation — prefer the `str_contains_ignore_case` macro which wraps
+/// needle literals with `PSTR()` automatically so they stay in flash instead of eating RAM.
+/// The needle must be a PROGMEM pointer on ESP8266; reads are plain dereferences elsewhere.
+bool str_contains_ignore_case_p(const char *haystack, const char *needle);
+
+#ifdef USE_ESP8266
+/// Case-insensitive check if needle string is contained in haystack (no heap allocation).
+/// On ESP8266 the needle literal is wrapped with PSTR() so it stays in flash.
+#define str_contains_ignore_case(haystack, needle) str_contains_ignore_case_p(haystack, PSTR(needle))
+#else
+/// Case-insensitive check if needle string is contained in haystack (no heap allocation).
 inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
   if (!needle || !haystack) {
     return false;
   }
 
 // strcasestr is a GNU extension: newlib only declares it when _GNU_SOURCE is set.
-// ESP32/ESP8266/host builds get it from their framework or from g++ on Linux;
+// ESP32/host builds get it from their framework or from g++ on Linux;
 // LibreTiny, RP2 and Zephyr do not, so they use the hand-rolled fallback.
 #if defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
   return str_contains_ignore_case_fallback(haystack, needle);
@@ -999,11 +1010,7 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
   return strcasestr(haystack, needle) != nullptr;
 #endif  // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
 }
-
-/// Case-insensitive check if needle string is contained in haystack (no heap allocation).
-/// The needle may live in flash (PROGMEM) on ESP8266 — wrap literals with PSTR().
-/// On all other platforms PROGMEM reads are plain dereferences, so any string works.
-bool str_contains_ignore_case_p(const char *haystack, const char *needle);
+#endif  // USE_ESP8266
 
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1007,10 +1007,6 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
   return strcasestr(haystack, needle) != nullptr;
 #endif  // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
 }
-/// PROGMEM is a no-op on this platform, so the flash-needle variant is the plain check.
-inline bool str_contains_ignore_case_p(const char *haystack, const char *needle) {
-  return str_contains_ignore_case(haystack, needle);
-}
 #endif  // USE_ESP8266
 
 // str_truncate moved to alloc_helpers.h - remove this include before 2026.11.0

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -984,13 +984,10 @@ inline bool str_endswith_ignore_case(const std::string &str, const char *suffix)
 /// Fallback implementation for case insensitive substring comparison.
 bool str_contains_ignore_case_fallback(const char *haystack, const char *needle);
 
-/// Case-insensitive check if needle string is contained in haystack (no heap allocation).
-/// ESP8266 internal implementation — prefer the `str_contains_ignore_case` macro which wraps
-/// needle literals with `PSTR()` automatically so they stay in flash instead of eating RAM.
-/// The needle must be a PROGMEM pointer on ESP8266; reads are plain dereferences elsewhere.
-bool str_contains_ignore_case_p(const char *haystack, const char *needle);
-
 #ifdef USE_ESP8266
+/// ESP8266 internal implementation reading the needle from flash — prefer the
+/// `str_contains_ignore_case` macro which wraps needle literals with PSTR() automatically.
+bool str_contains_ignore_case_p(const char *haystack, PGM_P needle);
 /// Case-insensitive check if needle string is contained in haystack (no heap allocation).
 /// On ESP8266 the needle literal is wrapped with PSTR() so it stays in flash.
 #define str_contains_ignore_case(haystack, needle) str_contains_ignore_case_p(haystack, PSTR(needle))
@@ -1009,6 +1006,10 @@ inline bool str_contains_ignore_case(const char *haystack, const char *needle) {
 #else   // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
   return strcasestr(haystack, needle) != nullptr;
 #endif  // defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ZEPHYR)
+}
+/// PROGMEM is a no-op on this platform, so the flash-needle variant is the plain check.
+inline bool str_contains_ignore_case_p(const char *haystack, const char *needle) {
+  return str_contains_ignore_case(haystack, needle);
 }
 #endif  // USE_ESP8266
 

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -129,4 +129,24 @@ TEST(StringContainsIgnoreCaseTest, FallbackMatchesLibc) {
   EXPECT_EQ(str_contains_ignore_case_fallback("ab", "abc"), str_contains_ignore_case("ab", "abc"));
 }
 
+TEST(StringContainsIgnoreCaseTest, ProgmemVariantNullPointerAlwaysFalse) {
+  const char *haystack = nullptr;
+  const char *needle = nullptr;
+
+  EXPECT_FALSE(str_contains_ignore_case_p(haystack, needle));
+  EXPECT_FALSE(str_contains_ignore_case_p("Hello World", needle));
+  EXPECT_FALSE(str_contains_ignore_case_p(haystack, "anything"));
+}
+
+TEST(StringContainsIgnoreCaseTest, ProgmemVariantMatchesFallback) {
+  const char *haystack = "Hello World";
+  for (const char *needle : {"", "Hello", "hELLO", "HELLO", "Hell", "world", "World", "Heaven", "Hello!", "d"}) {
+    EXPECT_EQ(str_contains_ignore_case_p(haystack, needle), str_contains_ignore_case_fallback(haystack, needle))
+        << "needle: " << needle;
+  }
+  EXPECT_TRUE(str_contains_ignore_case_p("", ""));
+  EXPECT_FALSE(str_contains_ignore_case_p("", "a"));
+  EXPECT_FALSE(str_contains_ignore_case_p("ab", "abc"));
+}
+
 }  // namespace esphome

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -90,10 +90,6 @@ TEST(StringContainsIgnoreCaseTest, NullPointerAlwaysFalse) {
   EXPECT_FALSE(str_contains_ignore_case(haystack, needle));
   EXPECT_FALSE(str_contains_ignore_case("Hello World", needle));
   EXPECT_FALSE(str_contains_ignore_case(haystack, "anything"));
-
-  EXPECT_FALSE(str_contains_ignore_case_p(haystack, needle));
-  EXPECT_FALSE(str_contains_ignore_case_p("Hello World", needle));
-  EXPECT_FALSE(str_contains_ignore_case_p(haystack, "anything"));
 }
 
 TEST(StringContainsIgnoreCaseTest, EmptySearchMatches) {
@@ -128,14 +124,9 @@ TEST(StringContainsIgnoreCaseTest, FallbackMatchesLibc) {
   for (const char *needle : {"", "Hello", "hELLO", "HELLO", "Hell", "world", "World", "Heaven", "Hello!", "d"}) {
     EXPECT_EQ(str_contains_ignore_case_fallback(haystack, needle), str_contains_ignore_case(haystack, needle))
         << "needle: " << needle;
-    EXPECT_EQ(str_contains_ignore_case_p(haystack, needle), str_contains_ignore_case(haystack, needle))
-        << "needle: " << needle;
   }
   EXPECT_EQ(str_contains_ignore_case_fallback("", ""), str_contains_ignore_case("", ""));
   EXPECT_EQ(str_contains_ignore_case_fallback("ab", "abc"), str_contains_ignore_case("ab", "abc"));
-  EXPECT_TRUE(str_contains_ignore_case_p("", ""));
-  EXPECT_FALSE(str_contains_ignore_case_p("", "a"));
-  EXPECT_FALSE(str_contains_ignore_case_p("ab", "abc"));
 }
 
 }  // namespace esphome

--- a/tests/components/core/helpers_test.cpp
+++ b/tests/components/core/helpers_test.cpp
@@ -90,6 +90,10 @@ TEST(StringContainsIgnoreCaseTest, NullPointerAlwaysFalse) {
   EXPECT_FALSE(str_contains_ignore_case(haystack, needle));
   EXPECT_FALSE(str_contains_ignore_case("Hello World", needle));
   EXPECT_FALSE(str_contains_ignore_case(haystack, "anything"));
+
+  EXPECT_FALSE(str_contains_ignore_case_p(haystack, needle));
+  EXPECT_FALSE(str_contains_ignore_case_p("Hello World", needle));
+  EXPECT_FALSE(str_contains_ignore_case_p(haystack, "anything"));
 }
 
 TEST(StringContainsIgnoreCaseTest, EmptySearchMatches) {
@@ -121,29 +125,14 @@ TEST(StringContainsIgnoreCaseTest, MiscNotMatching) {
 
 TEST(StringContainsIgnoreCaseTest, FallbackMatchesLibc) {
   const char *haystack = "Hello World";
-  for (const char *needle : {"", "Hello", "hELLO", "Hell", "world", "Heaven", "Hello!", "d"}) {
+  for (const char *needle : {"", "Hello", "hELLO", "HELLO", "Hell", "world", "World", "Heaven", "Hello!", "d"}) {
     EXPECT_EQ(str_contains_ignore_case_fallback(haystack, needle), str_contains_ignore_case(haystack, needle))
+        << "needle: " << needle;
+    EXPECT_EQ(str_contains_ignore_case_p(haystack, needle), str_contains_ignore_case(haystack, needle))
         << "needle: " << needle;
   }
   EXPECT_EQ(str_contains_ignore_case_fallback("", ""), str_contains_ignore_case("", ""));
   EXPECT_EQ(str_contains_ignore_case_fallback("ab", "abc"), str_contains_ignore_case("ab", "abc"));
-}
-
-TEST(StringContainsIgnoreCaseTest, ProgmemVariantNullPointerAlwaysFalse) {
-  const char *haystack = nullptr;
-  const char *needle = nullptr;
-
-  EXPECT_FALSE(str_contains_ignore_case_p(haystack, needle));
-  EXPECT_FALSE(str_contains_ignore_case_p("Hello World", needle));
-  EXPECT_FALSE(str_contains_ignore_case_p(haystack, "anything"));
-}
-
-TEST(StringContainsIgnoreCaseTest, ProgmemVariantMatchesFallback) {
-  const char *haystack = "Hello World";
-  for (const char *needle : {"", "Hello", "hELLO", "HELLO", "Hell", "world", "World", "Heaven", "Hello!", "d"}) {
-    EXPECT_EQ(str_contains_ignore_case_p(haystack, needle), str_contains_ignore_case_fallback(haystack, needle))
-        << "needle: " << needle;
-  }
   EXPECT_TRUE(str_contains_ignore_case_p("", ""));
   EXPECT_FALSE(str_contains_ignore_case_p("", "a"));
   EXPECT_FALSE(str_contains_ignore_case_p("ab", "abc"));


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #18497; on ESP8266, `str_contains_ignore_case` is now a macro that wraps the needle literal with `PSTR()` and calls an ESP8266 only implementation reading it from flash with `strlen_P` and `strncasecmp_P`, following the same pattern as `buf_append_str`. Other platforms keep the existing inline implementation, so call sites like the one in `audio` stay unchanged and get flash needles automatically if they are ever built for ESP8266. Deferred from https://github.com/esphome/esphome/pull/18497#discussion_r3816579665, intended for the upcoming image content type detection work.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/pull/18497#discussion_r3816579665

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
