### PR TITLE
[ethernet] Inline the trivial EthernetComponent setters

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -10,14 +10,6 @@ EthernetComponent *global_eth_component;  // NOLINT(cppcoreguidelines-avoid-non-
 
 EthernetComponent::EthernetComponent() { global_eth_component = this; }
 
-float EthernetComponent::get_setup_priority() const { return setup_priority::WIFI; }
-
-void EthernetComponent::set_type(EthernetType type) { this->type_ = type; }
-
-#ifdef USE_ETHERNET_MANUAL_IP
-void EthernetComponent::set_manual_ip(const ManualIP &manual_ip) { this->manual_ip_ = manual_ip; }
-#endif
-
 #ifdef USE_ETHERNET_IP_STATE_LISTENERS
 void EthernetComponent::notify_ip_state_listeners_() {
   auto ips = this->get_ip_addresses();

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -125,7 +125,7 @@ class EthernetComponent final : public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return setup_priority::WIFI; }
   void on_powerdown() override { powerdown(); }
   bool is_connected() { return this->state_ == EthernetComponentState::CONNECTED; }
 
@@ -146,9 +146,9 @@ class EthernetComponent final : public Component {
   esp_netif_t *get_esp_netif() { return this->eth_netif_; }
 #endif
 
-  void set_type(EthernetType type);
+  void set_type(EthernetType type) { this->type_ = type; }
 #ifdef USE_ETHERNET_MANUAL_IP
-  void set_manual_ip(const ManualIP &manual_ip);
+  void set_manual_ip(const ManualIP &manual_ip) { this->manual_ip_ = manual_ip; }
 #endif
   void set_fixed_mac(const std::array<uint8_t, MAC_ADDRESS_SIZE> &mac) { this->fixed_mac_ = mac; }
 
@@ -171,35 +171,35 @@ class EthernetComponent final : public Component {
   esp_eth_handle_t get_eth_handle() const { return this->eth_handle_; }
 
 #ifdef USE_ETHERNET_SPI
-  void set_clk_pin(uint8_t clk_pin);
-  void set_miso_pin(uint8_t miso_pin);
-  void set_mosi_pin(uint8_t mosi_pin);
-  void set_cs_pin(uint8_t cs_pin);
-  void set_interrupt_pin(uint8_t interrupt_pin);
-  void set_reset_pin(uint8_t reset_pin);
-  void set_clock_speed(int clock_speed);
-  void set_interface(spi_host_device_t interface);
+  void set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
+  void set_miso_pin(uint8_t miso_pin) { this->miso_pin_ = miso_pin; }
+  void set_mosi_pin(uint8_t mosi_pin) { this->mosi_pin_ = mosi_pin; }
+  void set_cs_pin(uint8_t cs_pin) { this->cs_pin_ = cs_pin; }
+  void set_interrupt_pin(uint8_t interrupt_pin) { this->interrupt_pin_ = interrupt_pin; }
+  void set_reset_pin(uint8_t reset_pin) { this->reset_pin_ = reset_pin; }
+  void set_clock_speed(int clock_speed) { this->clock_speed_ = clock_speed; }
+  void set_interface(spi_host_device_t interface) { this->interface_ = interface; }
 #ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
-  void set_polling_interval(uint32_t polling_interval);
+  void set_polling_interval(uint32_t polling_interval) { this->polling_interval_ = polling_interval; }
 #endif
 #else
-  void set_phy_addr(uint8_t phy_addr);
-  void set_power_pin(int power_pin);
-  void set_mdc_pin(uint8_t mdc_pin);
-  void set_mdio_pin(uint8_t mdio_pin);
-  void set_clk_pin(uint8_t clk_pin);
-  void set_clk_mode(emac_rmii_clock_mode_t clk_mode);
+  void set_phy_addr(uint8_t phy_addr) { this->phy_addr_ = phy_addr; }
+  void set_power_pin(int power_pin) { this->power_pin_ = power_pin; }
+  void set_mdc_pin(uint8_t mdc_pin) { this->mdc_pin_ = mdc_pin; }
+  void set_mdio_pin(uint8_t mdio_pin) { this->mdio_pin_ = mdio_pin; }
+  void set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
+  void set_clk_mode(emac_rmii_clock_mode_t clk_mode) { this->clk_mode_ = clk_mode; }
   void add_phy_register(PHYRegister register_value);
 #endif  // USE_ETHERNET_SPI
 #endif  // USE_ESP32
 
 #ifdef USE_RP2
-  void set_clk_pin(uint8_t clk_pin);
-  void set_miso_pin(uint8_t miso_pin);
-  void set_mosi_pin(uint8_t mosi_pin);
-  void set_cs_pin(uint8_t cs_pin);
-  void set_interrupt_pin(int8_t interrupt_pin);
-  void set_reset_pin(int8_t reset_pin);
+  void set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
+  void set_miso_pin(uint8_t miso_pin) { this->miso_pin_ = miso_pin; }
+  void set_mosi_pin(uint8_t mosi_pin) { this->mosi_pin_ = mosi_pin; }
+  void set_cs_pin(uint8_t cs_pin) { this->cs_pin_ = cs_pin; }
+  void set_interrupt_pin(int8_t interrupt_pin) { this->interrupt_pin_ = interrupt_pin; }
+  void set_reset_pin(int8_t reset_pin) { this->reset_pin_ = reset_pin; }
 #endif  // USE_RP2
 
 #ifdef USE_ETHERNET_IP_STATE_LISTENERS

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -125,7 +125,7 @@ class EthernetComponent final : public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::WIFI; }
+  float get_setup_priority() const override { return setup_priority::ETHERNET; }
   void on_powerdown() override { powerdown(); }
   bool is_connected() { return this->state_ == EthernetComponentState::CONNECTED; }
 

--- a/esphome/components/ethernet/ethernet_component_esp32.cpp
+++ b/esphome/components/ethernet/ethernet_component_esp32.cpp
@@ -908,25 +908,7 @@ void EthernetComponent::dump_connect_params_() {
 #endif /* USE_NETWORK_IPV6 */
 }
 
-#ifdef USE_ETHERNET_SPI
-void EthernetComponent::set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
-void EthernetComponent::set_miso_pin(uint8_t miso_pin) { this->miso_pin_ = miso_pin; }
-void EthernetComponent::set_mosi_pin(uint8_t mosi_pin) { this->mosi_pin_ = mosi_pin; }
-void EthernetComponent::set_cs_pin(uint8_t cs_pin) { this->cs_pin_ = cs_pin; }
-void EthernetComponent::set_interrupt_pin(uint8_t interrupt_pin) { this->interrupt_pin_ = interrupt_pin; }
-void EthernetComponent::set_reset_pin(uint8_t reset_pin) { this->reset_pin_ = reset_pin; }
-void EthernetComponent::set_clock_speed(int clock_speed) { this->clock_speed_ = clock_speed; }
-void EthernetComponent::set_interface(spi_host_device_t interface) { this->interface_ = interface; }
-#ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
-void EthernetComponent::set_polling_interval(uint32_t polling_interval) { this->polling_interval_ = polling_interval; }
-#endif
-#else
-void EthernetComponent::set_phy_addr(uint8_t phy_addr) { this->phy_addr_ = phy_addr; }
-void EthernetComponent::set_power_pin(int power_pin) { this->power_pin_ = power_pin; }
-void EthernetComponent::set_mdc_pin(uint8_t mdc_pin) { this->mdc_pin_ = mdc_pin; }
-void EthernetComponent::set_mdio_pin(uint8_t mdio_pin) { this->mdio_pin_ = mdio_pin; }
-void EthernetComponent::set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
-void EthernetComponent::set_clk_mode(emac_rmii_clock_mode_t clk_mode) { this->clk_mode_ = clk_mode; }
+#ifndef USE_ETHERNET_SPI
 void EthernetComponent::add_phy_register(PHYRegister register_value) { this->phy_registers_.push_back(register_value); }
 #endif
 

--- a/esphome/components/ethernet/ethernet_component_rp2.cpp
+++ b/esphome/components/ethernet/ethernet_component_rp2.cpp
@@ -355,13 +355,6 @@ void EthernetComponent::dump_connect_params_() {
                 this->get_eth_mac_address_pretty_into_buffer(mac_buf));
 }
 
