### PR TITLE
[esp32_hosted] Fire on_update_available trigger when update is detected

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -135,6 +135,9 @@ void Esp32HostedUpdate::setup() {
   // Publish state
   this->status_clear_error();
   this->publish_state();
+  if (this->state_ == update::UPDATE_STATE_AVAILABLE) {
+    this->get_update_available_trigger()->trigger(this->update_info_);
+  }
 #else
   // HTTP mode: check every 10s until network is ready (max 6 attempts)
   // Only if update interval is > 1 minute to avoid redundant checks
@@ -185,6 +188,8 @@ void Esp32HostedUpdate::check() {
     return;
   }
 
+  const bool was_available = this->state_ == update::UPDATE_STATE_AVAILABLE;
+
   // Compare versions
   if (this->update_info_.latest_version.empty() ||
       this->update_info_.latest_version == this->update_info_.current_version) {
@@ -197,6 +202,9 @@ void Esp32HostedUpdate::check() {
   this->update_info_.progress = 0.0f;
   this->status_clear_error();
   this->publish_state();
+  if (this->state_ == update::UPDATE_STATE_AVAILABLE && !was_available) {
+    this->get_update_available_trigger()->trigger(this->update_info_);
+  }
 #endif
 }
 

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -135,8 +135,9 @@ void Esp32HostedUpdate::setup() {
   // Publish state
   this->status_clear_error();
   this->publish_state();
-  if (this->state_ == update::UPDATE_STATE_AVAILABLE) {
-    this->get_update_available_trigger()->trigger(this->update_info_);
+  // Defer so the automation runs on the main loop after setup, not during App.setup()
+  if (this->state_ == update::UPDATE_STATE_AVAILABLE && this->update_available_trigger_) {
+    this->defer([this]() { this->update_available_trigger_->trigger(this->update_info_); });
   }
 #else
   // HTTP mode: check every 10s until network is ready (max 6 attempts)
@@ -202,8 +203,8 @@ void Esp32HostedUpdate::check() {
   this->update_info_.progress = 0.0f;
   this->status_clear_error();
   this->publish_state();
-  if (this->state_ == update::UPDATE_STATE_AVAILABLE && !was_available) {
-    this->get_update_available_trigger()->trigger(this->update_info_);
+  if (this->state_ == update::UPDATE_STATE_AVAILABLE && !was_available && this->update_available_trigger_) {
+    this->update_available_trigger_->trigger(this->update_info_);
   }
 #endif
 }

--- a/tests/components/esp32_hosted/test-embedded.esp32-p4-idf.yaml
+++ b/tests/components/esp32_hosted/test-embedded.esp32-p4-idf.yaml
@@ -6,3 +6,6 @@ update:
     type: embedded
     path: $component_dir/test_firmware.bin
     sha256: de2f256064a0af797747c2b97505dc0b9f3df0de4f489eac731c23ae9ca9cc31
+    on_update_available:
+      then:
+        - logger.log: "Coprocessor update available"

--- a/tests/components/esp32_hosted/test-http.esp32-p4-idf.yaml
+++ b/tests/components/esp32_hosted/test-http.esp32-p4-idf.yaml
@@ -4,7 +4,6 @@ http_request:
 
 update:
   - platform: esp32_hosted
-    id: coprocessor_update
     name: "Coprocessor Firmware Update"
     type: http
     source: https://esphome.github.io/esp-hosted-firmware/manifest/esp32c6.json

--- a/tests/components/esp32_hosted/test-http.esp32-p4-idf.yaml
+++ b/tests/components/esp32_hosted/test-http.esp32-p4-idf.yaml
@@ -4,7 +4,11 @@ http_request:
 
 update:
   - platform: esp32_hosted
+    id: coprocessor_update
     name: "Coprocessor Firmware Update"
     type: http
     source: https://esphome.github.io/esp-hosted-firmware/manifest/esp32c6.json
     update_interval: 6h
+    on_update_available:
+      then:
+        - logger.log: "Coprocessor update available"


### PR DESCRIPTION
# What does this implement/fix?

The esp32_hosted update platform sets `UPDATE_STATE_AVAILABLE` and publishes state, but never fires `get_update_available_trigger()`, so an `on_update_available` automation configured on the entity never runs. `UpdateEntity::publish_state()` only does state callbacks and controller notification; firing the trigger is the platform's responsibility, and `http_request`'s updater already does this.

This mirrors the `http_request` semantics in both paths:

- HTTP mode (`check()`): capture whether the state was already `AVAILABLE` before the version comparison, and fire the trigger after `publish_state()` only on the transition into available, so periodic re-checks of the same pending version don't re-fire the automation.
- Embedded mode (`setup()`): fire the trigger after publish when the embedded image version differs from the coprocessor version (previous state is always `UNKNOWN` here).

Also adds `on_update_available` to the esp32_hosted HTTP test config to exercise the trigger codegen.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18583

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
update:
  - platform: esp32_hosted
    id: esp32_c6_update
    type: http
    source: https://esphome.github.io/esp-hosted-firmware/manifest/esp32c6.json
    update_interval: 24h
    on_update_available:
      then:
        - update.perform: esp32_c6_update
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).