### PR TITLE
[max17043] Add model option with MAX17048 support

### DIFF
--- a/esphome/components/max17043/automation.h
+++ b/esphome/components/max17043/automation.h
@@ -1,4 +1,3 @@
-
 #pragma once
 #include "esphome/core/automation.h"
 #include "max17043.h"

--- a/esphome/components/max17043/max17043.cpp
+++ b/esphome/components/max17043/max17043.cpp
@@ -3,27 +3,55 @@
 
 namespace esphome::max17043 {
 
-// MAX174043 is a 1-Cell Fuel Gauge with ModelGauge and Low-Battery Alert
+// MAX17043 is a 1-Cell Fuel Gauge with ModelGauge and Low-Battery Alert
 // Consult the datasheet at https://www.analog.com/en/products/max17043.html
+// The MAX17048 is a register-compatible successor with a finer VCELL LSb, an extra
+// charge-rate register, and a MODE.EnSleep gate in front of CONFIG.SLEEP.
+// Consult the datasheet at https://www.analog.com/en/products/max17048.html
 
 static const char *const TAG = "max17043";
 
 static const uint8_t MAX17043_VCELL = 0x02;
 static const uint8_t MAX17043_SOC = 0x04;
+static const uint8_t MAX17043_MODE = 0x06;
+static const uint8_t MAX17043_VERSION = 0x08;
 static const uint8_t MAX17043_CONFIG = 0x0c;
+static const uint8_t MAX17048_CRATE = 0x16;
 
 static const uint16_t MAX17043_CONFIG_POWER_UP_DEFAULT = 0x971C;
-static const uint16_t MAX17043_CONFIG_SAFE_MASK = 0xFF1F;  // mask out sleep bit (7), unused bit (6) and alert bit (4)
+// Mask out SLEEP (7), ALRT (5), and bit 6, which is a don't-care on the MAX17043 but ALSC on the MAX17048.
+static const uint16_t MAX17043_CONFIG_SAFE_MASK = 0xFF1F;
 static const uint16_t MAX17043_CONFIG_SLEEP_MASK = 0x0080;
 
+// MAX17048 only: CONFIG.SLEEP is ignored unless MODE.EnSleep (bit 13) is set first.
+static const uint16_t MAX17048_MODE_EN_SLEEP = 0x2000;
+
+// MAX17048 only: CRATE has an LSb of 0.208%/hr.
+static const float MAX17048_CRATE_LSB = 0.208f;
+
+// Boards that gate the I2C rail can leave the bus unusable until after this component has
+// been set up, so a silent bus at setup is retried rather than treated as a missing device.
+// Each failed probe blocks for the I2C driver timeout (~100ms), so the interval is kept well
+// above that to bound how much of the main loop the retries can consume while booting.
+static const char *const CONFIGURE_RETRY = "configure";
+static const uint32_t CONFIGURE_RETRY_INTERVAL_MS = 500;
+static const uint8_t CONFIGURE_MAX_ATTEMPTS = 10;
+
 void MAX17043Component::update() {
-  uint16_t raw_voltage, raw_percent;
+  uint16_t raw_voltage, raw_percent, raw_charge_rate;
 
   if (this->voltage_sensor_ != nullptr) {
     if (!this->read_byte_16(MAX17043_VCELL, &raw_voltage)) {
       this->status_set_warning(LOG_STR("Unable to read MAX17043_VCELL"));
     } else {
-      float voltage = (1.25f * (float) (raw_voltage >> 4)) / 1000.0f;
+      // Each part is scaled by its own datasheet LSb: 1.25mV on the MAX17043, whose 12-bit
+      // reading sits in the top bits of the word, and 78.125uV on the MAX17048. Effective
+      // resolution is 1.25mV on both -- the MAX17048 ADC is 12-bit as well and its register
+      // holds that reading scaled by 16 -- so the two expressions agree for every value the
+      // hardware produces. Keeping them separate avoids depending on that low nibble being
+      // zero, which the register format does not promise.
+      float voltage = this->is_max17048_() ? (78.125f * (float) raw_voltage) / 1000000.0f
+                                           : (1.25f * (float) (raw_voltage >> 4)) / 1000.0f;
       this->voltage_sensor_->publish_state(voltage);
       this->status_clear_warning();
     }
@@ -37,36 +65,86 @@ void MAX17043Component::update() {
       this->status_clear_warning();
     }
   }
+  if (this->charge_rate_sensor_ != nullptr) {
+    if (!this->read_byte_16(MAX17048_CRATE, &raw_charge_rate)) {
+      this->status_set_warning(LOG_STR("Unable to read MAX17048_CRATE"));
+    } else {
+      // CRATE is two's complement: negative while the battery is discharging.
+      this->charge_rate_sensor_->publish_state((float) (int16_t) raw_charge_rate * MAX17048_CRATE_LSB);
+      this->status_clear_warning();
+    }
+  }
 }
 
 void MAX17043Component::setup() {
-  uint16_t config_reg;
-  if (this->write(&MAX17043_CONFIG, 1) != i2c::ERROR_OK) {
-    this->status_set_warning();
+  if (this->configure_())
     return;
-  }
 
-  if (this->read(reinterpret_cast<uint8_t *>(&config_reg), 2) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
+  // The gauge did not answer. On boards that gate the I2C rail (for example the I2C_POWER
+  // pin on Adafruit Feathers) the bus only becomes usable after this component is set up,
+  // so suspend polling and keep trying instead of reporting from a chip we never verified.
+  ESP_LOGD(TAG, "Gauge did not answer, deferring configuration");
+  this->stop_poller();
+  this->set_interval(CONFIGURE_RETRY, CONFIGURE_RETRY_INTERVAL_MS, [this]() {
+    if (this->is_failed()) {
+      this->cancel_interval(CONFIGURE_RETRY);
+      return;
+    }
+    if (this->configure_()) {
+      this->cancel_interval(CONFIGURE_RETRY);
+      this->start_poller();
+      return;
+    }
+    if (++this->configure_attempts_ >= CONFIGURE_MAX_ATTEMPTS) {
+      // Give up configuring, but still report: VCELL and SOC do not depend on the write-back,
+      // so polling anyway is never worse than not polling at all.
+      this->cancel_interval(CONFIGURE_RETRY);
+      ESP_LOGW(TAG, "Gauge never answered; polling anyway, any sleep bit is left set");
+      this->status_set_warning(LOG_STR("not configured"));
+      this->start_poller();
+    }
+  });
+}
+
+bool MAX17043Component::configure_() {
+  uint16_t config_reg;
+  if (this->write(&MAX17043_CONFIG, 1) != i2c::ERROR_OK)
+    return false;
+
+  if (this->read(reinterpret_cast<uint8_t *>(&config_reg), 2) != i2c::ERROR_OK)
+    return false;
 
   config_reg = i2c::i2ctohs(config_reg) & MAX17043_CONFIG_SAFE_MASK;
   ESP_LOGV(TAG, "MAX17043 CONFIG register reads 0x%X", config_reg);
 
+  // Both models power up with the same CONFIG value, so this only proves that something
+  // fuel-gauge shaped answered; it cannot tell the two of them apart.
   if (config_reg != MAX17043_CONFIG_POWER_UP_DEFAULT) {
-    ESP_LOGE(TAG, "Device does not appear to be a MAX17043");
+    ESP_LOGE(TAG, "Device does not appear to be a %s", this->model_name_());
     this->status_set_error(LOG_STR("unrecognised"));
     this->mark_failed();
-    return;
+    return false;
+  }
+
+  // Informational only. Both parts expose a production version at 0x08, but the values are
+  // not documented as a dependable way to distinguish them, so this never fails setup. It is
+  // logged here rather than in dump_config() because configuration can be deferred past it.
+  if (this->read_byte_16(MAX17043_VERSION, &this->version_)) {
+    ESP_LOGCONFIG(TAG, "%s IC version: 0x%04X", this->model_name_(), this->version_);
+  } else {
+    ESP_LOGW(TAG, "Unable to read the version register");
   }
 
   // need to write back to config register to reset the sleep bit
   if (!this->write_byte_16(MAX17043_CONFIG, MAX17043_CONFIG_POWER_UP_DEFAULT)) {
     this->status_set_error(LOG_STR("sleep reset failed"));
     this->mark_failed();
-    return;
+    return false;
   }
+
+  this->configured_ = true;
+  this->status_clear_warning();
+  return true;
 }
 
 void MAX17043Component::dump_config() {
@@ -75,17 +153,33 @@ void MAX17043Component::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
   }
+  ESP_LOGCONFIG(TAG, "  Model: %s", this->model_name_());
+  if (this->configured_) {
+    ESP_LOGCONFIG(TAG, "  IC version: 0x%04X", this->version_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  IC version: unread, configuration deferred");
+  }
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Battery Voltage", this->voltage_sensor_);
   LOG_SENSOR("  ", "Battery Level", this->battery_remaining_sensor_);
+  LOG_SENSOR("  ", "Battery Charge Rate", this->charge_rate_sensor_);
 }
 
 void MAX17043Component::sleep_mode() {
-  if (!this->is_failed()) {
-    if (!this->write_byte_16(MAX17043_CONFIG, MAX17043_CONFIG_POWER_UP_DEFAULT | MAX17043_CONFIG_SLEEP_MASK)) {
-      ESP_LOGW(TAG, "Unable to write the sleep bit to config register");
-      this->status_set_warning();
-    }
+  if (this->is_failed()) {
+    return;
+  }
+
+  // On the MAX17048 the sleep bit in CONFIG does nothing until MODE.EnSleep is set.
+  if (this->is_max17048_() && !this->write_byte_16(MAX17043_MODE, MAX17048_MODE_EN_SLEEP)) {
+    ESP_LOGW(TAG, "Unable to enable sleep mode in the mode register");
+    this->status_set_warning();
+    return;
+  }
+
+  if (!this->write_byte_16(MAX17043_CONFIG, MAX17043_CONFIG_POWER_UP_DEFAULT | MAX17043_CONFIG_SLEEP_MASK)) {
+    ESP_LOGW(TAG, "Unable to write the sleep bit to config register");
+    this->status_set_warning();
   }
 }
 

--- a/esphome/components/max17043/max17043.h
+++ b/esphome/components/max17043/max17043.h
@@ -6,6 +6,11 @@
 
 namespace esphome::max17043 {
 
+enum class MAX17043Model : uint8_t {
+  MAX17043_MODEL_MAX17043,
+  MAX17043_MODEL_MAX17048,
+};
+
 class MAX17043Component final : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
@@ -13,14 +18,28 @@ class MAX17043Component final : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   void sleep_mode();
 
+  void set_model(MAX17043Model model) { model_ = model; }
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_battery_remaining_sensor(sensor::Sensor *battery_remaining_sensor) {
     battery_remaining_sensor_ = battery_remaining_sensor;
   }
+  void set_charge_rate_sensor(sensor::Sensor *charge_rate_sensor) { charge_rate_sensor_ = charge_rate_sensor; }
 
  protected:
+  bool is_max17048_() const { return this->model_ == MAX17043Model::MAX17043_MODEL_MAX17048; }
+  const char *model_name_() const { return this->is_max17048_() ? "MAX17048" : "MAX17043"; }
+
+  /// Identify the gauge and clear any stale sleep bit. Returns false if it did not answer,
+  /// which is retryable; an answer from the wrong device marks the component failed instead.
+  bool configure_();
+
+  MAX17043Model model_{MAX17043Model::MAX17043_MODEL_MAX17043};
+  bool configured_{false};
+  uint8_t configure_attempts_{0};
+  uint16_t version_{0};
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *battery_remaining_sensor_{nullptr};
+  sensor::Sensor *charge_rate_sensor_{nullptr};
 };
 
 }  // namespace esphome::max17043

--- a/esphome/components/max17043/sensor.py
+++ b/esphome/components/max17043/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_BATTERY_LEVEL,
     CONF_BATTERY_VOLTAGE,
     CONF_ID,
+    CONF_MODEL,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_VOLTAGE,
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -20,18 +21,45 @@ from esphome.types import ConfigType
 
 DEPENDENCIES = ["i2c"]
 
+# Constants that do not yet exist in esphome/const.py
+CONF_BATTERY_CHARGE_RATE = "battery_charge_rate"
+UNIT_PERCENT_PER_HOUR = "%/h"
+
+MODEL_MAX17043 = "MAX17043"
+MODEL_MAX17048 = "MAX17048"
+
 max17043_ns = cg.esphome_ns.namespace("max17043")
 MAX17043Component = max17043_ns.class_(
     "MAX17043Component", cg.PollingComponent, i2c.I2CDevice
 )
 
+MAX17043Model = max17043_ns.enum("MAX17043Model", is_class=True)
+MODELS = {
+    MODEL_MAX17043: MAX17043Model.MAX17043_MODEL_MAX17043,
+    MODEL_MAX17048: MAX17043Model.MAX17043_MODEL_MAX17048,
+}
+
 # Actions
 SleepAction = max17043_ns.class_("SleepAction", automation.Action)
 
-CONFIG_SCHEMA = (
+
+def _validate_model_features(config):
+    # The CRATE register (0x16) only exists on the MAX17048/MAX17049.
+    if CONF_BATTERY_CHARGE_RATE in config and config[CONF_MODEL] != MODEL_MAX17048:
+        raise cv.Invalid(
+            f"{CONF_BATTERY_CHARGE_RATE} is only supported by model {MODEL_MAX17048}",
+            path=[CONF_BATTERY_CHARGE_RATE],
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MAX17043Component),
+            cv.Optional(CONF_MODEL, default=MODEL_MAX17043): cv.enum(
+                MODELS, upper=True
+            ),
             cv.Optional(CONF_BATTERY_VOLTAGE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_VOLT,
                 accuracy_decimals=3,
@@ -46,10 +74,17 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
+            cv.Optional(CONF_BATTERY_CHARGE_RATE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT_PER_HOUR,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
-    .extend(i2c.i2c_device_schema(0x36))
+    .extend(i2c.i2c_device_schema(0x36)),
+    _validate_model_features,
 )
 
 
@@ -58,13 +93,19 @@ async def to_code(config: ConfigType) -> None:
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
+    cg.add(var.set_model(config[CONF_MODEL]))
+
     if voltage_config := config.get(CONF_BATTERY_VOLTAGE):
         sens = await sensor.new_sensor(voltage_config)
         cg.add(var.set_voltage_sensor(sens))
 
-    if CONF_BATTERY_LEVEL in config:
-        sens = await sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+    if level_config := config.get(CONF_BATTERY_LEVEL):
+        sens = await sensor.new_sensor(level_config)
         cg.add(var.set_battery_remaining_sensor(sens))
+
+    if charge_rate_config := config.get(CONF_BATTERY_CHARGE_RATE):
+        sens = await sensor.new_sensor(charge_rate_config)
+        cg.add(var.set_charge_rate_sensor(sens))
 
 
 MAX17043_ACTION_SCHEMA = maybe_simple_id(

--- a/tests/components/max17043/common.yaml
+++ b/tests/components/max17043/common.yaml
@@ -2,6 +2,7 @@ esphome:
   on_boot:
     then:
       - max17043.sleep_mode: max17043_id
+      - max17043.sleep_mode: max17048_id
 
 sensor:
   - platform: max17043
@@ -11,4 +12,16 @@ sensor:
       name: "Battery Voltage"
     battery_level:
       name: Battery
+    update_interval: 10s
+
+  - platform: max17043
+    i2c_id: i2c_bus
+    id: max17048_id
+    model: MAX17048
+    battery_voltage:
+      name: "MAX17048 Battery Voltage"
+    battery_level:
+      name: MAX17048 Battery
+    battery_charge_rate:
+      name: MAX17048 Battery Charge Rate
     update_interval: 10s


### PR DESCRIPTION
# What does this implement/fix?

Adds a `model:` option (MAX17043, the default, or MAX17048) so the component can drive the register-compatible MAX17048 found on recent Adafruit Feather boards. Existing configurations don't need any changes.

- New `battery_charge_rate` sensor reading CRATE (0x16), rejected at validation time for the MAX17043, which has no such register. CRATE is signed two's complement; reading it as unsigned makes any discharge report ~13600 %/h.
- `sleep_mode` now writes MODE.EnSleep before CONFIG.SLEEP on the MAX17048. The datasheet gates the sleep bit behind it, so the action would not have worked on that hardware.
- Configuration is now retried rather than abandoned when the gauge does not answer during setup. Boards that gate the I2C rail (I2C_POWER on Adafruit Feathers) can leave the bus unusable until after setup runs, so the identity check and the sleep-bit write-back can be silently skipped. Polling is suspended while retrying and resumed once the gauge responds; a comms timeout is now retryable, and only a wrong CONFIG value marks the component failed.

Voltage is scaled by each part's own datasheet LSb. Both resolve to 1.25mV in practice, since the MAX17048 ADC is also 12-bit and its register holds that reading scaled by 16, so the two expressions agree for every value the hardware produces.

Verified against a MAX17048 on an Adafruit ESP32-S3 Feather over 3.87-4.19V and 14-99.6% SOC, with charge rate observed negative, zero and positive, and with both the deferred-configuration and sleep path exercised on hardware.

### Why `setup()` suspends polling

When the gauge does not answer during `setup()`, the component calls `stop_poller()`
and retries configuration on an interval, calling `start_poller()` once the device
responds. This avoids publishing from a gauge whose identity was never verified and
whose sleep bit may still be set.

The retry budget is bounded at 10 attempts on a 500 ms interval. If the gauge still has
not answered, the component logs a warning and calls `start_poller()` anyway rather than
failing: VCELL and SOC do not depend on the configuration write-back, so polling an
unconfigured gauge is never worse than the previous behaviour. `mark_failed()` is reserved
for a device that answers with an unexpected CONFIG value — a comms timeout is now retryable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: max17043
    id: battery_status
    model: MAX17048
    update_interval: 30s
    battery_voltage:
      name: Battery Voltage
    battery_level:
      name: Battery Level
    battery_charge_rate:
      name: Battery Charge Rate
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
