### PR TITLE
[version] Inline the trivial VersionTextSensor setters

### DIFF
--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -48,8 +48,6 @@ void VersionTextSensor::setup() {
   version_str[sizeof(version_str) - 1] = '\0';
   this->publish_state(version_str);
 }
-void VersionTextSensor::set_hide_hash(bool hide_hash) { this->hide_hash_ = hide_hash; }
-void VersionTextSensor::set_hide_timestamp(bool hide_timestamp) { this->hide_timestamp_ = hide_timestamp; }
 void VersionTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Version Text Sensor", this); }
 
 }  // namespace esphome::version

--- a/esphome/components/version/version_text_sensor.h
+++ b/esphome/components/version/version_text_sensor.h
@@ -7,8 +7,8 @@ namespace esphome::version {
 
 class VersionTextSensor final : public text_sensor::TextSensor, public Component {
  public:
-  void set_hide_hash(bool hide_hash);
-  void set_hide_timestamp(bool hide_timestamp);
+  void set_hide_hash(bool hide_hash) { this->hide_hash_ = hide_hash; }
+  void set_hide_timestamp(bool hide_timestamp) { this->hide_timestamp_ = hide_timestamp; }
   void setup() override;
   void dump_config() override;
 


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to version. `VersionTextSensor::set_hide_hash` and `set_hide_timestamp` move from `version_text_sensor.cpp` into the header so the compiler can inline them where the generated `setup()` calls them.

Measured with the CI version test config, target branch to this PR, RAM unchanged: esp32-idf 190775 to 190723 bytes (52 bytes saved); esp8266 266491 to 266427 bytes (64 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
text_sensor:
  - platform: version
    name: Version
    hide_timestamp: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
