### PR TITLE
[bk72xx_ble] Guard against bond-store erasing the bootloader

### DIFF
--- a/esphome/components/bk72xx_ble/bk72xx_ble.cpp
+++ b/esphome/components/bk72xx_ble/bk72xx_ble.cpp
@@ -77,6 +77,12 @@ extern struct bd_addr common_default_bdaddr;
 // ble_entry() brings up the BDK BLE stack; it is not declared in ble_api.h, so
 // declare it here.
 void ble_entry(void);
+
+// Flash-partition API used to validate the BLE bonding partition before the
+// BDK bond store can erase it — see the bootloader-erase guard in enable()
+// (esphome#18646). Provides bk_flash_get_info(), bk_logic_partition_t and the
+// BK_PARTITION_* enum, including BK_PARTITION_BLE_BONDING_FLASH.
+#include "BkDriverFlash.h"
 }
 
 namespace esphome::bk72xx_ble {
@@ -156,6 +162,29 @@ void BK72xxBLE::enable() {
   if (this->state_ != BLEComponentState::STATE_OFF)
     return;
   this->state_ = BLEComponentState::ENABLING;
+
+  // Guard against a BDK bond-store path that can permanently brick the device
+  // (esphome#18646). The BDK's bond init (app_sec.c) erases the flash sector at
+  // BK_PARTITION_BLE_BONDING_FLASH's start address on first boot, when the
+  // stored bond CRC fails against blank flash. bk_flash_get_info() returns a
+  // non-NULL pointer even for a partition the active flash-type table never
+  // populated, so on such a layout partition_start_addr reads back 0 and the
+  // erase destroys flash sector 0 — the bootloader — leaving the device
+  // unbootable, also via OTA, with safe mode unable to run. Refuse to bring up
+  // BLE unless the bonding partition sits above the application partition.
+  const bk_logic_partition_t *bond = bk_flash_get_info(BK_PARTITION_BLE_BONDING_FLASH);
+  const bk_logic_partition_t *app = bk_flash_get_info(BK_PARTITION_APPLICATION);
+  const uint32_t app_end = app != nullptr ? app->partition_start_addr + app->partition_length : 0;
+  if (bond == nullptr || bond->partition_length == 0 || bond->partition_start_addr < app_end) {
+    ESP_LOGE(TAG,
+             "BLE bonding partition invalid (start=0x%06lX len=0x%lX); refusing BLE init to avoid erasing the "
+             "bootloader on this flash layout",
+             static_cast<unsigned long>(bond != nullptr ? bond->partition_start_addr : 0),
+             static_cast<unsigned long>(bond != nullptr ? bond->partition_length : 0));
+    this->mark_failed();
+    this->state_ = BLEComponentState::STATE_OFF;
+    return;
+  }
 
   // One-time BLE stack init: register the notice callback, then bring up the
   // BDK BLE stack. The BDK has no teardown path — init happens at most once.


### PR DESCRIPTION
## What / why

Fixes the bricking half of #18646 (reproduced on BK7238 / Tuya T1-3S).

The Beken BDK BLE bond store (`driver/ble/ble_5_x/.../app_sec.c`) erases the flash sector at `BK_PARTITION_BLE_BONDING_FLASH`'s start address on first boot, when the stored bond CRC fails against blank flash. It reads that address from `bk_flash_get_info(BK_PARTITION_BLE_BONDING_FLASH)`.

LibreTiny supplies that partition table (`cores/beken-72xx/base/wraps/BkDriverFlash.c`) and **does not define a `[BK_PARTITION_BLE_BONDING_FLASH]` entry** — only BOOTLOADER / APPLICATION / OTA / RF_FIRMWARE / NET_PARAM. `bk_flash_get_info()` still returns a non-NULL pointer for that in-range enum, into the zero-initialised array slot, so `partition_start_addr` reads back **0**. The BDK then erases flash sector 0 — the bootloader — leaving the device permanently unbootable, also via OTA, with safe mode unable to run.

The real fix belongs in LibreTiny's partition table (and the board flash layouts need to reserve a bonding sector); I'm raising that separately. This PR is the safety net so no user can be bricked in the meantime.

## What this does

Before `ble_entry()`, validate the bonding partition and refuse BLE init unless it sits above the application partition:

- correct layout (e.g. BK7231N with a real bonding address) → passes unchanged, no behaviour change;
- broken layout (start 0, or below the app) → `mark_failed()` + error log, bootloader untouched.

Converts a permanent brick into "BLE unavailable on this chip, here's why" — recoverable by an ordinary OTA.

## Notes

- I don't have BK7238 hardware; root-caused from the BDK + LibreTiny sources, corroborated by the reporter's excellent forensics (sector 0 → all-`0xFF`, re-erased to the same hash every boot, only with the tracker present).
- The existing "may be unstable on untested SoCs" wording undersells this; I'll strengthen it in a follow-up once the LibreTiny fix lands.