### PR TITLE
[logger] Inline the trivial Logger accessors

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -201,16 +201,9 @@ void Logger::process_messages_() {
 #endif  // USE_ESPHOME_TASK_LOG_BUFFER
 }
 
-void Logger::set_baud_rate(uint32_t baud_rate) { this->baud_rate_ = baud_rate; }
 #ifdef USE_LOGGER_RUNTIME_TAG_LEVELS
 void Logger::set_log_level(const char *tag, uint8_t log_level) { this->log_levels_[tag] = log_level; }
 #endif
-
-#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
-UARTSelection Logger::get_uart() const { return this->uart_; }
-#endif
-
-float Logger::get_setup_priority() const { return setup_priority::BUS + 500.0f; }
 
 // Log level strings - packed into flash on ESP8266, indexed by log level (0-7)
 PROGMEM_STRING_TABLE(LogLevelStrings, "NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE");

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -148,7 +148,7 @@ class Logger final : public Component {
   void loop() override;
 #endif
   /// Manually set the baud rate for serial, set to 0 to disable.
-  void set_baud_rate(uint32_t baud_rate);
+  void set_baud_rate(uint32_t baud_rate) { this->baud_rate_ = baud_rate; }
   uint32_t get_baud_rate() const { return baud_rate_; }
 #if defined(USE_ARDUINO) && !defined(USE_ESP32)
   Stream *get_hw_serial() const { return hw_serial_; }
@@ -163,7 +163,7 @@ class Logger final : public Component {
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
   void set_uart_selection(UARTSelection uart_selection) { uart_ = uart_selection; }
   /// Get the UART used by the logger.
-  UARTSelection get_uart() const;
+  UARTSelection get_uart() const { return this->uart_; }
 #endif
 
   /// Set the default log level for this logger.
@@ -197,7 +197,7 @@ class Logger final : public Component {
   void add_level_listener(LoggerLevelListener *listener) { this->level_listeners_.push_back(listener); }
 #endif
 
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return setup_priority::BUS + 500.0f; }
 
   void log_vprintf_(uint8_t level, const char *tag, int line, const char *format, va_list args);  // NOLINT
 #ifdef USE_STORE_LOG_STR_IN_FLASH


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617 and #18618, applied to logger. `set_baud_rate`, `get_uart` and `get_setup_priority` move from `logger.cpp` into the header next to the other one line accessors. `set_log_level(tag, level)` stays out of line because it calls `std::map::operator[]`.

This one is tidying only. Measured with the CI logger test config, flash and RAM are byte for byte identical on esp32-idf (190959 bytes) and esp8266 (267255 bytes); the two setters were already dropped by the linker since nothing calls them, and `get_setup_priority` is virtual so its vtable entry is unchanged. No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
logger:
  level: DEBUG
  baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
