### PR TITLE
[cover] Inline the trivial Cover and CoverCall accessors

### DIFF
--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -135,10 +135,6 @@ CoverCall &CoverCall::set_stop(bool stop) {
   this->stop_ = stop;
   return *this;
 }
-bool CoverCall::get_stop() const { return this->stop_; }
-
-CoverCall Cover::make_call() { return {this}; }
-
 void Cover::publish_state(bool save) {
   this->position = clamp(this->position, 0.0f, 1.0f);
   this->tilt = clamp(this->tilt, 0.0f, 1.0f);
@@ -183,9 +179,6 @@ optional<CoverRestoreState> Cover::restore_state_() {
     return {};
   return recovered;
 }
-
-bool Cover::is_fully_open() const { return this->position == COVER_OPEN; }
-bool Cover::is_fully_closed() const { return this->position == COVER_CLOSED; }
 
 CoverCall CoverRestoreState::to_call(Cover *cover) {
   auto call = cover->make_call();

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -50,7 +50,7 @@ class CoverCall {
   void perform();
 
   const optional<float> &get_position() const;
-  bool get_stop() const;
+  bool get_stop() const { return this->stop_; }
   const optional<float> &get_tilt() const;
   const optional<bool> &get_toggle() const;
 
@@ -123,7 +123,7 @@ class Cover : public EntityBase {
   float tilt{COVER_OPEN};
 
   /// Construct a new cover call used to control the cover.
-  CoverCall make_call();
+  CoverCall make_call() { return {this}; }
 
   template<typename F> void add_on_state_callback(F &&f) { this->state_callback_.add(std::forward<F>(f)); }
 
@@ -139,9 +139,9 @@ class Cover : public EntityBase {
   virtual CoverTraits get_traits() = 0;
 
   /// Helper method to check if the cover is fully open. Equivalent to comparing .position against 1.0
-  bool is_fully_open() const;
+  bool is_fully_open() const { return this->position == COVER_OPEN; }
   /// Helper method to check if the cover is fully closed. Equivalent to comparing .position against 0.0
-  bool is_fully_closed() const;
+  bool is_fully_closed() const { return this->position == COVER_CLOSED; }
 
  protected:
   friend CoverCall;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18621 for select, applied to cover. `Cover::make_call`, `is_fully_open`, `is_fully_closed` and `CoverCall::get_stop` move from `cover.cpp` into the header so the compiler can inline them at the call site; `make_call` is what every automation, the api and the web server go through, and the CodSpeed cover benchmarks call it as well.

There is no `tests/components/cover` build, so this was measured with a template cover driven from `on_boot` (`make_call`, `cover.open`, `cover.toggle`, `is_fully_open`, `is_fully_closed`), target branch to this PR, RAM unchanged: esp32-idf 191463 to 191423 bytes (40 bytes saved); esp8266 265031 to 264951 bytes (80 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
cover:
  - platform: template
    id: cov1
    name: Cov
    lambda: return 0.5f;
    has_position: true
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
