### PR TITLE
[display] Inline the trivial DisplayPage setters and page navigation helpers

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -685,9 +685,6 @@ void Display::show_page(DisplayPage *page) {
   }
 }
 
-void Display::show_next_page() { this->page_->show_next(); }
-void Display::show_prev_page() { this->page_->show_prev(); }
-
 void Display::do_update_() {
   if (this->auto_clear_enabled_) {
     this->clear();
@@ -892,9 +889,6 @@ void DisplayPage::show_prev() {
   this->prev_->show();
 }
 
-void DisplayPage::set_parent(Display *parent) { this->parent_ = parent; }
-void DisplayPage::set_prev(DisplayPage *prev) { this->prev_ = prev; }
-void DisplayPage::set_next(DisplayPage *next) { this->next_ = next; }
 const display_writer_t &DisplayPage::get_writer() const { return this->writer_; }
 
 const LogString *text_align_to_string(TextAlign textalign) {

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -802,9 +802,9 @@ class DisplayPage final {
   void show();
   void show_next();
   void show_prev();
-  void set_parent(Display *parent);
-  void set_prev(DisplayPage *prev);
-  void set_next(DisplayPage *next);
+  void set_parent(Display *parent) { this->parent_ = parent; }
+  void set_prev(DisplayPage *prev) { this->prev_ = prev; }
+  void set_next(DisplayPage *next) { this->next_ = next; }
   const display_writer_t &get_writer() const;
 
  protected:
@@ -813,6 +813,9 @@ class DisplayPage final {
   DisplayPage *prev_{nullptr};
   DisplayPage *next_{nullptr};
 };
+
+inline void Display::show_next_page() { this->page_->show_next(); }
+inline void Display::show_prev_page() { this->page_->show_prev(); }
 
 template<typename... Ts> class DisplayPageShowAction final : public Action<Ts...> {
  public:


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as the other trivial accessor inlining PRs (#18617 and friends), applied to display. `DisplayPage::set_parent`, `set_prev` and `set_next` move into the class body, and `Display::show_next_page` and `show_prev_page` become inline definitions placed right after `DisplayPage` in `display.h` (they need the complete `DisplayPage` type). The setters are called from the generated `setup()` for every page, the navigation helpers from the `display.page.show_next` and `show_previous` actions. `set_rotation`, `fill` and `clear` are virtual and `set_writer` stores a `std::function`, so they stay as they are.

Small one. Measured with an ssd1306 display with two pages and the page actions in `on_boot`, target branch to this PR, RAM unchanged: esp32-idf 220219 to 220203 bytes (16 bytes saved); esp8266 280147 to 280131 bytes (16 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: ssd1306_i2c
    id: disp1
    model: SSD1306 128x64
    pages:
      - id: page1
        lambda: it.print(0, 0, id(f), "one");
      - id: page2
        lambda: it.print(0, 0, id(f), "two");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
