### PR TITLE
[bluetooth_proxy] Warn once per transaction when the TCP buffer is congested

### DIFF
--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -275,10 +275,15 @@ void BluetoothConnection::send_ack_(PendingAck kind, uint16_t handle, conn_err_t
   if (this->try_send_ack_(kind, handle, error))
     return;
   // Report a newly owed reply and a displaced one; displacing is the case
-  // that loses a reply. Re-refusing the same one stays quiet.
+  // that loses a reply. Re-refusing the same one stays quiet, and so does a
+  // fresh deferral for the handle already warned about: a congested bulk
+  // transfer re-asks the same handle every cycle and each ack would warn.
   if (!this->has_pending_ack_()) {
-    ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X deferred, TCP buffer full", this->connection_index_,
-             this->address_str_, handle);
+    if (!this->ack_deferred_warned_ || this->pending_ack_handle_ != handle) {
+      ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X deferred, TCP buffer full", this->connection_index_,
+               this->address_str_, handle);
+      this->ack_deferred_warned_ = true;
+    }
   } else if (this->pending_ack_handle_ != handle || this->pending_ack_ != kind) {
     ESP_LOGW(TAG, "[%d] [%s] GATT reply for handle 0x%04X dropped for handle 0x%04X", this->connection_index_,
              this->address_str_, this->pending_ack_handle_, handle);
@@ -365,8 +370,14 @@ void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, u
   resp.set_data(data, len);
   if (!api_connection->send_message(resp)) {
     // Not latched, same reason as the read reply. Notify data is lossy: the
-    // peripheral will not resend it.
-    ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
+    // peripheral will not resend it. Warn on the first drop only; a congested
+    // link drops a whole stream and one line per notify floods the log.
+    if (!this->notify_drop_warned_) {
+      ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
+      this->notify_drop_warned_ = true;
+    } else {
+      ESP_LOGV(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
+    }
   }
 }
 

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.cpp
@@ -373,10 +373,12 @@ void BluetoothConnection::on_notify_data(uint16_t handle, const uint8_t *data, u
     // peripheral will not resend it. Warn on the first drop only; a congested
     // link drops a whole stream and one line per notify floods the log.
     if (!this->notify_drop_warned_) {
-      ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
+      ESP_LOGW(TAG, "[%d] [%s] Failed to send notify data response, handle 0x%04X", this->connection_index_,
+               this->address_str_, handle);
       this->notify_drop_warned_ = true;
     } else {
-      ESP_LOGV(TAG, "[%d] [%s] Failed to send notify data response", this->connection_index_, this->address_str_);
+      ESP_LOGV(TAG, "[%d] [%s] Failed to send notify data response, handle 0x%04X", this->connection_index_,
+               this->address_str_, handle);
     }
   }
 }

--- a/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_hub.h
@@ -164,6 +164,8 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
     this->pending_ack_ = PendingAck::PENDING_ACK_NONE;
     this->batch_stalled_ = false;
     this->connected_reply_owed_ = false;
+    this->ack_deferred_warned_ = false;
+    this->notify_drop_warned_ = false;
   }
   /// Sole construction site for these replies, shared by send and retry.
   bool try_send_ack_(PendingAck kind, uint16_t handle, conn_err_t error);
@@ -238,7 +240,7 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
 
   // Group 5: bit-packed tail. The first two bytes were already full, so the
   // first added bit forced a third and took the 8-aligned object 48 -> 56;
-  // the handle, error and retry counter ride in that padding. Four bitfield
+  // the handle, error and retry counter ride in that padding. Two bitfield
   // bits left; another byte-sized member costs 8 per slot.
   static_assert(static_cast<uint8_t>(ClientState::ESTABLISHED) < (1 << 3), "state_ bitfield too narrow");
   static_assert(static_cast<uint8_t>(ConnectionType::V3_WITHOUT_CACHE) < (1 << 2),
@@ -258,6 +260,11 @@ class BluetoothConnection final : public ble_device_base::GattClientListener {
   bool batch_stalled_ : 1 {false};
   /// An owed connected=true reply; the proxy's paced drain re-offers it.
   bool connected_reply_owed_ : 1 {false};
+  /// Set once the deferred warn fired; with an unchanged pending_ack_handle_
+  /// it keeps re-deferrals of the same handle quiet (see send_ack_).
+  bool ack_deferred_warned_ : 1 {false};
+  /// Set on the first dropped notify; later drops log at verbose only.
+  bool notify_drop_warned_ : 1 {false};
   // Plain byte after the bitfields: takes the padding byte instead of
   // straddling pending_ack_'s storage unit and growing the object.
   static_assert(PENDING_ACK_RETRY_LIMIT <= 0xFF, "retry counter too narrow");


### PR DESCRIPTION
# What does this implement/fix?

When the API TCP buffer is congested, the proxy warned on every drop cycle; a bulk transfer to a device like an opendisplay screen produced several "GATT reply deferred" and "Failed to send notify data response" lines per second. These drops were silent before 2026.8, the warnings came with the reply latching in #18259 and #18278; the noise is new, not the behavior.

Now the deferred GATT reply warning fires once per handle; re-deferrals of the same handle stay quiet, a deferral on a different handle still warns. The dropped notify warning fires once per connection; later drops log at verbose so they stay visible when debugging. Both re-arm when the connection resets. The two flags use spare bits in the packed tail, so the per slot size is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
