### PR TITLE
[remote_transmitter] Fix repeat gap timing on LibreTiny Beken

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter.cpp
@@ -81,10 +81,13 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   ESP_LOGD(TAG, "Sending remote code");
   uint32_t on_time, off_time;
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
-  this->target_time_ = 0;
   this->transmit_trigger_.trigger();
   for (uint32_t i = 0; i < send_times; i++) {
     InterruptLock lock;
+    // Re-anchor every iteration: timing must never span a lock boundary, as micros() can
+    // jump when interrupts are re-enabled between repeats (e.g. LibreTiny's Beken micros()
+    // discards its interrupt-lock correction, stretching the repeat gap by the lock duration)
+    this->target_time_ = 0;
     for (int32_t item : this->temp_.get_data()) {
       if (item > 0) {
         const auto length = uint32_t(item);
@@ -98,8 +101,12 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     this->await_target_time_();  // wait for duration of last pulse
     this->pin_->digital_write(false);
 
-    if (i + 1 < send_times)
+    if (i + 1 < send_times) {
+      // Wait out the repeat gap inside the lock for the same reason; this does not extend
+      // the interrupt-disabled time, as the wait previously ran inside the next iteration's lock
       this->target_time_ += send_wait;
+      this->await_target_time_();
+    }
   }
   this->complete_trigger_.trigger();
 }

--- a/esphome/components/remote_transmitter/remote_transmitter.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter.cpp
@@ -83,29 +83,34 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
   this->transmit_trigger_.trigger();
   for (uint32_t i = 0; i < send_times; i++) {
-    InterruptLock lock;
-    // Re-anchor every iteration: timing must never span a lock boundary, as micros() can
-    // jump when interrupts are re-enabled between repeats (e.g. LibreTiny's Beken micros()
-    // discards its interrupt-lock correction, stretching the repeat gap by the lock duration)
-    this->target_time_ = 0;
-    for (int32_t item : this->temp_.get_data()) {
-      if (item > 0) {
-        const auto length = uint32_t(item);
-        this->mark_(on_time, off_time, length);
-      } else {
-        const auto length = uint32_t(-item);
-        this->space_(length);
+    {
+      InterruptLock lock;
+      // Re-anchor every iteration: timing must never span a lock boundary, as micros() can
+      // jump when interrupts are re-enabled between repeats (e.g. LibreTiny's Beken micros()
+      // discards its interrupt-lock correction, stretching the repeat gap by the lock duration)
+      this->target_time_ = 0;
+      for (int32_t item : this->temp_.get_data()) {
+        if (item > 0) {
+          const auto length = uint32_t(item);
+          this->mark_(on_time, off_time, length);
+        } else {
+          const auto length = uint32_t(-item);
+          this->space_(length);
+        }
+        App.feed_wdt();
       }
-      App.feed_wdt();
+      this->await_target_time_();  // wait for duration of last pulse
+      this->pin_->digital_write(false);
     }
-    this->await_target_time_();  // wait for duration of last pulse
-    this->pin_->digital_write(false);
 
     if (i + 1 < send_times) {
-      // Wait out the repeat gap inside the lock for the same reason; this does not extend
-      // the interrupt-disabled time, as the wait previously ran inside the next iteration's lock
-      this->target_time_ += send_wait;
-      this->await_target_time_();
+      // Wait out the repeat gap with interrupts enabled: wait_time is unbounded user config
+      // (previously this spin ran inside the next iteration's lock, disabling interrupts for
+      // the whole gap). Anchoring after the lock release keeps it exact on all platforms.
+      const uint32_t gap_end = micros() + send_wait;
+      while ((int32_t) (gap_end - micros()) > 0) {
+        App.feed_wdt();
+      }
     }
   }
   this->complete_trigger_.trigger();

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -72,7 +72,7 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   void space_(uint32_t usec);
 
   void await_target_time_();
-  uint32_t target_time_;
+  uint32_t target_time_{0};
 #endif
 
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED

--- a/tests/components/remote_transmitter/test.bk72xx-ard.yaml
+++ b/tests/components/remote_transmitter/test.bk72xx-ard.yaml
@@ -1,0 +1,7 @@
+remote_transmitter:
+  id: xmitr
+  pin: GPIO26
+  carrier_duty_percent: 50%
+
+packages:
+  buttons: !include common-buttons.yaml


### PR DESCRIPTION
# What does this implement/fix?

On LibreTiny Beken (BK72xx), the gap between repeated transmissions (`repeat:` / `send_wait`) comes out much longer than configured: the requested gap plus the duration the interrupts were disabled for the previous frame. A 25ms gap after a 68ms Pioneer frame measures exactly 91.0ms on a logic analyzer; after a 162ms two-frame transmission it measures exactly 185.0ms. Protocols that require tightly spaced repeats (e.g. Pioneer, which discards commands unless the frame arrives twice within ~25ms) do not work at all.

Root cause: the Beken core's `micros()` builds its result from the FreeRTOS tick plus a correction that accumulates while interrupts are disabled. When the transmitter's per-repeat `InterruptLock` is released between iterations, the next tick update makes `micros()` discard that correction and jump backward by the lock duration minus one tick. The transmitter carried `target_time_` across that boundary, so the first wait of the next iteration stretched by exactly the jump. (Waits that stay inside one lock are unaffected — verified to ±15µs from 5ms to 60ms with a raw-code timing probe.)

Fix, in the shared bit-bang implementation:

- `target_time_` is re-anchored at the start of every repeat iteration, so no timing measurement ever spans a lock boundary.
- The repeat gap is waited out after the lock is released, with interrupts enabled and the watchdog fed, anchored on a fresh `micros()` read taken after the release. This reduces the maximum interrupt-disabled window to a single frame (previously the gap spun inside the next iteration's lock, disabling interrupts for the entire user-configurable `wait_time`).

On platforms with a monotonic `micros()` (ESP8266, RP2040) the on-wire behavior is unchanged: verified on ESP8266 hardware (D1 mini) with the same logic-analyzer probe -- repeat gaps measure 25.01-25.06ms for a configured 25ms (re-measured on the current revision), and a raw-code staircase of 5-60ms spaces is exact to +-15us. RP2040 build test passes locally. Verified on BK7238 hardware with a logic analyzer: repeat gaps went from a deterministic 91.0ms to 25.4–27.3ms for a configured 25ms (eight presses on the current revision), and Pioneer equipment now responds. A bk72xx build test is added since this code path previously had no Beken coverage.

The underlying `micros()` backward jump will be reported to LibreTiny separately; this change makes the transmitter robust against it regardless.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_transmitter:
  id: ir_tx
  pin: 26
  carrier_duty_percent: 50%

button:
  - platform: template
    name: Pioneer Mute
    on_press:
      - remote_transmitter.transmit_pioneer:
          rc_code_1: 0xA512
          repeat:
            times: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
