### PR TITLE
[wifi] Inline the trivial WiFiScanResult accessors

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2396,14 +2396,6 @@ bool WiFiScanResult::matches(const WiFiAP &config) const {
   }
   return true;
 }
-bool WiFiScanResult::get_matches() const { return this->matches_; }
-void WiFiScanResult::set_matches(bool matches) { this->matches_ = matches; }
-const bssid_t &WiFiScanResult::get_bssid() const { return this->bssid_; }
-uint8_t WiFiScanResult::get_channel() const { return this->channel_; }
-int8_t WiFiScanResult::get_rssi() const { return this->rssi_; }
-bool WiFiScanResult::get_with_auth() const { return this->with_auth_; }
-bool WiFiScanResult::get_is_hidden() const { return this->is_hidden_; }
-
 bool WiFiScanResult::operator==(const WiFiScanResult &rhs) const { return this->bssid_ == rhs.bssid_; }
 
 void WiFiComponent::clear_roaming_state_() {

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -319,14 +319,14 @@ class WiFiScanResult {
 
   bool matches(const WiFiAP &config) const;
 
-  bool get_matches() const;
-  void set_matches(bool matches);
-  const bssid_t &get_bssid() const;
+  bool get_matches() const { return this->matches_; }
+  void set_matches(bool matches) { this->matches_ = matches; }
+  const bssid_t &get_bssid() const { return this->bssid_; }
   StringRef get_ssid() const { return this->ssid_.ref(); }
-  uint8_t get_channel() const;
-  int8_t get_rssi() const;
-  bool get_with_auth() const;
-  bool get_is_hidden() const;
+  uint8_t get_channel() const { return this->channel_; }
+  int8_t get_rssi() const { return this->rssi_; }
+  bool get_with_auth() const { return this->with_auth_; }
+  bool get_is_hidden() const { return this->is_hidden_; }
   int8_t get_priority() const { return priority_; }
   void set_priority(int8_t priority) { priority_ = priority; }
 


### PR DESCRIPTION
# What does this implement/fix?

`WiFiScanResult::get_matches()`, `set_matches()`, `get_bssid()`, `get_channel()`, `get_rssi()`, `get_with_auth()` and `get_is_hidden()` were one-line field reads (one field write for `set_matches()`) defined out of line in `wifi_component.cpp`. Every call site paid a call for a single load; there are about 40 call sites across the tree and these builds do not use LTO. This moves the bodies into the class definition in `wifi_component.h`, next to `get_ssid()` and `get_priority()` which were already inline, and deletes the out-of-line definitions. `matches()` and `operator==` are not touched.

Suggested by a review on #17847, split out as a standalone PR at a maintainer's request.

Measured with the example config below, dev `11ea819bc` vs this branch:

| Target | Flash dev | Flash branch | Delta | RAM dev | RAM branch |
| --- | --- | --- | --- | --- | --- |
| ESP8266 Arduino (d1_mini) | 352773 | 352741 | -32 bytes | 30676 | 30676 |
| ESP32-C3 ESP-IDF (esp32-c3-devkitm-1) | 840624 | 840586 | -38 bytes | 102154 | 102154 |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #17847

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: inline-test

# ESP8266 build
esp8266:
  board: d1_mini

# ESP32-C3 build (used instead of the esp8266 block above)
# esp32:
#   board: esp32-c3-devkitm-1
#   framework:
#     type: esp-idf

wifi:
  ssid: MySSID
  password: password1
  ap: {}

captive_portal:

logger:
  # hardware_uart: UART0  # ESP32-C3 build only

improv_serial:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
