### PR TITLE
[sx126x] Add configurability of enable pins

### DIFF
--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -213,7 +213,11 @@ CONFIG_SCHEMA = (
                 cv.frequency, cv.int_range(min=0, max=100000)
             ),
             cv.Required(CONF_DIO1_PIN): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_ENABLE_PINS_INVERTED, default=False): cv.boolean,
+            cv.Optional(
+                CONF_ENABLE_PINS_INVERTED,
+                default=False,
+                visibility=cv.Visibility.ADVANCED,
+            ): cv.boolean,
             cv.Required(CONF_FREQUENCY): cv.All(
                 cv.frequency, cv.int_range(min=int(137e6), max=int(1020e6))
             ),
@@ -230,7 +234,9 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_RST_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_RX_START, default=True): cv.boolean,
             cv.Required(CONF_RF_SWITCH): cv.boolean,
-            cv.Optional(CONF_RX_ENABLE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(
+                CONF_RX_ENABLE_PIN, visibility=cv.Visibility.ADVANCED
+            ): pins.gpio_output_pin_schema,
             cv.Optional(CONF_SHAPING, default="NONE"): cv.enum(SHAPING),
             cv.Optional(CONF_SPREADING_FACTOR, default=7): cv.int_range(min=6, max=12),
             cv.Optional(CONF_SYNC_VALUE, default=[]): cv.ensure_list(cv.hex_uint8_t),
@@ -243,7 +249,9 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_WHITENING_INITIAL, default=0x0100): cv.All(
                 cv.hex_int, cv.Range(min=0, max=0x1FF)
             ),
-            cv.Optional(CONF_TX_ENABLE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(
+                CONF_TX_ENABLE_PIN, visibility=cv.Visibility.ADVANCED
+            ): pins.gpio_output_pin_schema,
         },
     )
     .extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -26,6 +26,7 @@ CONF_CRC_POLYNOMIAL = "crc_polynomial"
 CONF_CRC_INITIAL = "crc_initial"
 CONF_DEVIATION = "deviation"
 CONF_DIO1_PIN = "dio1_pin"
+CONF_ENABLE_PINS_INVERTED = "enable_pins_inverted"
 CONF_HW_VERSION = "hw_version"
 CONF_MODULATION = "modulation"
 CONF_PA_POWER = "pa_power"
@@ -36,6 +37,7 @@ CONF_PREAMBLE_SIZE = "preamble_size"
 CONF_RST_PIN = "rst_pin"
 CONF_RX_START = "rx_start"
 CONF_RF_SWITCH = "rf_switch"
+CONF_RX_ENABLE_PIN = "rx_enable_pin"
 CONF_SHAPING = "shaping"
 CONF_SPREADING_FACTOR = "spreading_factor"
 CONF_SYNC_VALUE = "sync_value"
@@ -43,6 +45,7 @@ CONF_TCXO_VOLTAGE = "tcxo_voltage"
 CONF_TCXO_DELAY = "tcxo_delay"
 CONF_WHITENING_ENABLE = "whitening_enable"
 CONF_WHITENING_INITIAL = "whitening_initial"
+CONF_TX_ENABLE_PIN = "tx_enable_pin"
 
 sx126x_ns = cg.esphome_ns.namespace("sx126x")
 SX126x = sx126x_ns.class_("SX126x", cg.Component, spi.SPIDevice)
@@ -210,6 +213,7 @@ CONFIG_SCHEMA = (
                 cv.frequency, cv.int_range(min=0, max=100000)
             ),
             cv.Required(CONF_DIO1_PIN): pins.gpio_input_pin_schema,
+            cv.Optional(CONF_ENABLE_PINS_INVERTED, default=False): cv.boolean,
             cv.Required(CONF_FREQUENCY): cv.All(
                 cv.frequency, cv.int_range(min=int(137e6), max=int(1020e6))
             ),
