### PR TITLE
[fan] Inline the trivial Fan call helpers

### DIFF
--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -153,11 +153,6 @@ void FanRestoreState::apply(Fan &fan) {
   fan.publish_state();
 }
 
-FanCall Fan::turn_on() { return this->make_call().set_state(true); }
-FanCall Fan::turn_off() { return this->make_call().set_state(false); }
-FanCall Fan::toggle() { return this->make_call().set_state(!this->state); }
-FanCall Fan::make_call() { return FanCall(*this); }
-
 const char *Fan::find_preset_mode_(const char *preset_mode) {
   return this->find_preset_mode_(preset_mode, preset_mode ? strlen(preset_mode) : 0);
 }

--- a/esphome/components/fan/fan.h
+++ b/esphome/components/fan/fan.h
@@ -115,10 +115,10 @@ class Fan : public EntityBase {
   /// The current direction of the fan
   FanDirection direction{FanDirection::FORWARD};
 
-  FanCall turn_on();
-  FanCall turn_off();
-  FanCall toggle();
-  FanCall make_call();
+  FanCall turn_on() { return this->make_call().set_state(true); }
+  FanCall turn_off() { return this->make_call().set_state(false); }
+  FanCall toggle() { return this->make_call().set_state(!this->state); }
+  FanCall make_call() { return FanCall(*this); }
 
   /// Register a callback that will be called each time the state changes.
   template<typename F> void add_on_state_callback(F &&callback) {


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18621 for select and the cover PR, applied to fan. `Fan::make_call`, `turn_on`, `turn_off` and `toggle` move from `fan.cpp` into the header so the compiler can inline them at the call site; `FanCall` is a small struct whose constructor only stores the parent reference, so unlike light (#18620) this is a clear win here.

Measured target branch to this PR, RAM unchanged: CI fan test config on esp8266 273979 to 273931 bytes (48 bytes saved); a speed fan driven by `fan.turn_on`, `fan.toggle` and `fan.turn_off` from `on_boot` on esp32-idf 192495 to 192467 bytes (28 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
fan:
  - platform: speed
    id: fan1
    name: Fan
    output: out1
    speed_count: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
