### PR TITLE
[core] Inline the ESPTime::strftime std::string overload

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -114,8 +114,6 @@ std::string ESPTime::strftime(const char *format) {
   return std::string(buf, len);
 }
 
-std::string ESPTime::strftime(const std::string &format) { return this->strftime(format.c_str()); }
-
 // Helper to parse exactly N digits, returns false if not enough digits
 static bool parse_digits(const char *&p, const char *end, int count, uint16_t &value) {
   value = 0;

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -71,7 +71,7 @@ struct ESPTime {
    * @warning This method can return "ERROR" when the underlying strftime() call fails or when the
    * output exceeds STRFTIME_BUFFER_SIZE bytes.
    */
-  std::string strftime(const std::string &format);
+  std::string strftime(const std::string &format) { return this->strftime(format.c_str()); }
 
   /// @copydoc strftime(const std::string &format)
   std::string strftime(const char *format);


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the component inlining PRs (#18617 and friends), applied to `esphome/core`. `ESPTime::strftime(const std::string &)` only forwards to the `const char *` overload; it moves from `time.cpp` into `time.h` so the forwarding is inlined at the call site, which is usually a user lambda. Nothing else in core qualified: `PollingComponent::get_update_interval` and the `Component` defaults are virtual, `Component::cancel_*` need `App` (circular include), and `Application::get_config_hash` and friends read the generated `extern` build info that only `application.cpp` includes.

Measured with sntp time plus an `on_boot` lambda calling `strftime` with a `std::string`, target branch to this PR, RAM unchanged: esp32-idf 701559 to 701539 bytes (20 bytes saved); esp8266 317475 to 317443 bytes (32 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
time:
  - platform: sntp
    id: sntp_time
esphome:
  on_boot:
    - lambda: |-
        std::string fmt = "%H:%M";
        ESP_LOGI("t", "%s", id(sntp_time).now().strftime(fmt).c_str());
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