@@ -226,6 +230,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_RST_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_RX_START, default=True): cv.boolean,
             cv.Required(CONF_RF_SWITCH): cv.boolean,
+            cv.Optional(CONF_RX_ENABLE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_SHAPING, default="NONE"): cv.enum(SHAPING),
             cv.Optional(CONF_SPREADING_FACTOR, default=7): cv.int_range(min=6, max=12),
             cv.Optional(CONF_SYNC_VALUE, default=[]): cv.ensure_list(cv.hex_uint8_t),
@@ -238,10 +243,12 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_WHITENING_INITIAL, default=0x0100): cv.All(
                 cv.hex_int, cv.Range(min=0, max=0x1FF)
             ),
+            cv.Optional(CONF_TX_ENABLE_PIN): pins.gpio_output_pin_schema,
         },
     )
     .extend(cv.COMPONENT_SCHEMA)
     .extend(spi.spi_device_schema(True, 8e6, "mode0"))
+    .add_extra(cv.has_none_or_all_keys(CONF_RX_ENABLE_PIN, CONF_TX_ENABLE_PIN))
     .add_extra(validate_config)
 )
 
@@ -267,6 +274,11 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_rst_pin(rst_pin))
     busy_pin = await cg.gpio_pin_expression(config[CONF_BUSY_PIN])
     cg.add(var.set_busy_pin(busy_pin))
+    if (rx_enable_pin_config := config.get(CONF_RX_ENABLE_PIN)) is not None:
+        rx_enable_pin = await cg.gpio_pin_expression(rx_enable_pin_config)
+        tx_enable_pin = await cg.gpio_pin_expression(config[CONF_TX_ENABLE_PIN])
+        cg.add(var.set_enable_pins(rx_enable_pin, tx_enable_pin))
+        cg.add(var.set_enable_pins_inverted(config[CONF_ENABLE_PINS_INVERTED]))
     cg.add(var.set_bandwidth(config[CONF_BANDWIDTH]))
     cg.add(var.set_frequency(config[CONF_FREQUENCY]))
     cg.add(var.set_hw_version(config[CONF_HW_VERSION]))

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -21,6 +21,8 @@ static constexpr uint32_t RESET_DELAY_LOW_US = 2000;
 static constexpr uint32_t SWITCHING_DELAY_US = 1;
 static constexpr uint32_t TRANSMIT_TIMEOUT_MS = 4000;
 static constexpr uint32_t BUSY_TIMEOUT_MS = 20;
+static constexpr uint8_t ENABLE_RX = 0;
+static constexpr uint8_t ENABLE_TX = 1;
 
 // OCP (Over Current Protection) values
 static constexpr uint8_t OCP_80MA = 0x18;   // 80 mA max current
