### PR TITLE
[bk72xx_ble] Block BK7238 until the LibreTiny bonding partition fix lands

### DIFF
--- a/esphome/components/bk72xx_ble/__init__.py
+++ b/esphome/components/bk72xx_ble/__init__.py
@@ -6,7 +6,10 @@ on this component and contain no SDK calls of their own.
 
 Supported SoCs (BLE 5.x): BK7231N/BK7236 (BLE 5.1), BK7238/BK7252N/BK7253
 (BLE 5.2), and any future BLE-5.x SoC. Known non-5.x families are rejected in
-to_code; unknown families are capability-checked at compile time via
+to_code. BK7238 is also rejected for now: with BLE compiled in, the Beken SDK
+erases the bootloader flash sector at boot because LibreTiny's partition table
+has no BLE bonding entry (esphome#18646, libretiny-eu/libretiny#408).
+Unknown families are capability-checked at compile time via
 `__has_include("app_ble.h")`, a header only on the BLE 5.x include path
 (ble_api.h ships for every SoC, so it cannot be the probe). A non-5.x build
 fails with a clear #error.
@@ -65,6 +68,14 @@ def _unsupported_family_message(family: str) -> str | None:
         )
     if family == FAMILY_BK7231Q:
         return "bk72xx_ble does not support BK7231Q: this SoC has no BLE"
+    if family == FAMILY_BK7238:
+        return (
+            "bk72xx_ble is disabled on BK7238: with BLE compiled in, the Beken SDK "
+            "erases the bootloader flash sector at boot and the device can no longer "
+            "start (see https://github.com/esphome/esphome/issues/18646); support "
+            "returns once the LibreTiny partition table fix "
+            "(libretiny-eu/libretiny#408) is released"
+        )
     return None
 
 
@@ -113,18 +124,7 @@ async def to_code(config: ConfigType) -> None:
     # BK7231N, but NOT on BK7238 (its BLE stack has no such symbol; the address is
     # derived from the WiFi MAC instead — the BDK's own fallback). Tell the C++
     # which path is available so it doesn't reference a missing symbol.
-    family = libretiny.get_libretiny_family()
-    if family == FAMILY_BK7231N:
+    if libretiny.get_libretiny_family() == FAMILY_BK7231N:
         cg.add_define("BK72XX_BLE_HAS_COMMON_BDADDR")
-    elif family == FAMILY_BK7238:
-        # ESPHome's LibreTiny disables BLE on BK7238 because the SDK can hang at
-        # WiFi STA startup when BLE init runs. This component re-enables BLE, so
-        # warn loudly: BK7238 is accepted but not hardware-verified and may be
-        # WiFi-unstable with BLE on.
-        _LOGGER.warning(
-            "bk72xx_ble on BK7238: enabling BLE is known to risk a WiFi STA startup "
-            "hang on this family and is not yet hardware-verified. Expect possible "
-            "instability."
-        )
 
     cg.add_define("USE_BK72XX_BLE")

--- a/esphome/components/bk72xx_ble/__init__.py
+++ b/esphome/components/bk72xx_ble/__init__.py
@@ -4,12 +4,12 @@ The platform analog of esp32_ble / rp2040_ble: owns the Beken BDK BLE stack
 bring-up and the controller BLE address. Consumers (bk72xx_ble_tracker) build
 on this component and contain no SDK calls of their own.
 
-Supported SoCs (BLE 5.x): BK7231N/BK7236 (BLE 5.1), BK7238/BK7252N/BK7253
-(BLE 5.2), and any future BLE-5.x SoC. Known non-5.x families are rejected in
-to_code. BK7238 is also rejected for now: with BLE compiled in, the Beken SDK
-erases the bootloader flash sector at boot because LibreTiny's partition table
-has no BLE bonding entry (esphome#18646, libretiny-eu/libretiny#408).
-Unknown families are capability-checked at compile time via
+Supported SoCs (BLE 5.x): BK7231N/BK7236 (BLE 5.1), BK7252N/BK7253 (BLE 5.2),
+and any future BLE-5.x SoC. BK7238 (BLE 5.2) is blocked for now: with BLE
+compiled in, the Beken SDK erases the bootloader flash sector at boot because
+LibreTiny's partition table has no BLE bonding entry (esphome#18646,
+libretiny-eu/libretiny#408). Known non-5.x families and BK7238 are rejected in
+to_code. Unknown families are capability-checked at compile time via
 `__has_include("app_ble.h")`, a header only on the BLE 5.x include path
 (ble_api.h ships for every SoC, so it cannot be the probe). A non-5.x build
 fails with a clear #error.

--- a/tests/component_tests/bk72xx_ble/config/test_bk7238.yaml
+++ b/tests/component_tests/bk72xx_ble/config/test_bk7238.yaml
@@ -1,0 +1,7 @@
+esphome:
+  name: bk-family-gate-7238
+
+bk72xx:
+  board: generic-bk7238
+
+bk72xx_ble:

--- a/tests/component_tests/bk72xx_ble/test_family_gate.py
+++ b/tests/component_tests/bk72xx_ble/test_family_gate.py
@@ -16,6 +16,7 @@ from esphome.core import EsphomeError
         ("test_bk7231t.yaml", "BK7231T.*BLE 4.2"),
         ("test_bk7252.yaml", "BK7251.*BLE 4.2"),
         ("test_bk7231q.yaml", "BK7231Q.*no BLE"),
+        ("test_bk7238.yaml", "BK7238.*bootloader"),
     ],
 )
 def test_unsupported_family_rejected(


### PR DESCRIPTION
# What does this implement/fix?

On BK7238, any build with `bk72xx_ble` compiled in erases flash sector 0 (the bootloader) during SDK bring-up, before ESPHome code runs. The device no longer boots, also after an OTA update, and safe mode cannot start. The cause is in the LibreTiny partition table, which has no BLE bonding entry, so the Beken bond store erases address 0. The proper fix is libretiny-eu/libretiny#408, which has not been released yet. A runtime guard inside ESPHome was tried in #18647 and shown to be too late, since the erase happens before `setup()`.

Until the LibreTiny fix ships, this PR blocks `bk72xx_ble` on BK7238 through the existing family gate: `esphome config` warns that the configuration cannot compile, and `esphome compile` stops at code generation with a message that explains the problem and links the issue. The old BK7238 warning about a possible WiFi startup hang is removed since the build no longer gets that far. A BK7238 case is added to the family gate tests.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18646

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bk72xx:
  board: generic-bk7238

bk72xx_ble:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
