### PR TITLE
[network] Add tcp_send_buffer option

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -26,6 +26,15 @@ _LOGGER = logging.getLogger(__name__)
 # Components can request high performance networking and this configures lwip and WiFi settings
 KEY_HIGH_PERFORMANCE_NETWORKING = "high_performance_networking"
 CONF_ENABLE_HIGH_PERFORMANCE = "enable_high_performance"
+CONF_TCP_SEND_BUFFER = "tcp_send_buffer"
+
+# lwIP queues at most this many unsent/unacked bytes per TCP socket; the
+# stock ESP-IDF default (5744 bytes) stalls bursty senders like a Bluetooth
+# proxy streaming GATT notifications. Bounds follow the lwIP guidance for the
+# default 1440 byte MSS: at least 2 x MSS, at most 65535 without window
+# scaling.
+TCP_SEND_BUFFER_MIN = 2880
+TCP_SEND_BUFFER_MAX = 65535
 
 # Network priority tracking infrastructure
 # Components can query this to determine their relative setup priority.
@@ -306,6 +315,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_HIGH_PERFORMANCE): cv.All(
                 cv.boolean, cv.only_on_esp32
             ),
+            cv.Optional(CONF_TCP_SEND_BUFFER): cv.All(
+                cv.validate_bytes,
+                cv.int_range(min=TCP_SEND_BUFFER_MIN, max=TCP_SEND_BUFFER_MAX),
+                cv.only_on_esp32,
+            ),
             cv.Optional(CONF_PRIORITY): _validate_priority_list,
         }
     ),
@@ -445,6 +459,11 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 65534)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 64)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
+
+    # After the high performance block so an explicit size wins over the
+    # bundle's 65534 (last write wins in the sdkconfig store).
+    if (tcp_send_buffer := config.get(CONF_TCP_SEND_BUFFER)) is not None:
+        add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", tcp_send_buffer)
 
     if CORE.is_nrf52:
         zephyr_add_prj_conf("NETWORKING", True)

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -32,7 +32,8 @@ CONF_TCP_SEND_BUFFER = "tcp_send_buffer"
 # stock ESP-IDF default (5744 bytes) stalls bursty senders like a Bluetooth
 # proxy streaming GATT notifications. Bounds follow the lwIP guidance for the
 # default 1440 byte MSS: at least 2 x MSS, at most 65535 without window
-# scaling.
+# scaling. The cap is kept even when window scaling is on (high performance
+# with PSRAM) as a deliberate conservative bound.
 TCP_SEND_BUFFER_MIN = 2880
 TCP_SEND_BUFFER_MAX = 65535
 
@@ -463,6 +464,11 @@ async def to_code(config):
     # After the high performance block so an explicit size wins over the
     # bundle's 65534 (last write wins in the sdkconfig store).
     if (tcp_send_buffer := config.get(CONF_TCP_SEND_BUFFER)) is not None:
+        if CORE.is_esp32 and should_enable:
+            _LOGGER.info(
+                "TCP send buffer set to %d bytes by configuration (overriding high performance value)",
+                tcp_send_buffer,
+            )
         add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", tcp_send_buffer)
 
     if CORE.is_nrf52:

--- a/esphome/components/network/network_component.cpp
+++ b/esphome/components/network/network_component.cpp
@@ -6,6 +6,7 @@
 #include "esp_err.h"
 #include "esp_netif.h"
 #include "esp_event.h"
+#include "lwip/opt.h"
 
 #ifdef USE_NETWORK_DEFAULT_ROUTE
 #include "esphome/core/application.h"
@@ -41,6 +42,15 @@ void NetworkComponent::setup() {
     this->mark_failed();
     return;
   }
+}
+
+void NetworkComponent::dump_config() {
+  // The effective compile-time lwIP value, so the log reflects tcp_send_buffer
+  // or the high performance bundle when either changed it.
+  ESP_LOGCONFIG(TAG,
+                "Network:\n"
+                "  TCP send buffer: %d bytes",
+                TCP_SND_BUF);
 }
 
 #ifdef USE_NETWORK_DEFAULT_ROUTE

