### PR TITLE
[mqtt] Inline the trivial MQTT client, component and sensor accessors

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -668,9 +668,7 @@ void MQTTClientComponent::on_message(const std::string &topic, const std::string
 // Setters
 void MQTTClientComponent::disable_log_message() { this->log_message_.topic = ""; }
 bool MQTTClientComponent::is_log_message_enabled() const { return !this->log_message_.topic.empty(); }
-void MQTTClientComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 void MQTTClientComponent::register_mqtt_component(MQTTComponent *component) { this->children_.push_back(component); }
-void MQTTClientComponent::set_log_level(int level) { this->log_level_ = level; }
 void MQTTClientComponent::set_keep_alive(uint16_t keep_alive_s) { this->mqtt_backend_.set_keep_alive(keep_alive_s); }
 void MQTTClientComponent::set_log_message_template(MQTTMessage &&message) { this->log_message_ = std::move(message); }
 const MQTTDiscoveryInfo &MQTTClientComponent::get_discovery_info() const { return this->discovery_info_; }
@@ -683,10 +681,6 @@ void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix, cons
   }
 }
 const std::string &MQTTClientComponent::get_topic_prefix() const { return this->topic_prefix_; }
-void MQTTClientComponent::set_publish_nan_as_none(bool publish_nan_as_none) {
-  this->publish_nan_as_none_ = publish_nan_as_none;
-}
-bool MQTTClientComponent::is_publish_nan_as_none() const { return this->publish_nan_as_none_; }
 void MQTTClientComponent::disable_birth_message() {
   this->birth_message_.topic = "";
   this->recalculate_availability_();
@@ -766,8 +760,6 @@ MQTTClientComponent *global_mqtt_client = nullptr;  // NOLINT(cppcoreguidelines-
 
 // MQTTMessageTrigger
 MQTTMessageTrigger::MQTTMessageTrigger(std::string topic) : topic_(std::move(topic)) {}
-void MQTTMessageTrigger::set_qos(uint8_t qos) { this->qos_ = qos; }
-void MQTTMessageTrigger::set_payload(const std::string &payload) { this->payload_ = payload; }
 void MQTTMessageTrigger::setup() {
   global_mqtt_client->subscribe(
       this->topic_,

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -159,7 +159,7 @@ class MQTTClientComponent final : public Component {
 
   /// Manually set the topic used for logging.
   void set_log_message_template(MQTTMessage &&message);
-  void set_log_level(int level);
+  void set_log_level(int level) { this->log_level_ = level; }
   /// Get the topic used for logging. Defaults to "<topic_prefix>/debug" and the value is cached for speed.
   void disable_log_message();
   bool is_log_message_enabled() const;
@@ -241,7 +241,7 @@ class MQTTClientComponent final : public Component {
 
   void check_connected();
 
-  void set_reboot_timeout(uint32_t reboot_timeout);
+  void set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 
   void register_mqtt_component(MQTTComponent *component);
 
@@ -262,8 +262,8 @@ class MQTTClientComponent final : public Component {
   void set_on_disconnect(mqtt_on_disconnect_callback_t &&callback);
 
   // Publish None state instead of NaN for Home Assistant
-  void set_publish_nan_as_none(bool publish_nan_as_none);
-  bool is_publish_nan_as_none() const;
+  void set_publish_nan_as_none(bool publish_nan_as_none) { this->publish_nan_as_none_ = publish_nan_as_none; }
+  bool is_publish_nan_as_none() const { return this->publish_nan_as_none_; }
 
   void set_wait_for_connection(bool wait_for_connection) { this->wait_for_connection_ = wait_for_connection; }
 
@@ -344,8 +344,8 @@ class MQTTMessageTrigger final : public Trigger<std::string>, public Component {
  public:
   explicit MQTTMessageTrigger(std::string topic);
 
-  void set_qos(uint8_t qos);
-  void set_payload(const std::string &payload);
+  void set_qos(uint8_t qos) { this->qos_ = qos; }
+  void set_payload(const std::string &payload) { this->payload_ = payload; }
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override;

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -340,10 +340,6 @@ bool MQTTComponent::send_discovery_() {
   // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
-uint8_t MQTTComponent::get_qos() const { return this->qos_; }
-
-bool MQTTComponent::get_retain() const { return this->retain_; }
-
 bool MQTTComponent::is_discovery_enabled() const {
   return this->discovery_enabled_ && global_mqtt_client->is_discovery_enabled();
 }

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -108,11 +108,11 @@ class MQTTComponent : public Component {
 
   /// Set QOS for state messages.
   void set_qos(uint8_t qos);
-  uint8_t get_qos() const;
+  uint8_t get_qos() const { return this->qos_; }
 
   /// Set whether state message should be retained.
   void set_retain(bool retain);
-  bool get_retain() const;
+  bool get_retain() const { return this->retain_; }
 
   /// Disable discovery. Sets friendly name to "".
   void disable_discovery();

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -39,8 +39,6 @@ uint32_t MQTTSensorComponent::get_expire_after() const {
     return *this->expire_after_;
   return 0;
 }
-void MQTTSensorComponent::set_expire_after(uint32_t expire_after) { this->expire_after_ = expire_after; }
-void MQTTSensorComponent::disable_expire_after() { this->expire_after_ = 0; }
 
 void MQTTSensorComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson

--- a/esphome/components/mqtt/mqtt_sensor.h
+++ b/esphome/components/mqtt/mqtt_sensor.h
@@ -22,9 +22,9 @@ class MQTTSensorComponent final : public mqtt::MQTTComponent {
   explicit MQTTSensorComponent(sensor::Sensor *sensor);
 
   /// Setup an expiry, 0 disables it
-  void set_expire_after(uint32_t expire_after);
+  void set_expire_after(uint32_t expire_after) { this->expire_after_ = expire_after; }
   /// Disable Home Assistant value expiry.
-  void disable_expire_after();
+  void disable_expire_after() { this->expire_after_ = 0; }
 
   void send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) override;
 


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to mqtt. `MQTTClientComponent::set_reboot_timeout`, `set_log_level`, `set_publish_nan_as_none`, `is_publish_nan_as_none`, `MQTTMessageTrigger::set_qos` and `set_payload`, `MQTTComponent::get_qos` and `get_retain`, and `MQTTSensorComponent::set_expire_after` and `disable_expire_after` move from the `.cpp` files into the headers so the compiler can inline them where the generated `setup()` and the mqtt entity components call them.

Two groups were tried and deliberately left out of line because they made the esp8266 build larger: the `MQTTComponent` bitfield setters (`set_qos`, `set_retain`, `set_subscribe_qos`, `set_command_retain`, `disable_discovery`, `schedule_resend_state`), which turn into a read modify write at every entity's call site, and the `is_discovery_enabled` and `is_log_message_enabled` style getters that expand `std::string::empty()` at each caller. `register_mqtt_component` and `is_connected` stay out of line as well.

Measured with the CI mqtt test config, target branch to this PR, RAM unchanged: esp32-idf 1010783 to 1010671 bytes (112 bytes saved); esp8266 647553 to 647489 bytes (64 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
mqtt:
  broker: 192.168.1.10
  reboot_timeout: 15min
  log_topic:
    level: INFO
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
