### PR TITLE
[text] Inline the trivial Text publish_state forwarding overloads

### DIFF
--- a/esphome/components/text/text.cpp
+++ b/esphome/components/text/text.cpp
@@ -8,10 +8,6 @@ namespace esphome::text {
 
 static const char *const TAG = "text";
 
-void Text::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }
-
-void Text::publish_state(const char *state) { this->publish_state(state, strlen(state)); }
-
 void Text::publish_state(const char *state, size_t len) {
   this->set_has_state(true);
   // Only assign if changed to avoid heap allocation

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -23,8 +23,8 @@ class Text : public EntityBase {
   std::string state;
   TextTraits traits;
 
-  void publish_state(const std::string &state);
-  void publish_state(const char *state);
+  void publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }
+  void publish_state(const char *state) { this->publish_state(state, strlen(state)); }
   void publish_state(const char *state, size_t len);
 
   /// Instantiate a TextCall object to modify this text component's state.


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18623 for text_sensor, applied to text. The `std::string` and `const char *` overloads of `Text::publish_state` only forward to the pointer plus length overload; they move from `text.cpp` into the header so the compiler can inline the forwarding at the call site.

Measured with the CI text test config, target branch to this PR, RAM unchanged: esp32-idf 192171 to 192139 bytes (32 bytes saved); esp8266 267767 to 267735 bytes (32 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
text:
  - platform: template
    name: Text
    optimistic: true
    min_length: 0
    max_length: 100
    mode: text
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
