### PR TITLE
[switch] Inline the trivial inverted accessors

### DIFF
--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -69,9 +69,6 @@ void Switch::publish_state(bool state) {
 }
 bool Switch::assumed_state() { return false; }
 
-void Switch::set_inverted(bool inverted) { this->inverted_ = inverted; }
-bool Switch::is_inverted() const { return this->inverted_; }
-
 void log_switch(const char *tag, const char *prefix, const char *type, Switch *obj) {
   if (obj != nullptr) {
     // Prepare restore mode string

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -87,7 +87,7 @@ class Switch : public EntityBase {
    *
    * @param inverted Whether to invert this switch.
    */
-  void set_inverted(bool inverted);
+  void set_inverted(bool inverted) { this->inverted_ = inverted; }
 
   /** Set callback for state changes.
    *
@@ -117,7 +117,7 @@ class Switch : public EntityBase {
    */
   virtual bool assumed_state();
 
-  bool is_inverted() const;
+  bool is_inverted() const { return this->inverted_; }
 
   void set_restore_mode(SwitchRestoreMode restore_mode) { this->restore_mode = restore_mode; }
 


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18621 for select, applied to switch. `Switch::set_inverted` and `is_inverted` move from `switch.cpp` into the header so the compiler can inline them; `set_inverted` is called from the generated `setup()` and is on the CodSpeed switch benchmark path, `is_inverted` from the switch platforms. `assumed_state` is virtual and stays as it is.

Tiny one. Measured with the CI switch test config, target branch to this PR, RAM unchanged: esp32-idf 193535 to 193531 bytes (4 bytes saved); esp8266 269983 to 269983 bytes (no change). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
switch:
  - platform: template
    name: Sw
    optimistic: true
    inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
