### PR TITLE
[datetime] Inline the trivial make_call helpers

### DIFF
--- a/esphome/components/datetime/date_entity.cpp
+++ b/esphome/components/datetime/date_entity.cpp
@@ -37,8 +37,6 @@ void DateEntity::publish_state() {
 #endif
 }
 
-DateCall DateEntity::make_call() { return DateCall(this); }
-
 void DateCall::validate_() {
   if (this->year_.has_value() && (this->year_ < 1970 || this->year_ > 3000)) {
     ESP_LOGE(TAG, "Year must be between 1970 and 3000");

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -96,6 +96,8 @@ class DateCall {
   optional<uint8_t> day_;
 };
 
+inline DateCall DateEntity::make_call() { return DateCall(this); }
+
 template<typename... Ts> class DateSetAction final : public Action<Ts...>, public Parented<DateEntity> {
  public:
   TEMPLATABLE_VALUE(ESPTime, date)

--- a/esphome/components/datetime/datetime_entity.cpp
+++ b/esphome/components/datetime/datetime_entity.cpp
@@ -53,8 +53,6 @@ void DateTimeEntity::publish_state() {
 #endif
 }
 
-DateTimeCall DateTimeEntity::make_call() { return DateTimeCall(this); }
-
 ESPTime DateTimeEntity::state_as_esptime() const {
   ESPTime obj;
   obj.year = this->year_;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -121,6 +121,8 @@ class DateTimeCall {
   optional<uint8_t> second_;
 };
 
+inline DateTimeCall DateTimeEntity::make_call() { return DateTimeCall(this); }
+
 template<typename... Ts> class DateTimeSetAction final : public Action<Ts...>, public Parented<DateTimeEntity> {
  public:
   TEMPLATABLE_VALUE(ESPTime, datetime)

--- a/esphome/components/datetime/time_entity.cpp
+++ b/esphome/components/datetime/time_entity.cpp
@@ -33,8 +33,6 @@ void TimeEntity::publish_state() {
 #endif
 }
 
-TimeCall TimeEntity::make_call() { return TimeCall(this); }
-
 void TimeCall::validate_() {
   if (this->hour_.has_value() && this->hour_ > 23) {
     ESP_LOGE(TAG, "Hour must be between 0 and 23");

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -98,6 +98,8 @@ class TimeCall {
   optional<uint8_t> second_;
 };
 
+inline TimeCall TimeEntity::make_call() { return TimeCall(this); }
+
 template<typename... Ts> class TimeSetAction final : public Action<Ts...>, public Parented<TimeEntity> {
  public:
   TEMPLATABLE_VALUE(ESPTime, time)


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18631 for fan, applied to datetime. `DateEntity::make_call`, `TimeEntity::make_call` and `DateTimeEntity::make_call` become inline definitions placed right after the matching `DateCall`, `TimeCall` and `DateTimeCall` class in each header (the call classes are declared after the entities, so the body cannot live inside the entity class). Every `datetime.*.set` action, the api and the web server go through `make_call`.

The CI datetime test config has no datetime entity (it compiles to the bare reference size), so this was measured with three template entities, the three `set` actions and a lambda calling `make_call` from `on_boot`, with sntp time and wifi; target branch to this PR, RAM unchanged: esp32-idf 683047 to 682999 bytes (48 bytes saved); esp8266 314247 to 314183 bytes (64 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
datetime:
  - platform: template
    id: d1
    type: date
    name: D
    optimistic: true
    initial_value: "2024-01-01"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
