### PR TITLE
[core] Dump the main.cpp config comment with sorted keys

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -762,7 +762,9 @@ def _wrap_to_code(name, comp, yaml_util):
     async def wrapped(conf):
         cg.add(cg.LineComment(f"{name}:"))
         if comp.config_schema is not None:
-            conf_str = yaml_util.dump(conf)
+            # sort_keys: voluptuous fills defaults in set order, so an
+            # unsorted dump would churn main.cpp and relink every run
+            conf_str = yaml_util.dump(conf, sort_keys=True)
             conf_str = conf_str.replace("//", "")
             # remove tailing \ to avoid multi-line comment warning
             conf_str = conf_str.replace("\\\n", "\n")

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -766,7 +766,7 @@ def _wrap_to_code(name, comp, yaml_util):
             # unsorted dump would churn main.cpp and relink every run
             conf_str = yaml_util.dump(conf, sort_keys=True)
             conf_str = conf_str.replace("//", "")
-            # remove tailing \ to avoid multi-line comment warning
+            # remove trailing \ to avoid multi-line comment warning
             conf_str = conf_str.replace("\\\n", "\n")
             cg.add(cg.LineComment(indent(conf_str)))
         await coro(conf)

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -7148,9 +7148,13 @@ async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
     comp = SimpleNamespace(to_code=to_code, config_schema=object())
     wrapped = _wrap_to_code("demo", comp, yaml_util)
     with patch("esphome.codegen.add", side_effect=lambda st: comments.append(str(st))):
-        await wrapped({"beta": 1, "alpha": 2})
-        first = list(comments)
+        # Nested on purpose: the real churn lives in nested action configs,
+        # so sorting must apply at every mapping level
+        await wrapped({"beta": 1, "alpha": {"z": 1, "a": 2}})
+        first = "\n".join(comments)
         comments.clear()
-        await wrapped({"alpha": 2, "beta": 1})
-    assert first == comments
-    assert "alpha: 2" in comments[1]
+        await wrapped({"alpha": {"a": 2, "z": 1}, "beta": 1})
+    second = "\n".join(comments)
+    assert first == second
+    assert second.index("alpha") < second.index("beta")
+    assert second.index("a: 2") < second.index("z: 1")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import re
 import sys
 import time
+from types import SimpleNamespace
 from typing import Any, Self
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -18,7 +19,7 @@ import pytest
 from pytest import CaptureFixture
 from zeroconf import ServiceStateChange
 
-from esphome import __main__ as main
+from esphome import __main__ as main, yaml_util
 from esphome.__main__ import (
     Purpose,
     _get_configured_xtal_freq,
@@ -29,6 +30,7 @@ from esphome.__main__ import (
     _unresolved_default_error,
     _validate_bootloader_binary,
     _validate_partition_table_binary,
+    _wrap_to_code,
     check_permissions,
     choose_upload_log_host,
     command_analyze_memory,
@@ -7137,11 +7139,6 @@ async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
     """The config comment dumps with sorted keys: voluptuous fills schema
     defaults in set-iteration order, so an unsorted dump would churn
     main.cpp and relink the firmware on every run."""
-    from types import SimpleNamespace
-
-    from esphome import yaml_util
-    from esphome.__main__ import _wrap_to_code
-
     comments: list[str] = []
 
     async def to_code(conf):

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -118,6 +118,7 @@ from esphome.espota2 import (
     OTA_TYPE_UPDATE_PARTITION_TABLE,
 )
 from esphome.platformio import toolchain
+from esphome.types import ConfigType
 from esphome.util import BootselResult, FlashImage
 from esphome.zeroconf import _await_discovery, discover_mdns_devices
 
@@ -7141,7 +7142,7 @@ async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
     main.cpp and relink the firmware on every run."""
     comments: list[str] = []
 
-    async def to_code(conf):
+    async def to_code(conf: ConfigType) -> None:
         """Accept any config; only the wrapper's comment output matters."""
 
     comp = SimpleNamespace(to_code=to_code, config_schema=object())

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -7142,7 +7142,7 @@ async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
     comments: list[str] = []
 
     async def to_code(conf):
-        pass
+        """Accept any config; only the wrapper's comment output matters."""
 
     comp = SimpleNamespace(to_code=to_code, config_schema=object())
     wrapped = _wrap_to_code("demo", comp, yaml_util)

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -7130,3 +7130,29 @@ def test_warn_source_tree_mismatch_falls_back_when_stat_fails(
 
     # Same tree, so the path comparison still finds them equal and stays silent
     assert not caplog.text
+
+
+@pytest.mark.asyncio
+async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
+    """The config comment dumps with sorted keys: voluptuous fills schema
+    defaults in set-iteration order, so an unsorted dump would churn
+    main.cpp and relink the firmware on every run."""
+    from types import SimpleNamespace
+
+    from esphome import yaml_util
+    from esphome.__main__ import _wrap_to_code
+
+    comments: list[str] = []
+
+    async def to_code(conf):
+        pass
+
+    comp = SimpleNamespace(to_code=to_code, config_schema=object())
+    wrapped = _wrap_to_code("demo", comp, yaml_util)
+    with patch("esphome.codegen.add", side_effect=lambda st: comments.append(str(st))):
+        await wrapped({"beta": 1, "alpha": 2})
+        first = list(comments)
+        comments.clear()
+        await wrapped({"alpha": 2, "beta": 1})
+    assert first == comments
+    assert "alpha: 2" in comments[1]


### PR DESCRIPTION
# What does this implement/fix?

Fixes a spurious full relink on every `esphome compile`, on every build backend (ESP-IDF, PlatformIO, and the native toolchains alike).

voluptuous fills schema defaults in set-iteration order, so a validated config dict's key order changes with each process's hash seed. `_wrap_to_code` dumps that dict as the YAML comment block in `main.cpp` unsorted, so any config using an action with several defaulted keys (a `logger.log` in an `on_press` is enough) reorders its comment lines between runs. main.cpp changes, and every backend recompiles it and relinks the firmware even though nothing real changed.

The comment now dumps with `sort_keys=True`, making main.cpp byte-stable across runs; a test pins that two insertion orders of the same config produce identical comments. The first compile after upgrading rebuilds once as the comment settles into sorted form.

Found while testing incremental builds for the ESP8266 native toolchain chain (#18539); split out since it fixes all existing backends.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18539

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config with a defaults-heavy action relinks every run without this fix
button:
  - platform: template
    name: "Toggle"
    on_press:
      - logger.log: "Button pressed"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
