### PR TITLE
[esp32_ble] Log connection parameter update results

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -643,8 +643,23 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
       App.wake_loop_threadsafe();
       return;
 
+    // Log the result of connection parameter updates: a peer can reject or
+    // never answer an update, and without this the link silently stays on the
+    // old parameters (visible only as unexplained supervision timeouts).
+    case ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT: {
+      char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      format_mac_addr_upper(param->update_conn_params.bda, mac_s);
+      if (param->update_conn_params.status != ESP_BT_STATUS_SUCCESS) {
+        ESP_LOGW(TAG, "[%s] Conn param update failed, status=%d", mac_s, param->update_conn_params.status);
+      } else {
+        ESP_LOGD(TAG, "[%s] Conn params updated: interval=%u latency=%u timeout=%u", mac_s,
+                 param->update_conn_params.conn_int, param->update_conn_params.latency,
+                 param->update_conn_params.timeout);
+      }
+      return;
+    }
+
     // Ignore these GAP events as they are not relevant for our use case
-    case ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT:
     case ESP_GAP_BLE_SET_PKT_LENGTH_COMPLETE_EVT:
     case ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT:       // BLE 5.0 PHY update complete
     case ESP_GAP_BLE_CHANNEL_SELECT_ALGORITHM_EVT:  // BLE 5.0 channel selection algorithm

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -647,15 +647,20 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
     // never answer an update, and without this the link silently stays on the
     // old parameters (visible only as unexplained supervision timeouts).
     case ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT: {
-      char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-      format_mac_addr_upper(param->update_conn_params.bda, mac_s);
       if (param->update_conn_params.status != ESP_BT_STATUS_SUCCESS) {
+        char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+        format_mac_addr_upper(param->update_conn_params.bda, mac_s);
         ESP_LOGW(TAG, "[%s] Conn param update failed, status=%d", mac_s, param->update_conn_params.status);
-      } else {
-        ESP_LOGV(TAG, "[%s] Conn params updated: interval=%u latency=%u timeout=%u", mac_s,
+      }
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+      else {
+        char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+        format_mac_addr_upper(param->update_conn_params.bda, mac_s);
+        ESP_LOGV(TAG, "[%s] Conn params updated: interval=%u (x1.25ms) latency=%u timeout=%u (x10ms)", mac_s,
                  param->update_conn_params.conn_int, param->update_conn_params.latency,
                  param->update_conn_params.timeout);
       }
+#endif
       return;
     }
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -652,7 +652,7 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
       if (param->update_conn_params.status != ESP_BT_STATUS_SUCCESS) {
         ESP_LOGW(TAG, "[%s] Conn param update failed, status=%d", mac_s, param->update_conn_params.status);
       } else {
-        ESP_LOGD(TAG, "[%s] Conn params updated: interval=%u latency=%u timeout=%u", mac_s,
+        ESP_LOGV(TAG, "[%s] Conn params updated: interval=%u latency=%u timeout=%u", mac_s,
                  param->update_conn_params.conn_int, param->update_conn_params.latency,
                  param->update_conn_params.timeout);
       }


### PR DESCRIPTION
# What does this implement/fix?

The stack reports the result of every BLE connection parameter update through `ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT`, but we ignored the event. When a peer rejects an update the link silently stays on the old parameters; the only visible symptom is an unexplained supervision timeout later. Log a warning when an update fails, and log the applied parameters at verbose on success. Found while debugging a bluetooth proxy link that dropped with reason 0x08 shortly after the peer rejected our update with unsupported LL parameter value.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_tracker:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
