### PR TITLE
[esp32] Exclude esp_gdbstub from the build by default

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -233,6 +233,7 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "esp_driver_touch_sens",  # Touch sensor driver - only needed by esp32_touch
     "esp_driver_twai",  # TWAI/CAN driver - only needed by esp32_can component
     "esp_eth",  # Ethernet driver - only needed by ethernet component
+    "esp_gdbstub",  # GDB stub panic handler - unused by ESPHome; bt pulls it back
     "esp_hid",  # HID host/device support - ESPHome doesn't implement HID functionality
     "esp_http_client",  # HTTP client - only needed by http_request component
     "esp_https_ota",  # ESP-IDF HTTPS OTA - ESPHome has its own OTA implementation


### PR DESCRIPTION
# What does this implement/fix?

Adds `esp_gdbstub` to the default IDF component exclusion list. ESPHome never uses the GDB stub panic handler, no in tree source includes its header, and nothing in IDF hard requires it (esp_system and freertos only reference it through `idf_component_optional_requires`); the `bt` component does list it as a private requirement, so BLE builds pull it back automatically and need no re-include.

The same sweep looked at `esp_driver_spi` and `esp_psram`, and both turned out to be no-ops on IDF 5.5.5: `esp_driver_uart` (never excluded) hard requires `esp_psram`, and `esp_psram` in turn hard requires `esp_driver_spi`, so neither ever leaves the build.

Measured on a wifi only ESP32 config (no BLE) with #18599 applied: 790 objects drop to 783, the esp_gdbstub build directory no longer exists. On current dev the change is behavior neutral until #18599 lands, because `bt` is still in the build set and pulls esp_gdbstub back.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18536 and #18599

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed; an external component that includes esp_gdbstub.h
# can re-enable it:
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      include_builtin_idf_components:
        - esp_gdbstub
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
