### PR TITLE
[deep_sleep] Reject wakeup_pin_mode at both levels on BK72xx

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -163,6 +163,11 @@ def validate_config(config: ConfigType) -> ConfigType:
                     "You need to remove the global wakeup_pin_mode and define it per pin"
                 )
             if wakeup_pins:
+                if CONF_WAKEUP_PIN_MODE in wakeup_pins[0]:
+                    raise cv.Invalid(
+                        "Specify wakeup_pin_mode either at the top level under deep_sleep "
+                        "or under the pin entry, not both"
+                    )
                 wakeup_pins[0][CONF_WAKEUP_PIN_MODE] = config.pop(CONF_WAKEUP_PIN_MODE)
     elif (
         isinstance(config.get(CONF_WAKEUP_PIN), list)

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -1,5 +1,13 @@
 """Tests for the deep sleep component."""
 
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components import deep_sleep
+from esphome.const import CONF_WAKEUP_PIN, PlatformFramework
+
+from ..types import SetCoreConfigCallable
+
 
 def test_deep_sleep_setup(generate_main):
     """
@@ -83,3 +91,35 @@ def test_deep_sleep_run_duration_dictionary(generate_main):
         "    .gpio_cause = 30000,\n"
         "});"
     ) in main_cpp
+
+
+def test_deep_sleep_bk72xx_wakeup_pin_mode_at_both_levels_rejected(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """On BK72xx, wakeup_pin_mode at the top level and under the pin entry is an error."""
+    set_core_config(PlatformFramework.BK72XX_ARDUINO)
+    config = {
+        CONF_WAKEUP_PIN: [
+            {"pin": "GPIO12", deep_sleep.CONF_WAKEUP_PIN_MODE: "KEEP_AWAKE"}
+        ],
+        deep_sleep.CONF_WAKEUP_PIN_MODE: "INVERT_WAKEUP",
+    }
+    with pytest.raises(cv.Invalid, match="not both"):
+        deep_sleep.validate_config(config)
+
+
+def test_deep_sleep_bk72xx_top_level_wakeup_pin_mode_moved_onto_single_pin(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """On BK72xx, a top-level wakeup_pin_mode is moved onto the only pin entry."""
+    set_core_config(PlatformFramework.BK72XX_ARDUINO)
+    config = {
+        CONF_WAKEUP_PIN: [{"pin": "GPIO12"}],
+        deep_sleep.CONF_WAKEUP_PIN_MODE: "INVERT_WAKEUP",
+    }
+    result = deep_sleep.validate_config(config)
+
+    assert deep_sleep.CONF_WAKEUP_PIN_MODE not in result
+    assert (
+        result[CONF_WAKEUP_PIN][0][deep_sleep.CONF_WAKEUP_PIN_MODE] == "INVERT_WAKEUP"
+    )


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to esphome/esphome#16618, which made ESP32 reject `wakeup_pin_mode` set both at the top level under `deep_sleep` and under the single pin entry. On BK72xx the top-level value was copied onto the pin entry without checking whether the entry already had its own `wakeup_pin_mode`, so the nested value was silently overwritten. Such a config was already misconfigured, since one of the two values was never used. Validation now raises the same "not both" error on BK72xx. A top-level `wakeup_pin_mode` with a mode-less pin entry is still moved onto the entry as before.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# Now rejected on BK72xx with:
# "Specify wakeup_pin_mode either at the top level under deep_sleep or under the pin entry, not both"
deep_sleep:
  wakeup_pin_mode: INVERT_WAKEUP
  wakeup_pin:
    - pin: P8
      wakeup_pin_mode: KEEP_AWAKE
```

## Checklist:
  - [x] The code change is tested and works locally. (validation-level, no hardware)
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
