### PR TITLE
[tuya] Add forced minute boundary time sync

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -3,6 +3,7 @@ import esphome.codegen as cg
 from esphome.components import time, uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT, CONF_TIME_ID, CONF_TRIGGER_ID
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["uart"]
 
@@ -11,6 +12,7 @@ CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS = "ignore_mcu_update_on_datapoints"
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
 CONF_DATAPOINT_TYPE = "datapoint_type"
 CONF_STATUS_PIN = "status_pin"
+CONF_FORCE_TIME_SYNC = "force_time_sync"
 
 tuya_ns = cg.esphome_ns.namespace("tuya")
 TuyaDatapointType = tuya_ns.enum("TuyaDatapointType", is_class=True)
@@ -81,11 +83,23 @@ def assign_declare_id(value):
 
 
 CONF_TUYA_ID = "tuya_id"
-CONFIG_SCHEMA = (
+
+
+def _validate_time_options(config: ConfigType) -> ConfigType:
+    if config[CONF_FORCE_TIME_SYNC] and CONF_TIME_ID not in config:
+        raise cv.Invalid(
+            f"{CONF_FORCE_TIME_SYNC} requires {CONF_TIME_ID}",
+            path=[CONF_FORCE_TIME_SYNC],
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Tuya),
             cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+            cv.Optional(CONF_FORCE_TIME_SYNC, default=False): cv.boolean,
             cv.Optional(CONF_IGNORE_MCU_UPDATE_ON_DATAPOINTS): cv.ensure_list(
                 cv.uint8_t
             ),
@@ -105,7 +119,8 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
+    _validate_time_options,
 )
 
 
@@ -113,9 +128,10 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    if CONF_TIME_ID in config:
-        time_ = await cg.get_variable(config[CONF_TIME_ID])
+    if (time_id := config.get(CONF_TIME_ID)) is not None:
+        time_ = await cg.get_variable(time_id)
         cg.add(var.set_time_id(time_))
+        cg.add(var.set_force_time_sync(config[CONF_FORCE_TIME_SYNC]))
     if CONF_STATUS_PIN in config:
         status_pin_ = await cg.gpio_pin_expression(config[CONF_STATUS_PIN])
         cg.add(var.set_status_pin(status_pin_))

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -19,11 +19,18 @@ static const char *const TAG = "tuya";
 static const int COMMAND_DELAY = 10;
 static const int RECEIVE_TIMEOUT = 300;
 static const int MAX_RETRIES = 5;
