### PR TITLE
[esp32] Report abort and task watchdog panics correctly in crash handler

### DIFF
--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -124,6 +124,15 @@ static uint8_t IRAM_ATTR capture_riscv_backtrace(RvExcFrame *frame, uint32_t *ou
 // Version is uint32_t because it would be padded to 4 bytes anyway before the next
 // uint32_t field, so we use the full width rather than wasting 3 bytes of padding.
 static constexpr uint32_t CRASH_DATA_VERSION = 4;
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+// EXCCAUSE is a 6-bit register; larger recorded values mean the frame's
+// cause/vaddr slots were never written (not a real exception frame).
+static constexpr uint32_t XTENSA_EXCCAUSE_COUNT = XCHAL_EXCCAUSE_NUM;
+#elif CONFIG_IDF_TARGET_ARCH_RISCV
+// Synchronous mcause exception codes are small and have no interrupt bit;
+// anything else in a non-pseudo record is a stale slot.
+static constexpr uint32_t RISCV_EXCEPTION_CAUSE_COUNT = 32;
+#endif
 struct RawCrashData {
   uint32_t version;
   uint32_t magic;
@@ -198,10 +207,28 @@ void crash_handler_clear() {
   s_raw_crash_data.magic = 0;
 }
 
+// Whether the cause slot was written by a real exception frame.
+static bool cause_slot_was_written() {
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+  return s_raw_crash_data.cause < XTENSA_EXCCAUSE_COUNT;
+#else
+  return s_raw_crash_data.cause < RISCV_EXCEPTION_CAUSE_COUNT;
+#endif
+}
+
 // Look up the exception cause as a human-readable string.
 // Tables mirror ESP-IDF's panic_arch_fill_info() which uses local static arrays
 // not exposed via any public API.
 static const char *get_exception_reason() {
+  uint8_t exception = s_raw_crash_data.exception;
+  if (exception == PANIC_EXCEPTION_ABORT || exception == PANIC_EXCEPTION_TWDT) {
+    // Abort-class panics carry no cause register
+    return nullptr;
+  }
+  if (!cause_slot_was_written()) {
+    // Garbage from old-build or corrupt records; report just the type
+    return nullptr;
+  }
 #if CONFIG_IDF_TARGET_ARCH_XTENSA
   if (s_raw_crash_data.pseudo_excause) {
     // SoC-level panic: watchdog, cache error, etc.
@@ -354,10 +381,11 @@ static const char *const FAULT_ADDR_REG = "MTVAL";
 static const char *const FAULT_ADDR_REG_LOWER = "mtval";
 #endif
 
-// Whether the fault address is meaningful — real CPU faults only, not
-// aborts/watchdogs or SoC-level pseudo exceptions.
+// Whether the fault address is meaningful: real CPU faults with a validly
+// written frame only.
 static bool has_fault_addr() {
-  return s_raw_crash_data.exception == PANIC_EXCEPTION_FAULT && !s_raw_crash_data.pseudo_excause;
+  return s_raw_crash_data.exception == PANIC_EXCEPTION_FAULT && !s_raw_crash_data.pseudo_excause &&
+         cause_slot_was_written();
 }
 
 // The record was captured by a different firmware build (it survives soft
@@ -458,6 +486,10 @@ void crash_handler_log() {
 // into NOINIT memory before the normal panic handler runs.
 //
 extern "C" {
+// Set by IDF's task watchdog (task_wdt.c, no header) before it simulates an
+// abort; weak so builds without the task watchdog still link.
+extern bool g_twdt_isr __attribute__((weak));
+
 // NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 // Names are mandated by the --wrap linker mechanism
 extern void __real_esp_panic_handler(panic_info_t *info);
@@ -470,6 +502,14 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   s_raw_crash_data.exception = (uint8_t) info->exception;
   s_raw_crash_data.pseudo_excause = info->pseudo_excause ? 1 : 0;
   s_raw_crash_data.crashed_core = (uint8_t) info->core;
+  if (g_panic_abort) {
+    // IDF reclassifies to ABORT only inside esp_panic_handler(), after this
+    // wrapper captured info->exception; correct it here. TWDT is our own
+    // distinction (IDF never assigns PANIC_EXCEPTION_TWDT). The abort text is
+    // not stored; the symbolized backtrace already identifies the site.
+    bool is_twdt = &g_twdt_isr != nullptr && g_twdt_isr;
+    s_raw_crash_data.exception = (uint8_t) (is_twdt ? PANIC_EXCEPTION_TWDT : PANIC_EXCEPTION_ABORT);
+  }
   // Zero unconditionally so a null frame doesn't leave stale .noinit data from a previous boot
   s_raw_crash_data.cause = 0;
   s_raw_crash_data.fault_addr = 0;
@@ -487,8 +527,12 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   // Xtensa: walk the backtrace using the public API
   if (info->frame != nullptr) {
     auto *xt_frame = (XtExcFrame *) info->frame;
-    s_raw_crash_data.cause = xt_frame->exccause;
-    s_raw_crash_data.fault_addr = xt_frame->excvaddr;
+    if (!g_panic_abort) {
+      // Abort-class frames carry no useful cause/vaddr: TWDT task snapshots
+      // never wrote them and abort() traps describe only the synthetic trap.
+      s_raw_crash_data.cause = xt_frame->exccause;
+      s_raw_crash_data.fault_addr = xt_frame->excvaddr;
+    }
     s_raw_crash_data.backtrace_count = walk_xtensa_backtrace(xt_frame, s_raw_crash_data.backtrace, MAX_BACKTRACE);
   }
 
@@ -510,8 +554,11 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   // RISC-V: capture MEPC + RA, then scan stack for code addresses
   if (info->frame != nullptr) {
     auto *rv_frame = (RvExcFrame *) info->frame;
-    s_raw_crash_data.cause = rv_frame->mcause;
-    s_raw_crash_data.fault_addr = rv_frame->mtval;
+    if (!g_panic_abort) {
+      // See the Xtensa branch: abort-class frames carry no valid cause/vaddr.
+      s_raw_crash_data.cause = rv_frame->mcause;
+      s_raw_crash_data.fault_addr = rv_frame->mtval;
+    }
     s_raw_crash_data.backtrace_count =
         capture_riscv_backtrace(rv_frame, s_raw_crash_data.backtrace, MAX_BACKTRACE, &s_raw_crash_data.reg_frame_count);
   }


### PR DESCRIPTION
# What does this implement/fix?

The crash handler captured `info->exception` before the real panic handler reclassifies abort style panics, so `abort()`, assert failures and task watchdog timeouts were all recorded as memory faults. A task watchdog panic also hands over an interrupt frame whose cause and address slots were never written, so those reports showed stack garbage such as `Fault - Unknown (cause 2148484196)` with a bogus EXCVADDR, pointing investigations at the wrong code (see the linked issues, which were really task watchdog timeouts).

The wrapper now checks `g_panic_abort` and records the panic as Abort, or Task wdt when the task watchdog flag is set; for abort class panics the cause and fault address slots are left zeroed at capture time since the frame never carried valid values, and the log side additionally refuses to print cause or EXCVADDR values that are impossible for the 6 bit EXCCAUSE register, which still protects records captured by older firmware. The record layout and version are unchanged; after an OTA rollback an old build reading a new abort record prints `Abort - IllegalInstruction (cause 0)`, mislabeled but harmless. The garbage guard now covers both architectures, so a post fix build reading a pre fix task watchdog record suppresses the bogus cause and fault address on RISC-V as well as Xtensa. The backtrace is still printed for aborts since for a task watchdog it shows exactly where the loop was stuck, and the symbolized backtrace already identifies the abort or assert site, so the abort message text is deliberately not stored; the fix uses only fields that already existed and adds zero RAM.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/18568 and https://github.com/esphome/esphome/issues/17766; both reports were mislabeled by this bug, the underlying stall is fixed separately

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
