### PR TITLE
[text_sensor] Inline the trivial TextSensor forwarding overloads

### DIFF
--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -18,10 +18,6 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
   LOG_ENTITY_ICON(tag, prefix, *obj);
 }
 
-void TextSensor::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }
-
-void TextSensor::publish_state(const char *state) { this->publish_state(state, strlen(state)); }
-
 void TextSensor::publish_state(const char *state, size_t len) {
 #ifdef USE_TEXT_SENSOR_FILTER
   if (this->filter_list_ == nullptr) {
@@ -91,10 +87,6 @@ const std::string &TextSensor::get_raw_state() const {
 #endif
   return this->state;  // No filters, raw == filtered
 }
-void TextSensor::internal_send_state_to_frontend(const std::string &state) {
-  this->internal_send_state_to_frontend(state.data(), state.size());
-}
-
 void TextSensor::internal_send_state_to_frontend(const char *state, size_t len) {
   // Only assign if changed to avoid heap allocation
   if (len != this->state.size() || memcmp(state, this->state.data(), len) != 0) {

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -37,8 +37,8 @@ class TextSensor : public EntityBase {
   /// Returns the raw (pre-filter) state.
   const std::string &get_raw_state() const;
 
-  void publish_state(const std::string &state);
-  void publish_state(const char *state);
+  void publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }
+  void publish_state(const char *state) { this->publish_state(state, strlen(state)); }
   void publish_state(const char *state, size_t len);
 
 #ifdef USE_TEXT_SENSOR_FILTER
@@ -70,7 +70,9 @@ class TextSensor : public EntityBase {
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
 
-  void internal_send_state_to_frontend(const std::string &state);
+  void internal_send_state_to_frontend(const std::string &state) {
+    this->internal_send_state_to_frontend(state.data(), state.size());
+  }
   void internal_send_state_to_frontend(const char *state, size_t len);
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617, #18618, #18620, #18621 and #18622, applied to text_sensor. The `std::string` and `const char *` overloads of `TextSensor::publish_state`, and the `std::string` overload of `internal_send_state_to_frontend`, only forward to the pointer plus length overload; they move from `text_sensor.cpp` into the header so the compiler can inline the forwarding at the call site. `LambdaFilter::set_lambda_filter` assigns a `std::function`, so it stays as it is.

Measured target branch to this PR, RAM unchanged: CI text_sensor test config on esp8266 270787 to 270755 bytes (32 bytes saved); a template text sensor with a `to_upper` filter on esp32-idf 189679 to 189651 bytes (28 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
text_sensor:
  - platform: template
    name: Text
    lambda: return {"hello"};
    update_interval: 1s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
