### PR TITLE
[sendspin] Convert tests to package-style includes

### DIFF
--- a/tests/components/sendspin/common-action.yaml
+++ b/tests/components/sendspin/common-action.yaml
@@ -1,6 +1,6 @@
 # `sendspin.switch` action enables the controller role, so we use a standalone test
 packages:
-  base: !include common.yaml
+  sendspin: !include common.yaml
 
 wifi:
   on_connect:

--- a/tests/components/sendspin/common-ethernet.yaml
+++ b/tests/components/sendspin/common-ethernet.yaml
@@ -1,5 +1,5 @@
 packages:
   sendspin_hub: !include common-hub.yaml
 
-wifi:
-  ap:
+ethernet:
+  type: OPENETH

--- a/tests/components/sendspin/common-hub.yaml
+++ b/tests/components/sendspin/common-hub.yaml
@@ -1,0 +1,6 @@
+psram:
+  mode: quad
+
+sendspin:
+  id: sendspin_hub_id
+  task_stack_in_psram: true

--- a/tests/components/sendspin/common-media_player.yaml
+++ b/tests/components/sendspin/common-media_player.yaml
@@ -1,4 +1,5 @@
-<<: !include common.yaml
+packages:
+  sendspin: !include common.yaml
 
 media_player:
   - platform: sendspin

--- a/tests/components/sendspin/common-media_source.yaml
+++ b/tests/components/sendspin/common-media_source.yaml
@@ -1,4 +1,5 @@
-<<: !include common.yaml
+packages:
+  sendspin: !include common.yaml
 
 media_source:
   - platform: sendspin

--- a/tests/components/sendspin/common-sensor.yaml
+++ b/tests/components/sendspin/common-sensor.yaml
@@ -1,4 +1,5 @@
-<<: !include common.yaml
+packages:
+  sendspin: !include common.yaml
 
 sensor:
   - platform: sendspin

--- a/tests/components/sendspin/common-text_sensor.yaml
+++ b/tests/components/sendspin/common-text_sensor.yaml
@@ -1,4 +1,5 @@
-<<: !include common.yaml
+packages:
+  sendspin: !include common.yaml
 
 text_sensor:
   - platform: sendspin

--- a/tests/components/sendspin/test-action.esp32-idf.yaml
+++ b/tests/components/sendspin/test-action.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common-action.yaml
+packages:
+  sendspin: !include common-action.yaml

--- a/tests/components/sendspin/test-ethernet.esp32-idf.yaml
+++ b/tests/components/sendspin/test-ethernet.esp32-idf.yaml
@@ -1,9 +1,2 @@
-ethernet:
-  type: OPENETH
-
-psram:
-  mode: quad
-
-sendspin:
-  id: sendspin_hub_id
-  task_stack_in_psram: true
+packages:
+  sendspin: !include common-ethernet.yaml

--- a/tests/components/sendspin/test-media_player.esp32-idf.yaml
+++ b/tests/components/sendspin/test-media_player.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common-media_player.yaml
+packages:
+  sendspin: !include common-media_player.yaml

--- a/tests/components/sendspin/test-media_source.esp32-idf.yaml
+++ b/tests/components/sendspin/test-media_source.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common-media_source.yaml
+packages:
+  sendspin: !include common-media_source.yaml

--- a/tests/components/sendspin/test-sensor.esp32-idf.yaml
+++ b/tests/components/sendspin/test-sensor.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common-sensor.yaml
+packages:
+  sendspin: !include common-sensor.yaml

--- a/tests/components/sendspin/test-text_sensor.esp32-idf.yaml
+++ b/tests/components/sendspin/test-text_sensor.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common-text_sensor.yaml
+packages:
+  sendspin: !include common-text_sensor.yaml

--- a/tests/components/sendspin/test.esp32-idf.yaml
+++ b/tests/components/sendspin/test.esp32-idf.yaml
@@ -1,1 +1,2 @@
-<<: !include common.yaml
+packages:
+  sendspin: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Most of the sendspin test fixtures predate the packages convention and pull in their shared config with the YAML merge key (`<<: !include common.yaml`). The CI grouping scripts only understand dict-style `packages:`, so these files cannot take part in batch grouping. The image tests added later already follow the convention; this brings the rest in line.

No configuration coverage changes. Every test resolves to the same config it did before, only the include mechanism differs.

**Merge keys**

`common-media_player.yaml`, `common-media_source.yaml`, `common-sensor.yaml`, `common-text_sensor.yaml` and the matching `test-*.esp32-idf.yaml` files, plus `test.esp32-idf.yaml`, now include through `packages:` keyed by the component name. `common-action.yaml` was already using a package; its key is renamed from `base` to `sendspin` so all the fixtures read the same way.

**Ethernet test**

`test-ethernet.esp32-idf.yaml` carried its own copy of the psram and hub config because it cannot include `common.yaml`, which sets up wifi. The shared part moves to a new `common-hub.yaml`, so `common.yaml` is now that package plus wifi and a new `common-ethernet.yaml` is that same package plus ethernet. The test file is a plain package include like the others, and the hub settings live in one place.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable. This only touches test fixtures; there is no configuration change.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

`script/test_build_components.py -c sendspin -t esp32-idf -e config` passes all nine sendspin tests, and `script/ci_check_duplicate_test_ids.py` is clean.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
