### PR TITLE
[valve] Inline the trivial Valve and ValveCall accessors

### DIFF
--- a/esphome/components/valve/valve.cpp
+++ b/esphome/components/valve/valve.cpp
@@ -120,10 +120,6 @@ ValveCall &ValveCall::set_stop(bool stop) {
   this->stop_ = stop;
   return *this;
 }
-bool ValveCall::get_stop() const { return this->stop_; }
-
-ValveCall Valve::make_call() { return {this}; }
-
 void Valve::publish_state(bool save) {
   this->position = clamp(this->position, 0.0f, 1.0f);
 
@@ -161,9 +157,6 @@ optional<ValveRestoreState> Valve::restore_state_() {
     return {};
   return recovered;
 }
-
-bool Valve::is_fully_open() const { return this->position == VALVE_OPEN; }
-bool Valve::is_fully_closed() const { return this->position == VALVE_CLOSED; }
 
 ValveCall ValveRestoreState::to_call(Valve *valve) {
   auto call = valve->make_call();

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -47,7 +47,7 @@ class ValveCall {
   void perform();
 
   const optional<float> &get_position() const;
-  bool get_stop() const;
+  bool get_stop() const { return this->stop_; }
   const optional<bool> &get_toggle() const;
 
  protected:
@@ -114,7 +114,7 @@ class Valve : public EntityBase {
   float position;
 
   /// Construct a new valve call used to control the valve.
-  ValveCall make_call();
+  ValveCall make_call() { return {this}; }
 
   template<typename F> void add_on_state_callback(F &&f) { this->state_callback_.add(std::forward<F>(f)); }
 
@@ -130,9 +130,9 @@ class Valve : public EntityBase {
   virtual ValveTraits get_traits() = 0;
 
   /// Helper method to check if the valve is fully open. Equivalent to comparing .position against 1.0
-  bool is_fully_open() const;
+  bool is_fully_open() const { return this->position == VALVE_OPEN; }
   /// Helper method to check if the valve is fully closed. Equivalent to comparing .position against 0.0
-  bool is_fully_closed() const;
+  bool is_fully_closed() const { return this->position == VALVE_CLOSED; }
 
  protected:
   friend ValveCall;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18621 for select, applied to valve, mirroring the cover change in #18630. `Valve::make_call`, `is_fully_open`, `is_fully_closed` and `ValveCall::get_stop` move from `valve.cpp` into the header so the compiler can inline them at the call site; `make_call` is what every automation, the api and the web server go through.

There is no `tests/components/valve` build, so this was measured with a template valve driven from `on_boot` (`make_call`, `valve.open`, `valve.toggle`, `is_fully_open`, `is_fully_closed`), target branch to this PR, RAM unchanged: esp32-idf 191091 to 191047 bytes (44 bytes saved); esp8266 264607 to 264543 bytes (64 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
valve:
  - platform: template
    id: v1
    name: Valve
    lambda: return 0.5f;
    has_position: true
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
