### PR TITLE
[wifi] Inline the remaining trivial WiFiAP and WiFiComponent accessors

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -618,8 +618,6 @@ static const char *eap_phase2_to_str(esp_eap_ttls_phase2_types type) {
 }
 #endif
 
-float WiFiComponent::get_setup_priority() const { return setup_priority::WIFI; }
-
 void WiFiComponent::setup() {
   this->wifi_pre_setup_();
 
@@ -931,10 +929,6 @@ void WiFiComponent::loop() {
 
 WiFiComponent::WiFiComponent() { global_wifi_component = this; }
 
-#ifdef USE_WIFI_11KV_SUPPORT
-void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }
-void WiFiComponent::set_rrm(bool rrm) { this->rrm_ = rrm; }
-#endif
 network::IPAddresses WiFiComponent::get_ip_addresses() {
   if (this->has_sta())
     return this->wifi_sta_ip_addresses();
@@ -1023,8 +1017,6 @@ void WiFiComponent::set_ap(const WiFiAP &ap) {
 }
 #endif  // USE_WIFI_AP
 
-void WiFiComponent::init_sta(size_t count) { this->sta_.init(count); }
-void WiFiComponent::add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
 void WiFiComponent::clear_sta() {
   // Clear roaming state - no more configured networks
   this->clear_roaming_state_();
@@ -1326,8 +1318,6 @@ void WiFiComponent::disable() {
   this->wifi_disconnect_();
   this->wifi_mode_(false, false);
 }
-
-bool WiFiComponent::is_disabled() { return this->state_ == WIFI_COMPONENT_STATE_DISABLED; }
 
 void WiFiComponent::start_scanning() {
   this->action_started_ = millis();
@@ -2196,15 +2186,12 @@ void WiFiComponent::retry_connect() {
   }
 }
 
-void WiFiComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   this->configured_power_save_ = power_save;
 #endif
 }
-
-void WiFiComponent::set_passive_scan(bool passive) { this->passive_scan_ = passive; }
 
 bool WiFiComponent::is_captive_portal_active_() {
 #ifdef USE_CAPTIVE_PORTAL
@@ -2323,33 +2310,6 @@ void WiFiComponent::save_fast_connect_settings_(const bssid_t &bssid, uint8_t ch
   ESP_LOGD(TAG, "Saved fast_connect settings");
 }
 #endif
-
-void WiFiAP::set_ssid(const std::string &ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
-void WiFiAP::set_ssid(const char *ssid) { this->ssid_ = CompactString(ssid, strlen(ssid)); }
-void WiFiAP::set_bssid(const bssid_t &bssid) { this->bssid_ = bssid; }
-void WiFiAP::clear_bssid() { this->bssid_ = {}; }
-void WiFiAP::set_password(const std::string &password) {
-  this->password_ = CompactString(password.c_str(), password.size());
-}
-void WiFiAP::set_password(const char *password) { this->password_ = CompactString(password, strlen(password)); }
-#ifdef USE_WIFI_WPA2_EAP
-void WiFiAP::set_eap(optional<EAPAuth> eap_auth) { this->eap_ = std::move(eap_auth); }
-#endif
-void WiFiAP::set_channel(uint8_t channel) { this->channel_ = channel; }
-void WiFiAP::clear_channel() { this->channel_ = 0; }
-#ifdef USE_WIFI_MANUAL_IP
-void WiFiAP::set_manual_ip(optional<ManualIP> manual_ip) { this->manual_ip_ = manual_ip; }
-#endif
-void WiFiAP::set_hidden(bool hidden) { this->hidden_ = hidden; }
-const bssid_t &WiFiAP::get_bssid() const { return this->bssid_; }
-bool WiFiAP::has_bssid() const { return this->bssid_ != bssid_t{}; }
-#ifdef USE_WIFI_WPA2_EAP
-const optional<EAPAuth> &WiFiAP::get_eap() const { return this->eap_; }
-#endif
-#ifdef USE_WIFI_MANUAL_IP
-const optional<ManualIP> &WiFiAP::get_manual_ip() const { return this->manual_ip_; }
-#endif
-bool WiFiAP::get_hidden() const { return this->hidden_; }
 
 WiFiScanResult::WiFiScanResult(const bssid_t &bssid, const char *ssid, size_t ssid_len, uint8_t channel, int8_t rssi,
                                bool with_auth, bool is_hidden)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1017,6 +1017,8 @@ void WiFiComponent::set_ap(const WiFiAP &ap) {
 }
 #endif  // USE_WIFI_AP
 
+void WiFiComponent::init_sta(size_t count) { this->sta_.init(count); }
+void WiFiComponent::add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
 void WiFiComponent::clear_sta() {
   // Clear roaming state - no more configured networks
   this->clear_roaming_state_();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -443,7 +443,7 @@ class WiFiComponent final : public Component {
   void set_sta(const WiFiAP &ap);
   // Returns a copy of the currently selected AP configuration
   WiFiAP get_sta() const;
-  // Kept out of line: inlining these into the generated setup() grows flash
+  // init_sta/add_sta kept out of line: inlining them into the generated setup() grows flash
   void init_sta(size_t count);
   void add_sta(const WiFiAP &ap);
   void clear_sta();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -442,8 +442,9 @@ class WiFiComponent final : public Component {
   void set_sta(const WiFiAP &ap);
   // Returns a copy of the currently selected AP configuration
   WiFiAP get_sta() const;
-  void init_sta(size_t count) { this->sta_.init(count); }
-  void add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
+  // Kept out of line: inlining these into the generated setup() grows flash
+  void init_sta(size_t count);
+  void add_sta(const WiFiAP &ap);
   void clear_sta();
 
 #ifdef USE_WIFI_AP

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -261,38 +261,38 @@ class WiFiAP {
   friend class WiFiScanResult;
 
  public:
-  void set_ssid(const std::string &ssid);
-  void set_ssid(const char *ssid);
+  void set_ssid(const std::string &ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
+  void set_ssid(const char *ssid) { this->ssid_ = CompactString(ssid, strlen(ssid)); }
   void set_ssid(StringRef ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
-  void set_bssid(const bssid_t &bssid);
-  void clear_bssid();
-  void set_password(const std::string &password);
-  void set_password(const char *password);
+  void set_bssid(const bssid_t &bssid) { this->bssid_ = bssid; }
+  void clear_bssid() { this->bssid_ = {}; }
+  void set_password(const std::string &password) { this->password_ = CompactString(password.c_str(), password.size()); }
+  void set_password(const char *password) { this->password_ = CompactString(password, strlen(password)); }
   void set_password(StringRef password) { this->password_ = CompactString(password.c_str(), password.size()); }
 #ifdef USE_WIFI_WPA2_EAP
-  void set_eap(optional<EAPAuth> eap_auth);
+  void set_eap(optional<EAPAuth> eap_auth) { this->eap_ = std::move(eap_auth); }
 #endif  // USE_WIFI_WPA2_EAP
-  void set_channel(uint8_t channel);
-  void clear_channel();
+  void set_channel(uint8_t channel) { this->channel_ = channel; }
+  void clear_channel() { this->channel_ = 0; }
   void set_priority(int8_t priority) { priority_ = priority; }
 #ifdef USE_WIFI_MANUAL_IP
-  void set_manual_ip(optional<ManualIP> manual_ip);
+  void set_manual_ip(optional<ManualIP> manual_ip) { this->manual_ip_ = manual_ip; }
 #endif
-  void set_hidden(bool hidden);
+  void set_hidden(bool hidden) { this->hidden_ = hidden; }
   StringRef get_ssid() const { return this->ssid_.ref(); }
   StringRef get_password() const { return this->password_.ref(); }
-  const bssid_t &get_bssid() const;
-  bool has_bssid() const;
+  const bssid_t &get_bssid() const { return this->bssid_; }
+  bool has_bssid() const { return this->bssid_ != bssid_t{}; }
 #ifdef USE_WIFI_WPA2_EAP
-  const optional<EAPAuth> &get_eap() const;
+  const optional<EAPAuth> &get_eap() const { return this->eap_; }
 #endif  // USE_WIFI_WPA2_EAP
   uint8_t get_channel() const { return this->channel_; }
   bool has_channel() const { return this->channel_ != 0; }
   int8_t get_priority() const { return priority_; }
 #ifdef USE_WIFI_MANUAL_IP
-  const optional<ManualIP> &get_manual_ip() const;
+  const optional<ManualIP> &get_manual_ip() const { return this->manual_ip_; }
 #endif
-  bool get_hidden() const;
+  bool get_hidden() const { return this->hidden_; }
 
  protected:
   CompactString ssid_;
@@ -442,8 +442,8 @@ class WiFiComponent final : public Component {
   void set_sta(const WiFiAP &ap);
   // Returns a copy of the currently selected AP configuration
   WiFiAP get_sta() const;
-  void init_sta(size_t count);
-  void add_sta(const WiFiAP &ap);
+  void init_sta(size_t count) { this->sta_.init(count); }
+  void add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
   void clear_sta();
 
 #ifdef USE_WIFI_AP
@@ -461,7 +461,7 @@ class WiFiComponent final : public Component {
 
   void enable();
   void disable();
-  bool is_disabled();
+  bool is_disabled() { return this->state_ == WIFI_COMPONENT_STATE_DISABLED; }
   void start_scanning();
   void check_scanning_finished();
   void start_connecting(const WiFiAP &ap);
@@ -472,7 +472,7 @@ class WiFiComponent final : public Component {
 
   void retry_connect();
 
-  void set_reboot_timeout(uint32_t reboot_timeout);
+  void set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 
   bool is_connected() const { return this->connected_; }
 
@@ -492,7 +492,7 @@ class WiFiComponent final : public Component {
   void set_phy_mode(WiFi8266PhyMode phy_mode) { this->phy_mode_ = phy_mode; }
 #endif
 
-  void set_passive_scan(bool passive);
+  void set_passive_scan(bool passive) { this->passive_scan_ = passive; }
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
   void save_wifi_sta(const char *ssid, const char *password);
@@ -506,7 +506,7 @@ class WiFiComponent final : public Component {
   void dump_config() override;
   void restart_adapter();
   /// WIFI setup_priority.
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return setup_priority::WIFI; }
   /// Reconnect WiFi if required.
   void loop() override;
 
@@ -515,8 +515,8 @@ class WiFiComponent final : public Component {
   bool is_ap_active() const { return this->ap_started_; }
 
 #ifdef USE_WIFI_11KV_SUPPORT
-  void set_btm(bool btm);
-  void set_rrm(bool rrm);
+  void set_btm(bool btm) { this->btm_ = btm; }
+  void set_rrm(bool rrm) { this->rrm_ = rrm; }
 #endif
 
   network::IPAddress get_dns_address(int num);

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -21,6 +21,7 @@
 #include <span>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #ifdef USE_LIBRETINY
@@ -262,12 +263,12 @@ class WiFiAP {
 
  public:
   void set_ssid(const std::string &ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
-  void set_ssid(const char *ssid) { this->ssid_ = CompactString(ssid, strlen(ssid)); }
+  void set_ssid(const char *ssid) { this->set_ssid(StringRef(ssid)); }
   void set_ssid(StringRef ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
   void set_bssid(const bssid_t &bssid) { this->bssid_ = bssid; }
   void clear_bssid() { this->bssid_ = {}; }
   void set_password(const std::string &password) { this->password_ = CompactString(password.c_str(), password.size()); }
-  void set_password(const char *password) { this->password_ = CompactString(password, strlen(password)); }
+  void set_password(const char *password) { this->set_password(StringRef(password)); }
   void set_password(StringRef password) { this->password_ = CompactString(password.c_str(), password.size()); }
 #ifdef USE_WIFI_WPA2_EAP
   void set_eap(optional<EAPAuth> eap_auth) { this->eap_ = std::move(eap_auth); }


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #18613. Moves the remaining one line `WiFiAP` setters and getters, plus `get_setup_priority`, `set_btm`, `set_rrm`, `is_disabled`, `set_reboot_timeout` and `set_passive_scan` on `WiFiComponent`, from `wifi_component.cpp` into the header so the compiler can inline them. `init_sta` and `add_sta` stay out of line on purpose; inlining them into the generated `setup()` made the firmware larger, so the first CI memory report showed a net zero.

Measured sizes, target branch to this PR: CI wifi test config on esp8266 312191 to 312143 bytes (48 bytes saved); minimal wifi plus logger config on esp32-idf 720431 to 720379 bytes (52 bytes saved), esp8266 303027 to 302979 bytes (48 bytes saved); RAM unchanged on all. No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wifi:
  networks:
    - ssid: MySSID
      password: password1
      priority: 10
    - ssid: MySSID2
      password: password2
      bssid: AA:BB:CC:DD:EE:FF
      hidden: true
  ap:
    ssid: Fallback AP
    password: fallback_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
