### PR TITLE
[deep_sleep] Inline the trivial DeepSleepComponent setters

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -43,10 +43,6 @@ void DeepSleepComponent::loop() {
     this->begin_sleep();
 }
 
-void DeepSleepComponent::set_sleep_duration(uint32_t time_ms) { this->sleep_duration_ = uint64_t(time_ms) * 1000; }
-
-void DeepSleepComponent::set_run_duration(uint32_t time_ms) { this->run_duration_ = time_ms; }
-
 void DeepSleepComponent::begin_sleep(bool manual) {
   if (this->prevent_ && !manual) {
     this->next_enter_deep_sleep_ = true;
@@ -75,9 +71,5 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 }
 
 float DeepSleepComponent::get_setup_priority() const { return setup_priority::LATE; }
-
-void DeepSleepComponent::prevent_deep_sleep() { this->prevent_ = true; }
-
-void DeepSleepComponent::allow_deep_sleep() { this->prevent_ = false; }
 
 }  // namespace esphome::deep_sleep

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -132,7 +132,7 @@ template<typename... Ts> class PreventDeepSleepAction;
 class DeepSleepComponent final : public Component {
  public:
   /// Set the duration in ms the component should sleep once it's in deep sleep mode.
-  void set_sleep_duration(uint32_t time_ms);
+  void set_sleep_duration(uint32_t time_ms) { this->sleep_duration_ = uint64_t(time_ms) * 1000; }
 #if defined(USE_ESP32)
   /** Set the pin to wake up to on the ESP32 once it's in deep sleep mode.
    * Use the inverted property to set the wakeup level.
@@ -157,7 +157,7 @@ class DeepSleepComponent final : public Component {
 #if !defined(USE_ESP32_VARIANT_ESP32C2) && !defined(USE_ESP32_VARIANT_ESP32C3) && \
     !defined(USE_ESP32_VARIANT_ESP32C5) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
     !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
-  void set_touch_wakeup(bool touch_wakeup);
+  void set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
 #endif
 
   // Set the duration in ms for how long the code should run before entering
@@ -166,7 +166,7 @@ class DeepSleepComponent final : public Component {
 #endif  // USE_ESP32
 
   /// Set a duration in ms for how long the code should run before entering deep sleep mode.
-  void set_run_duration(uint32_t time_ms);
+  void set_run_duration(uint32_t time_ms) { this->run_duration_ = time_ms; }
 
   void setup() override;
   void dump_config() override;
@@ -176,8 +176,8 @@ class DeepSleepComponent final : public Component {
   /// Helper to enter deep sleep mode
   void begin_sleep(bool manual = false);
 
-  void prevent_deep_sleep();
-  void allow_deep_sleep();
+  void prevent_deep_sleep() { this->prevent_ = true; }
+  void allow_deep_sleep() { this->prevent_ = false; }
 
  protected:
   // Returns nullopt if no run duration is set. Otherwise, returns the run

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -74,12 +74,6 @@ void DeepSleepComponent::set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode) {
 void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wakeup_ = ext1_wakeup; }
 #endif
 
-#if !defined(USE_ESP32_VARIANT_ESP32C2) && !defined(USE_ESP32_VARIANT_ESP32C3) && \
-    !defined(USE_ESP32_VARIANT_ESP32C5) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
-    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32H2)
-void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
-#endif
-
 void DeepSleepComponent::set_run_duration(WakeupCauseToRunDuration wakeup_cause_to_run_duration) {
   wakeup_cause_to_run_duration_ = wakeup_cause_to_run_duration;
 }


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to deep_sleep. `DeepSleepComponent::set_sleep_duration`, `set_run_duration(uint32_t)`, `prevent_deep_sleep`, `allow_deep_sleep` and the esp32 only `set_touch_wakeup` move from the `.cpp` files into the header so the compiler can inline them; the setters are called from the generated `setup()` and the prevent and allow pair from the `deep_sleep.prevent` and `deep_sleep.allow` actions. The platform specific `get_run_duration_` and `prepare_to_sleep_` stay as they are.

Measured with the CI deep_sleep test config, target branch to this PR, RAM unchanged: esp32-idf 211067 to 211011 bytes (56 bytes saved); esp8266 266867 to 266819 bytes (48 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
deep_sleep:
  run_duration: 10s
  sleep_duration: 5min
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
