### PR TITLE
[safe_mode] Inline the trivial set_safe_mode setters

### DIFF
--- a/esphome/components/safe_mode/button/safe_mode_button.cpp
+++ b/esphome/components/safe_mode/button/safe_mode_button.cpp
@@ -7,10 +7,6 @@ namespace esphome::safe_mode {
 
 static const char *const TAG = "safe_mode.button";
 
-void SafeModeButton::set_safe_mode(SafeModeComponent *safe_mode_component) {
-  this->safe_mode_component_ = safe_mode_component;
-}
-
 void SafeModeButton::press_action() {
   ESP_LOGI(TAG, "Restarting in safe mode");
   this->safe_mode_component_->set_safe_mode_pending(true);

--- a/esphome/components/safe_mode/button/safe_mode_button.h
+++ b/esphome/components/safe_mode/button/safe_mode_button.h
@@ -9,7 +9,7 @@ namespace esphome::safe_mode {
 class SafeModeButton final : public button::Button, public Component {
  public:
   void dump_config() override;
-  void set_safe_mode(SafeModeComponent *safe_mode_component);
+  void set_safe_mode(SafeModeComponent *safe_mode_component) { this->safe_mode_component_ = safe_mode_component; }
 
  protected:
   SafeModeComponent *safe_mode_component_;

--- a/esphome/components/safe_mode/switch/safe_mode_switch.cpp
+++ b/esphome/components/safe_mode/switch/safe_mode_switch.cpp
@@ -7,10 +7,6 @@ namespace esphome::safe_mode {
 
 static const char *const TAG = "safe_mode.switch";
 
-void SafeModeSwitch::set_safe_mode(SafeModeComponent *safe_mode_component) {
-  this->safe_mode_component_ = safe_mode_component;
-}
-
 void SafeModeSwitch::write_state(bool state) {
   // Acknowledge
   this->publish_state(false);

--- a/esphome/components/safe_mode/switch/safe_mode_switch.h
+++ b/esphome/components/safe_mode/switch/safe_mode_switch.h
@@ -9,7 +9,7 @@ namespace esphome::safe_mode {
 class SafeModeSwitch final : public switch_::Switch, public Component {
  public:
   void dump_config() override;
-  void set_safe_mode(SafeModeComponent *safe_mode_component);
+  void set_safe_mode(SafeModeComponent *safe_mode_component) { this->safe_mode_component_ = safe_mode_component; }
 
  protected:
   SafeModeComponent *safe_mode_component_;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617, #18618, #18620, #18621, #18622, #18623, #18624 and #18625, applied to safe_mode. `SafeModeButton::set_safe_mode` and `SafeModeSwitch::set_safe_mode` only store a pointer; they move from the `.cpp` files into the headers so the compiler can inline them where the generated `setup()` calls them. `get_setup_priority` and the `dump_config` overrides are virtual and stay as they are.

Measured target branch to this PR with `safe_mode` plus its button and switch, RAM unchanged: esp32-idf 191387 to 191363 bytes (24 bytes saved); esp8266 265391 to 265375 bytes (16 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
safe_mode:
  id: sm
button:
  - platform: safe_mode
    name: SM Button
switch:
  - platform: safe_mode
    name: SM Switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
