### PR TITLE
[water_heater] Inline the trivial visual override setters

### DIFF
--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -233,18 +233,6 @@ WaterHeaterTraits WaterHeater::get_traits() {
   return traits;
 }
 
-#ifdef USE_WATER_HEATER_VISUAL_OVERRIDES
-void WaterHeater::set_visual_min_temperature_override(float min_temperature_override) {
-  this->visual_min_temperature_override_ = min_temperature_override;
-}
-void WaterHeater::set_visual_max_temperature_override(float max_temperature_override) {
-  this->visual_max_temperature_override_ = max_temperature_override;
-}
-void WaterHeater::set_visual_target_temperature_step_override(float visual_target_temperature_step_override) {
-  this->visual_target_temperature_step_override_ = visual_target_temperature_step_override;
-}
-#endif
-
 // Water heater mode strings indexed by WaterHeaterMode enum (0-6): OFF, ECO, ELECTRIC, PERFORMANCE, HIGH_DEMAND,
 // HEAT_PUMP, GAS
 PROGMEM_STRING_TABLE(WaterHeaterModeStrings, "OFF", "ECO", "ELECTRIC", "PERFORMANCE", "HIGH_DEMAND", "HEAT_PUMP", "GAS",

--- a/esphome/components/water_heater/water_heater.h
+++ b/esphome/components/water_heater/water_heater.h
@@ -217,9 +217,15 @@ class WaterHeater : public EntityBase {
   virtual WaterHeaterCallInternal make_call() = 0;
 
 #ifdef USE_WATER_HEATER_VISUAL_OVERRIDES
-  void set_visual_min_temperature_override(float min_temperature_override);
-  void set_visual_max_temperature_override(float max_temperature_override);
-  void set_visual_target_temperature_step_override(float visual_target_temperature_step_override);
+  void set_visual_min_temperature_override(float min_temperature_override) {
+    this->visual_min_temperature_override_ = min_temperature_override;
+  }
+  void set_visual_max_temperature_override(float max_temperature_override) {
+    this->visual_max_temperature_override_ = max_temperature_override;
+  }
+  void set_visual_target_temperature_step_override(float visual_target_temperature_step_override) {
+    this->visual_target_temperature_step_override_ = visual_target_temperature_step_override;
+  }
 #endif
   virtual void control(const WaterHeaterCall &call) = 0;
 


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18624 for climate, applied to water_heater. The three `WaterHeater::set_visual_*_override` setters behind `USE_WATER_HEATER_VISUAL_OVERRIDES` only store a float; they move from `water_heater.cpp` into the header so the compiler can inline them where the generated `setup()` calls them.

Measured with a template water heater with a `visual:` block, target branch to this PR, RAM unchanged: esp32-idf 190243 to 190207 bytes (36 bytes saved); esp8266 263683 to 263667 bytes (16 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
water_heater:
  - platform: template
    name: "Test Boiler"
    optimistic: true
    current_temperature: !lambda return 45.0f;
    visual:
      min_temperature: 10
      max_temperature: 85
      target_temperature_step: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
