### PR TITLE
[thermostat] Inline the trivial ThermostatClimate setters and getters

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -76,11 +76,6 @@ void ThermostatClimate::loop() {
   }
 }
 
-float ThermostatClimate::cool_deadband() { return this->cooling_deadband_; }
-float ThermostatClimate::cool_overrun() { return this->cooling_overrun_; }
-float ThermostatClimate::heat_deadband() { return this->heating_deadband_; }
-float ThermostatClimate::heat_overrun() { return this->heating_overrun_; }
-
 void ThermostatClimate::refresh() {
   this->switch_to_mode_(this->mode, false);
   this->switch_to_action_(this->compute_action_(), false);
@@ -120,8 +115,6 @@ bool ThermostatClimate::fan_mode_change_delayed() {
 }
 
 climate::ClimateAction ThermostatClimate::delayed_climate_action() { return this->compute_action_(true); }
-
-climate::ClimateFanMode ThermostatClimate::locked_fan_mode() { return this->prev_fan_mode_; }
 
 bool ThermostatClimate::hysteresis_valid() {
   if ((this->supports_cool_ || (this->supports_fan_only_ && this->supports_fan_only_cooling_)) &&
@@ -1286,10 +1279,6 @@ bool ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTem
   return something_changed;
 }
 
-void ThermostatClimate::set_preset_config(std::initializer_list<PresetEntry> presets) {
-  this->preset_config_ = presets;
-}
-
 void ThermostatClimate::set_custom_preset_config(std::initializer_list<CustomPresetEntry> presets) {
   this->custom_preset_config_ = presets;
   // Populate Climate base class custom presets vector
@@ -1316,19 +1305,6 @@ void ThermostatClimate::set_default_preset(const char *custom_preset) {
 }
 
 void ThermostatClimate::set_default_preset(climate::ClimatePreset preset) { this->default_preset_ = preset; }
-
-void ThermostatClimate::set_on_boot_restore_from(thermostat::OnBootRestoreFrom on_boot_restore_from) {
-  this->on_boot_restore_from_ = on_boot_restore_from;
-}
-void ThermostatClimate::set_set_point_minimum_differential(float differential) {
-  this->set_point_minimum_differential_ = differential;
-}
-void ThermostatClimate::set_cool_deadband(float deadband) { this->cooling_deadband_ = deadband; }
-void ThermostatClimate::set_cool_overrun(float overrun) { this->cooling_overrun_ = overrun; }
-void ThermostatClimate::set_heat_deadband(float deadband) { this->heating_deadband_ = deadband; }
-void ThermostatClimate::set_heat_overrun(float overrun) { this->heating_overrun_ = overrun; }
-void ThermostatClimate::set_supplemental_cool_delta(float delta) { this->supplemental_cool_delta_ = delta; }
-void ThermostatClimate::set_supplemental_heat_delta(float delta) { this->supplemental_heat_delta_ = delta; }
 
 void ThermostatClimate::set_timer_duration_in_sec_(ThermostatClimateTimerIndex timer_index, uint32_t time) {
   uint32_t new_duration_ms = 1000 * (time < this->min_timer_duration_ ? this->min_timer_duration_ : time);
@@ -1389,79 +1365,8 @@ void ThermostatClimate::set_heating_minimum_run_time_in_sec(uint32_t time) {
 void ThermostatClimate::set_idle_minimum_time_in_sec(uint32_t time) {
   this->set_timer_duration_in_sec_(thermostat::THERMOSTAT_TIMER_IDLE_ON, time);
 }
-void ThermostatClimate::set_sensor(sensor::Sensor *sensor) { this->sensor_ = sensor; }
-void ThermostatClimate::set_humidity_sensor(sensor::Sensor *humidity_sensor) {
-  this->humidity_sensor_ = humidity_sensor;
-}
 void ThermostatClimate::set_humidity_hysteresis(float humidity_hysteresis) {
   this->humidity_hysteresis_ = std::clamp<float>(humidity_hysteresis, 0.0f, 100.0f);
-}
-void ThermostatClimate::set_use_startup_delay(bool use_startup_delay) { this->use_startup_delay_ = use_startup_delay; }
-void ThermostatClimate::set_supports_heat_cool(bool supports_heat_cool) {
-  this->supports_heat_cool_ = supports_heat_cool;
-}
-void ThermostatClimate::set_supports_auto(bool supports_auto) { this->supports_auto_ = supports_auto; }
-void ThermostatClimate::set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
-void ThermostatClimate::set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }
-void ThermostatClimate::set_supports_fan_only(bool supports_fan_only) { this->supports_fan_only_ = supports_fan_only; }
-void ThermostatClimate::set_supports_fan_only_action_uses_fan_mode_timer(
-    bool supports_fan_only_action_uses_fan_mode_timer) {
-  this->supports_fan_only_action_uses_fan_mode_timer_ = supports_fan_only_action_uses_fan_mode_timer;
-}
-void ThermostatClimate::set_supports_fan_only_cooling(bool supports_fan_only_cooling) {
-  this->supports_fan_only_cooling_ = supports_fan_only_cooling;
-}
-void ThermostatClimate::set_supports_fan_with_cooling(bool supports_fan_with_cooling) {
-  this->supports_fan_with_cooling_ = supports_fan_with_cooling;
-}
-void ThermostatClimate::set_supports_fan_with_heating(bool supports_fan_with_heating) {
-  this->supports_fan_with_heating_ = supports_fan_with_heating;
-}
-void ThermostatClimate::set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
-void ThermostatClimate::set_supports_fan_mode_on(bool supports_fan_mode_on) {
-  this->supports_fan_mode_on_ = supports_fan_mode_on;
-}
-void ThermostatClimate::set_supports_fan_mode_off(bool supports_fan_mode_off) {
-  this->supports_fan_mode_off_ = supports_fan_mode_off;
-}
-void ThermostatClimate::set_supports_fan_mode_auto(bool supports_fan_mode_auto) {
-  this->supports_fan_mode_auto_ = supports_fan_mode_auto;
-}
-void ThermostatClimate::set_supports_fan_mode_low(bool supports_fan_mode_low) {
-  this->supports_fan_mode_low_ = supports_fan_mode_low;
-}
-void ThermostatClimate::set_supports_fan_mode_medium(bool supports_fan_mode_medium) {
-  this->supports_fan_mode_medium_ = supports_fan_mode_medium;
-}
-void ThermostatClimate::set_supports_fan_mode_high(bool supports_fan_mode_high) {
-  this->supports_fan_mode_high_ = supports_fan_mode_high;
-}
-void ThermostatClimate::set_supports_fan_mode_middle(bool supports_fan_mode_middle) {
-  this->supports_fan_mode_middle_ = supports_fan_mode_middle;
-}
-void ThermostatClimate::set_supports_fan_mode_focus(bool supports_fan_mode_focus) {
-  this->supports_fan_mode_focus_ = supports_fan_mode_focus;
-}
-void ThermostatClimate::set_supports_fan_mode_diffuse(bool supports_fan_mode_diffuse) {
-  this->supports_fan_mode_diffuse_ = supports_fan_mode_diffuse;
-}
-void ThermostatClimate::set_supports_fan_mode_quiet(bool supports_fan_mode_quiet) {
-  this->supports_fan_mode_quiet_ = supports_fan_mode_quiet;
-}
-void ThermostatClimate::set_supports_swing_mode_both(bool supports_swing_mode_both) {
-  this->supports_swing_mode_both_ = supports_swing_mode_both;
-}
-void ThermostatClimate::set_supports_swing_mode_off(bool supports_swing_mode_off) {
-  this->supports_swing_mode_off_ = supports_swing_mode_off;
-}
-void ThermostatClimate::set_supports_swing_mode_horizontal(bool supports_swing_mode_horizontal) {
-  this->supports_swing_mode_horizontal_ = supports_swing_mode_horizontal;
-}
-void ThermostatClimate::set_supports_swing_mode_vertical(bool supports_swing_mode_vertical) {
-  this->supports_swing_mode_vertical_ = supports_swing_mode_vertical;
-}
-void ThermostatClimate::set_supports_two_points(bool supports_two_points) {
-  this->supports_two_points_ = supports_two_points;
 }
 void ThermostatClimate::set_supports_dehumidification(bool supports_dehumidification) {
   this->supports_dehumidification_ = supports_dehumidification;

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -93,14 +93,16 @@ class ThermostatClimate final : public climate::Climate, public Component {
 
   void set_default_preset(const char *custom_preset);
   void set_default_preset(climate::ClimatePreset preset);
-  void set_on_boot_restore_from(OnBootRestoreFrom on_boot_restore_from);
-  void set_set_point_minimum_differential(float differential);
-  void set_cool_deadband(float deadband);
-  void set_cool_overrun(float overrun);
-  void set_heat_deadband(float deadband);
-  void set_heat_overrun(float overrun);
-  void set_supplemental_cool_delta(float delta);
-  void set_supplemental_heat_delta(float delta);
+  void set_on_boot_restore_from(thermostat::OnBootRestoreFrom on_boot_restore_from) {
+    this->on_boot_restore_from_ = on_boot_restore_from;
+  }
+  void set_set_point_minimum_differential(float differential) { this->set_point_minimum_differential_ = differential; }
+  void set_cool_deadband(float deadband) { this->cooling_deadband_ = deadband; }
+  void set_cool_overrun(float overrun) { this->cooling_overrun_ = overrun; }
+  void set_heat_deadband(float deadband) { this->heating_deadband_ = deadband; }
+  void set_heat_overrun(float overrun) { this->heating_overrun_ = overrun; }
+  void set_supplemental_cool_delta(float delta) { this->supplemental_cool_delta_ = delta; }
+  void set_supplemental_heat_delta(float delta) { this->supplemental_heat_delta_ = delta; }
   void set_cooling_maximum_run_time_in_sec(uint32_t time);
   void set_heating_maximum_run_time_in_sec(uint32_t time);
   void set_cooling_minimum_off_time_in_sec(uint32_t time);
@@ -111,39 +113,69 @@ class ThermostatClimate final : public climate::Climate, public Component {
   void set_heating_minimum_off_time_in_sec(uint32_t time);
   void set_heating_minimum_run_time_in_sec(uint32_t time);
   void set_idle_minimum_time_in_sec(uint32_t time);
-  void set_sensor(sensor::Sensor *sensor);
-  void set_humidity_sensor(sensor::Sensor *humidity_sensor);
+  void set_sensor(sensor::Sensor *sensor) { this->sensor_ = sensor; }
+  void set_humidity_sensor(sensor::Sensor *humidity_sensor) { this->humidity_sensor_ = humidity_sensor; }
   void set_humidity_hysteresis(float humidity_hysteresis);
-  void set_use_startup_delay(bool use_startup_delay);
-  void set_supports_auto(bool supports_auto);
-  void set_supports_heat_cool(bool supports_heat_cool);
-  void set_supports_cool(bool supports_cool);
-  void set_supports_dry(bool supports_dry);
-  void set_supports_fan_only(bool supports_fan_only);
-  void set_supports_fan_only_action_uses_fan_mode_timer(bool fan_only_action_uses_fan_mode_timer);
-  void set_supports_fan_only_cooling(bool supports_fan_only_cooling);
-  void set_supports_fan_with_cooling(bool supports_fan_with_cooling);
-  void set_supports_fan_with_heating(bool supports_fan_with_heating);
-  void set_supports_heat(bool supports_heat);
-  void set_supports_fan_mode_on(bool supports_fan_mode_on);
-  void set_supports_fan_mode_off(bool supports_fan_mode_off);
-  void set_supports_fan_mode_auto(bool supports_fan_mode_auto);
-  void set_supports_fan_mode_low(bool supports_fan_mode_low);
-  void set_supports_fan_mode_medium(bool supports_fan_mode_medium);
-  void set_supports_fan_mode_high(bool supports_fan_mode_high);
-  void set_supports_fan_mode_middle(bool supports_fan_mode_middle);
-  void set_supports_fan_mode_focus(bool supports_fan_mode_focus);
-  void set_supports_fan_mode_diffuse(bool supports_fan_mode_diffuse);
-  void set_supports_fan_mode_quiet(bool supports_fan_mode_quiet);
-  void set_supports_swing_mode_both(bool supports_swing_mode_both);
-  void set_supports_swing_mode_horizontal(bool supports_swing_mode_horizontal);
-  void set_supports_swing_mode_off(bool supports_swing_mode_off);
-  void set_supports_swing_mode_vertical(bool supports_swing_mode_vertical);
+  void set_use_startup_delay(bool use_startup_delay) { this->use_startup_delay_ = use_startup_delay; }
+  void set_supports_auto(bool supports_auto) { this->supports_auto_ = supports_auto; }
+  void set_supports_heat_cool(bool supports_heat_cool) { this->supports_heat_cool_ = supports_heat_cool; }
+  void set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
+  void set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }
+  void set_supports_fan_only(bool supports_fan_only) { this->supports_fan_only_ = supports_fan_only; }
+  void set_supports_fan_only_action_uses_fan_mode_timer(bool supports_fan_only_action_uses_fan_mode_timer) {
+    this->supports_fan_only_action_uses_fan_mode_timer_ = supports_fan_only_action_uses_fan_mode_timer;
+  }
+  void set_supports_fan_only_cooling(bool supports_fan_only_cooling) {
+    this->supports_fan_only_cooling_ = supports_fan_only_cooling;
+  }
+  void set_supports_fan_with_cooling(bool supports_fan_with_cooling) {
+    this->supports_fan_with_cooling_ = supports_fan_with_cooling;
+  }
+  void set_supports_fan_with_heating(bool supports_fan_with_heating) {
+    this->supports_fan_with_heating_ = supports_fan_with_heating;
+  }
+  void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
+  void set_supports_fan_mode_on(bool supports_fan_mode_on) { this->supports_fan_mode_on_ = supports_fan_mode_on; }
+  void set_supports_fan_mode_off(bool supports_fan_mode_off) { this->supports_fan_mode_off_ = supports_fan_mode_off; }
+  void set_supports_fan_mode_auto(bool supports_fan_mode_auto) {
+    this->supports_fan_mode_auto_ = supports_fan_mode_auto;
+  }
+  void set_supports_fan_mode_low(bool supports_fan_mode_low) { this->supports_fan_mode_low_ = supports_fan_mode_low; }
+  void set_supports_fan_mode_medium(bool supports_fan_mode_medium) {
+    this->supports_fan_mode_medium_ = supports_fan_mode_medium;
+  }
+  void set_supports_fan_mode_high(bool supports_fan_mode_high) {
+    this->supports_fan_mode_high_ = supports_fan_mode_high;
+  }
+  void set_supports_fan_mode_middle(bool supports_fan_mode_middle) {
+    this->supports_fan_mode_middle_ = supports_fan_mode_middle;
+  }
+  void set_supports_fan_mode_focus(bool supports_fan_mode_focus) {
+    this->supports_fan_mode_focus_ = supports_fan_mode_focus;
+  }
+  void set_supports_fan_mode_diffuse(bool supports_fan_mode_diffuse) {
+    this->supports_fan_mode_diffuse_ = supports_fan_mode_diffuse;
+  }
+  void set_supports_fan_mode_quiet(bool supports_fan_mode_quiet) {
+    this->supports_fan_mode_quiet_ = supports_fan_mode_quiet;
+  }
+  void set_supports_swing_mode_both(bool supports_swing_mode_both) {
+    this->supports_swing_mode_both_ = supports_swing_mode_both;
+  }
+  void set_supports_swing_mode_horizontal(bool supports_swing_mode_horizontal) {
+    this->supports_swing_mode_horizontal_ = supports_swing_mode_horizontal;
+  }
+  void set_supports_swing_mode_off(bool supports_swing_mode_off) {
+    this->supports_swing_mode_off_ = supports_swing_mode_off;
+  }
+  void set_supports_swing_mode_vertical(bool supports_swing_mode_vertical) {
+    this->supports_swing_mode_vertical_ = supports_swing_mode_vertical;
+  }
   void set_supports_dehumidification(bool supports_dehumidification);
   void set_supports_humidification(bool supports_humidification);
-  void set_supports_two_points(bool supports_two_points);
+  void set_supports_two_points(bool supports_two_points) { this->supports_two_points_ = supports_two_points; }
 
-  void set_preset_config(std::initializer_list<PresetEntry> presets);
+  void set_preset_config(std::initializer_list<PresetEntry> presets) { this->preset_config_ = presets; }
   void set_custom_preset_config(std::initializer_list<CustomPresetEntry> presets);
 
   Trigger<> *get_cool_action_trigger();
@@ -181,10 +213,10 @@ class ThermostatClimate final : public climate::Climate, public Component {
   Trigger<> *get_humidity_control_humidify_action_trigger();
   Trigger<> *get_humidity_control_off_action_trigger();
   /// Get current hysteresis values
-  float cool_deadband();
-  float cool_overrun();
-  float heat_deadband();
-  float heat_overrun();
+  float cool_deadband() { return this->cooling_deadband_; }
+  float cool_overrun() { return this->cooling_overrun_; }
+  float heat_deadband() { return this->heating_deadband_; }
+  float heat_overrun() { return this->heating_overrun_; }
   /// Call triggers based on updated climate states (modes/actions)
   void refresh();
   /// Returns true if a climate action/fan mode transition is being delayed
@@ -193,7 +225,7 @@ class ThermostatClimate final : public climate::Climate, public Component {
   /// Returns the climate action that is being delayed (check climate_action_change_delayed(), first!)
   climate::ClimateAction delayed_climate_action();
   /// Returns the fan mode that is locked in (check fan_mode_change_delayed(), first!)
-  climate::ClimateFanMode locked_fan_mode();
+  climate::ClimateFanMode locked_fan_mode() { return this->prev_fan_mode_; }
   /// Set point and hysteresis validation
   bool hysteresis_valid();               // returns true if valid
   bool humidity_hysteresis_valid();      // returns true if valid


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to thermostat. The 42 `ThermostatClimate` members whose body is a single assignment or a single field read (all the `set_supports_*`, `set_*_deadband` and `set_*_overrun` setters, `set_sensor`, `set_humidity_sensor`, `set_preset_config`, `set_on_boot_restore_from`, `set_set_point_minimum_differential`, `set_use_startup_delay`, the `cool_*` and `heat_*` getters and `locked_fan_mode`) move from `thermostat_climate.cpp` into the header so the compiler can inline them; nearly all of them are called once from the generated `setup()`. Everything that does more than that (the timer setters, `set_humidity_hysteresis`, `delayed_climate_action`, the overloaded `set_default_preset`) stays as it is.

Measured with the CI thermostat test config, target branch to this PR, RAM unchanged: esp32-idf 212527 to 212047 bytes (480 bytes saved); esp8266 290103 to 289591 bytes (512 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
climate:
  - platform: thermostat
    name: Thermostat
    sensor: temp
    min_cooling_off_time: 300s
    min_cooling_run_time: 300s
    min_idle_time: 30s
    cool_action:
      - switch.turn_on: cool
    idle_action:
      - switch.turn_off: cool
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