--- a/esphome/components/network/network_component.h
+++ b/esphome/components/network/network_component.h
@@ -13,6 +13,7 @@ namespace esphome::network {
 class NetworkComponent final : public Component {
  public:
   void setup() override;
+  void dump_config() override;
   // AFTER_BLUETOOTH: BLE controller must initialize before esp_netif_init per IDF guidance.
   float get_setup_priority() const override { return setup_priority::AFTER_BLUETOOTH; }
 

--- a/tests/component_tests/network/config/tcp_send_buffer.yaml
+++ b/tests/component_tests/network/config/tcp_send_buffer.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+network:
+  tcp_send_buffer: 32kB

--- a/tests/component_tests/network/config/tcp_send_buffer_high_perf.yaml
+++ b/tests/component_tests/network/config/tcp_send_buffer_high_perf.yaml
@@ -1,0 +1,15 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+network:
+  enable_high_performance: true
+  tcp_send_buffer: 16384

--- a/tests/component_tests/network/test_tcp_send_buffer.py
+++ b/tests/component_tests/network/test_tcp_send_buffer.py
@@ -14,16 +14,23 @@ import pytest
 from voluptuous import Invalid
 
 from esphome import config_validation as cv
-from esphome.components.esp32.const import KEY_VARIANT, VARIANT_ESP32
-from esphome.components.network import CONFIG_SCHEMA
-from esphome.const import KEY_FRAMEWORK_VERSION, PlatformFramework
+from esphome.components.esp32.const import (
+    KEY_SDKCONFIG_OPTIONS,
+    KEY_VARIANT,
+    VARIANT_ESP32,
+)
+from esphome.components.network import (
+    CONF_TCP_SEND_BUFFER,
+    CONFIG_SCHEMA,
+    TCP_SEND_BUFFER_MAX,
+    TCP_SEND_BUFFER_MIN,
+)
+from esphome.const import KEY_ESP32, KEY_FRAMEWORK_VERSION, PlatformFramework
 from esphome.core import CORE
 from tests.component_tests.types import SetCoreConfigCallable
 
 
 def _sdkconfig_option(name: str) -> int | None:
-    from esphome.components.esp32.const import KEY_ESP32, KEY_SDKCONFIG_OPTIONS
-
     return CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS].get(name)
 
 
@@ -42,6 +49,18 @@ def test_tcp_send_buffer_overrides_high_performance(
     """An explicit size wins over the high performance bundle's 65534."""
     generate_main(component_config_path("tcp_send_buffer_high_perf.yaml"))
     assert _sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT") == 16384
+
+
+@pytest.mark.parametrize("value", [TCP_SEND_BUFFER_MIN, TCP_SEND_BUFFER_MAX])
+def test_boundary_values_accepted(
+    set_core_config: SetCoreConfigCallable, value: int
+) -> None:
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        core_data={KEY_FRAMEWORK_VERSION: cv.Version(5, 5, 5)},
+        platform_data={KEY_VARIANT: VARIANT_ESP32},
+    )
+    assert CONFIG_SCHEMA({"tcp_send_buffer": value})[CONF_TCP_SEND_BUFFER] == value
 
 
 @pytest.mark.parametrize("value", ["1kB", "128kB"])

--- a/tests/component_tests/network/test_tcp_send_buffer.py
+++ b/tests/component_tests/network/test_tcp_send_buffer.py
@@ -1,0 +1,66 @@
+"""Tests for the ``network: tcp_send_buffer:`` option.
+
+The option sets lwIP's per-socket TCP send buffer
+(CONFIG_LWIP_TCP_SND_BUF_DEFAULT) on ESP-IDF. The stock default (5744 bytes)
+stalls bursty senders such as a Bluetooth proxy streaming GATT notifications;
+until now the only way to raise it was the all-or-nothing
+``enable_high_performance`` bundle.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from voluptuous import Invalid
+
+from esphome import config_validation as cv
+from esphome.components.esp32.const import KEY_VARIANT, VARIANT_ESP32
+from esphome.components.network import CONFIG_SCHEMA
+from esphome.const import KEY_FRAMEWORK_VERSION, PlatformFramework
+from esphome.core import CORE
+from tests.component_tests.types import SetCoreConfigCallable
+
+
+def _sdkconfig_option(name: str) -> int | None:
+    from esphome.components.esp32.const import KEY_ESP32, KEY_SDKCONFIG_OPTIONS
+
+    return CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS].get(name)
+
+
+def test_tcp_send_buffer_sets_sdkconfig(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    generate_main(component_config_path("tcp_send_buffer.yaml"))
+    assert _sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT") == 32000
+
+
+def test_tcp_send_buffer_overrides_high_performance(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """An explicit size wins over the high performance bundle's 65534."""
+    generate_main(component_config_path("tcp_send_buffer_high_perf.yaml"))
+    assert _sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT") == 16384
+
+
+@pytest.mark.parametrize("value", ["1kB", "128kB"])
+def test_out_of_range_rejected(
+    set_core_config: SetCoreConfigCallable, value: str
+) -> None:
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        core_data={KEY_FRAMEWORK_VERSION: cv.Version(5, 5, 5)},
+        platform_data={KEY_VARIANT: VARIANT_ESP32},
+    )
+    with pytest.raises(Invalid):
+        CONFIG_SCHEMA({"tcp_send_buffer": value})
+
+
+def test_rejected_on_esp8266(set_core_config: SetCoreConfigCallable) -> None:
+    set_core_config(
+        PlatformFramework.ESP8266_ARDUINO,
+        core_data={KEY_FRAMEWORK_VERSION: cv.Version(3, 1, 2)},
+    )
+    with pytest.raises(Invalid, match="esp32"):
+        CONFIG_SCHEMA({"tcp_send_buffer": "32kB"})

--- a/tests/components/network/test-tcp-send-buffer.esp32-idf.yaml
+++ b/tests/components/network/test-tcp-send-buffer.esp32-idf.yaml
@@ -1,0 +1,6 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+network:
+  tcp_send_buffer: 32kB

--- a/tests/components/network/test-tcp-send-buffer.esp32-idf.yaml
+++ b/tests/components/network/test-tcp-send-buffer.esp32-idf.yaml
@@ -1,6 +1,0 @@
-wifi:
-  ssid: MySSID
-  password: password1
-
-network:
-  tcp_send_buffer: 32kB

--- a/tests/components/network/test.esp32-idf.yaml
+++ b/tests/components/network/test.esp32-idf.yaml
@@ -2,3 +2,4 @@
 
 network:
   enable_high_performance: true
+  tcp_send_buffer: 32kB


### PR DESCRIPTION
# What does this implement/fix?

Bluetooth proxies now surface dropped GATT replies with "TCP buffer full" warnings, but a user seeing them has no easy way to raise the buffer; the only existing knob is `enable_high_performance`, which also raises TCP windows and mailbox sizes and costs far more RAM than an original ESP32 without PSRAM can spare.

This adds a `tcp_send_buffer` option to the `network` component that sets lwIP's per socket send buffer (`CONFIG_LWIP_TCP_SND_BUF_DEFAULT`) on ESP-IDF; the stock default is 5744 bytes, which stalls bursty senders like a proxy streaming GATT notifications. An explicit size also wins over the high performance bundle's value when both are configured.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7239

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
network:
  tcp_send_buffer: 32kB
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

