### PR TITLE
[wireguard] Inline the trivial Wireguard setters

### DIFF
--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -178,25 +178,6 @@ time_t Wireguard::get_latest_handshake() const {
   return result;
 }
 
-void Wireguard::set_keepalive(const uint16_t seconds) { this->keepalive_ = seconds; }
-void Wireguard::set_reboot_timeout(const uint32_t seconds) { this->reboot_timeout_ = seconds; }
-void Wireguard::set_srctime(time::RealTimeClock *srctime) { this->srctime_ = srctime; }
-
-#ifdef USE_BINARY_SENSOR
-void Wireguard::set_status_sensor(binary_sensor::BinarySensor *sensor) { this->status_sensor_ = sensor; }
-void Wireguard::set_enabled_sensor(binary_sensor::BinarySensor *sensor) { this->enabled_sensor_ = sensor; }
-#endif
-
-#ifdef USE_SENSOR
-void Wireguard::set_handshake_sensor(sensor::Sensor *sensor) { this->handshake_sensor_ = sensor; }
-#endif
-
-#ifdef USE_TEXT_SENSOR
-void Wireguard::set_address_sensor(text_sensor::TextSensor *sensor) { this->address_sensor_ = sensor; }
-#endif
-
-void Wireguard::disable_auto_proceed() { this->proceed_allowed_ = false; }
-
 void Wireguard::enable() {
   this->enabled_ = true;
   ESP_LOGI(TAG, "Enabled");
@@ -217,8 +198,6 @@ void Wireguard::publish_enabled_state() {
   }
 #endif
 }
-
-bool Wireguard::is_enabled() { return this->enabled_; }
 
 void Wireguard::start_connection_() {
   if (!this->enabled_) {

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -63,25 +63,25 @@ class Wireguard final : public PollingComponent {
   /// Prevent accidental use of std::string which would dangle
   void set_allowed_ips(std::initializer_list<std::tuple<std::string, std::string>> ips) = delete;
 
-  void set_keepalive(uint16_t seconds);
-  void set_reboot_timeout(uint32_t seconds);
-  void set_srctime(time::RealTimeClock *srctime);
+  void set_keepalive(const uint16_t seconds) { this->keepalive_ = seconds; }
+  void set_reboot_timeout(const uint32_t seconds) { this->reboot_timeout_ = seconds; }
+  void set_srctime(time::RealTimeClock *srctime) { this->srctime_ = srctime; }
 
 #ifdef USE_BINARY_SENSOR
-  void set_status_sensor(binary_sensor::BinarySensor *sensor);
-  void set_enabled_sensor(binary_sensor::BinarySensor *sensor);
+  void set_status_sensor(binary_sensor::BinarySensor *sensor) { this->status_sensor_ = sensor; }
+  void set_enabled_sensor(binary_sensor::BinarySensor *sensor) { this->enabled_sensor_ = sensor; }
 #endif
 
 #ifdef USE_SENSOR
-  void set_handshake_sensor(sensor::Sensor *sensor);
+  void set_handshake_sensor(sensor::Sensor *sensor) { this->handshake_sensor_ = sensor; }
 #endif
 
 #ifdef USE_TEXT_SENSOR
-  void set_address_sensor(text_sensor::TextSensor *sensor);
+  void set_address_sensor(text_sensor::TextSensor *sensor) { this->address_sensor_ = sensor; }
 #endif
 
   /// Block the setup step until peer is connected.
-  void disable_auto_proceed();
+  void disable_auto_proceed() { this->proceed_allowed_ = false; }
 
   /// Enable the WireGuard component.
   void enable();
@@ -93,7 +93,7 @@ class Wireguard final : public PollingComponent {
   void publish_enabled_state();
 
   /// Return if the WireGuard component is or is not enabled.
-  bool is_enabled();
+  bool is_enabled() { return this->enabled_; }
 
   bool is_peer_up() const;
   time_t get_latest_handshake() const;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to wireguard. `Wireguard::set_keepalive`, `set_reboot_timeout`, `set_srctime`, the four `set_*_sensor` setters, `disable_auto_proceed` and `is_enabled` move from `wireguard.cpp` into the header so the compiler can inline them where the generated `setup()` and the `wireguard.enabled` condition call them; the `#ifdef USE_*_SENSOR` guards stay exactly as they were. `can_proceed` and `on_shutdown` are virtual and stay as they are.

Measured with the CI wireguard test config, target branch to this PR, RAM unchanged: esp32-idf 852227 to 852027 bytes (200 bytes saved); esp8266 461339 to 461211 bytes (128 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wireguard:
  address: 172.16.34.100
  private_key: ...
  peer_endpoint: wg.example.com
  peer_public_key: ...
  peer_persistent_keepalive: 25s
  reboot_timeout: 15min
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
