### PR TITLE
[radio_frequency] Inline the trivial make_call helper

### DIFF
--- a/esphome/components/radio_frequency/radio_frequency.cpp
+++ b/esphome/components/radio_frequency/radio_frequency.cpp
@@ -81,8 +81,6 @@ void RadioFrequency::dump_config() {
   }
 }
 
-RadioFrequencyCall RadioFrequency::make_call() { return RadioFrequencyCall(this); }
-
 uint32_t RadioFrequency::get_capability_flags() const {
   uint32_t flags = 0;
   if (this->traits_.get_supports_transmitter())

--- a/esphome/components/radio_frequency/radio_frequency.h
+++ b/esphome/components/radio_frequency/radio_frequency.h
@@ -157,7 +157,7 @@ class RadioFrequency : public Component, public EntityBase, public remote_base::
   const RadioFrequencyTraits &get_traits() const { return this->traits_; }
 
   /// Create a call object for transmitting
-  RadioFrequencyCall make_call();
+  RadioFrequencyCall make_call() { return RadioFrequencyCall(this); }
 
   /// Get capability flags for this radio frequency instance
   uint32_t get_capability_flags() const;


### PR DESCRIPTION
# What does this implement/fix?

Same cleanup as #18631 for fan and #18643 for datetime, applied to radio_frequency. `RadioFrequency::make_call` moves from `radio_frequency.cpp` into the header; `RadioFrequencyCall` is declared before `RadioFrequency` and its constructor only stores the parent pointer, so the body can live in the class. Every `radio_frequency.transmit` action goes through `make_call`.

Small one. Measured with the CI radio_frequency test config, target branch to this PR, RAM unchanged: esp32-idf 730127 to 730115 bytes (12 bytes saved); esp8266 343879 to 343863 bytes (16 bytes saved). No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
radio_frequency:
  id: rf
  name: RF
  transmitter: tx
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
