### PR TITLE
[api] Inline the trivial APIServer accessors

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -423,12 +423,6 @@ void APIServer::send_infrared_rf_receive_event([[maybe_unused]] uint32_t device_
 API_DISPATCH_UPDATE(alarm_control_panel::AlarmControlPanel, alarm_control_panel)
 #endif
 
-float APIServer::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
-
-void APIServer::set_port(uint16_t port) { this->port_ = port; }
-
-void APIServer::set_batch_delay(uint16_t batch_delay) { this->batch_delay_ = batch_delay; }
-
 #ifdef USE_API_HOMEASSISTANT_SERVICES
 void APIServer::send_homeassistant_action(const HomeassistantActionRequest &call) {
   bool has_subscriber = false;
@@ -552,10 +546,6 @@ const std::vector<APIServer::HomeAssistantStateSubscription> &APIServer::get_sta
   return this->state_subs_;
 }
 #endif
-
-uint16_t APIServer::get_port() const { return this->port_; }
-
-void APIServer::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 
 #ifdef USE_API_NOISE
 bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg,

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -51,8 +51,8 @@ class APIServer final : public Component,
  public:
   APIServer();
   void setup() override;
-  uint16_t get_port() const;
-  float get_setup_priority() const override;
+  uint16_t get_port() const { return this->port_; }
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void loop() override;
   void dump_config() override;
   void on_shutdown() override;
@@ -63,9 +63,9 @@ class APIServer final : public Component,
 #ifdef USE_CAMERA
   void on_camera_image(const std::shared_ptr<camera::CameraImage> &image) override;
 #endif
-  void set_port(uint16_t port);
-  void set_reboot_timeout(uint32_t reboot_timeout);
-  void set_batch_delay(uint16_t batch_delay);
+  void set_port(uint16_t port) { this->port_ = port; }
+  void set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
+  void set_batch_delay(uint16_t batch_delay) { this->batch_delay_ = batch_delay; }
   uint16_t get_batch_delay() const { return batch_delay_; }
   void set_listen_backlog(uint8_t listen_backlog) { this->listen_backlog_ = listen_backlog; }
 


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18613, #18617, #18618, #18620, #18621, #18622, #18623, #18624, #18625 and #18626, applied to api. `APIServer::set_port`, `set_reboot_timeout`, `set_batch_delay`, `get_port` and `get_setup_priority` move from `api_server.cpp` into the header so the compiler can inline them; the setters are called from the generated `setup()` and `get_port` from mdns and `dump_config`. The `on_*` handlers and `varint_slow` stay as they are, the first are virtual and the second is a deliberate slow path.

Measured with the CI api test config, target branch to this PR, RAM unchanged: esp32-idf 781983 to 781935 bytes (48 bytes saved); esp8266 439087 to 439055 bytes (32 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  port: 6053
  reboot_timeout: 15min
  batch_delay: 100ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