+static constexpr uint32_t FORCE_TIME_SYNC_CHECK_INTERVAL = 1000;
 // Max bytes to log for datapoint values (larger values are truncated)
 static constexpr size_t MAX_DATAPOINT_LOG_BYTES = 16;
 
 void Tuya::setup() {
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
+#ifdef USE_TIME
+  if (this->time_id_ != nullptr && this->force_time_sync_) {
+    this->register_local_time_sync_callback_();
+    this->set_interval("force_time_sync", FORCE_TIME_SYNC_CHECK_INTERVAL, [this] { this->check_force_time_sync_(); });
+  }
+#endif
   if (this->status_pin_ != nullptr) {
     this->status_pin_->digital_write(false);
   }
@@ -84,6 +91,9 @@ void Tuya::dump_config() {
   }
   LOG_PIN("  Status Pin: ", this->status_pin_);
   ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
+#ifdef USE_TIME
+  ESP_LOGCONFIG(TAG, "  Force time sync: %s", YESNO(this->force_time_sync_));
+#endif
 }
 
 bool Tuya::validate_message_() {
@@ -291,12 +301,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
 #ifdef USE_TIME
       if (this->time_id_ != nullptr) {
         this->send_local_time_();
-
-        if (!this->time_sync_callback_registered_) {
-          // tuya mcu supports time, so we let them know when our time changed
-          this->time_id_->add_on_time_sync_callback([this] { this->send_local_time_(); });
-          this->time_sync_callback_registered_ = true;
-        }
+        this->register_local_time_sync_callback_();
       } else
 #endif
       {
@@ -601,6 +606,32 @@ void Tuya::send_wifi_status_() {
 }
 
 #ifdef USE_TIME
+void Tuya::register_local_time_sync_callback_() {
+  if (this->time_sync_callback_registered_) {
+    return;
+  }
+  this->time_id_->add_on_time_sync_callback([this] { this->send_local_time_(); });
+  this->time_sync_callback_registered_ = true;
+}
+
+void Tuya::check_force_time_sync_() {
+  ESPTime now = this->time_id_->now();
+  if (!now.is_valid()) {
+    return;
+  }
+
+  if (this->last_force_time_sync_minute_ == 0xFF) {
+    this->last_force_time_sync_minute_ = now.minute;
+    return;
+  }
+  if (now.minute == this->last_force_time_sync_minute_) {
+    return;
+  }
+
+  this->last_force_time_sync_minute_ = now.minute;
+  this->send_local_time_();
+}
+
 void Tuya::send_local_time_() {
   std::vector<uint8_t> payload;
   ESPTime now = this->time_id_->now();

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -108,6 +108,7 @@ class Tuya final : public Component, public uart::UARTDevice {
   TuyaInitState get_init_state();
 #ifdef USE_TIME
   void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
+  void set_force_time_sync(bool force_time_sync) { this->force_time_sync_ = force_time_sync; }
 #endif
   void add_ignore_mcu_update_on_datapoints(uint8_t ignore_mcu_update_on_datapoints) {
     this->ignore_mcu_update_on_datapoints_.push_back(ignore_mcu_update_on_datapoints);
@@ -138,9 +139,13 @@ class Tuya final : public Component, public uart::UARTDevice {
   uint8_t get_wifi_rssi_();
 
 #ifdef USE_TIME
+  void register_local_time_sync_callback_();
+  void check_force_time_sync_();
   void send_local_time_();
   void send_gmt_time_();
   time::RealTimeClock *time_id_{nullptr};
+  bool force_time_sync_{false};
+  uint8_t last_force_time_sync_minute_{0xFF};
   bool time_sync_callback_registered_{false};
   bool gmt_time_sync_callback_registered_{false};
 #endif

--- a/tests/component_tests/tuya/test_init.py
+++ b/tests/component_tests/tuya/test_init.py
@@ -1,0 +1,29 @@
+"""Tests for Tuya time synchronization configuration validation."""
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.tuya import CONF_FORCE_TIME_SYNC, CONFIG_SCHEMA
+from esphome.const import CONF_TIME_ID
+
+
+def test_force_time_sync_defaults_to_false() -> None:
+    config = CONFIG_SCHEMA({})
+
+    assert config[CONF_FORCE_TIME_SYNC] is False
+
+
+def test_force_time_sync_accepts_time_id() -> None:
+    config = CONFIG_SCHEMA(
+        {
+            CONF_FORCE_TIME_SYNC: True,
+            CONF_TIME_ID: "tuya_time",
+        }
+    )
+
+    assert config[CONF_FORCE_TIME_SYNC] is True
+
+
+def test_force_time_sync_requires_time_id() -> None:
+    with pytest.raises(cv.Invalid, match="force_time_sync requires time_id"):
+        CONFIG_SCHEMA({CONF_FORCE_TIME_SYNC: True})

--- a/tests/components/tuya/test-force-time-sync.esp32-idf.yaml
+++ b/tests/components/tuya/test-force-time-sync.esp32-idf.yaml
@@ -1,0 +1,16 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+  status_pin: GPIO12
+
+packages:
+  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+  common: !include common.yaml
+
+time:
+  - platform: sntp
+    id: tuya_time
+
+tuya:
+  time_id: tuya_time
+  force_time_sync: true

--- a/tests/components/tuya/test-force-time-sync.esp8266-ard.yaml
+++ b/tests/components/tuya/test-force-time-sync.esp8266-ard.yaml
@@ -1,0 +1,16 @@
+substitutions:
+  tx_pin: GPIO0
+  rx_pin: GPIO2
+  status_pin: GPIO15
+
+packages:
+  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+  common: !include common.yaml
+
+time:
+  - platform: sntp
+    id: tuya_time
+
+tuya:
+  time_id: tuya_time
+  force_time_sync: true


### PR DESCRIPTION
# What does this implement/fix?

Some Tuya MCUs do not maintain a stable display clock between time updates.

When enabled, `force_time_sync` sends local time whenever ESPHome observes a new minute, in addition to existing time query and time source synchronization behavior.

The schedule uses the clock from `time_id` and does not depend on a new synchronization event from the time source. This works without waiting for an MCU time request, and avoids unusually frequent Home Assistant time polling.

The option defaults to `false`. Existing configurations keep their current behavior.

Minute boundary updates kept the tested Moes BHT-002 display clock synchronized without glitches.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7235

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- Not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Configuration validation and firmware build coverage have been added. Minute change scheduling was hardware tested on a Moes BHT-002.

The ESP32-IDF and RP2040 checks used component configuration tests. The ESP8266 checks included firmware builds for the default and forced-sync configurations.

The tested thermostat reports product response `IAYz2WK1th0cMLmL1.0.0`. It uses Tuya protocol version `0x01` 

## Example entry for `config.yaml`:

```yaml
time:
  - platform: homeassistant
    id: ha_time

tuya:
  time_id: ha_time
  force_time_sync: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
