### PR TITLE
[ota] Log prepare, upload, and total OTA timing in espota2

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -542,11 +542,11 @@ def perform_ota(
         raise _committed_error(err) from err
     commit_duration = time.perf_counter() - commit_start
 
-    # Spans the binary size send through the commit ack; connect, handshake,
-    # and auth are not included
+    # Sum of the named windows so the breakdown is self consistent; connect,
+    # handshake, auth, and the one MD5 round trip are not included
     _LOGGER.info(
         "Update took %.2f seconds (prepare %.2f, upload %.2f, commit %.2f)",
-        time.perf_counter() - prepare_start,
+        prepare_duration + duration + commit_duration,
         prepare_duration,
         duration,
         commit_duration,

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -534,17 +534,22 @@ def perform_ota(
     # reboots on its own; the exact commit point is not observable from
     # here, so treat everything past the data phase as non-retryable. A
     # re-upload could flash a device that already updated successfully.
+    commit_start = time.perf_counter()
     try:
         receive_exactly(sock, 1, "update receive result", RESPONSE_RECEIVE_OK)
         receive_exactly(sock, 1, "update end result", RESPONSE_UPDATE_END_OK)
     except OTANetworkError as err:
         raise _committed_error(err) from err
+    commit_duration = time.perf_counter() - commit_start
 
+    # Spans the binary size send through the commit ack; connect, handshake,
+    # and auth are not included
     _LOGGER.info(
-        "OTA took %.2f seconds total (prepare %.2f, upload %.2f)",
+        "Update took %.2f seconds (prepare %.2f, upload %.2f, commit %.2f)",
         time.perf_counter() - prepare_start,
         prepare_duration,
         duration,
+        commit_duration,
     )
 
     try:

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -460,8 +460,14 @@ def perform_ota(
         (upload_size >> 8) & 0xFF,
         (upload_size >> 0) & 0xFF,
     ]
+    # The device erases flash between receiving the size and acking the
+    # prepare, so this window shows the erase cost (near zero when the
+    # device erases lazily during the upload)
+    prepare_start = time.perf_counter()
     send_check(sock, upload_size_encoded, "binary size")
     receive_exactly(sock, 1, "update prepare result", RESPONSE_UPDATE_PREPARE_OK)
+    prepare_duration = time.perf_counter() - prepare_start
+    _LOGGER.info("Preparing for upload took %.2f seconds", prepare_duration)
 
     upload_md5 = hashlib.md5(upload_contents).hexdigest()
     _LOGGER.debug("MD5 of upload is %s", upload_md5)
@@ -533,6 +539,13 @@ def perform_ota(
         receive_exactly(sock, 1, "update end result", RESPONSE_UPDATE_END_OK)
     except OTANetworkError as err:
         raise _committed_error(err) from err
+
+    _LOGGER.info(
+        "OTA took %.2f seconds total (prepare %.2f, upload %.2f)",
+        time.perf_counter() - prepare_start,
+        prepare_duration,
+        duration,
+    )
 
     try:
         send_check(sock, RESPONSE_OK, "end acknowledgement")

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -392,7 +392,13 @@ def test_perform_ota_no_auth(
 
     mock_socket.recv.side_effect = recv_responses
 
-    with caplog.at_level(logging.INFO):
+    # Distinct window lengths pin each duration to its label; exactly the 7
+    # expected perf_counter calls, so an unaccounted timing window raises
+    timings = [0.0, 2.0, 10.0, 15.0, 20.0, 27.0, 30.0]
+    with (
+        patch("time.perf_counter", side_effect=timings),
+        caplog.at_level(logging.INFO),
+    ):
         espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
     # Should not send any auth-related data
@@ -403,10 +409,13 @@ def test_perform_ota_no_auth(
     ]
     assert len(auth_calls) == 0
 
-    # The timing summary is the observable output of the upload
-    assert "Preparing for upload took" in caplog.text
-    assert "Update took" in caplog.text
-    assert "commit" in caplog.text
+    # The timing summary is the observable output of the upload; exact strings
+    # pin each duration to its label
+    assert "Preparing for upload took 2.00 seconds" in caplog.text
+    assert (
+        "Update took 30.00 seconds (prepare 2.00, upload 5.00, commit 7.00)"
+        in caplog.text
+    )
 
 
 @pytest.mark.usefixtures("mock_time")

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 import gzip
 import hashlib
 import io
+import itertools
 from pathlib import Path
 import socket
 import struct
@@ -53,8 +54,9 @@ def mock_sleep() -> Generator[Mock]:
 @pytest.fixture
 def mock_time(mock_sleep: Mock) -> Generator[None]:
     """Mock time-related functions for consistent testing."""
-    # Provide enough values for multiple calls (tests may call perform_ota multiple times)
-    with patch("time.perf_counter", side_effect=[0, 1, 0, 1, 0, 1]):
+    # Monotonically increasing, never exhausted regardless of how many timing
+    # windows perform_ota measures or how many times a test calls it
+    with patch("time.perf_counter", side_effect=itertools.count()):
         yield
 
 

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -392,9 +392,9 @@ def test_perform_ota_no_auth(
 
     mock_socket.recv.side_effect = recv_responses
 
-    # Distinct window lengths pin each duration to its label; exactly the 7
+    # Distinct window lengths pin each duration to its label; exactly the 6
     # expected perf_counter calls, so an unaccounted timing window raises
-    timings = [0.0, 2.0, 10.0, 15.0, 20.0, 27.0, 30.0]
+    timings = [0.0, 2.0, 10.0, 15.0, 20.0, 27.0]
     with (
         patch("time.perf_counter", side_effect=timings),
         caplog.at_level(logging.INFO),
@@ -413,7 +413,7 @@ def test_perform_ota_no_auth(
     # pin each duration to its label
     assert "Preparing for upload took 2.00 seconds" in caplog.text
     assert (
-        "Update took 30.00 seconds (prepare 2.00, upload 5.00, commit 7.00)"
+        "Update took 14.00 seconds (prepare 2.00, upload 5.00, commit 7.00)"
         in caplog.text
     )
 

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -7,6 +7,7 @@ import gzip
 import hashlib
 import io
 import itertools
+import logging
 from pathlib import Path
 import socket
 import struct
@@ -374,7 +375,9 @@ def test_perform_ota_successful_md5_auth(
 
 
 @pytest.mark.usefixtures("mock_time")
-def test_perform_ota_no_auth(mock_socket: Mock, mock_file: io.BytesIO) -> None:
+def test_perform_ota_no_auth(
+    mock_socket: Mock, mock_file: io.BytesIO, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test OTA without authentication."""
     recv_responses = [
         bytes([espota2.RESPONSE_OK]),  # First byte of version response
@@ -389,7 +392,8 @@ def test_perform_ota_no_auth(mock_socket: Mock, mock_file: io.BytesIO) -> None:
 
     mock_socket.recv.side_effect = recv_responses
 
-    espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
+    with caplog.at_level(logging.INFO):
+        espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
     # Should not send any auth-related data
     auth_calls = [
@@ -398,6 +402,11 @@ def test_perform_ota_no_auth(mock_socket: Mock, mock_file: io.BytesIO) -> None:
         if "cnonce" in str(call) or "result" in str(call)
     ]
     assert len(auth_calls) == 0
+
+    # The timing summary is the observable output of the upload
+    assert "Preparing for upload took" in caplog.text
+    assert "Update took" in caplog.text
+    assert "commit" in caplog.text
 
 
 @pytest.mark.usefixtures("mock_time")


### PR DESCRIPTION
# What does this implement/fix?

The device erases flash between receiving the binary size and acking the update prepare; that erase can take many seconds, the client shows nothing while it waits, and the upload timer only starts after the ack, so the erase never appears in any reported number. Users see a silent pause after "Handshake complete" with no explanation, and "Upload took" undercounts the real OTA time.

Log the prepare window and a total at the end alongside the existing upload time, so erase, transfer, and end to end are each visible. This also keeps measurements comparable for #18580, which moves the erase into the transfer window; without separate numbers that change reads as a slower upload when the end to end time is actually the same or better.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
