### PR TITLE
[light] Inline the trivial LightState accessors

### DIFF
--- a/esphome/components/light/esp_range_view.cpp
+++ b/esphome/components/light/esp_range_view.cpp
@@ -13,8 +13,6 @@ ESPColorView ESPRangeView::operator[](int32_t index) const {
   index = interpret_index(index, this->size()) + this->begin_;
   return (*this->parent_)[index];
 }
-ESPRangeIterator ESPRangeView::begin() { return {*this, this->begin_}; }
-ESPRangeIterator ESPRangeView::end() { return {*this, this->end_}; }
 
 void ESPRangeView::set(const Color &color) {
   for (int32_t i = this->begin_; i < this->end_; i++) {

--- a/esphome/components/light/esp_range_view.h
+++ b/esphome/components/light/esp_range_view.h
@@ -75,4 +75,7 @@ class ESPRangeIterator {
   int32_t i_;
 };
 
+inline ESPRangeIterator ESPRangeView::begin() { return {*this, this->begin_}; }
+inline ESPRangeIterator ESPRangeView::end() { return {*this, this->end_}; }
+
 }  // namespace esphome::light

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -157,8 +157,6 @@ void LightState::loop() {
   }
 }
 
-float LightState::get_setup_priority() const { return setup_priority::HARDWARE - 1.0f; }
-
 void LightState::publish_state() {
   if (this->remote_values_listeners_) {
     for (auto *listener : *this->remote_values_listeners_) {
@@ -194,25 +192,11 @@ void LightState::add_target_state_reached_listener(LightTargetStateReachedListen
   this->target_state_reached_listeners_->push_back(listener);
 }
 
-void LightState::set_default_transition_length(uint32_t default_transition_length) {
-  this->default_transition_length_ = default_transition_length;
-}
-uint32_t LightState::get_default_transition_length() const { return this->default_transition_length_; }
-void LightState::set_flash_transition_length(uint32_t flash_transition_length) {
-  this->flash_transition_length_ = flash_transition_length;
-}
-uint32_t LightState::get_flash_transition_length() const { return this->flash_transition_length_; }
-void LightState::set_gamma_correct(float gamma_correct) { this->gamma_correct_ = gamma_correct; }
-void LightState::set_restore_mode(LightRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }
-void LightState::set_initial_state(void (*callback)(LightStateRTCState &)) { this->initial_state_callback_ = callback; }
-bool LightState::supports_effects() { return !this->effects_.empty(); }
-const FixedVector<LightEffect *> &LightState::get_effects() const { return this->effects_; }
 void LightState::add_effects(const std::initializer_list<LightEffect *> &effects) {
   // Called once from Python codegen during setup with all effects from YAML config
   this->effects_ = effects;
 }
 
-void LightState::current_values_as_binary(bool *binary) { this->current_values.as_binary(binary); }
 void LightState::current_values_as_brightness(float *brightness) {
   this->current_values.as_brightness(brightness);
   *brightness = this->gamma_correct_lut(*brightness);
@@ -332,8 +316,6 @@ float LightState::gamma_uncorrect_lut(float value) const {
   return (lo + frac) / 255.0f;
 }
 #endif  // USE_LIGHT_GAMMA_LUT
-
-bool LightState::is_transformer_active() { return this->is_transformer_active_; }
 
 void LightState::start_effect_(uint32_t effect_index) {
   this->stop_effect_();

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -109,7 +109,7 @@ class LightState : public EntityBase, public Component {
   void dump_config() override;
   void loop() override;
   /// Shortly after HARDWARE.
-  float get_setup_priority() const override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
 
   /** The current values of the light as outputted to the light.
    *
@@ -157,15 +157,19 @@ class LightState : public EntityBase, public Component {
   void add_target_state_reached_listener(LightTargetStateReachedListener *listener);
 
   /// Set the default transition length, i.e. the transition length when no transition is provided.
-  void set_default_transition_length(uint32_t default_transition_length);
-  uint32_t get_default_transition_length() const;
+  void set_default_transition_length(uint32_t default_transition_length) {
+    this->default_transition_length_ = default_transition_length;
+  }
+  uint32_t get_default_transition_length() const { return this->default_transition_length_; }
 
   /// Set the flash transition length
-  void set_flash_transition_length(uint32_t flash_transition_length);
-  uint32_t get_flash_transition_length() const;
+  void set_flash_transition_length(uint32_t flash_transition_length) {
+    this->flash_transition_length_ = flash_transition_length;
+  }
+  uint32_t get_flash_transition_length() const { return this->flash_transition_length_; }
 
   /// Set the gamma correction factor
-  void set_gamma_correct(float gamma_correct);
+  void set_gamma_correct(float gamma_correct) { this->gamma_correct_ = gamma_correct; }
   float get_gamma_correct() const { return this->gamma_correct_; }
 
 #ifdef USE_LIGHT_GAMMA_LUT
@@ -186,17 +190,17 @@ class LightState : public EntityBase, public Component {
 #endif  // USE_LIGHT_GAMMA_LUT
 
   /// Set the restore mode of this light
-  void set_restore_mode(LightRestoreMode restore_mode);
+  void set_restore_mode(LightRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }
 
   /// Set a callback to populate the initial state defaults during setup.
   /// The callback is called once, then cleared. Values live in flash as code.
-  void set_initial_state(void (*callback)(LightStateRTCState &));
+  void set_initial_state(void (*callback)(LightStateRTCState &)) { this->initial_state_callback_ = callback; }
 
   /// Return whether the light has any effects that meet the trait requirements.
-  bool supports_effects();
+  bool supports_effects() { return !this->effects_.empty(); }
 
   /// Get all effects for this light state.
-  const FixedVector<LightEffect *> &get_effects() const;
+  const FixedVector<LightEffect *> &get_effects() const { return this->effects_; }
 
   /// Add effects for this light state.
   void add_effects(const std::initializer_list<LightEffect *> &effects);
@@ -254,7 +258,7 @@ class LightState : public EntityBase, public Component {
   }
 
   /// The result of all the current_values_as_* methods have gamma correction applied.
-  void current_values_as_binary(bool *binary);
+  void current_values_as_binary(bool *binary) { this->current_values.as_binary(binary); }
 
   void current_values_as_brightness(float *brightness);
 
@@ -281,7 +285,7 @@ class LightState : public EntityBase, public Component {
    *   return;
    * }
    */
-  bool is_transformer_active();
+  bool is_transformer_active() { return this->is_transformer_active_; }
 
  protected:
   friend LightOutput;

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -197,7 +197,7 @@ class LightState : public EntityBase, public Component {
   void set_initial_state(void (*callback)(LightStateRTCState &)) { this->initial_state_callback_ = callback; }
 
   /// Return whether the light has any effects that meet the trait requirements.
-  bool supports_effects() { return !this->effects_.empty(); }
+  bool supports_effects() const { return !this->effects_.empty(); }
 
   /// Get all effects for this light state.
   const FixedVector<LightEffect *> &get_effects() const { return this->effects_; }
@@ -285,7 +285,7 @@ class LightState : public EntityBase, public Component {
    *   return;
    * }
    */
-  bool is_transformer_active() { return this->is_transformer_active_; }
+  bool is_transformer_active() const { return this->is_transformer_active_; }
 
  protected:
   friend LightOutput;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617 and #18618, applied to light. The one line `LightState` accessors (`get_setup_priority`, the default and flash transition length setters and getters, `set_gamma_correct`, `set_restore_mode`, `set_initial_state`, `supports_effects`, `get_effects`, `current_values_as_binary`, `is_transformer_active`) move from `light_state.cpp` into the header, and `ESPRangeView::begin()` and `end()` become inline definitions placed after `ESPRangeIterator` in `esp_range_view.h`.

While they were being moved, `supports_effects()` and `is_transformer_active()` gained `const`; neither touches state, and the neighbouring `get_effects()` was already `const`. Both are non virtual and every in tree caller uses a non const object, so nothing else changes.

Left out on purpose: `make_call`, `turn_on`, `turn_off` and `toggle` (inlining them was a wash, 12 bytes larger on esp32-idf and 32 smaller on esp8266, so they stay as they are), `add_effects` (assigns a `FixedVector` from an initializer list) and `get_traits` (`LightOutput` is only forward declared in `light_state.h`).

Measured with the CI light test config, target branch to this PR, RAM unchanged: esp32-idf 235851 to 235595 bytes (256 bytes saved); esp8266 302815 to 302527 bytes (288 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: binary
    name: Test Light
    output: out1
    restore_mode: ALWAYS_OFF
    default_transition_length: 500ms
    gamma_correct: 2.8
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
