### PR TITLE
[select] Inline the trivial Select accessors

### DIFF
--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -32,11 +32,6 @@ void Select::publish_state(size_t index) {
 #endif
 }
 
-size_t Select::size() const {
-  const auto &options = traits.get_options();
-  return options.size();
-}
-
 optional<size_t> Select::index_of(const char *option, size_t len) const {
   const auto &options = traits.get_options();
   for (size_t i = 0; i < options.size(); i++) {

--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -8,8 +8,6 @@ namespace esphome::select {
 
 static const char *const TAG = "select";
 
-void Select::publish_state(const std::string &state) { this->publish_state(state.c_str()); }
-
 void Select::publish_state(const char *state) {
   auto index = this->index_of(state);
   if (index.has_value()) {
@@ -33,16 +31,6 @@ void Select::publish_state(size_t index) {
   ControllerRegistry::notify_select_update(this);
 #endif
 }
-
-StringRef Select::current_option() const {
-  return this->has_state() ? StringRef(this->option_at(this->active_index_)) : StringRef();
-}
-
-bool Select::has_option(const std::string &option) const { return this->index_of(option.c_str()).has_value(); }
-
-bool Select::has_option(const char *option) const { return this->index_of(option).has_value(); }
-
-bool Select::has_index(size_t index) const { return index < this->size(); }
 
 size_t Select::size() const {
   const auto &options = traits.get_options();

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -33,24 +33,26 @@ class Select : public EntityBase {
   Select() = default;
   ~Select() = default;
 
-  void publish_state(const std::string &state);
+  void publish_state(const std::string &state) { this->publish_state(state.c_str()); }
   void publish_state(const char *state);
   void publish_state(size_t index);
 
   /// Return the currently selected option, or empty StringRef if no state.
   /// The returned StringRef points to string literals from codegen (static storage).
   /// Traits are set once at startup and valid for the lifetime of the program.
-  StringRef current_option() const;
+  StringRef current_option() const {
+    return this->has_state() ? StringRef(this->option_at(this->active_index_)) : StringRef();
+  }
 
   /// Instantiate a SelectCall object to modify this select component's state.
   SelectCall make_call() { return SelectCall(this); }
 
   /// Return whether this select component contains the provided option.
-  bool has_option(const std::string &option) const;
-  bool has_option(const char *option) const;
+  bool has_option(const std::string &option) const { return this->index_of(option.c_str()).has_value(); }
+  bool has_option(const char *option) const { return this->index_of(option).has_value(); }
 
   /// Return whether this select component contains the provided index offset.
-  bool has_index(size_t index) const;
+  bool has_index(size_t index) const { return index < this->size(); }
 
   /// Return the number of options in this select component.
   size_t size() const;

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -48,14 +48,14 @@ class Select : public EntityBase {
   SelectCall make_call() { return SelectCall(this); }
 
   /// Return whether this select component contains the provided option.
-  bool has_option(const std::string &option) const { return this->index_of(option.c_str()).has_value(); }
+  bool has_option(const std::string &option) const { return this->index_of(option).has_value(); }
   bool has_option(const char *option) const { return this->index_of(option).has_value(); }
 
   /// Return whether this select component contains the provided index offset.
   bool has_index(size_t index) const { return index < this->size(); }
 
   /// Return the number of options in this select component.
-  size_t size() const;
+  size_t size() const { return this->traits.get_options().size(); }
 
   /// Find the (optional) index offset of the provided option value.
   optional<size_t> index_of(const char *option, size_t len) const;

--- a/esphome/components/select/select_traits.cpp
+++ b/esphome/components/select/select_traits.cpp
@@ -11,6 +11,4 @@ void SelectTraits::set_options(const FixedVector<const char *> &options) {
   }
 }
 
-const FixedVector<const char *> &SelectTraits::get_options() const { return this->options_; }
-
 }  // namespace esphome::select

--- a/esphome/components/select/select_traits.h
+++ b/esphome/components/select/select_traits.h
@@ -9,7 +9,7 @@ class SelectTraits {
  public:
   void set_options(const std::initializer_list<const char *> &options);
   void set_options(const FixedVector<const char *> &options);
-  const FixedVector<const char *> &get_options() const;
+  const FixedVector<const char *> &get_options() const { return this->options_; }
 
  protected:
   FixedVector<const char *> options_;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617, #18618 and #18620, applied to select. `Select::publish_state(const std::string &)`, `current_option`, both `has_option` overloads, `has_index`, `size` and `SelectTraits::get_options` move from the `.cpp` files into the headers so the compiler can inline them at the call site. `SelectTraits::set_options` stays out of line since it fills a `FixedVector` from the generated `setup()`.

Two small things picked up on the way: `size()` is inlined too so `has_index()` collapses to a load and compare instead of still calling out of line, and `has_option(const std::string &)` now uses the existing length based `index_of(const std::string &)` overload instead of going through `c_str()`, which avoids a `strlen` per call and matches what `control(const std::string &)` does.

`size()` used to bind `traits.get_options()` to a local reference first; that local dates from #10741, when `get_options()` still returned a `std::vector<std::string>` by value. Since #11514 it returns a const reference to a member, so calling `.size()` on it directly is the same thing with one line less.

There is no `tests/components/select` build, so this was measured two ways, target branch to this PR, RAM unchanged. A template select that calls `select.set`, `select.set_index`, `has_option`, `has_index` and `current_option` from `on_boot`: esp32-idf 191023 to 190831 bytes (192 bytes saved), esp8266 264915 to 264675 bytes (240 bytes saved). The same select with `api:` and `web_server:` enabled so `current_option()` is expanded at several call sites: esp32-idf 733011 to 732935 bytes (76 bytes saved), esp8266 366289 to 366209 bytes (80 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
select:
  - platform: template
    id: sel1
    name: Sel
    optimistic: true
    options:
      - one
      - two
      - three
    initial_option: one
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