-void EthernetComponent::set_clk_pin(uint8_t clk_pin) { this->clk_pin_ = clk_pin; }
-void EthernetComponent::set_miso_pin(uint8_t miso_pin) { this->miso_pin_ = miso_pin; }
-void EthernetComponent::set_mosi_pin(uint8_t mosi_pin) { this->mosi_pin_ = mosi_pin; }
-void EthernetComponent::set_cs_pin(uint8_t cs_pin) { this->cs_pin_ = cs_pin; }
-void EthernetComponent::set_interrupt_pin(int8_t interrupt_pin) { this->interrupt_pin_ = interrupt_pin; }
-void EthernetComponent::set_reset_pin(int8_t reset_pin) { this->reset_pin_ = reset_pin; }
-
 void EthernetComponent::enable() {
   // RP2040 uses arduino-pico's LwipIntfDev which manages link state internally;
   // there is no clean enable/disable hook today. The YAML option is accepted on


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613 and #18617, applied to ethernet. The one line `EthernetComponent` setters (`set_type`, `set_manual_ip`, the SPI pin, clock speed, interface and polling interval setters, the RMII phy address, power, mdc, mdio, clk pin and clk mode setters, and the rp2040 pin setters) plus `get_setup_priority` move from the `.cpp` files into the header so the compiler can inline them at the call site. The bodies were identical across the esp32 and rp2040 files, so they now live once in the header inside the same `#ifdef` blocks as before. `add_phy_register` stays out of line since it calls `std::vector::push_back`.

While the line was being moved, `get_setup_priority` now returns `setup_priority::ETHERNET` instead of `setup_priority::WIFI`; both constants are 250.0f, so this is a readability rename with no behavior change.

Measured sizes, target branch to this PR, RAM unchanged on all: CI ethernet test config (LAN8720 RMII) on esp32-idf 338943 to 338823 bytes (120 bytes saved); W5500 SPI on esp32-idf 346543 to 346403 bytes (140 bytes saved); W5500 on rp2040 369200 to 369112 bytes (88 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ethernet:
  type: W5500
  clk_pin: 19
  mosi_pin: 21
  miso_pin: 23
  cs_pin: 18
  interrupt_pin: 36
  reset_pin: 22
  clock_speed: 10Mhz
  interface: spi2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
