### PR TITLE
[climate] Inline the trivial visual override setters

### DIFF
--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -511,29 +511,6 @@ ClimateTraits Climate::get_traits() {
   return traits;
 }
 
-#ifdef USE_CLIMATE_VISUAL_OVERRIDES
-void Climate::set_visual_min_temperature_override(float visual_min_temperature_override) {
-  this->visual_min_temperature_override_ = visual_min_temperature_override;
-}
-
-void Climate::set_visual_max_temperature_override(float visual_max_temperature_override) {
-  this->visual_max_temperature_override_ = visual_max_temperature_override;
-}
-
-void Climate::set_visual_temperature_step_override(float target, float current) {
-  this->visual_target_temperature_step_override_ = target;
-  this->visual_current_temperature_step_override_ = current;
-}
-
-void Climate::set_visual_min_humidity_override(float visual_min_humidity_override) {
-  this->visual_min_humidity_override_ = visual_min_humidity_override;
-}
-
-void Climate::set_visual_max_humidity_override(float visual_max_humidity_override) {
-  this->visual_max_humidity_override_ = visual_max_humidity_override;
-}
-#endif
-
 ClimateCall Climate::make_call() { return ClimateCall(this); }
 
 ClimateCall ClimateDeviceRestoreState::to_call(Climate *climate) {

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -228,11 +228,22 @@ class Climate : public EntityBase {
   ClimateTraits get_traits();
 
 #ifdef USE_CLIMATE_VISUAL_OVERRIDES
-  void set_visual_min_temperature_override(float visual_min_temperature_override);
-  void set_visual_max_temperature_override(float visual_max_temperature_override);
-  void set_visual_temperature_step_override(float target, float current);
-  void set_visual_min_humidity_override(float visual_min_humidity_override);
-  void set_visual_max_humidity_override(float visual_max_humidity_override);
+  void set_visual_min_temperature_override(float visual_min_temperature_override) {
+    this->visual_min_temperature_override_ = visual_min_temperature_override;
+  }
+  void set_visual_max_temperature_override(float visual_max_temperature_override) {
+    this->visual_max_temperature_override_ = visual_max_temperature_override;
+  }
+  void set_visual_temperature_step_override(float target, float current) {
+    this->visual_target_temperature_step_override_ = target;
+    this->visual_current_temperature_step_override_ = current;
+  }
+  void set_visual_min_humidity_override(float visual_min_humidity_override) {
+    this->visual_min_humidity_override_ = visual_min_humidity_override;
+  }
+  void set_visual_max_humidity_override(float visual_max_humidity_override) {
+    this->visual_max_humidity_override_ = visual_max_humidity_override;
+  }
 #endif
 
   /// Set the supported custom fan modes (stored on Climate, referenced by ClimateTraits).


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617, #18618, #18620, #18621, #18622 and #18623, applied to climate. The five `Climate::set_visual_*_override` setters behind `USE_CLIMATE_VISUAL_OVERRIDES` only store a float or two; they move from `climate.cpp` into the header so the compiler can inline them where the generated `setup()` calls them. `make_call` and the protected mode helpers stay as they are.

Measured target branch to this PR, RAM unchanged: a bang bang climate with a `visual:` block on esp32-idf 195355 to 195319 bytes (36 bytes saved); the CI climate test config on esp8266 293075 to 293075 bytes (no change, that config does not set any visual overrides). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
climate:
  - platform: bang_bang
    name: Clim
    sensor: temp
    default_target_temperature_low: 18
    default_target_temperature_high: 22
    heat_action:
      - switch.turn_on: heat
    idle_action:
      - switch.turn_off: heat
    visual:
      min_temperature: 10
      max_temperature: 30
      temperature_step: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
