### PR TITLE
[infrared] Inline the trivial make_call helper

### DIFF
--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -75,8 +75,6 @@ void Infrared::dump_config() {
                 YESNO(this->traits_.get_supports_receiver()));
 }
 
-InfraredCall Infrared::make_call() { return InfraredCall(this); }
-
 void Infrared::control(const InfraredCall &call) {
   if (this->transmitter_ == nullptr) {
     ESP_LOGW(TAG, "No transmitter configured");

--- a/esphome/components/infrared/infrared.h
+++ b/esphome/components/infrared/infrared.h
@@ -134,7 +134,7 @@ class Infrared : public Component, public EntityBase, public remote_base::Remote
   const InfraredTraits &get_traits() const { return this->traits_; }
 
   /// Create a call object for transmitting
-  InfraredCall make_call();
+  InfraredCall make_call() { return InfraredCall(this); }
 
   /// Get capability flags for this infrared instance
   uint32_t get_capability_flags() const;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18631 for fan and #18643 for datetime, applied to infrared. `Infrared::make_call` moves from `infrared.cpp` into the header; `InfraredCall` is declared before `Infrared` and its constructor only stores the parent pointer, so the body can live in the class. Every `infrared.transmit` action goes through `make_call`.

Small one. Measured with the CI infrared test config, target branch to this PR, RAM unchanged: esp32-idf 729795 to 729783 bytes (12 bytes saved); esp8266 343515 to 343499 bytes (16 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
infrared:
  id: ir
  name: IR
  transmitter: tx
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