@@ -110,6 +112,11 @@ void SX126x::setup() {
   this->busy_pin_->setup();
   this->rst_pin_->setup();
   this->dio1_pin_->setup();
+  if (this->rx_enable_pin_ != nullptr) {
+    this->rx_enable_pin_->setup();
+    this->tx_enable_pin_->setup();
+    this->set_rx_tx_enable_pins_(ENABLE_RX);
+  }
   if (this->dio1_pin_->is_internal()) {
     static_cast<InternalGPIOPin *>(this->dio1_pin_)
         ->attach_interrupt(&SX126x::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
@@ -423,6 +430,8 @@ void SX126x::run_image_cal() {
 void SX126x::set_mode_rx() {
   uint8_t buf[8];
 
+  this->set_rx_tx_enable_pins_(ENABLE_RX);
+
   // configure irq params
   uint16_t irq = IRQ_RX_DONE | IRQ_RX_TX_TIMEOUT | IRQ_CRC_ERROR;
   buf[0] = (irq >> 8) & 0xFF;
@@ -448,6 +457,8 @@ void SX126x::set_mode_rx() {
 
 void SX126x::set_mode_tx() {
   uint8_t buf[8];
+
+  this->set_rx_tx_enable_pins_(ENABLE_TX);
 
   // configure irq params
   uint16_t irq = IRQ_TX_DONE | IRQ_RX_TX_TIMEOUT;
@@ -481,6 +492,14 @@ void SX126x::set_mode_standby(SX126xStandbyMode mode) {
   this->write_opcode_(RADIO_SET_STANDBY, buf, 1);
 }
 
+void SX126x::set_rx_tx_enable_pins_(uint8_t mode) {
+  if (this->rx_enable_pin_ == nullptr) {
+    return;
+  }
+  this->rx_enable_pin_->digital_write((mode == ENABLE_RX) == this->enable_pins_inverted_);
+  this->tx_enable_pin_->digital_write((mode == ENABLE_TX) == this->enable_pins_inverted_);
+}
+
 void SX126x::wait_busy_() {
   // wait if the device is busy, the maximum delay is only be a few ms
   // with most commands taking only a few us
@@ -500,6 +519,8 @@ void SX126x::dump_config() {
   LOG_PIN("  BUSY Pin: ", this->busy_pin_);
   LOG_PIN("  RST Pin: ", this->rst_pin_);
   LOG_PIN("  DIO1 Pin: ", this->dio1_pin_);
+  LOG_PIN("  RX Enable Pin: ", this->rx_enable_pin_);
+  LOG_PIN("  TX Enable Pin: ", this->tx_enable_pin_);
   ESP_LOGCONFIG(TAG,
                 "  HW Version: %15s\n"
                 "  Frequency: %" PRIu32 " Hz\n"

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -75,6 +75,13 @@ class SX126x final : public Component,
   void set_whitening_initial(uint16_t whitening_initial) { this->whitening_initial_ = whitening_initial; }
   void set_deviation(uint32_t deviation) { this->deviation_ = deviation; }
   void set_dio1_pin(GPIOPin *dio1_pin) { this->dio1_pin_ = dio1_pin; }
+  void set_enable_pins(GPIOPin *rx_enable_pin, GPIOPin *tx_enable_pin) {
+    this->rx_enable_pin_ = rx_enable_pin;
+    this->tx_enable_pin_ = tx_enable_pin;
+  }
+  void set_enable_pins_inverted(bool enable_pins_inverted) {
+    this->enable_pins_inverted_ = enable_pins_inverted;
+  }
   void set_frequency(uint32_t frequency) { this->frequency_ = frequency; }
   void set_hw_version(const std::string &hw_version) { this->hw_version_ = hw_version; }
   void set_mode_rx();
@@ -105,6 +112,7 @@ class SX126x final : public Component,
   static void IRAM_ATTR gpio_intr(SX126x *arg);
   void configure_fsk_ook_();
   void configure_lora_();
+  void set_rx_tx_enable_pins_(uint8_t mode);
   void set_packet_params_(uint8_t payload_length);
   uint8_t read_fifo_(uint8_t offset, std::vector<uint8_t> &packet);
   void write_fifo_(uint8_t offset, const std::vector<uint8_t> &packet);
@@ -120,13 +128,16 @@ class SX126x final : public Component,
   std::vector<uint8_t> sync_value_;
   GPIOPin *busy_pin_{nullptr};
   GPIOPin *dio1_pin_{nullptr};
+  GPIOPin *rx_enable_pin_{nullptr};
   GPIOPin *rst_pin_{nullptr};
+  GPIOPin *tx_enable_pin_{nullptr};
   std::string hw_version_;
   char version_[16];
   SX126xBw bandwidth_{SX126X_BW_125000};
   uint32_t bitrate_{0};
   bool crc_enable_{false};
   bool crc_inverted_{false};
+  bool enable_pins_inverted_{false};
   uint8_t crc_size_{0};
   uint16_t crc_polynomial_{0};
   uint16_t crc_initial_{0};

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -79,9 +79,7 @@ class SX126x final : public Component,
     this->rx_enable_pin_ = rx_enable_pin;
     this->tx_enable_pin_ = tx_enable_pin;
   }
-  void set_enable_pins_inverted(bool enable_pins_inverted) {
-    this->enable_pins_inverted_ = enable_pins_inverted;
-  }
+  void set_enable_pins_inverted(bool enable_pins_inverted) { this->enable_pins_inverted_ = enable_pins_inverted; }
   void set_frequency(uint32_t frequency) { this->frequency_ = frequency; }
   void set_hw_version(const std::string &hw_version) { this->hw_version_ = hw_version; }
   void set_mode_rx();

--- a/tests/components/sx126x/common.yaml
+++ b/tests/components/sx126x/common.yaml
@@ -2,6 +2,7 @@ sx126x:
   dio1_pin: ${dio1_pin}
   cs_pin: ${cs_pin}
   busy_pin: ${busy_pin}
+  enable_pins_inverted: true
   rst_pin: ${rst_pin}
   pa_power: 3
   bandwidth: 125_0kHz
@@ -15,6 +16,7 @@ sx126x:
   rx_start: true
   hw_version: sx1262
   rf_switch: true
+  rx_enable_pin: ${rx_enable_pin}
   sync_value: [0x14, 0x24]
   preamble_size: 8
   spreading_factor: 7
@@ -23,6 +25,7 @@ sx126x:
   tcxo_delay: 5ms
   whitening_enable: false
   whitening_initial: 0x1FF
+  tx_enable_pin: ${tx_enable_pin}
   on_packet:
     then:
       - lambda: |-

--- a/tests/components/sx126x/test.esp32-idf.yaml
+++ b/tests/components/sx126x/test.esp32-idf.yaml
@@ -3,6 +3,8 @@ substitutions:
   rst_pin: GPIO13
   busy_pin: GPIO25
   dio1_pin: GPIO26
+  rx_enable_pin: GPIO27
+  tx_enable_pin: GPIO14
 
 packages:
   spi: !include ../../test_build_components/common/spi/esp32-idf.yaml

--- a/tests/components/sx126x/test.esp8266-ard.yaml
+++ b/tests/components/sx126x/test.esp8266-ard.yaml
@@ -6,6 +6,8 @@ substitutions:
   rst_pin: GPIO2
   busy_pin: GPIO4
   dio1_pin: GPIO3
+  rx_enable_pin: GPIO12
+  tx_enable_pin: GPIO13
 
 packages:
   spi: !include ../../test_build_components/common/spi/esp8266-ard.yaml

--- a/tests/components/sx126x/test.rp2040-ard.yaml
+++ b/tests/components/sx126x/test.rp2040-ard.yaml
@@ -6,6 +6,8 @@ substitutions:
   rst_pin: GPIO6
   busy_pin: GPIO8
   dio1_pin: GPIO7
+  rx_enable_pin: GPIO9
+  tx_enable_pin: GPIO10
 
 packages:
   spi: !include ../../test_build_components/common/spi/rp2040-ard.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds optional `rx_enable_pin`, `tx_enable_pin`, and `enable_pins_inverted` configuration options to the `sx126x` component. This is required for boards like the Waveshare Core1262-868M module (and other modules/boards with custom RF frontend switches/amplifiers) where RXEN and TXEN pins must be driven by the MCU during RX/TX transitions rather than via DIO2 RF switching.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes: enables to use the waveshare board above, otherwise not possible, I did not create an issue

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7232

still in preperation

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

still in preperation


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:


```yaml
# Example config.yaml
sx126x:
  cs_pin: GPIO1
  rst_pin: GPIO2
  busy_pin: GPIO33
  dio1_pin: GPIO44
  frequency: 868MHz
  hw_version: sx1262
  rf_switch: false
  rx_enable_pin: GPIO15
  tx_enable_pin: GPIO16
  # enable_pins_inverted: false  # optional
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
