### PR TITLE
[esp8266] Don't report stale crash state after hardware WDT resets

### DIFF
--- a/esphome/components/esp8266/crash_handler.cpp
+++ b/esphome/components/esp8266/crash_handler.cpp
@@ -118,8 +118,6 @@ static const LogString *get_exception_cause(uint32_t cause) {
 }
 
 static const LogString *get_reset_reason(uint32_t reason) {
-  if (reason == REASON_WDT_RST)
-    return LOG_STR("Hardware WDT");
   if (reason == REASON_EXCEPTION_RST)
     return LOG_STR("Exception");
   if (reason == REASON_SOFT_WDT_RST)
@@ -162,13 +160,20 @@ void crash_handler_log() {
   if (!is_crash_reason(resetInfo.reason))
     return;
 
+  ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
+  if (resetInfo.reason == REASON_WDT_RST) {
+    // A hardware WDT reset happens entirely in hardware: the postmortem hook
+    // never runs, so rst_info epc1/exccause and the RTC backtrace are
+    // leftovers from an earlier crash. Don't misattribute them (#18596).
+    ESP_LOGE(TAG, "  Reason: Hardware WDT (no crash state is recorded for hardware WDT resets)");
+    return;
+  }
+
   // Read and filter backtrace from RTC into stack-local buffer (no persistent RAM cost).
   // Both resetInfo and RTC data survive until the next reset, so this can be
   // called multiple times (logger init + API subscribe) with the same result.
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t bt_count = read_rtc_backtrace(backtrace, MAX_BACKTRACE);
-
-  ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
   // GCC's ROM divide routine triggers IllegalInstruction (exccause=0) at specific
   // ROM addresses instead of IntegerDivideByZero (exccause=6). Patch to match
   // the Arduino core's postmortem handler behavior.


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 a hardware WDT reset is performed entirely in hardware, so the Arduino postmortem hook never runs and nothing captures fresh crash state. The crash handler still printed `epc1`/`exccause` from `rst_info` and replayed the backtrace stored in RTC memory, but those values are leftovers from an earlier soft WDT or exception crash. This produced misleading reports like "Hardware WDT in wdt_feed" with a ROM PC and `exccause=4` (the soft WDT signature), and the Device Builder log viewer turned them into crash reports pointing at the wrong code.

The crash banner is still logged for hardware WDT resets, but the stale PC, exception cause, and backtrace are no longer printed. Exception and soft WDT resets are unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/18596 (the reported backtrace is stale data from a previous crash; this PR stops printing it)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes; any ESP8266 config exercises this path
esp8266:
  board: esp01_1m

logger:
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
