### PR TITLE
[sprinkler] Inline the trivial Sprinkler accessors

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -211,8 +211,6 @@ uint32_t SprinklerValveOperator::time_remaining() {
   return 0;  // run completed
 }
 
-SprinklerState SprinklerValveOperator::state() { return this->state_; }
-
 switch_::Switch *SprinklerValveOperator::pump_switch() {
   if ((this->controller_ == nullptr) || (this->valve_ == nullptr)) {
     return nullptr;
@@ -288,10 +286,7 @@ SprinklerValveRunRequest::SprinklerValveRunRequest(size_t valve_number, uint32_t
                                                    SprinklerValveOperator *valve_op)
     : valve_number_(valve_number), run_duration_(run_duration), valve_op_(valve_op) {}
 
-bool SprinklerValveRunRequest::has_request() { return this->has_valve_; }
 bool SprinklerValveRunRequest::has_valve_operator() { return !(this->valve_op_ == nullptr); }
-
-void SprinklerValveRunRequest::set_request_from(SprinklerValveRunRequestOrigin origin) { this->origin_ = origin; }
 
 void SprinklerValveRunRequest::set_run_duration(uint32_t run_duration) { this->run_duration_ = run_duration; }
 
@@ -317,8 +312,6 @@ void SprinklerValveRunRequest::reset() {
 
 uint32_t SprinklerValveRunRequest::run_duration() { return this->run_duration_; }
 
-size_t SprinklerValveRunRequest::valve() { return this->valve_number_; }
-
 optional<size_t> SprinklerValveRunRequest::valve_as_opt() {
   if (this->has_valve_) {
     return this->valve_number_;
@@ -327,8 +320,6 @@ optional<size_t> SprinklerValveRunRequest::valve_as_opt() {
 }
 
 SprinklerValveOperator *SprinklerValveRunRequest::valve_operator() { return this->valve_op_; }
-
-SprinklerValveRunRequestOrigin SprinklerValveRunRequest::request_is_from() { return this->origin_; }
 
 Sprinkler::Sprinkler() : Sprinkler("") {}
 Sprinkler::Sprinkler(const char *name) : name_(name) {
@@ -414,32 +405,12 @@ void Sprinkler::set_controller_main_switch(SprinklerControllerSwitch *controller
   this->sprinkler_turn_on_automation_->add_actions({sprinkler_resumeorstart_action_.get()});
 }
 
-void Sprinkler::set_controller_auto_adv_switch(SprinklerControllerSwitch *auto_adv_switch) {
-  this->auto_adv_sw_ = auto_adv_switch;
-}
-
-void Sprinkler::set_controller_queue_enable_switch(SprinklerControllerSwitch *queue_enable_switch) {
-  this->queue_enable_sw_ = queue_enable_switch;
-}
-
-void Sprinkler::set_controller_reverse_switch(SprinklerControllerSwitch *reverse_switch) {
-  this->reverse_sw_ = reverse_switch;
-}
-
 void Sprinkler::set_controller_standby_switch(SprinklerControllerSwitch *standby_switch) {
   this->standby_sw_ = standby_switch;
 
   this->sprinkler_standby_turn_on_automation_ = make_unique<Automation<>>(standby_switch->get_turn_on_trigger());
   this->sprinkler_standby_shutdown_action_ = make_unique<sprinkler::ShutdownAction<>>(this);
   this->sprinkler_standby_turn_on_automation_->add_actions({sprinkler_standby_shutdown_action_.get()});
-}
-
-void Sprinkler::set_controller_multiplier_number(SprinklerControllerNumber *multiplier_number) {
-  this->multiplier_number_ = multiplier_number;
-}
-
-void Sprinkler::set_controller_repeat_number(SprinklerControllerNumber *repeat_number) {
-  this->repeat_number_ = repeat_number;
 }
 
 void Sprinkler::configure_valve_switch(size_t valve_number, switch_::Switch *valve_switch, uint32_t run_duration) {
@@ -498,10 +469,6 @@ void Sprinkler::set_multiplier(const optional<float> multiplier) {
   call.perform();
 }
 
-void Sprinkler::set_next_prev_ignore_disabled_valves(bool ignore_disabled) {
-  this->next_prev_ignore_disabled_ = ignore_disabled;
-}
-
 void Sprinkler::set_pump_start_delay(uint32_t start_delay) {
   this->start_delay_is_valve_delay_ = false;
   this->start_delay_ = start_delay;
@@ -520,10 +487,6 @@ void Sprinkler::set_valve_start_delay(uint32_t start_delay) {
 void Sprinkler::set_valve_stop_delay(uint32_t stop_delay) {
   this->stop_delay_is_valve_delay_ = true;
   this->stop_delay_ = stop_delay;
-}
-
-void Sprinkler::set_pump_switch_off_during_valve_open_delay(bool pump_switch_off_during_valve_open_delay) {
-  this->pump_switch_off_during_valve_open_delay_ = pump_switch_off_during_valve_open_delay;
 }
 
 void Sprinkler::set_valve_open_delay(const uint32_t valve_open_delay) {
@@ -945,18 +908,12 @@ optional<size_t> Sprinkler::active_valve() {
   return this->active_req_.valve_as_opt();
 }
 
-optional<size_t> Sprinkler::paused_valve() { return this->paused_valve_; }
-
 optional<size_t> Sprinkler::queued_valve() {
   if (!this->queued_valves_.empty()) {
     return this->queued_valves_.back().valve_number;
   }
   return nullopt;
 }
-
-optional<size_t> Sprinkler::manual_valve() { return this->manual_valve_; }
-
-size_t Sprinkler::number_of_valves() { return this->valve_.size(); }
 
 bool Sprinkler::is_a_valid_valve(const size_t valve_number) { return (valve_number < this->number_of_valves()); }
 

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -124,9 +124,9 @@ class SprinklerValveOperator {
   void set_stop_delay(uint32_t stop_delay, bool stop_delay_is_valve_delay);
   void start();
   void stop();
-  uint32_t run_duration();         // returns the desired run duration in seconds
-  uint32_t time_remaining();       // returns seconds remaining (does not include stop_delay_)
-  SprinklerState state();          // returns the valve's state/status
+  uint32_t run_duration();    // returns the desired run duration in seconds
+  uint32_t time_remaining();  // returns seconds remaining (does not include stop_delay_)
+  SprinklerState state() { return this->state_; }
   switch_::Switch *pump_switch();  // returns this SprinklerValveOperator's pump switch
 
  protected:
@@ -152,18 +152,18 @@ class SprinklerValveRunRequest {
  public:
   SprinklerValveRunRequest();
   SprinklerValveRunRequest(size_t valve_number, uint32_t run_duration, SprinklerValveOperator *valve_op);
-  bool has_request();
+  bool has_request() { return this->has_valve_; }
   bool has_valve_operator();
-  void set_request_from(SprinklerValveRunRequestOrigin origin);
+  void set_request_from(SprinklerValveRunRequestOrigin origin) { this->origin_ = origin; }
   void set_run_duration(uint32_t run_duration);
   void set_valve(size_t valve_number);
   void set_valve_operator(SprinklerValveOperator *valve_op);
   void reset();
   uint32_t run_duration();
-  size_t valve();
+  size_t valve() { return this->valve_number_; }
   optional<size_t> valve_as_opt();
   SprinklerValveOperator *valve_operator();
-  SprinklerValveRunRequestOrigin request_is_from();
+  SprinklerValveRunRequestOrigin request_is_from() { return this->origin_; }
 
  protected:
   bool has_valve_{false};
@@ -189,14 +189,20 @@ class Sprinkler final : public Component {
 
   /// configure important controller switches
   void set_controller_main_switch(SprinklerControllerSwitch *controller_switch);
-  void set_controller_auto_adv_switch(SprinklerControllerSwitch *auto_adv_switch);
-  void set_controller_queue_enable_switch(SprinklerControllerSwitch *queue_enable_switch);
-  void set_controller_reverse_switch(SprinklerControllerSwitch *reverse_switch);
+  void set_controller_auto_adv_switch(SprinklerControllerSwitch *auto_adv_switch) {
+    this->auto_adv_sw_ = auto_adv_switch;
+  }
+  void set_controller_queue_enable_switch(SprinklerControllerSwitch *queue_enable_switch) {
+    this->queue_enable_sw_ = queue_enable_switch;
+  }
+  void set_controller_reverse_switch(SprinklerControllerSwitch *reverse_switch) { this->reverse_sw_ = reverse_switch; }
   void set_controller_standby_switch(SprinklerControllerSwitch *standby_switch);
 
   /// configure important controller number components
-  void set_controller_multiplier_number(SprinklerControllerNumber *multiplier_number);
-  void set_controller_repeat_number(SprinklerControllerNumber *repeat_number);
+  void set_controller_multiplier_number(SprinklerControllerNumber *multiplier_number) {
+    this->multiplier_number_ = multiplier_number;
+  }
+  void set_controller_repeat_number(SprinklerControllerNumber *repeat_number) { this->repeat_number_ = repeat_number; }
 
   /// configure a valve's switch object and run duration. run_duration is time in seconds.
   void configure_valve_switch(size_t valve_number, switch_::Switch *valve_switch, uint32_t run_duration);
@@ -214,7 +220,9 @@ class Sprinkler final : public Component {
   void set_multiplier(optional<float> multiplier);
 
   /// enable/disable skipping of disabled valves by the next and previous actions
-  void set_next_prev_ignore_disabled_valves(bool ignore_disabled);
+  void set_next_prev_ignore_disabled_valves(bool ignore_disabled) {
+    this->next_prev_ignore_disabled_ = ignore_disabled;
+  }
 
   /// set how long the pump should start after the valve (when the pump is starting)
   void set_pump_start_delay(uint32_t start_delay);
@@ -230,7 +238,9 @@ class Sprinkler final : public Component {
 
   /// if pump_switch_off_during_valve_open_delay is true, the controller will switch off the pump during the
   ///  valve_open_delay interval
-  void set_pump_switch_off_during_valve_open_delay(bool pump_switch_off_during_valve_open_delay);
+  void set_pump_switch_off_during_valve_open_delay(bool pump_switch_off_during_valve_open_delay) {
+    this->pump_switch_off_during_valve_open_delay_ = pump_switch_off_during_valve_open_delay;
+  }
 
   /// set how long the controller should wait to open/switch on the valve after it becomes active
   void set_valve_open_delay(uint32_t valve_open_delay);
@@ -335,17 +345,17 @@ class Sprinkler final : public Component {
   optional<size_t> active_valve();
 
   /// returns the number of the valve that is paused, if any. check with 'has_value()'
-  optional<size_t> paused_valve();
+  optional<size_t> paused_valve() { return this->paused_valve_; }
 
   /// returns the number of the next valve in the queue, if any. check with 'has_value()'
   optional<size_t> queued_valve();
 
   /// returns the number of the valve that is manually selected, if any. check with 'has_value()'
   ///  this is set by next_valve() and previous_valve() when manual_selection_delay_ > 0
-  optional<size_t> manual_valve();
+  optional<size_t> manual_valve() { return this->manual_valve_; }
 
   /// returns the number of valves the controller is configured with
-  size_t number_of_valves();
+  size_t number_of_valves() { return this->valve_.size(); }
 
   /// returns true if valve number is valid
   bool is_a_valid_valve(size_t valve_number);


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to sprinkler. The 15 members whose body is a single assignment or a single field read (`SprinklerValveOperator::state`, the `SprinklerValveRunRequest` getters and setters for origin and valve number, the `Sprinkler::set_controller_*` and `set_next_prev_ignore_disabled_valves` and `set_pump_switch_off_during_valve_open_delay` setters, `paused_valve`, `manual_valve` and `number_of_valves`) move from `sprinkler.cpp` into the header so the compiler can inline them; most are called from the generated `setup()` or from the sprinkler actions. `run_duration` and `set_run_duration` exist on two classes and stay as they are, as does everything that does more than a single store or load.

Measured with the CI sprinkler test config, target branch to this PR, RAM unchanged: esp32-idf 206459 to 206403 bytes (56 bytes saved); esp8266 285279 to 285183 bytes (96 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sprinkler:
  - id: lawn
    main_switch: Lawn Sprinklers
    auto_advance_switch: Lawn Auto Advance
    valves:
      - valve_switch: Front Lawn
        run_duration: 15min
        valve_switch_id: valve_sw0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
