### PR TITLE
[esp32_ble_tracker] Scan at the default window while a GATT connection is active

### DIFF
--- a/esphome/components/ble_device_base/__init__.py
+++ b/esphome/components/ble_device_base/__init__.py
@@ -211,23 +211,22 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
             f"Scan window ({window}) needs to be smaller than scan interval ({interval})"
         )
 
-    windows = [("window", window)]
+    # Labels name the YAML key the user typed so the errors are greppable.
+    windows = [("Scan window", window)]
     if (connection_window := config.get(CONF_CONNECTION_SCAN_WINDOW)) is not None:
         if connection_window > interval:
             raise cv.Invalid(
-                f"Connection scan window ({connection_window}) needs to be smaller "
-                f"than scan interval ({interval})"
+                f"{CONF_CONNECTION_SCAN_WINDOW} ({connection_window}) needs to be "
+                f"smaller than scan interval ({interval})"
             )
-        windows.append(("connection window", connection_window))
+        windows.append((CONF_CONNECTION_SCAN_WINDOW, connection_window))
 
     # BLE scan interval/window are programmed in 0.625 ms units as a 16-bit value; the
     # controller only accepts 2.5 ms .. 10240 ms (0x0004 .. 0x4000). Reject out-of-range
     # values here instead of letting the unit conversion silently overflow.
-    for name, value in (("interval", interval), *windows):
+    for name, value in (("Scan interval", interval), *windows):
         if value.total_microseconds < 2500 or value.total_microseconds > 10_240_000:
-            raise cv.Invalid(
-                f"Scan {name} ({value}) must be between 2.5 ms and 10240 ms"
-            )
+            raise cv.Invalid(f"{name} ({value}) must be between 2.5 ms and 10240 ms")
 
     # Validate what actually reaches the controller: both values are truncated to
     # whole 0.625 ms units, so a window/interval pair that differs by less than one
@@ -237,7 +236,7 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
     for name, value in windows:
         if to_ble_units(value) == interval_units and value < interval:
             raise cv.Invalid(
-                f"Scan {name} ({value}) and interval ({interval}) both truncate to "
+                f"{name} ({value}) and interval ({interval}) both truncate to "
                 f"{interval_units} x 0.625 ms, which the controller scans at a 100 % duty "
                 f"cycle. Separate them by at least 0.625 ms."
             )

--- a/esphome/components/ble_device_base/__init__.py
+++ b/esphome/components/ble_device_base/__init__.py
@@ -234,13 +234,13 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
     # unit collapses to the same value — silently programming a 100 % duty cycle
     # (radio permanently on) from a config that asked for less.
     interval_units = to_ble_units(interval)
-    window_units = to_ble_units(window)
-    if window_units == interval_units and window < interval:
-        raise cv.Invalid(
-            f"Scan window ({window}) and interval ({interval}) both truncate to "
-            f"{interval_units} x 0.625 ms, which the controller scans at a 100 % duty "
-            f"cycle. Separate them by at least 0.625 ms."
-        )
+    for name, value in windows:
+        if to_ble_units(value) == interval_units and value < interval:
+            raise cv.Invalid(
+                f"Scan {name} ({value}) and interval ({interval}) both truncate to "
+                f"{interval_units} x 0.625 ms, which the controller scans at a 100 % duty "
+                f"cycle. Separate them by at least 0.625 ms."
+            )
 
     if interval.total_microseconds * 3 > duration.total_microseconds:
         raise cv.Invalid(

--- a/esphome/components/ble_device_base/__init__.py
+++ b/esphome/components/ble_device_base/__init__.py
@@ -206,20 +206,16 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
     interval = config[CONF_INTERVAL]
     window = config[CONF_WINDOW]
 
-    if window > interval:
-        raise cv.Invalid(
-            f"Scan window ({window}) needs to be smaller than scan interval ({interval})"
-        )
-
-    # Labels name the YAML key the user typed so the errors are greppable.
+    # Labels are reused in every error below; the optional one names its key.
     windows = [("Scan window", window)]
     if (connection_window := config.get(CONF_CONNECTION_SCAN_WINDOW)) is not None:
-        if connection_window > interval:
-            raise cv.Invalid(
-                f"{CONF_CONNECTION_SCAN_WINDOW} ({connection_window}) needs to be "
-                f"smaller than scan interval ({interval})"
-            )
         windows.append((CONF_CONNECTION_SCAN_WINDOW, connection_window))
+
+    for name, value in windows:
+        if value > interval:
+            raise cv.Invalid(
+                f"{name} ({value}) needs to be smaller than scan interval ({interval})"
+            )
 
     # BLE scan interval/window are programmed in 0.625 ms units as a 16-bit value; the
     # controller only accepts 2.5 ms .. 10240 ms (0x0004 .. 0x4000). Reject out-of-range

--- a/esphome/components/ble_device_base/__init__.py
+++ b/esphome/components/ble_device_base/__init__.py
@@ -211,10 +211,19 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
             f"Scan window ({window}) needs to be smaller than scan interval ({interval})"
         )
 
+    windows = [("window", window)]
+    if (connection_window := config.get(CONF_CONNECTION_SCAN_WINDOW)) is not None:
+        if connection_window > interval:
+            raise cv.Invalid(
+                f"Connection scan window ({connection_window}) needs to be smaller "
+                f"than scan interval ({interval})"
+            )
+        windows.append(("connection window", connection_window))
+
     # BLE scan interval/window are programmed in 0.625 ms units as a 16-bit value; the
     # controller only accepts 2.5 ms .. 10240 ms (0x0004 .. 0x4000). Reject out-of-range
     # values here instead of letting the unit conversion silently overflow.
