### PR TITLE
[esphome] Inline the trivial OTA port accessors

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -588,8 +588,6 @@ bool ESPHomeOTAComponent::writeall_(const uint8_t *buf, size_t len) {
 }
 
 float ESPHomeOTAComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
-uint16_t ESPHomeOTAComponent::get_port() const { return this->port_; }
-void ESPHomeOTAComponent::set_port(uint16_t port) { this->port_ = port; }
 
 void ESPHomeOTAComponent::log_socket_error_(const LogString *msg) {
   ESP_LOGW(TAG, "Socket %s: errno %d", LOG_STR_ARG(msg), errno);

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -39,14 +39,14 @@ class ESPHomeOTAComponent final : public ota::OTAComponent {
 #endif  // USE_OTA_PASSWORD
 
   /// Manually set the port OTA should listen on
-  void set_port(uint16_t port);
+  void set_port(uint16_t port) { this->port_ = port; }
 
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
   void loop() override;
 
-  uint16_t get_port() const;
+  uint16_t get_port() const { return this->port_; }
 
  protected:
   void handle_handshake_();


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617, #18618, #18620, #18621, #18622, #18623 and #18624, applied to the esphome OTA platform. `ESPHomeOTAComponent::set_port` and `get_port` move from `ota_esphome.cpp` into the header so the compiler can inline them; `set_port` is called from the generated `setup()` and `get_port` from `dump_config` and mdns. The `log_*` helpers stay out of line on purpose, they exist to keep the log calls in one place.

Measured target branch to this PR with wifi plus `ota: platform: esphome`, RAM unchanged: esp32-idf 685979 to 685927 bytes (52 bytes saved); esp8266 318163 to 318147 bytes (16 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ota:
  - platform: esphome
    port: 3232
    password: otapass
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