-    for name, value in (("interval", interval), ("window", window)):
+    for name, value in (("interval", interval), *windows):
         if value.total_microseconds < 2500 or value.total_microseconds > 10_240_000:
             raise cv.Invalid(
                 f"Scan {name} ({value}) must be between 2.5 ms and 10240 ms"
@@ -247,11 +256,14 @@ def validate_scan_parameters(config: ConfigType) -> ConfigType:
 # their own; also the fallback for esp32's conditional default.
 DEFAULT_SCAN_WINDOW = "30ms"
 
+CONF_CONNECTION_SCAN_WINDOW = "connection_scan_window"
+
 
 def scan_parameters_schema(
     interval_default: str,
     *,
     window_default: str | Callable[[], TimePeriod] = DEFAULT_SCAN_WINDOW,
+    connection_window: bool = False,
 ) -> cv.All:
     """Build the scan_parameters value schema shared by all BLE trackers.
 
@@ -263,7 +275,9 @@ def scan_parameters_schema(
     can adjust it once sibling keys are resolved). The `active` option
     (default on) is unconditional: active scanning is part of the tracker
     contract — every current proxy client assumes it, so a passive-only
-    tracker must not share this schema.
+    tracker must not share this schema. connection_window opts in to the
+    `connection_scan_window` option for trackers that can fall back to a
+    smaller window while a GATT connection is active.
     """
     schema = {
         cv.Optional(CONF_DURATION, default="5min"): cv.positive_time_period_seconds,
@@ -272,6 +286,8 @@ def scan_parameters_schema(
         cv.Optional(CONF_CONTINUOUS, default=True): cv.boolean,
         cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
     }
+    if connection_window:
+        schema[cv.Optional(CONF_CONNECTION_SCAN_WINDOW)] = cv.positive_time_period
     return cv.All(cv.Schema(schema), validate_scan_parameters)
 
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -189,7 +189,9 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
         params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
         # A full-duty scan must not compete with an active GATT connection
         # for airtime, so arm the connection-time fallback window as well
-        # unless the user picked one themselves.
+        # unless the user picked one themselves. Injected after validation;
+        # safe only because it equals the window default, which already
+        # passed the <= interval and controller range checks.
         if CONF_CONNECTION_SCAN_WINDOW not in params:
             params[CONF_CONNECTION_SCAN_WINDOW] = cv.positive_time_period(
                 ble_device_base.DEFAULT_SCAN_WINDOW

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -7,6 +7,7 @@ import logging
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import ble_device_base, esp32_ble, ota
+from esphome.components.ble_device_base import CONF_CONNECTION_SCAN_WINDOW
 from esphome.components.const import CONF_ON_SCAN_END, CONF_SCAN_PARAMETERS, CONF_WINDOW
 from esphome.components.esp32 import (
     add_idf_sdkconfig_option,
@@ -186,6 +187,13 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
         # Copy so the config dump shows a plain value instead of a YAML
         # anchor/alias pair pointing at the interval.
         params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
+        # A full-duty scan must not compete with an active GATT connection
+        # for airtime, so arm the connection-time fallback window as well
+        # unless the user picked one themselves.
+        if CONF_CONNECTION_SCAN_WINDOW not in params:
+            params[CONF_CONNECTION_SCAN_WINDOW] = cv.positive_time_period(
+                ble_device_base.DEFAULT_SCAN_WINDOW
+            )
     return config
 
 
@@ -194,7 +202,7 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
 # window/interval pairs that collapse to the same 0.625 ms unit count.
 # The window default is conditional (see _scan_window_default above).
 SCAN_PARAMETERS_SCHEMA = ble_device_base.scan_parameters_schema(
-    "320ms", window_default=_scan_window_default
+    "320ms", window_default=_scan_window_default, connection_window=True
 )
 
 # Codegen helpers are owned by ble_device_base; kept under the historical names
@@ -288,6 +296,15 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_scan_duration(params[CONF_DURATION]))
     cg.add(var.set_scan_interval(ble_device_base.to_ble_units(params[CONF_INTERVAL])))
     cg.add(var.set_scan_window(ble_device_base.to_ble_units(params[CONF_WINDOW])))
+    if (connection_window := params.get(CONF_CONNECTION_SCAN_WINDOW)) is not None:
+        # Set by the user, or defaulted by _raise_defaulted_scan_window when
+        # the window was raised to full duty; while a GATT connection is
+        # active the scanner falls back to it (see start_scan_).
+        cg.add(
+            var.set_connection_scan_window(
+                ble_device_base.to_ble_units(connection_window)
+            )
+        )
     cg.add(var.set_scan_active(params[CONF_ACTIVE]))
     cg.add(var.set_scan_continuous(params[CONF_CONTINUOUS]))
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -178,9 +178,8 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
     honors the window strictly (>= 5.5.5); without the arbiter a full-duty
     scan would starve wifi outright, and a user-set window is never touched.
     Raising to the interval cannot invalidate the already-validated
-    parameters, so no re-validation is needed. Also checks the connection
-    window against the window here, after the raise, so a fallback below a
-    raised window validates while one that would widen the scan is rejected.
+    parameters, so no re-validation is needed. The connection window is
+    checked against the window here, after the raise.
     """
     params = config[CONF_SCAN_PARAMETERS]
     if (
@@ -191,11 +190,8 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
         # Copy so the config dump shows a plain value instead of a YAML
         # anchor/alias pair pointing at the interval.
         params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
-        # A full-duty scan must not compete with an active GATT connection
-        # for airtime, so arm the connection-time fallback window as well
-        # unless the user picked one themselves. Injected after validation;
-        # safe only because it equals the window default, which already
-        # passed the <= interval and controller range checks.
+        # Arm the connection-time fallback unless the user set one. Injected
+        # after validation; safe because it equals the validated window default.
         if CONF_CONNECTION_SCAN_WINDOW not in params:
             params[CONF_CONNECTION_SCAN_WINDOW] = cv.positive_time_period(
                 ble_device_base.DEFAULT_SCAN_WINDOW
@@ -204,8 +200,7 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
     if (
         connection_window := params.get(CONF_CONNECTION_SCAN_WINDOW)
     ) is not None and connection_window > params[CONF_WINDOW]:
-        # A larger value would widen the scan during connections, the exact
-        # airtime contention the option exists to remove.
+        # A larger value would widen the scan during connections.
         raise cv.Invalid(
             f"{CONF_CONNECTION_SCAN_WINDOW} ({connection_window}) needs to be "
             f"smaller than the scan window ({params[CONF_WINDOW]})"
@@ -313,11 +308,8 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_scan_interval(ble_device_base.to_ble_units(params[CONF_INTERVAL])))
     cg.add(var.set_scan_window(ble_device_base.to_ble_units(params[CONF_WINDOW])))
     if (connection_window := params.get(CONF_CONNECTION_SCAN_WINDOW)) is not None:
-        # Set by the user, or defaulted by _raise_defaulted_scan_window when
-        # the window was raised to full duty; while a GATT connection is
-        # active the scanner falls back to it (see start_scan_). Emitted at
-        # FINAL priority so a scan-only build (no GATT clients registered,
-        # so the guarded C++ path compiles out) skips the call entirely.
+        # Emitted at FINAL so a scan-only build, where the guarded C++ path
+        # compiles out, skips the call entirely.
         window_units = ble_device_base.to_ble_units(connection_window)
 
         @coroutine_with_priority(CoroPriority.FINAL)
@@ -325,8 +317,7 @@ async def to_code(config: ConfigType) -> None:
             if cg.get_slot_count(CLIENT_COUNT_DEFINE):
                 cg.add(var.set_connection_scan_window(window_units))
             elif not _get_data().connection_window_injected:
-                # A user-set value that cannot take effect deserves a heads-up;
-                # the auto-injected default is dropped silently.
+                # Warn only for a user-set value; the injected default drops silently.
                 _LOGGER.warning(
                     "'%s' has no effect because this build has no BLE client "
                     "components (for example bluetooth_proxy with active "

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -203,7 +203,8 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
         # A larger value would widen the scan during connections.
         raise cv.Invalid(
             f"{CONF_CONNECTION_SCAN_WINDOW} ({connection_window}) needs to be "
-            f"smaller than the scan window ({params[CONF_WINDOW]})"
+            f"smaller than the scan window ({params[CONF_WINDOW]})",
+            path=[CONF_SCAN_PARAMETERS, CONF_CONNECTION_SCAN_WINDOW],
         )
     return config
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -74,8 +74,9 @@ def _get_required_features() -> set[BLEFeatures]:
 
 # Slot counters sizing the tracker's StaticVector storage; one request per
 # registered listener or client.
+CLIENT_COUNT_DEFINE = "ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT"
 _request_listener_slot = cg.slot_counter("ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT")
-_request_client_slot = cg.slot_counter("ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT")
+_request_client_slot = cg.slot_counter(CLIENT_COUNT_DEFINE)
 
 
 def register_ble_features(features: set[BLEFeatures]) -> None:
@@ -301,12 +302,17 @@ async def to_code(config: ConfigType) -> None:
     if (connection_window := params.get(CONF_CONNECTION_SCAN_WINDOW)) is not None:
         # Set by the user, or defaulted by _raise_defaulted_scan_window when
         # the window was raised to full duty; while a GATT connection is
-        # active the scanner falls back to it (see start_scan_).
-        cg.add(
-            var.set_connection_scan_window(
-                ble_device_base.to_ble_units(connection_window)
-            )
-        )
+        # active the scanner falls back to it (see start_scan_). Emitted at
+        # FINAL priority so a scan-only build (no GATT clients registered,
+        # so the guarded C++ path compiles out) skips the call entirely.
+        window_units = ble_device_base.to_ble_units(connection_window)
+
+        @coroutine_with_priority(CoroPriority.FINAL)
+        async def _emit_connection_scan_window() -> None:
+            if cg.get_slot_count(CLIENT_COUNT_DEFINE):
+                cg.add(var.set_connection_scan_window(window_units))
+
+        CORE.add_job(_emit_connection_scan_window)
     cg.add(var.set_scan_active(params[CONF_ACTIVE]))
     cg.add(var.set_scan_continuous(params[CONF_CONTINUOUS]))
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -149,6 +149,7 @@ class TrackerData:
     """Per-run validation state, namespaced under DOMAIN in CORE.data."""
 
     scan_window_defaulted: bool = False
+    connection_window_injected: bool = False
 
 
 def _get_data() -> TrackerData:
@@ -177,14 +178,16 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
     honors the window strictly (>= 5.5.5); without the arbiter a full-duty
     scan would starve wifi outright, and a user-set window is never touched.
     Raising to the interval cannot invalidate the already-validated
-    parameters, so no re-validation is needed.
+    parameters, so no re-validation is needed. Also checks the connection
+    window against the window here, after the raise, so a fallback below a
+    raised window validates while one that would widen the scan is rejected.
     """
+    params = config[CONF_SCAN_PARAMETERS]
     if (
         _get_data().scan_window_defaulted
         and config.get(CONF_SOFTWARE_COEXISTENCE)
         and idf_version() >= IDF_SCAN_WINDOW_FIX_VERSION
     ):
-        params = config[CONF_SCAN_PARAMETERS]
         # Copy so the config dump shows a plain value instead of a YAML
         # anchor/alias pair pointing at the interval.
         params[CONF_WINDOW] = copy.copy(params[CONF_INTERVAL])
@@ -197,6 +200,16 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
             params[CONF_CONNECTION_SCAN_WINDOW] = cv.positive_time_period(
                 ble_device_base.DEFAULT_SCAN_WINDOW
             )
+            _get_data().connection_window_injected = True
+    if (
+        connection_window := params.get(CONF_CONNECTION_SCAN_WINDOW)
+    ) is not None and connection_window > params[CONF_WINDOW]:
+        # A larger value would widen the scan during connections, the exact
+        # airtime contention the option exists to remove.
+        raise cv.Invalid(
+            f"{CONF_CONNECTION_SCAN_WINDOW} ({connection_window}) needs to be "
+            f"smaller than the scan window ({params[CONF_WINDOW]})"
+        )
     return config
 
 
@@ -311,6 +324,15 @@ async def to_code(config: ConfigType) -> None:
         async def _emit_connection_scan_window() -> None:
             if cg.get_slot_count(CLIENT_COUNT_DEFINE):
                 cg.add(var.set_connection_scan_window(window_units))
+            elif not _get_data().connection_window_injected:
+                # A user-set value that cannot take effect deserves a heads-up;
+                # the auto-injected default is dropped silently.
+                _LOGGER.warning(
+                    "'%s' has no effect because this build has no BLE client "
+                    "components (for example bluetooth_proxy with active "
+                    "connections, or ble_client)",
+                    CONF_CONNECTION_SCAN_WINDOW,
+                )
 
         CORE.add_job(_emit_connection_scan_window)
     cg.add(var.set_scan_active(params[CONF_ACTIVE]))

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -155,9 +155,8 @@ void ESP32BLETracker::loop() {
   if (this->using_connection_window_ && !counts.active && !counts.disconnecting && this->scan_continuous_ &&
       this->scanner_state_ == ScannerState::RUNNING) {
     // Same logical scan period continues: cleanup_scan_state_ and start_scan_
-    // both skip their on_scan_end sweep.
-    this->skip_next_scan_end_ = true;
-    this->stop_scan_();
+    // both skip their on_scan_end sweep. Only armed when the stop was issued.
+    this->skip_next_scan_end_ = this->stop_scan_();
   }
 #endif
   /*
@@ -211,19 +210,23 @@ void ESP32BLETracker::stop_scan() {
   // reason at D themselves, and the user-facing stop action is deliberate.
   ESP_LOGV(TAG, "Stopping scan.");
   this->scan_continuous_ = false;
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
+  // The window-change restart is abandoned with continuous scanning.
+  this->skip_next_scan_end_ = false;
+#endif
   this->stop_scan_();
 }
 
 void ESP32BLETracker::ble_before_disabled_event_handler() { this->stop_scan_(); }
 
-void ESP32BLETracker::stop_scan_() {
+bool ESP32BLETracker::stop_scan_() {
   if (this->scanner_state_ != ScannerState::RUNNING && this->scanner_state_ != ScannerState::FAILED) {
     // IDLE means there is nothing to stop; STOPPING means a stop is already in
     // flight and will finish on its own. Neither is an error.
     if (this->scanner_state_ != ScannerState::IDLE && this->scanner_state_ != ScannerState::STOPPING) {
       ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
     }
-    return;
+    return false;
   }
   // Reset timeout state machine when stopping scan
   this->scan_timeout_state_ = ScanTimeoutState::INACTIVE;
@@ -231,8 +234,9 @@ void ESP32BLETracker::stop_scan_() {
   esp_err_t err = esp_ble_gap_stop_scanning();
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_ble_gap_stop_scanning failed: %d", err);
-    return;
+    return false;
   }
+  return true;
 }
 
 void ESP32BLETracker::start_scan_(bool first) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -566,6 +566,8 @@ void ESP32BLETracker::try_promote_discovered_clients_() {
 
     if (this->scanner_state_ == ScannerState::RUNNING) {
       ESP_LOGD(TAG, "Stopping scan to make connection");
+      // A connect ends the scan period a window-change restart was continuing.
+      this->skip_next_scan_end_ = false;
       this->stop_scan_();
       // Don't wait for scan stop complete - promote immediately.
       // This is safe because ESP-IDF processes BLE commands sequentially through its internal mailbox queue.

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -154,7 +154,8 @@ void ESP32BLETracker::loop() {
   // scan would not restart); !disconnecting matches the restart gate below.
   if (this->using_connection_window_ && !counts.active && !counts.disconnecting && this->scan_continuous_ &&
       this->scanner_state_ == ScannerState::RUNNING) {
-    // Same logical scan period continues: no extra on_scan_end for listeners.
+    // Same logical scan period continues: cleanup_scan_state_ and start_scan_
+    // both skip their on_scan_end sweep.
     this->skip_next_scan_end_ = true;
     this->stop_scan_();
   }
@@ -528,14 +529,22 @@ void ESP32BLETracker::cleanup_scan_state_(bool is_stop_complete) {
   // Reset timeout state machine instead of cancelling scheduler timeout
   this->scan_timeout_state_ = ScanTimeoutState::INACTIVE;
 
+  bool notify_scan_end = true;
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
+  // Window-change restart continues the scan period: no on_scan_end here.
+  // The flag stays set so start_scan_ skips its sweep too.
+  notify_scan_end = !this->skip_next_scan_end_;
+#endif
+  if (notify_scan_end) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
-  for (auto *listener : this->listeners_)
-    listener->on_scan_end();
+    for (auto *listener : this->listeners_)
+      listener->on_scan_end();
 #endif
 #ifdef ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT
-  for (auto *listener : this->neutral_listeners_)
-    listener->on_scan_end();
+    for (auto *listener : this->neutral_listeners_)
+      listener->on_scan_end();
 #endif
+  }
 
   this->set_scanner_state_(ScannerState::IDLE);
 }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -158,6 +158,10 @@ void ESP32BLETracker::loop() {
   // in flight, matching the restart gate below.
   if (this->using_connection_window_ && !counts.active && !counts.disconnecting && this->scan_continuous_ &&
       this->scanner_state_ == ScannerState::RUNNING) {
+    // The restart continues the same logical scan period, so the listeners
+    // must not get an extra on_scan_end (ble_rssi would publish NAN for
+    // beacons not yet seen in the period).
+    this->skip_next_scan_end_ = true;
     this->stop_scan_();
   }
 #endif
@@ -247,7 +251,15 @@ void ESP32BLETracker::start_scan_(bool first) {
   }
   this->set_scanner_state_(ScannerState::STARTING);
   ESP_LOGV(TAG, "Starting scan, set scanner state to STARTING.");
-  if (!first) {
+  bool notify_scan_end = !first;
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
+  if (this->skip_next_scan_end_) {
+    // Window-change restart: the same logical scan period continues.
+    this->skip_next_scan_end_ = false;
+    notify_scan_end = false;
+  }
+#endif
+  if (notify_scan_end) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
     for (auto *listener : this->listeners_)
       listener->on_scan_end();
@@ -267,8 +279,12 @@ void ESP32BLETracker::start_scan_(bool first) {
   uint32_t window = this->scan_window_;
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   // Count fresh rather than reading the loop() cache: an automation can start
-  // a scan before loop() has refreshed the counts for a new connection.
-  this->using_connection_window_ = this->connection_scan_window_ != 0 && this->count_client_states_().active > 0;
+  // a scan before loop() has refreshed the counts for a new connection. An
+  // equal connection window changes nothing, so it must not arm the
+  // last-disconnect restart in loop().
+  this->using_connection_window_ = this->connection_scan_window_ != 0 &&
+                                   this->connection_scan_window_ != this->scan_window_ &&
+                                   this->count_client_states_().active > 0;
   if (this->using_connection_window_) {
     // While a GATT connection is active, fall back to the connection scan
     // window so the connection events get guaranteed airtime instead of

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -567,8 +567,6 @@ void ESP32BLETracker::try_promote_discovered_clients_() {
 
     if (this->scanner_state_ == ScannerState::RUNNING) {
       ESP_LOGD(TAG, "Stopping scan to make connection");
-      // A connect ends the scan period a window-change restart was continuing.
-      this->skip_next_scan_end_ = false;
       this->stop_scan_();
       // Don't wait for scan stop complete - promote immediately.
       // This is safe because ESP-IDF processes BLE commands sequentially through its internal mailbox queue.
@@ -577,6 +575,8 @@ void ESP32BLETracker::try_promote_discovered_clients_() {
     }
 
     ESP_LOGD(TAG, "Promoting client to connect");
+    // A connect ends the scan period a window-change restart was continuing.
+    this->skip_next_scan_end_ = false;
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
     this->update_coex_preference_(true);
 #endif

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -122,8 +122,8 @@ void ESP32BLETracker::loop() {
   // - start_scan_(): scanner_state_ becomes IDLE via set_scanner_state_() in cleanup_scan_state_()
   // - try_promote_discovered_clients_(): client enters DISCOVERED via set_state(), or
   //   connecting client finishes (state change), or scanner reaches RUNNING/IDLE
-  // - connection-window restart: using_connection_window_ is only written in
-  //   start_scan_() (which changes scanner state via set_scanner_state_()), and
+  // - connection-window restart: scan_params_ is only written in start_scan_()
+  //   (which changes scanner state via set_scanner_state_()), and
   //   counts.active/disconnecting only change on client state changes
   //
   // All conditions that affect the logic below are tied to state changes that increment
@@ -149,13 +149,14 @@ void ESP32BLETracker::loop() {
   }
 
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  // Last connection dropped: restart so the configured window returns now
+  // The programmed window no longer matches the connection state (typically
+  // the last connection dropped): restart so the right window applies now
   // instead of at the end of the scan period. Continuous only (a user-started
   // scan would not restart); !disconnecting matches the restart gate below.
-  if (this->using_connection_window_ && !counts.active && !counts.disconnecting && this->scan_continuous_ &&
-      this->scanner_state_ == ScannerState::RUNNING) {
-    // Same logical scan period continues: cleanup_scan_state_ and start_scan_
-    // both skip their on_scan_end sweep. Only armed when the stop was issued.
+  if (this->scanner_state_ == ScannerState::RUNNING && this->scan_continuous_ && !counts.disconnecting &&
+      this->scan_params_.scan_window != this->desired_scan_window_(counts.active)) {
+    // Same logical scan period continues: no on_scan_end sweeps for this
+    // restart. Only armed when the stop was issued.
     this->skip_next_scan_end_ = this->stop_scan_();
   }
 #endif
@@ -250,24 +251,11 @@ void ESP32BLETracker::start_scan_(bool first) {
   }
   this->set_scanner_state_(ScannerState::STARTING);
   ESP_LOGV(TAG, "Starting scan, set scanner state to STARTING.");
-  bool notify_scan_end = !first;
+  if (!first)
+    this->notify_scan_end_();
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  if (this->skip_next_scan_end_) {
-    // Window-change restart continues the same scan period.
-    this->skip_next_scan_end_ = false;
-    notify_scan_end = false;
-  }
+  this->skip_next_scan_end_ = false;
 #endif
-  if (notify_scan_end) {
-#ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
-    for (auto *listener : this->listeners_)
-      listener->on_scan_end();
-#endif
-#ifdef ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT
-    for (auto *listener : this->neutral_listeners_)
-      listener->on_scan_end();
-#endif
-  }
 #ifdef USE_ESP32_BLE_DEVICE
   this->discovered_log_.clear();
 #endif
@@ -277,15 +265,11 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.scan_interval = this->scan_interval_;
   uint32_t window = this->scan_window_;
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  // Count fresh: an automation can start a scan before loop() refreshes the
-  // counts. An equal window changes nothing and must not arm the restart.
-  this->using_connection_window_ = this->connection_scan_window_ != 0 &&
-                                   this->connection_scan_window_ != this->scan_window_ &&
-                                   this->count_client_states_().active > 0;
-  if (this->using_connection_window_) {
+  // Count fresh: an automation can start a scan before loop() refreshes the counts.
+  window = this->desired_scan_window_(this->count_client_states_().active);
+  if (window != this->scan_window_) {
     // Guarantee the connection airtime instead of scanning wall to wall.
-    ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", this->connection_scan_window_);
-    window = this->connection_scan_window_;
+    ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", window);
   }
 #endif
   this->scan_params_.scan_window = window;
@@ -533,24 +517,26 @@ void ESP32BLETracker::cleanup_scan_state_(bool is_stop_complete) {
   // Reset timeout state machine instead of cancelling scheduler timeout
   this->scan_timeout_state_ = ScanTimeoutState::INACTIVE;
 
-  bool notify_scan_end = true;
-#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  // Window-change restart continues the scan period: no on_scan_end here.
-  // The flag stays set so start_scan_ skips its sweep too.
-  notify_scan_end = !this->skip_next_scan_end_;
-#endif
-  if (notify_scan_end) {
-#ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
-    for (auto *listener : this->listeners_)
-      listener->on_scan_end();
-#endif
-#ifdef ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT
-    for (auto *listener : this->neutral_listeners_)
-      listener->on_scan_end();
-#endif
-  }
+  this->notify_scan_end_();
 
   this->set_scanner_state_(ScannerState::IDLE);
+}
+
+void ESP32BLETracker::notify_scan_end_() {
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
+  // Window-change restart continues the same scan period; the flag stays set
+  // across the stop and is cleared by the restart in start_scan_.
+  if (this->skip_next_scan_end_)
+    return;
+#endif
+#ifdef ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT
+  for (auto *listener : this->listeners_)
+    listener->on_scan_end();
+#endif
+#ifdef ESPHOME_BLE_DEVICE_BASE_LISTENER_COUNT
+  for (auto *listener : this->neutral_listeners_)
+    listener->on_scan_end();
+#endif
 }
 
 void ESP32BLETracker::handle_scanner_failure_() {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -263,14 +263,15 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.own_addr_type = BLE_ADDR_TYPE_PUBLIC;
   this->scan_params_.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
   this->scan_params_.scan_interval = this->scan_interval_;
-  uint32_t window = this->scan_window_;
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   // Count fresh: an automation can start a scan before loop() refreshes the counts.
-  window = this->desired_scan_window_(this->count_client_states_().active);
+  const uint32_t window = this->desired_scan_window_(this->count_client_states_().active);
   if (window != this->scan_window_) {
     // Guarantee the connection airtime instead of scanning wall to wall.
     ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", window);
   }
+#else
+  const uint32_t window = this->scan_window_;
 #endif
   this->scan_params_.scan_window = window;
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -247,7 +247,16 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.own_addr_type = BLE_ADDR_TYPE_PUBLIC;
   this->scan_params_.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
   this->scan_params_.scan_interval = this->scan_interval_;
-  this->scan_params_.scan_window = this->scan_window_;
+  uint32_t window = this->scan_window_;
+  if (this->connection_scan_window_ != 0 && this->client_state_counts_.active > 0) {
+    // The defaulted window was raised to full duty for advertisement
+    // throughput; while a GATT connection is active, fall back so the
+    // connection events get guaranteed airtime instead of competing with
+    // a wall-to-wall scan on the shared radio.
+    ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", this->connection_scan_window_);
+    window = this->connection_scan_window_;
+  }
+  this->scan_params_.scan_window = window;
 
   // Start timeout monitoring in loop() instead of using scheduler
   // This prevents false reboots when the loop is blocked

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -144,6 +144,16 @@ void ESP32BLETracker::loop() {
       (this->scan_set_param_failed_ && this->scanner_state_ == ScannerState::RUNNING)) {
     this->handle_scanner_failure_();
   }
+
+  // The window is chosen at scan start, so when the last connection drops
+  // mid-scan the reduced connection-time window would persist for the rest
+  // of the scan period (up to scan_duration_); stop the scan so the restart
+  // below returns to the configured window. Only for continuous scanning:
+  // a user-started scan would not be restarted.
+  if (this->scan_window_reduced_ && !counts.active && this->scan_continuous_ &&
+      this->scanner_state_ == ScannerState::RUNNING) {
+    this->stop_scan_();
+  }
   /*
 
     Avoid starting the scanner if:
@@ -248,11 +258,11 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
   this->scan_params_.scan_interval = this->scan_interval_;
   uint32_t window = this->scan_window_;
-  if (this->connection_scan_window_ != 0 && this->client_state_counts_.active > 0) {
-    // The defaulted window was raised to full duty for advertisement
-    // throughput; while a GATT connection is active, fall back so the
-    // connection events get guaranteed airtime instead of competing with
-    // a wall-to-wall scan on the shared radio.
+  this->scan_window_reduced_ = this->connection_scan_window_ != 0 && this->client_state_counts_.active > 0;
+  if (this->scan_window_reduced_) {
+    // While a GATT connection is active, fall back to the connection scan
+    // window so the connection events get guaranteed airtime instead of
+    // competing with a wall-to-wall scan on the shared radio.
     ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", this->connection_scan_window_);
     window = this->connection_scan_window_;
   }
@@ -417,6 +427,9 @@ void ESP32BLETracker::dump_config() {
                 "  Continuous Scanning: %s",
                 this->scan_duration_, this->scan_interval_ * 0.625f, this->scan_window_ * 0.625f,
                 this->scan_active_ ? "ACTIVE" : "PASSIVE", YESNO(this->scan_continuous_));
+  if (this->connection_scan_window_ != 0) {
+    ESP_LOGCONFIG(TAG, "  Connection Scan Window: %.1f ms", this->connection_scan_window_ * 0.625f);
+  }
   ESP_LOGCONFIG(TAG,
                 "  Scanner State: %s\n"
                 "  Connecting: %d, discovered: %d, disconnecting: %d, active: %d",

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -258,7 +258,9 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
   this->scan_params_.scan_interval = this->scan_interval_;
   uint32_t window = this->scan_window_;
-  this->scan_window_reduced_ = this->connection_scan_window_ != 0 && this->client_state_counts_.active > 0;
+  // Count fresh rather than reading the loop() cache: an automation can start
+  // a scan before loop() has refreshed the counts for a new connection.
+  this->scan_window_reduced_ = this->connection_scan_window_ != 0 && this->count_client_states_().active > 0;
   if (this->scan_window_reduced_) {
     // While a GATT connection is active, fall back to the connection scan
     // window so the connection events get guaranteed airtime instead of

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -149,18 +149,12 @@ void ESP32BLETracker::loop() {
   }
 
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  // The window is chosen at scan start, so when the last connection drops
-  // mid-scan the connection-time window would persist for the rest of the
-  // scan period (up to scan_duration_); stop the scan so the restart below
-  // returns to the configured window. Only for continuous scanning: a
-  // user-started scan would not be restarted. Waiting for disconnecting to
-  // reach zero keeps the stop off the controller while a GATT disconnect is
-  // in flight, matching the restart gate below.
+  // Last connection dropped: restart so the configured window returns now
+  // instead of at the end of the scan period. Continuous only (a user-started
+  // scan would not restart); !disconnecting matches the restart gate below.
   if (this->using_connection_window_ && !counts.active && !counts.disconnecting && this->scan_continuous_ &&
       this->scanner_state_ == ScannerState::RUNNING) {
-    // The restart continues the same logical scan period, so the listeners
-    // must not get an extra on_scan_end (ble_rssi would publish NAN for
-    // beacons not yet seen in the period).
+    // Same logical scan period continues: no extra on_scan_end for listeners.
     this->skip_next_scan_end_ = true;
     this->stop_scan_();
   }
@@ -254,7 +248,7 @@ void ESP32BLETracker::start_scan_(bool first) {
   bool notify_scan_end = !first;
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   if (this->skip_next_scan_end_) {
-    // Window-change restart: the same logical scan period continues.
+    // Window-change restart continues the same scan period.
     this->skip_next_scan_end_ = false;
     notify_scan_end = false;
   }
@@ -278,17 +272,13 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.scan_interval = this->scan_interval_;
   uint32_t window = this->scan_window_;
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  // Count fresh rather than reading the loop() cache: an automation can start
-  // a scan before loop() has refreshed the counts for a new connection. An
-  // equal connection window changes nothing, so it must not arm the
-  // last-disconnect restart in loop().
+  // Count fresh: an automation can start a scan before loop() refreshes the
+  // counts. An equal window changes nothing and must not arm the restart.
   this->using_connection_window_ = this->connection_scan_window_ != 0 &&
                                    this->connection_scan_window_ != this->scan_window_ &&
                                    this->count_client_states_().active > 0;
   if (this->using_connection_window_) {
-    // While a GATT connection is active, fall back to the connection scan
-    // window so the connection events get guaranteed airtime instead of
-    // competing with a wall-to-wall scan on the shared radio.
+    // Guarantee the connection airtime instead of scanning wall to wall.
     ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", this->connection_scan_window_);
     window = this->connection_scan_window_;
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -122,6 +122,9 @@ void ESP32BLETracker::loop() {
   // - start_scan_(): scanner_state_ becomes IDLE via set_scanner_state_() in cleanup_scan_state_()
   // - try_promote_discovered_clients_(): client enters DISCOVERED via set_state(), or
   //   connecting client finishes (state change), or scanner reaches RUNNING/IDLE
+  // - connection-window restart: using_connection_window_ is only written in
+  //   start_scan_() (which changes scanner state via set_scanner_state_()), and
+  //   counts.active/disconnecting only change on client state changes
   //
   // All conditions that affect the logic below are tied to state changes that increment
   // state_version_, so the fast path is safe.
@@ -145,15 +148,19 @@ void ESP32BLETracker::loop() {
     this->handle_scanner_failure_();
   }
 
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   // The window is chosen at scan start, so when the last connection drops
-  // mid-scan the reduced connection-time window would persist for the rest
-  // of the scan period (up to scan_duration_); stop the scan so the restart
-  // below returns to the configured window. Only for continuous scanning:
-  // a user-started scan would not be restarted.
-  if (this->scan_window_reduced_ && !counts.active && this->scan_continuous_ &&
+  // mid-scan the connection-time window would persist for the rest of the
+  // scan period (up to scan_duration_); stop the scan so the restart below
+  // returns to the configured window. Only for continuous scanning: a
+  // user-started scan would not be restarted. Waiting for disconnecting to
+  // reach zero keeps the stop off the controller while a GATT disconnect is
+  // in flight, matching the restart gate below.
+  if (this->using_connection_window_ && !counts.active && !counts.disconnecting && this->scan_continuous_ &&
       this->scanner_state_ == ScannerState::RUNNING) {
     this->stop_scan_();
   }
+#endif
   /*
 
     Avoid starting the scanner if:
@@ -258,16 +265,18 @@ void ESP32BLETracker::start_scan_(bool first) {
   this->scan_params_.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
   this->scan_params_.scan_interval = this->scan_interval_;
   uint32_t window = this->scan_window_;
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   // Count fresh rather than reading the loop() cache: an automation can start
   // a scan before loop() has refreshed the counts for a new connection.
-  this->scan_window_reduced_ = this->connection_scan_window_ != 0 && this->count_client_states_().active > 0;
-  if (this->scan_window_reduced_) {
+  this->using_connection_window_ = this->connection_scan_window_ != 0 && this->count_client_states_().active > 0;
+  if (this->using_connection_window_) {
     // While a GATT connection is active, fall back to the connection scan
     // window so the connection events get guaranteed airtime instead of
     // competing with a wall-to-wall scan on the shared radio.
     ESP_LOGV(TAG, "Connection active, using %" PRIu32 " unit scan window", this->connection_scan_window_);
     window = this->connection_scan_window_;
   }
+#endif
   this->scan_params_.scan_window = window;
 
   // Start timeout monitoring in loop() instead of using scheduler
@@ -429,9 +438,11 @@ void ESP32BLETracker::dump_config() {
                 "  Continuous Scanning: %s",
                 this->scan_duration_, this->scan_interval_ * 0.625f, this->scan_window_ * 0.625f,
                 this->scan_active_ ? "ACTIVE" : "PASSIVE", YESNO(this->scan_continuous_));
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   if (this->connection_scan_window_ != 0) {
     ESP_LOGCONFIG(TAG, "  Connection Scan Window: %.1f ms", this->connection_scan_window_ * 0.625f);
   }
+#endif
   ESP_LOGCONFIG(TAG,
                 "  Scanner State: %s\n"
                 "  Connecting: %d, discovered: %d, disconnecting: %d, active: %d",

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -229,7 +229,8 @@ class ESP32BLETracker final : public Component,
   ScannerState get_scanner_state() const { return this->scanner_state_; }
 
  protected:
-  void stop_scan_();
+  /// Returns true when a stop was issued to the controller.
+  bool stop_scan_();
   /// Start a single scan by setting up the parameters and doing some esp-idf calls.
   void start_scan_(bool first);
   /// Called when a `ESP_GAP_BLE_SCAN_RESULT_EVT` event is received.

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -338,7 +338,7 @@ class ESP32BLETracker final : public Component,
   /// state_version_ to detect if any state changed since last iteration.
   uint8_t last_processed_version_{0};
   ScannerState scanner_state_{ScannerState::IDLE};
-  // Single-bit flags packed into one byte so new flags stop growing the class.
+  // Packed 1-bit flags.
   bool scan_continuous_ : 1;
   bool scan_active_ : 1;
 #ifdef USE_OTA_STATE_LISTENER
@@ -350,8 +350,7 @@ class ESP32BLETracker final : public Component,
   /// The running scan was started with connection_scan_window_; lets loop()
   /// restart the scan at the configured window when the last connection drops.
   bool using_connection_window_ : 1 {false};
-  /// The next start_scan_ continues the same logical scan period (set by the
-  /// window-change restart), so the on_scan_end sweep is skipped once.
+  /// Skip one on_scan_end sweep: the window-change restart continues the period.
   bool skip_next_scan_end_ : 1 {false};
 #endif
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -169,6 +169,7 @@ class ESP32BLETracker final : public Component,
   void set_scan_duration(uint32_t scan_duration) { scan_duration_ = scan_duration; }
   void set_scan_interval(uint32_t scan_interval) { scan_interval_ = scan_interval; }
   void set_scan_window(uint32_t scan_window) { scan_window_ = scan_window; }
+  void set_connection_scan_window(uint32_t scan_window) { connection_scan_window_ = scan_window; }
   void set_scan_active(bool scan_active) { scan_active_ = scan_active; }
   bool get_scan_active() const { return scan_active_; }
   void set_scan_continuous(bool scan_continuous) { scan_continuous_ = scan_continuous; }
@@ -313,6 +314,9 @@ class ESP32BLETracker final : public Component,
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
+  /// Window used while a GATT connection is active; only set when the
+  /// defaulted window was raised to full duty (0 = no fallback).
+  uint32_t connection_scan_window_{0};
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -338,20 +338,24 @@ class ESP32BLETracker final : public Component,
   /// state_version_ to detect if any state changed since last iteration.
   uint8_t last_processed_version_{0};
   ScannerState scanner_state_{ScannerState::IDLE};
-  bool scan_continuous_;
-  bool scan_active_;
+  // Single-bit flags packed into one byte so new flags stop growing the class.
+  bool scan_continuous_ : 1;
+  bool scan_active_ : 1;
 #ifdef USE_OTA_STATE_LISTENER
-  bool scan_continuous_before_ota_{false};
+  bool scan_continuous_before_ota_ : 1 {false};
 #endif
-  bool ble_was_disabled_{true};
-  bool parse_advertisements_{false};
+  bool ble_was_disabled_ : 1 {true};
+  bool parse_advertisements_ : 1 {false};
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   /// The running scan was started with connection_scan_window_; lets loop()
   /// restart the scan at the configured window when the last connection drops.
-  bool using_connection_window_{false};
+  bool using_connection_window_ : 1 {false};
+  /// The next start_scan_ continues the same logical scan period (set by the
+  /// window-change restart), so the on_scan_end sweep is skipped once.
+  bool skip_next_scan_end_ : 1 {false};
 #endif
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
-  bool coex_prefer_ble_{false};
+  bool coex_prefer_ble_ : 1 {false};
 #endif
   // Scan timeout state machine
   enum class ScanTimeoutState : uint8_t {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -169,7 +169,9 @@ class ESP32BLETracker final : public Component,
   void set_scan_duration(uint32_t scan_duration) { scan_duration_ = scan_duration; }
   void set_scan_interval(uint32_t scan_interval) { scan_interval_ = scan_interval; }
   void set_scan_window(uint32_t scan_window) { scan_window_ = scan_window; }
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   void set_connection_scan_window(uint32_t scan_window) { connection_scan_window_ = scan_window; }
+#endif
   void set_scan_active(bool scan_active) { scan_active_ = scan_active; }
   bool get_scan_active() const { return scan_active_; }
   void set_scan_continuous(bool scan_continuous) { scan_continuous_ = scan_continuous; }
@@ -314,9 +316,11 @@ class ESP32BLETracker final : public Component,
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   /// Window used while a GATT connection is active; set by the user, or
   /// defaulted when the window was raised to full duty (0 = no fallback).
   uint32_t connection_scan_window_{0};
+#endif
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
 
@@ -341,9 +345,11 @@ class ESP32BLETracker final : public Component,
 #endif
   bool ble_was_disabled_{true};
   bool parse_advertisements_{false};
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   /// The running scan was started with connection_scan_window_; lets loop()
   /// restart the scan at the configured window when the last connection drops.
-  bool scan_window_reduced_{false};
+  bool using_connection_window_{false};
+#endif
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
   bool coex_prefer_ble_{false};
 #endif

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -231,6 +231,8 @@ class ESP32BLETracker final : public Component,
  protected:
   /// Returns true when a stop was issued to the controller.
   bool stop_scan_();
+  /// Fire on_scan_end on every listener unless a window-change restart suppressed it.
+  void notify_scan_end_();
   /// Start a single scan by setting up the parameters and doing some esp-idf calls.
   void start_scan_(bool first);
   /// Called when a `ESP_GAP_BLE_SCAN_RESULT_EVT` event is received.
@@ -321,6 +323,10 @@ class ESP32BLETracker final : public Component,
   /// Window used while a GATT connection is active; set by the user, or
   /// defaulted when the window was raised to full duty (0 = no fallback).
   uint32_t connection_scan_window_{0};
+  /// The window to scan at for the given number of active GATT connections.
+  uint32_t desired_scan_window_(uint8_t active) const {
+    return (this->connection_scan_window_ != 0 && active > 0) ? this->connection_scan_window_ : this->scan_window_;
+  }
 #endif
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
@@ -348,9 +354,6 @@ class ESP32BLETracker final : public Component,
   bool ble_was_disabled_ : 1 {true};
   bool parse_advertisements_ : 1 {false};
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  /// The running scan was started with connection_scan_window_; lets loop()
-  /// restart the scan at the configured window when the last connection drops.
-  bool using_connection_window_ : 1 {false};
   /// Suppress the window-change restart's on_scan_end sweeps (stop and start).
   bool skip_next_scan_end_ : 1 {false};
 #endif
@@ -363,10 +366,10 @@ class ESP32BLETracker final : public Component,
     MONITORING,     // Actively monitoring for timeout
     EXCEEDED_WAIT,  // Timeout exceeded, waiting one loop before reboot
   };
+  ScanTimeoutState scan_timeout_state_{ScanTimeoutState::INACTIVE};
   uint32_t scan_start_time_{0};
   /// Precomputed timeout value: scan_duration_ * 2000
   uint32_t scan_timeout_ms_{0};
-  ScanTimeoutState scan_timeout_state_{ScanTimeoutState::INACTIVE};
 };
 
 // NOLINTNEXTLINE

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -350,7 +350,7 @@ class ESP32BLETracker final : public Component,
   /// The running scan was started with connection_scan_window_; lets loop()
   /// restart the scan at the configured window when the last connection drops.
   bool using_connection_window_ : 1 {false};
-  /// Skip one on_scan_end sweep: the window-change restart continues the period.
+  /// Suppress the window-change restart's on_scan_end sweeps (stop and start).
   bool skip_next_scan_end_ : 1 {false};
 #endif
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -314,8 +314,8 @@ class ESP32BLETracker final : public Component,
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
-  /// Window used while a GATT connection is active; only set when the
-  /// defaulted window was raised to full duty (0 = no fallback).
+  /// Window used while a GATT connection is active; set by the user, or
+  /// defaulted when the window was raised to full duty (0 = no fallback).
   uint32_t connection_scan_window_{0};
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
@@ -341,6 +341,9 @@ class ESP32BLETracker final : public Component,
 #endif
   bool ble_was_disabled_{true};
   bool parse_advertisements_{false};
+  /// The running scan was started with connection_scan_window_; lets loop()
+  /// restart the scan at the configured window when the last connection drops.
+  bool scan_window_reduced_{false};
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
   bool coex_prefer_ble_{false};
 #endif

--- a/tests/component_tests/esp32_ble_tracker/config/scan_window_explicit.yaml
+++ b/tests/component_tests/esp32_ble_tracker/config/scan_window_explicit.yaml
@@ -12,3 +12,8 @@ wifi:
 esp32_ble_tracker:
   scan_parameters:
     window: 30ms
+
+bluetooth_proxy:
+  active: true
+
+api:

--- a/tests/component_tests/esp32_ble_tracker/config/scan_window_explicit.yaml
+++ b/tests/component_tests/esp32_ble_tracker/config/scan_window_explicit.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: scan-window-explicit
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: MySSID
+
+esp32_ble_tracker:
+  scan_parameters:
+    window: 30ms

--- a/tests/component_tests/esp32_ble_tracker/config/scan_window_raised.yaml
+++ b/tests/component_tests/esp32_ble_tracker/config/scan_window_raised.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: scan-window-raised
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: MySSID
+
+esp32_ble_tracker:

--- a/tests/component_tests/esp32_ble_tracker/config/scan_window_scan_only.yaml
+++ b/tests/component_tests/esp32_ble_tracker/config/scan_window_scan_only.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: scan-window-raised
+  name: scan-window-scan-only
 
 esp32:
   board: esp32dev
@@ -10,8 +10,3 @@ wifi:
   ssid: MySSID
 
 esp32_ble_tracker:
-
-bluetooth_proxy:
-  active: true
-
-api:

--- a/tests/component_tests/esp32_ble_tracker/config/scan_window_user_set_scan_only.yaml
+++ b/tests/component_tests/esp32_ble_tracker/config/scan_window_user_set_scan_only.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: scan-window-user-scan-only
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: MySSID
+
+esp32_ble_tracker:
+  scan_parameters:
+    connection_scan_window: 20ms

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -163,6 +163,23 @@ def test_connection_scan_window_above_interval_rejected(
         _scan_params({"scan_parameters": {"connection_scan_window": "400ms"}})
 
 
+def test_connection_scan_window_truncation_collapse_rejected(
+    stage_esp32: Callable[..., None],
+) -> None:
+    """A connection window that truncates into the interval's 0.625 ms unit
+    would silently program a full-duty scan during connections."""
+    stage_esp32("5.5.5", wifi=True)
+    with pytest.raises(cv.Invalid, match="connection window .* both truncate"):
+        _scan_params(
+            {
+                "scan_parameters": {
+                    "interval": "320.5ms",
+                    "connection_scan_window": "320.2ms",
+                }
+            }
+        )
+
+
 def test_codegen_connection_window_when_raised(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -195,44 +195,29 @@ def test_connection_scan_window_truncation_collapse_rejected(
         )
 
 
-def test_codegen_connection_window_when_raised(
-    generate_main: Callable[[str | Path], str],
-    component_config_path: Callable[[str], Path],
-) -> None:
-    main_cpp = generate_main(component_config_path("scan_window_raised.yaml"))
-    assert "set_scan_window(512)" in main_cpp
-    assert "set_connection_scan_window(48)" in main_cpp
-
-
-def test_codegen_no_connection_window_for_explicit_window(
-    generate_main: Callable[[str | Path], str],
-    component_config_path: Callable[[str], Path],
-) -> None:
-    main_cpp = generate_main(component_config_path("scan_window_explicit.yaml"))
-    assert "set_scan_window(48)" in main_cpp
-    assert "set_connection_scan_window" not in main_cpp
-
-
-def test_codegen_no_connection_window_without_gatt_clients(
-    generate_main: Callable[[str | Path], str],
-    component_config_path: Callable[[str], Path],
-) -> None:
-    """Scan-only builds compile the connection-window path out, so the raised
-    default must not emit a call to the guarded setter."""
-    main_cpp = generate_main(component_config_path("scan_window_scan_only.yaml"))
-    assert "set_scan_window(512)" in main_cpp
-    assert "set_connection_scan_window" not in main_cpp
-
-
-def test_user_set_connection_window_warns_without_gatt_clients(
+@pytest.mark.parametrize(
+    ("config_file", "window_call", "connection_call", "warns"),
+    [
+        # Raised window with GATT clients: the injected fallback is emitted.
+        ("scan_window_raised.yaml", "set_scan_window(512)", True, False),
+        # Explicit window: nothing injected.
+        ("scan_window_explicit.yaml", "set_scan_window(48)", False, False),
+        # Scan-only build compiles the path out: the injected default is
+        # dropped silently, a user-set value warns.
+        ("scan_window_scan_only.yaml", "set_scan_window(512)", False, False),
+        ("scan_window_user_set_scan_only.yaml", "set_scan_window(512)", False, True),
+    ],
+)
+def test_connection_scan_window_codegen(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
     caplog: pytest.LogCaptureFixture,
+    config_file: str,
+    window_call: str,
+    connection_call: bool,
+    warns: bool,
 ) -> None:
-    """A user-set value that cannot take effect warns; the injected default
-    (previous test) is dropped silently."""
-    main_cpp = generate_main(
-        component_config_path("scan_window_user_set_scan_only.yaml")
-    )
-    assert "set_connection_scan_window" not in main_cpp
-    assert "'connection_scan_window' has no effect" in caplog.text
+    main_cpp = generate_main(component_config_path(config_file))
+    assert window_call in main_cpp
+    assert ("set_connection_scan_window(48)" in main_cpp) == connection_call
+    assert ("'connection_scan_window' has no effect" in caplog.text) == warns

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -222,3 +222,17 @@ def test_codegen_no_connection_window_without_gatt_clients(
     main_cpp = generate_main(component_config_path("scan_window_scan_only.yaml"))
     assert "set_scan_window(512)" in main_cpp
     assert "set_connection_scan_window" not in main_cpp
+
+
+def test_user_set_connection_window_warns_without_gatt_clients(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A user-set value that cannot take effect warns; the injected default
+    (previous test) is dropped silently."""
+    main_cpp = generate_main(
+        component_config_path("scan_window_user_set_scan_only.yaml")
+    )
+    assert "set_connection_scan_window" not in main_cpp
+    assert "'connection_scan_window' has no effect" in caplog.text

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -12,11 +12,12 @@ arbiter a full-duty scan would starve wifi, so the 30 ms default is kept.
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
 from esphome import config_validation as cv
-from esphome.components.ble_device_base import to_ble_units
+from esphome.components.ble_device_base import CONF_CONNECTION_SCAN_WINDOW, to_ble_units
 from esphome.components.const import CONF_SCAN_PARAMETERS, CONF_WINDOW
 from esphome.components.esp32 import KEY_IDF_VERSION
 from esphome.components.esp32_ble_tracker import (
@@ -120,3 +121,61 @@ def test_short_interval_without_window_still_rejected(
     stage_esp32("5.5.5", wifi=True)
     with pytest.raises(cv.Invalid, match="needs to be smaller than scan interval"):
         _scan_params({"scan_parameters": {"interval": "20ms"}})
+
+
+# The connection-time fallback window: while a GATT connection is active the
+# scanner drops from a raised full-duty window back to this value so the
+# connection gets guaranteed airtime.
+
+
+def test_raise_arms_connection_scan_window_default(
+    stage_esp32: Callable[..., None],
+) -> None:
+    stage_esp32("5.5.5", wifi=True)
+    params = _scan_params({})
+    assert params[CONF_WINDOW] == params[CONF_INTERVAL]
+    assert to_ble_units(params[CONF_CONNECTION_SCAN_WINDOW]) == 48
+
+
+def test_user_connection_scan_window_survives_raise(
+    stage_esp32: Callable[..., None],
+) -> None:
+    stage_esp32("5.5.5", wifi=True)
+    params = _scan_params({"scan_parameters": {"connection_scan_window": "60ms"}})
+    assert params[CONF_WINDOW] == params[CONF_INTERVAL]
+    assert to_ble_units(params[CONF_CONNECTION_SCAN_WINDOW]) == 96
+
+
+def test_unraised_window_gets_no_connection_scan_window_default(
+    stage_esp32: Callable[..., None],
+) -> None:
+    stage_esp32("5.5.4", wifi=True)
+    assert CONF_CONNECTION_SCAN_WINDOW not in _scan_params({})
+
+
+def test_connection_scan_window_above_interval_rejected(
+    stage_esp32: Callable[..., None],
+) -> None:
+    stage_esp32("5.5.5", wifi=True)
+    with pytest.raises(
+        cv.Invalid, match="Connection scan window .* needs to be smaller"
+    ):
+        _scan_params({"scan_parameters": {"connection_scan_window": "400ms"}})
+
+
+def test_codegen_connection_window_when_raised(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    main_cpp = generate_main(component_config_path("scan_window_raised.yaml"))
+    assert "set_scan_window(512)" in main_cpp
+    assert "set_connection_scan_window(48)" in main_cpp
+
+
+def test_codegen_no_connection_window_for_explicit_window(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    main_cpp = generate_main(component_config_path("scan_window_explicit.yaml"))
+    assert "set_scan_window(48)" in main_cpp
+    assert "set_connection_scan_window" not in main_cpp

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -158,7 +158,7 @@ def test_connection_scan_window_above_interval_rejected(
 ) -> None:
     stage_esp32("5.5.5", wifi=True)
     with pytest.raises(
-        cv.Invalid, match="Connection scan window .* needs to be smaller"
+        cv.Invalid, match="connection_scan_window .* needs to be smaller"
     ):
         _scan_params({"scan_parameters": {"connection_scan_window": "400ms"}})
 
@@ -169,7 +169,7 @@ def test_connection_scan_window_truncation_collapse_rejected(
     """A connection window that truncates into the interval's 0.625 ms unit
     would silently program a full-duty scan during connections."""
     stage_esp32("5.5.5", wifi=True)
-    with pytest.raises(cv.Invalid, match="connection window .* both truncate"):
+    with pytest.raises(cv.Invalid, match="connection_scan_window .* both truncate"):
         _scan_params(
             {
                 "scan_parameters": {
@@ -195,4 +195,15 @@ def test_codegen_no_connection_window_for_explicit_window(
 ) -> None:
     main_cpp = generate_main(component_config_path("scan_window_explicit.yaml"))
     assert "set_scan_window(48)" in main_cpp
+    assert "set_connection_scan_window" not in main_cpp
+
+
+def test_codegen_no_connection_window_without_gatt_clients(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Scan-only builds compile the connection-window path out, so the raised
+    default must not emit a call to the guarded setter."""
+    main_cpp = generate_main(component_config_path("scan_window_scan_only.yaml"))
+    assert "set_scan_window(512)" in main_cpp
     assert "set_connection_scan_window" not in main_cpp

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -163,6 +163,21 @@ def test_connection_scan_window_above_interval_rejected(
         _scan_params({"scan_parameters": {"connection_scan_window": "400ms"}})
 
 
+def test_connection_scan_window_above_window_rejected(
+    stage_esp32: Callable[..., None],
+) -> None:
+    """A connection window above the (post-raise) window would widen the scan
+    during connections; the reject runs after the raise so a fallback below a
+    raised window still validates (covered by the survives-raise test)."""
+    stage_esp32("5.5.5", wifi=True)
+    with pytest.raises(
+        cv.Invalid, match="connection_scan_window .* needs to be smaller"
+    ):
+        _scan_params(
+            {"scan_parameters": {"window": "30ms", "connection_scan_window": "300ms"}}
+        )
+
+
 def test_connection_scan_window_truncation_collapse_rejected(
     stage_esp32: Callable[..., None],
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression in 2026.8.0 as a result of the esp-idf coexistence fix saga. Since the defaulted scan window is raised to full duty on IDF 5.5.5 with wifi coexistence, the scanner competes with active GATT connections for airtime on the shared radio; an original ESP32 proxy loses its connection to a peripheral with supervision timeouts about 12 to 17 seconds after every connect, while the same setup worked on 2026.7. The reporter confirmed this change restores the connection on an ESP32-WROOM-32 proxy that could no longer hold a link to an OpenDisplay peripheral. See https://github.com/espressif/esp-idf/issues/18931 for the full history of the upstream IDF change.

This adds a `connection_scan_window` option under `scan_parameters`; while a GATT connection is active, scans run at that window instead of the raised one. When the window was auto raised it defaults to the historical 30ms, restoring the exact pre raise radio behavior during connections, so this keeps backwards compatibility for proxies that hold connections. A user set `window:` is never touched and gets no automatic fallback; users can still opt in by setting `connection_scan_window` themselves. When the last connection drops mid scan, the scan restarts so the configured window returns right away; the restart continues the same scan period without firing `on_scan_end`, though it lets coexistence revert to balanced a little earlier than a natural scan period end would. On scan only builds without GATT clients the whole path compiles out, and the tracker's boolean flags were packed into one bit fields so the new flags do not grow the class.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes a regression in 2026.8.0, reported in Discord: https://ptb.discord.com/channels/429907082951524364/1540456698718986292
- fixes https://github.com/esphome/esphome/issues/18614

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7238

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_tracker:
  scan_parameters:
    connection_scan_window: 30ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).






