### PR TITLE
[remote_transmitter] ISR-driven transmission and non_blocking support on BK7231N/BK7238

### DIFF
--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -4,7 +4,11 @@ from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import esp32, esp32_rmt, remote_base
 from esphome.components.libretiny import get_libretiny_family
-from esphome.components.libretiny.const import FAMILY_RTL8720C
+from esphome.components.libretiny.const import (
+    FAMILY_BK7231N,
+    FAMILY_BK7238,
+    FAMILY_RTL8720C,
+)
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -45,14 +49,19 @@ DigitalWriteAction = remote_transmitter_ns.class_(
 )
 
 
+_NON_BLOCKING_LIBRETINY_FAMILIES = (FAMILY_RTL8720C, FAMILY_BK7231N, FAMILY_BK7238)
+
+
 def _validate_non_blocking_platform(value: bool) -> bool:
-    # non_blocking requires hardware transmission: RMT on ESP32, the gtimer
-    # envelope chain on RTL8720C. Reject everywhere else at config time.
+    # non_blocking requires hardware transmission: RMT on ESP32, a hardware timer
+    # envelope chain on the listed LibreTiny families. Reject elsewhere at config time.
     if CORE.is_esp32:
         return cv.boolean(value)
-    if CORE.is_libretiny and get_libretiny_family() == FAMILY_RTL8720C:
+    if CORE.is_libretiny and get_libretiny_family() in _NON_BLOCKING_LIBRETINY_FAMILIES:
         return cv.boolean(value)
-    raise cv.Invalid("non_blocking is only supported on ESP32 and RTL8720C")
+    raise cv.Invalid(
+        "non_blocking is only supported on ESP32, RTL8720C, BK7231N and BK7238"
+    )
 
 
 MULTI_CONF = True
@@ -201,6 +210,9 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
         },
         "remote_transmitter_rtl87xx.cpp": {
             PlatformFramework.RTL87XX_ARDUINO,
+        },
+        "remote_transmitter_bk72xx.cpp": {
+            PlatformFramework.BK72XX_ARDUINO,
         },
         "remote_transmitter.cpp": {
             PlatformFramework.ESP32_ARDUINO,

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -214,6 +214,10 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
         "remote_transmitter_bk72xx.cpp": {
             PlatformFramework.BK72XX_ARDUINO,
         },
+        "remote_transmitter_libretiny_isr.cpp": {
+            PlatformFramework.RTL87XX_ARDUINO,
+            PlatformFramework.BK72XX_ARDUINO,
+        },
         "remote_transmitter.cpp": {
             PlatformFramework.ESP32_ARDUINO,
             PlatformFramework.ESP32_IDF,

--- a/esphome/components/remote_transmitter/remote_transmitter.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter.cpp
@@ -2,8 +2,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-#if (defined(USE_LIBRETINY) && !defined(USE_RTL87XX)) || defined(USE_ESP8266) || defined(USE_RP2) || \
-    (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
+#if (defined(USE_LIBRETINY) && !defined(USE_RTL87XX) && !defined(REMOTE_TRANSMITTER_BK_PWM)) || \
+    defined(USE_ESP8266) || defined(USE_RP2) || (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
 
 namespace esphome::remote_transmitter {
 

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -12,6 +12,14 @@
 #endif  // SOC_RMT_SUPPORTED
 #endif  // USE_ESP32
 
+// The BK7231N-style PWM block (hardware shadow-load duty updates) enables the ISR-driven
+// transmitter on these families; family-level proxy for the SDK's CFG_SOC_NAME gate.
+// See remote_transmitter_bk72xx.cpp.
+#if defined(USE_LIBRETINY_VARIANT_BK7231N) || defined(USE_LIBRETINY_VARIANT_BK7238) || \
+    defined(USE_LIBRETINY_VARIANT_BK7252N)
+#define REMOTE_TRANSMITTER_BK_PWM
+#endif
+
 namespace esphome::remote_transmitter {
 
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED
@@ -57,10 +65,11 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
   void set_eot_level(bool eot_level) { this->eot_level_ = eot_level; }
 #endif
-#if (defined(USE_ESP32) && SOC_RMT_SUPPORTED) || defined(USE_LIBRETINY_VARIANT_RTL8720C)
+#if (defined(USE_ESP32) && SOC_RMT_SUPPORTED) || defined(USE_LIBRETINY_VARIANT_RTL8720C) || \
+    defined(REMOTE_TRANSMITTER_BK_PWM)
   void set_non_blocking(bool non_blocking) { this->non_blocking_ = non_blocking; }
 #endif
-#ifdef USE_LIBRETINY_VARIANT_RTL8720C
+#if defined(USE_LIBRETINY_VARIANT_RTL8720C) || defined(REMOTE_TRANSMITTER_BK_PWM)
   void loop() override;
   // called from the envelope timer ISR trampoline; not part of the public API
   void advance_envelope_isr();
@@ -71,7 +80,8 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
 
  protected:
   void send_internal(uint32_t send_times, uint32_t send_wait) override;
-#if defined(USE_ESP8266) || (defined(USE_LIBRETINY) && !defined(USE_LIBRETINY_VARIANT_RTL8720C)) || \
+#if defined(USE_ESP8266) || \
+    (defined(USE_LIBRETINY) && !defined(USE_LIBRETINY_VARIANT_RTL8720C) && !defined(REMOTE_TRANSMITTER_BK_PWM)) || \
     defined(USE_RP2) || (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
   void await_target_time_();
   uint32_t target_time_{0};
@@ -89,17 +99,14 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   uint32_t current_carrier_frequency_{0};
   void *pwm_{nullptr};  // pwmout_t*, opaque here to keep the SDK header out of this shared header
 #endif
-#ifdef USE_LIBRETINY_VARIANT_RTL8720C
+#if defined(USE_LIBRETINY_VARIANT_RTL8720C) || defined(REMOTE_TRANSMITTER_BK_PWM)
   void start_isr_item_(size_t index);
   void arm_envelope_timer_(uint32_t duration_us);
   void abort_stalled_chain_();
   void deliver_completion_();
   void wait_until_idle_();
   void arm_chain_(uint32_t send_times, uint32_t send_wait);
-  void update_carrier_(uint32_t carrier_frequency);
   std::vector<int32_t> isr_data_;  // owned copy of the frame; temp_ may be re-encoded mid-flight
-  float isr_mark_duty_{0.0f};
-  float isr_space_duty_{0.0f};
   volatile size_t isr_index_{0};
   volatile uint32_t isr_repeats_left_{0};
   uint32_t isr_send_wait_{0};
@@ -109,6 +116,18 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   bool non_blocking_{false};
   bool complete_pending_{false};
   bool stall_aborted_{false};  // this transmission ended via abort; blocks warning clear
+#endif
+#ifdef USE_LIBRETINY_VARIANT_RTL8720C
+  void update_carrier_(uint32_t carrier_frequency);
+  float isr_mark_duty_{0.0f};
+  float isr_space_duty_{0.0f};
+#endif
+#ifdef REMOTE_TRANSMITTER_BK_PWM
+  void write_pwm_t1_(uint32_t t1_counts);
+  int8_t pwm_channel_{-1};
+  uint32_t isr_mark_t1_{0};
+  uint32_t isr_space_t1_{0};
+  uint32_t isr_period_t4_{684};  // 26MHz counts; ~38kHz default until a send sets the real carrier
 #endif
 
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -73,6 +73,8 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   void loop() override;
   // called from the envelope timer ISR trampoline; not part of the public API
   void advance_envelope_isr();
+  // same, for trampolines whose SDK callback carries no user argument
+  static void advance_active_isr();
 #endif
 
   Trigger<> *get_transmit_trigger() { return &this->transmit_trigger_; }
@@ -100,12 +102,20 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   void *pwm_{nullptr};  // pwmout_t*, opaque here to keep the SDK header out of this shared header
 #endif
 #if defined(USE_LIBRETINY_VARIANT_RTL8720C) || defined(REMOTE_TRANSMITTER_BK_PWM)
+  // Envelope chain, shared by every family that paces transmission from a hardware timer
+  // (remote_transmitter_libretiny_isr.cpp)
   void start_isr_item_(size_t index);
   void arm_envelope_timer_(uint32_t duration_us);
   void abort_stalled_chain_();
   void deliver_completion_();
   void wait_until_idle_();
   void arm_chain_(uint32_t send_times, uint32_t send_wait);
+  // Hooks implemented per family: everything the chain needs from the hardware
+  bool envelope_ready_() const;                       // PWM claimed successfully in setup()
+  void prepare_carrier_(uint32_t carrier_frequency);  // retune period, stage mark/space levels
+  void write_envelope_level_(bool mark);              // drive carrier (mark) or idle (space)
+  void arm_one_shot_(uint32_t duration_us);           // fire advance_envelope_isr after duration_us
+  void stop_envelope_timer_();
   std::vector<int32_t> isr_data_;  // owned copy of the frame; temp_ may be re-encoded mid-flight
   volatile size_t isr_index_{0};
   volatile uint32_t isr_repeats_left_{0};
@@ -118,7 +128,6 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   bool stall_aborted_{false};  // this transmission ended via abort; blocks warning clear
 #endif
 #ifdef USE_LIBRETINY_VARIANT_RTL8720C
-  void update_carrier_(uint32_t carrier_frequency);
   float isr_mark_duty_{0.0f};
   float isr_space_duty_{0.0f};
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -124,10 +124,10 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
 #endif
 #ifdef REMOTE_TRANSMITTER_BK_PWM
   void write_pwm_t1_(uint32_t t1_counts);
-  int8_t pwm_channel_{-1};
   uint32_t isr_mark_t1_{0};
   uint32_t isr_space_t1_{0};
   uint32_t isr_period_t4_{684};  // 26MHz counts; ~38kHz default until a send sets the real carrier
+  int8_t pwm_channel_{-1};
 #endif
 
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -15,8 +15,7 @@
 // The BK7231N-style PWM block (hardware shadow-load duty updates) enables the ISR-driven
 // transmitter on these families; family-level proxy for the SDK's CFG_SOC_NAME gate.
 // See remote_transmitter_bk72xx.cpp.
-#if defined(USE_LIBRETINY_VARIANT_BK7231N) || defined(USE_LIBRETINY_VARIANT_BK7238) || \
-    defined(USE_LIBRETINY_VARIANT_BK7252N)
+#if defined(USE_LIBRETINY_VARIANT_BK7231N) || defined(USE_LIBRETINY_VARIANT_BK7238)
 #define REMOTE_TRANSMITTER_BK_PWM
 #endif
 
@@ -88,7 +87,8 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   void await_target_time_();
   uint32_t target_time_{0};
 #endif
-#if defined(USE_ESP8266) || (defined(USE_LIBRETINY) && !defined(USE_RTL87XX)) || defined(USE_RP2) || \
+#if defined(USE_ESP8266) || \
+    (defined(USE_LIBRETINY) && !defined(USE_RTL87XX) && !defined(REMOTE_TRANSMITTER_BK_PWM)) || defined(USE_RP2) || \
     (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
   void calculate_on_off_time_(uint32_t carrier_frequency, uint32_t *on_time_period, uint32_t *off_time_period);
 

--- a/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
@@ -1,0 +1,335 @@
+#include "remote_transmitter.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+// clang-tidy cannot parse the Beken SDK headers pulled in via ArduinoPrivate.h
+#if defined(USE_BK72XX) && !defined(CLANG_TIDY)
+
+// ArduinoPrivate.h = Arduino.h + the BDK SDK headers (pwm_pub.h, bk_timer_pub.h, icu_pub.h)
+// with the core's fixes for type-name collisions between the two
+#include <ArduinoPrivate.h>
+
+// Only the BK7231N-style PWM block (shadow registers with a hardware CFG_UPDATA load bit)
+// supports glitch-free per-edge duty updates; older SoCs compile the generic bit-bang
+// implementation (remote_transmitter.cpp) instead, and this file compiles to nothing.
+// REMOTE_TRANSMITTER_BK_PWM is set per-family in remote_transmitter.h.
+
+namespace esphome::remote_transmitter {
+
+static const char *const TAG = "remote_transmitter";
+
+#ifdef REMOTE_TRANSMITTER_BK_PWM
+
+// PWM peripheral carrier (26MHz block), envelope paced by a BKTIMER1 interrupt chain: each
+// interrupt writes the next duty through the shadow registers (T1..T4 + CFG_UPDATA hardware
+// load, glitch-free at the next carrier period). Direct register writes beat the driver's
+// pwm_update_param() (~19us vs ~26us edge error) and have no shared state to race against.
+// BKTIMER1 is the only free channel: TIMER0 = FreeRTOS tick, TIMER2 = SDK cal, TIMER4 = wdt.
+
+static constexpr uint32_t REG_PWM_BASE = 0x00802B00UL;
+static constexpr uint32_t REG_PWM_GROUP_STRIDE = 0x40;       // one register group per channel pair
+static constexpr uint32_t REG_PWM_T_REGS[2] = {0x04, 0x14};  // T1..T4 offsets within a group
+static constexpr uint32_t PWM_INT_STATUS_MASK = 3UL << 30;   // write-1-clear -- always write as zero
+static constexpr uint8_t ENVELOPE_TIMER = BKTIMER1;
+// Margin past a transmission's expected duration before the chain is declared stalled
+static constexpr uint32_t STALL_MARGIN_MS = 1000;
+// Longest single one-shot armed; longer durations are chained (driver computes period_us * 26
+// in 32 bits, overflowing past ~165s)
+static constexpr uint32_t MAX_ONE_SHOT_US = 50000;
+
+// The bk_timer handler receives only the channel number, so the active instance is tracked
+// statically; it doubles as the cross-instance serialization token (MULTI_CONF).
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static RemoteTransmitterComponent *volatile s_active_transmitter = nullptr;
+// Deadline for the in-flight transmission (millis-based); only touched from the main task
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static uint32_t s_expected_end_ms = 0;
+
+// No IRAM_ATTR: hal.h makes it a no-op on BK72xx (the SDK masks IRQs around flash writes)
+static void envelope_timer_isr(UINT8 channel) {
+  auto *transmitter = s_active_transmitter;
+  if (transmitter != nullptr)
+    transmitter->advance_envelope_isr();
+}
+
+// PWM channel per pin on the BK7231N-style block
+struct PwmPinChannel {
+  uint8_t pin;
+  int8_t channel;
+};
+static constexpr PwmPinChannel PWM_PIN_CHANNELS[] = {{6, 0}, {7, 1}, {8, 2}, {9, 3}, {24, 4}, {26, 5}};
+
+static int8_t pwm_channel_for_pin(uint8_t pin) {
+  for (const auto &entry : PWM_PIN_CHANNELS) {
+    if (entry.pin == pin)
+      return entry.channel;
+  }
+  return -1;
+}
+
+void RemoteTransmitterComponent::setup() {
+  // Deliberately no pin_->setup(): the pin must belong to the PWM function, not GPIO
+  const int8_t channel = pwm_channel_for_pin(this->pin_->get_pin());
+  if (channel < 0) {
+    ESP_LOGE(TAG, "Pin %u is not PWM-capable", this->pin_->get_pin());
+    this->mark_failed();
+    return;
+  }
+  this->pwm_channel_ = channel;
+  const uint32_t idle_t1 = this->pin_->is_inverted() ? this->isr_period_t4_ : 0;
+  pwm_param_st param{};
+  param.chan = channel;
+  param.t1 = idle_t1;
+  param.t4 = this->isr_period_t4_;
+  param.init_level = idle_t1 ? 1 : 0;
+  if (pwm_init_param(&param) != 0 || pwm_start(channel) != 0) {
+    ESP_LOGE(TAG, "PWM init failed on pin %u", this->pin_->get_pin());
+    this->pwm_channel_ = -1;
+    this->mark_failed();
+    return;
+  }
+  this->disable_loop();  // loop() is only needed while a non-blocking completion is pending
+}
+
+void RemoteTransmitterComponent::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "Remote Transmitter:\n"
+                "  Carrier Duty: %u%%\n"
+                "  Non-blocking: %s",
+                this->carrier_duty_percent_, YESNO(this->non_blocking_));
+  LOG_PIN("  Pin: ", this->pin_);
+}
+
+// Writes the duty compare registers and sets the hardware CFG_UPDATA shadow-load bit;
+// the new duty latches glitch-free at the next carrier period. ISR-safe: registers only.
+void RemoteTransmitterComponent::write_pwm_t1_(uint32_t t1_counts) {
+  const uint32_t group = this->pwm_channel_ / 2;
+  const uint32_t post = this->pwm_channel_ % 2;
+  const uint32_t group_base = REG_PWM_BASE + REG_PWM_GROUP_STRIDE * group;
+  auto *t_regs = (volatile uint32_t *) (group_base + REG_PWM_T_REGS[post]);
+  auto *ctrl = (volatile uint32_t *) group_base;
+  const uint32_t init_level_bit = 1UL << (8 * post + 6);  // output level while the counter is stopped
+  const uint32_t cfg_updata_bit = 1UL << (8 * post + 7);  // 0->1 latches T1..T4 at the next period
+  t_regs[0] = t1_counts;                                  // T1: high time
+  t_regs[1] = 0;                                          // T2
+  t_regs[2] = 0;                                          // T3
+  t_regs[3] = this->isr_period_t4_;                       // T4: period
+  uint32_t cfg = *ctrl;
+  cfg &= ~(PWM_INT_STATUS_MASK | init_level_bit | cfg_updata_bit);
+  if (t1_counts != 0)
+    cfg |= init_level_bit;
+  *ctrl = cfg;
+  *ctrl = cfg | cfg_updata_bit;
+}
+
+// Arms the shared envelope timer, chaining durations longer than MAX_ONE_SHOT_US. ISR-safe.
+void RemoteTransmitterComponent::arm_envelope_timer_(uint32_t duration_us) {
+  // clamp to 1us (a zero-length one-shot never fires); the remainder must not underflow
+  const uint32_t chunk = std::max(uint32_t(1), std::min(duration_us, MAX_ONE_SHOT_US));
+  this->isr_wait_remaining_ = duration_us > chunk ? duration_us - chunk : 0;
+  timer_param_t param{};
+  param.channel = ENVELOPE_TIMER;
+  param.div = 1;
+  param.period = chunk;
+  param.t_Int_Handler = envelope_timer_isr;
+  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_INIT_PARAM_US, &param);
+}
+
+// Aborts a chain that stopped advancing: stop the timer, idle the pin, release the token.
+// Every step is a no-op if the chain completed meanwhile. Task context only.
+void RemoteTransmitterComponent::abort_stalled_chain_() {
+  // cleared first so a straggler one-shot bails at the ISR entry check
+  this->transmitting_ = false;
+  UINT32 channel = ENVELOPE_TIMER;
+  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_UNIT_DISABLE, &channel);
+  this->write_pwm_t1_(this->isr_space_t1_);
+  s_active_transmitter = nullptr;
+  this->stall_aborted_ = true;
+  this->status_set_warning("envelope timer stalled");
+  ESP_LOGE(TAG, "Envelope timer stalled; transmission aborted");
+  delay(1);  // let any already-latched interrupt land while the chain state is safe
+}
+
+// Delivers one deferred completion with its status bookkeeping
+void RemoteTransmitterComponent::deliver_completion_() {
+  if (!this->stall_aborted_)
+    this->status_clear_warning();
+  this->complete_pending_ = false;
+  this->complete_trigger_.trigger();
+}
+
+void RemoteTransmitterComponent::start_isr_item_(size_t index) {
+  const int32_t item = this->isr_data_[index];
+  this->write_pwm_t1_(item > 0 ? this->isr_mark_t1_ : this->isr_space_t1_);
+  this->arm_envelope_timer_(uint32_t(item > 0 ? item : -item));
+}
+
+void RemoteTransmitterComponent::advance_envelope_isr() {
+  if (!this->transmitting_)
+    return;  // chain was aborted; this is a stale one-shot that was already latched
+  if (this->isr_wait_remaining_ > 0) {
+    // continue a duration longer than one hardware one-shot
+    this->arm_envelope_timer_(this->isr_wait_remaining_);
+    return;
+  }
+  if (this->isr_in_gap_) {
+    // inter-repeat gap elapsed; restart the item chain
+    this->isr_in_gap_ = false;
+    this->isr_index_ = 0;
+    this->start_isr_item_(0);
+    return;
+  }
+  this->isr_index_++;
+  if (this->isr_index_ < this->isr_data_.size()) {
+    this->start_isr_item_(this->isr_index_);
+    return;
+  }
+  // end of one repetition
+  this->write_pwm_t1_(this->isr_space_t1_);
+  if (this->isr_repeats_left_ > 1) {
+    this->isr_repeats_left_--;
+    this->isr_index_ = 0;
+    if (this->isr_send_wait_ > 0) {
+      this->isr_in_gap_ = true;
+      this->arm_envelope_timer_(this->isr_send_wait_);
+    } else {
+      this->start_isr_item_(0);
+    }
+    return;
+  }
+  UINT32 channel = ENVELOPE_TIMER;
+  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_UNIT_DISABLE, &channel);
+  this->transmitting_ = false;
+  s_active_transmitter = nullptr;
+}
+
+void RemoteTransmitterComponent::digital_write(bool value) {
+  if (this->pwm_channel_ < 0)
+    return;
+  // serialize behind an in-flight chain, matching the ESP32/RMT non-blocking behavior
+  this->wait_until_idle_();
+  this->write_pwm_t1_((value != this->pin_->is_inverted()) ? this->isr_period_t4_ : 0);
+}
+
+// Waits until no chain is in flight, delivering any deferred completions; a completion
+// automation may start a new send, so repeat until truly idle. Bounded by the stall deadline.
+void RemoteTransmitterComponent::wait_until_idle_() {
+  while (true) {
+    while (true) {
+      // snapshot: the final ISR can clear the volatile pointer between a check and a use
+      auto *active = s_active_transmitter;
+      if (active == nullptr)
+        break;
+      if ((int32_t) (millis() - s_expected_end_ms) > 0) {
+        active->abort_stalled_chain_();
+        break;
+      }
+      App.feed_wdt();
+      delay(1);
+    }
+    if (!this->complete_pending_)
+      break;
+    this->deliver_completion_();
+  }
+}
+
+// Stages the repeat schedule and stall deadline, then starts the interrupt chain
+void RemoteTransmitterComponent::arm_chain_(uint32_t send_times, uint32_t send_wait) {
+  this->isr_repeats_left_ = send_times;
+  this->isr_send_wait_ = send_wait;
+  this->isr_index_ = 0;
+  this->isr_in_gap_ = false;
+  this->stall_aborted_ = false;
+  uint64_t frame_us = 0;
+  for (int32_t item : this->isr_data_)
+    frame_us += uint32_t(item > 0 ? item : -item);
+  const uint64_t total_us = frame_us * send_times + uint64_t(send_wait) * (send_times - 1);
+  s_expected_end_ms = millis() + uint32_t(total_us / 1000) + STALL_MARGIN_MS;
+  this->transmitting_ = true;
+  s_active_transmitter = this;
+  this->start_isr_item_(0);
+}
+
+void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
+  if (this->pwm_channel_ < 0) {
+    ESP_LOGW(TAG, "Cannot send: PWM not initialized");
+    return;
+  }
+  this->wait_until_idle_();
+  if (send_times == 0) {
+    // parity with the loop-based implementations: transmit nothing, but both triggers
+    // still fire so an on_complete-sequenced automation does not stall
+    this->transmit_trigger_.trigger();
+    this->deliver_completion_();
+    return;
+  }
+  ESP_LOGD(TAG, "Sending remote code");
+  const uint32_t carrier_frequency = this->temp_.get_carrier_frequency();
+  // period in 26MHz counts; unmodulated protocols drive the pin constantly during marks
+  if (carrier_frequency > 0) {
+    this->isr_period_t4_ = std::max(uint32_t(2), (26000000UL + carrier_frequency / 2) / carrier_frequency);
+  }
+  uint32_t mark_t1 = (carrier_frequency > 0 && this->carrier_duty_percent_ < 100)
+                         ? std::max(uint32_t(1), this->isr_period_t4_ * this->carrier_duty_percent_ / 100)
+                         : this->isr_period_t4_;
+  uint32_t space_t1 = 0;
+  if (this->pin_->is_inverted()) {
+    mark_t1 = this->isr_period_t4_ - mark_t1;
+    space_t1 = this->isr_period_t4_;
+  }
+  // own copy: with non_blocking the caller may re-encode temp_ while this frame is in flight
+  this->isr_data_.assign(this->temp_.get_data().begin(), this->temp_.get_data().end());
+  if (this->isr_data_.empty()) {
+    ESP_LOGW(TAG, "Empty data");
+    this->transmit_trigger_.trigger();
+    this->deliver_completion_();
+    return;
+  }
+  this->isr_mark_t1_ = mark_t1;
+  this->isr_space_t1_ = space_t1;
+  // trigger first: the deadline computed in arm_chain_ must not be charged for user code
+  this->transmit_trigger_.trigger();
+  // the automation may have started a send on another instance; let it finish before
+  // claiming the shared timer (a same-instance send remains unsupported here)
+  this->wait_until_idle_();
+  this->arm_chain_(send_times, send_wait);
+  if (this->non_blocking_) {
+    this->complete_pending_ = true;
+    this->enable_loop();
+    return;
+  }
+  // blocking mode: wait out the chain, bounded by the stall deadline
+  while (this->transmitting_) {
+    if ((int32_t) (millis() - s_expected_end_ms) > 0) {
+      this->abort_stalled_chain_();
+      break;
+    }
+    App.feed_wdt();
+    delay(1);
+  }
+  this->deliver_completion_();
+}
+
+void RemoteTransmitterComponent::loop() {
+  if (!this->complete_pending_) {
+    this->disable_loop();
+    return;
+  }
+  if (this->transmitting_) {
+    // non-blocking stall recovery: without this, a dead chain would leave the carrier
+    // driven and on_complete unfired until the next send happened to abort it
+    if ((int32_t) (millis() - s_expected_end_ms) <= 0)
+      return;
+    this->abort_stalled_chain_();
+  }
+  // release the loop before user code runs: the automation may start a new non-blocking
+  // send, and its enable_loop() must be the last writer or its completion would strand
+  this->disable_loop();
+  this->deliver_completion_();
+}
+
+#endif  // REMOTE_TRANSMITTER_BK_PWM
+
+}  // namespace esphome::remote_transmitter
+
+#endif  // USE_BK72XX && !CLANG_TIDY

--- a/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
@@ -31,26 +31,11 @@ static constexpr uint32_t REG_PWM_GROUP_STRIDE = 0x40;       // one register gro
 static constexpr uint32_t REG_PWM_T_REGS[2] = {0x04, 0x14};  // T1..T4 offsets within a group
 static constexpr uint32_t PWM_INT_STATUS_MASK = 3UL << 30;   // write-1-clear -- always write as zero
 static constexpr uint8_t ENVELOPE_TIMER = BKTIMER1;
-// Margin past a transmission's expected duration before the chain is declared stalled
-static constexpr uint32_t STALL_MARGIN_MS = 1000;
-// Longest single one-shot armed; longer durations are chained (driver computes period_us * 26
-// in 32 bits, overflowing past ~165s)
-static constexpr uint32_t MAX_ONE_SHOT_US = 50000;
 
-// The bk_timer handler receives only the channel number, so the active instance is tracked
-// statically; it doubles as the cross-instance serialization token (MULTI_CONF).
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static RemoteTransmitterComponent *volatile s_active_transmitter = nullptr;
-// Deadline for the in-flight transmission (millis-based); only touched from the main task
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static uint32_t s_expected_end_ms = 0;
-
-// No IRAM_ATTR: hal.h makes it a no-op on BK72xx (the SDK masks IRQs around flash writes)
-static void envelope_timer_isr(UINT8 channel) {
-  auto *transmitter = s_active_transmitter;
-  if (transmitter != nullptr)
-    transmitter->advance_envelope_isr();
-}
+// The bk_timer handler receives only the channel number, so the chain resolves the instance
+// that owns the timer. No IRAM_ATTR: hal.h makes it a no-op on BK72xx (the SDK masks IRQs
+// around flash writes).
+static void envelope_timer_isr(UINT8 channel) { RemoteTransmitterComponent::advance_active_isr(); }
 
 // PWM channel per pin on the BK7231N-style block
 struct PwmPinChannel {
@@ -122,150 +107,13 @@ void RemoteTransmitterComponent::write_pwm_t1_(uint32_t t1_counts) {
   *ctrl = cfg | cfg_updata_bit;
 }
 
-// Arms the shared envelope timer, chaining durations longer than MAX_ONE_SHOT_US. ISR-safe.
-void RemoteTransmitterComponent::arm_envelope_timer_(uint32_t duration_us) {
-  // clamp to 1us (a zero-length one-shot never fires); the remainder must not underflow
-  const uint32_t chunk = std::max(uint32_t(1), std::min(duration_us, MAX_ONE_SHOT_US));
-  this->isr_wait_remaining_ = duration_us > chunk ? duration_us - chunk : 0;
-  timer_param_t param{};
-  param.channel = ENVELOPE_TIMER;
-  param.div = 1;
-  param.period = chunk;
-  param.t_Int_Handler = envelope_timer_isr;
-  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_INIT_PARAM_US, &param);
-}
+// --- envelope chain hooks (see remote_transmitter_libretiny_isr.cpp) ---
 
-// Aborts a chain that stopped advancing: stop the timer, idle the pin, release the token.
-// Every step is a no-op if the chain completed meanwhile. Task context only.
-void RemoteTransmitterComponent::abort_stalled_chain_() {
-  // cleared first so a straggler one-shot bails at the ISR entry check
-  this->transmitting_ = false;
-  UINT32 channel = ENVELOPE_TIMER;
-  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_UNIT_DISABLE, &channel);
-  this->write_pwm_t1_(this->isr_space_t1_);
-  s_active_transmitter = nullptr;
-  this->stall_aborted_ = true;
-  this->status_set_warning("envelope timer stalled");
-  ESP_LOGE(TAG, "Envelope timer stalled; transmission aborted");
-  delay(1);  // let any already-latched interrupt land while the chain state is safe
-}
+bool RemoteTransmitterComponent::envelope_ready_() const { return this->pwm_channel_ >= 0; }
 
-// Delivers one deferred completion with its status bookkeeping
-void RemoteTransmitterComponent::deliver_completion_() {
-  if (!this->stall_aborted_)
-    this->status_clear_warning();
-  this->complete_pending_ = false;
-  this->complete_trigger_.trigger();
-}
-
-void RemoteTransmitterComponent::start_isr_item_(size_t index) {
-  const int32_t item = this->isr_data_[index];
-  this->write_pwm_t1_(item > 0 ? this->isr_mark_t1_ : this->isr_space_t1_);
-  this->arm_envelope_timer_(uint32_t(item > 0 ? item : -item));
-}
-
-void RemoteTransmitterComponent::advance_envelope_isr() {
-  if (!this->transmitting_)
-    return;  // chain was aborted; this is a stale one-shot that was already latched
-  if (this->isr_wait_remaining_ > 0) {
-    // continue a duration longer than one hardware one-shot
-    this->arm_envelope_timer_(this->isr_wait_remaining_);
-    return;
-  }
-  if (this->isr_in_gap_) {
-    // inter-repeat gap elapsed; restart the item chain
-    this->isr_in_gap_ = false;
-    this->isr_index_ = 0;
-    this->start_isr_item_(0);
-    return;
-  }
-  this->isr_index_++;
-  if (this->isr_index_ < this->isr_data_.size()) {
-    this->start_isr_item_(this->isr_index_);
-    return;
-  }
-  // end of one repetition
-  this->write_pwm_t1_(this->isr_space_t1_);
-  if (this->isr_repeats_left_ > 1) {
-    this->isr_repeats_left_--;
-    this->isr_index_ = 0;
-    if (this->isr_send_wait_ > 0) {
-      this->isr_in_gap_ = true;
-      this->arm_envelope_timer_(this->isr_send_wait_);
-    } else {
-      this->start_isr_item_(0);
-    }
-    return;
-  }
-  UINT32 channel = ENVELOPE_TIMER;
-  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_UNIT_DISABLE, &channel);
-  this->transmitting_ = false;
-  s_active_transmitter = nullptr;
-}
-
-void RemoteTransmitterComponent::digital_write(bool value) {
-  if (this->pwm_channel_ < 0)
-    return;
-  // serialize behind an in-flight chain, matching the ESP32/RMT non-blocking behavior
-  this->wait_until_idle_();
-  this->write_pwm_t1_((value != this->pin_->is_inverted()) ? this->isr_period_t4_ : 0);
-}
-
-// Waits until no chain is in flight, delivering any deferred completions; a completion
-// automation may start a new send, so repeat until truly idle. Bounded by the stall deadline.
-void RemoteTransmitterComponent::wait_until_idle_() {
-  while (true) {
-    while (true) {
-      // snapshot: the final ISR can clear the volatile pointer between a check and a use
-      auto *active = s_active_transmitter;
-      if (active == nullptr)
-        break;
-      if ((int32_t) (millis() - s_expected_end_ms) > 0) {
-        active->abort_stalled_chain_();
-        break;
-      }
-      App.feed_wdt();
-      delay(1);
-    }
-    if (!this->complete_pending_)
-      break;
-    this->deliver_completion_();
-  }
-}
-
-// Stages the repeat schedule and stall deadline, then starts the interrupt chain
-void RemoteTransmitterComponent::arm_chain_(uint32_t send_times, uint32_t send_wait) {
-  this->isr_repeats_left_ = send_times;
-  this->isr_send_wait_ = send_wait;
-  this->isr_index_ = 0;
-  this->isr_in_gap_ = false;
-  this->stall_aborted_ = false;
-  uint64_t frame_us = 0;
-  for (int32_t item : this->isr_data_)
-    frame_us += uint32_t(item > 0 ? item : -item);
-  const uint64_t total_us = frame_us * send_times + uint64_t(send_wait) * (send_times - 1);
-  s_expected_end_ms = millis() + uint32_t(total_us / 1000) + STALL_MARGIN_MS;
-  this->transmitting_ = true;
-  s_active_transmitter = this;
-  this->start_isr_item_(0);
-}
-
-void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
-  if (this->pwm_channel_ < 0) {
-    ESP_LOGW(TAG, "Cannot send: PWM not initialized");
-    return;
-  }
-  this->wait_until_idle_();
-  if (send_times == 0) {
-    // parity with the loop-based implementations: transmit nothing, but both triggers
-    // still fire so an on_complete-sequenced automation does not stall
-    this->transmit_trigger_.trigger();
-    this->deliver_completion_();
-    return;
-  }
-  ESP_LOGD(TAG, "Sending remote code");
-  const uint32_t carrier_frequency = this->temp_.get_carrier_frequency();
-  // period in 26MHz counts; unmodulated protocols drive the pin constantly during marks
+// Recomputes the carrier period in 26MHz counts and stages the per-item duties;
+// unmodulated protocols drive the pin constantly during marks
+void RemoteTransmitterComponent::prepare_carrier_(uint32_t carrier_frequency) {
   if (carrier_frequency > 0) {
     this->isr_period_t4_ = std::max(uint32_t(2), (26000000UL + carrier_frequency / 2) / carrier_frequency);
   }
@@ -277,55 +125,36 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     mark_t1 = this->isr_period_t4_ - mark_t1;
     space_t1 = this->isr_period_t4_;
   }
-  // own copy: with non_blocking the caller may re-encode temp_ while this frame is in flight
-  this->isr_data_.assign(this->temp_.get_data().begin(), this->temp_.get_data().end());
-  if (this->isr_data_.empty()) {
-    ESP_LOGW(TAG, "Empty data");
-    this->transmit_trigger_.trigger();
-    this->deliver_completion_();
-    return;
-  }
   this->isr_mark_t1_ = mark_t1;
   this->isr_space_t1_ = space_t1;
-  // trigger first: the deadline computed in arm_chain_ must not be charged for user code
-  this->transmit_trigger_.trigger();
-  // the automation may have started a send on another instance; let it finish before
-  // claiming the shared timer (a same-instance send remains unsupported here)
-  this->wait_until_idle_();
-  this->arm_chain_(send_times, send_wait);
-  if (this->non_blocking_) {
-    this->complete_pending_ = true;
-    this->enable_loop();
-    return;
-  }
-  // blocking mode: wait out the chain, bounded by the stall deadline
-  while (this->transmitting_) {
-    if ((int32_t) (millis() - s_expected_end_ms) > 0) {
-      this->abort_stalled_chain_();
-      break;
-    }
-    App.feed_wdt();
-    delay(1);
-  }
-  this->deliver_completion_();
 }
 
-void RemoteTransmitterComponent::loop() {
-  if (!this->complete_pending_) {
-    this->disable_loop();
+void RemoteTransmitterComponent::write_envelope_level_(bool mark) {
+  this->write_pwm_t1_(mark ? this->isr_mark_t1_ : this->isr_space_t1_);
+}
+
+// The driver's microsecond init path is register writes under a nested interrupt guard,
+// so it is safe to call from the chain's own interrupt
+void RemoteTransmitterComponent::arm_one_shot_(uint32_t duration_us) {
+  timer_param_t param{};
+  param.channel = ENVELOPE_TIMER;
+  param.div = 1;
+  param.period = duration_us;
+  param.t_Int_Handler = envelope_timer_isr;
+  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_INIT_PARAM_US, &param);
+}
+
+void RemoteTransmitterComponent::stop_envelope_timer_() {
+  UINT32 channel = ENVELOPE_TIMER;
+  sddev_control((char *) TIMER_DEV_NAME, CMD_TIMER_UNIT_DISABLE, &channel);
+}
+
+void RemoteTransmitterComponent::digital_write(bool value) {
+  if (this->pwm_channel_ < 0)
     return;
-  }
-  if (this->transmitting_) {
-    // non-blocking stall recovery: without this, a dead chain would leave the carrier
-    // driven and on_complete unfired until the next send happened to abort it
-    if ((int32_t) (millis() - s_expected_end_ms) <= 0)
-      return;
-    this->abort_stalled_chain_();
-  }
-  // release the loop before user code runs: the automation may start a new non-blocking
-  // send, and its enable_loop() must be the last writer or its completion would strand
-  this->disable_loop();
-  this->deliver_completion_();
+  // serialize behind an in-flight chain, matching the ESP32/RMT non-blocking behavior
+  this->wait_until_idle_();
+  this->write_pwm_t1_((value != this->pin_->is_inverted()) ? this->isr_period_t4_ : 0);
 }
 
 #endif  // REMOTE_TRANSMITTER_BK_PWM

--- a/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
@@ -37,12 +37,33 @@ static constexpr uint8_t ENVELOPE_TIMER = BKTIMER1;
 // around flash writes).
 static void envelope_timer_isr(UINT8 channel) { RemoteTransmitterComponent::advance_active_isr(); }
 
-// PWM channel per pin on the BK7231N-style block
+// Channel <-> pin comes from the board variant's own PIN_PWMn defines rather than a
+// family-wide assumption, so an unusual pinout maps correctly instead of silently
+// driving another pad
 struct PwmPinChannel {
   uint8_t pin;
   int8_t channel;
 };
-static constexpr PwmPinChannel PWM_PIN_CHANNELS[] = {{6, 0}, {7, 1}, {8, 2}, {9, 3}, {24, 4}, {26, 5}};
+static constexpr PwmPinChannel PWM_PIN_CHANNELS[] = {
+#ifdef PIN_PWM0
+    {PIN_PWM0, 0},
+#endif
+#ifdef PIN_PWM1
+    {PIN_PWM1, 1},
+#endif
+#ifdef PIN_PWM2
+    {PIN_PWM2, 2},
+#endif
+#ifdef PIN_PWM3
+    {PIN_PWM3, 3},
+#endif
+#ifdef PIN_PWM4
+    {PIN_PWM4, 4},
+#endif
+#ifdef PIN_PWM5
+    {PIN_PWM5, 5},
+#endif
+};
 
 static int8_t pwm_channel_for_pin(uint8_t pin) {
   for (const auto &entry : PWM_PIN_CHANNELS) {
@@ -87,6 +108,8 @@ void RemoteTransmitterComponent::dump_config() {
 
 // Writes the duty compare registers and sets the hardware CFG_UPDATA shadow-load bit;
 // the new duty latches glitch-free at the next carrier period. ISR-safe: registers only.
+// The group control word is shared with the paired channel, but every SDK write to it runs
+// under GLOBAL_INT_DISABLE (bk_pwm), so it cannot be torn by this interrupt.
 void RemoteTransmitterComponent::write_pwm_t1_(uint32_t t1_counts) {
   const uint32_t group = this->pwm_channel_ / 2;
   const uint32_t post = this->pwm_channel_ % 2;

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
@@ -1,0 +1,219 @@
+#include "remote_transmitter.h"
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+// Envelope chain shared by the LibreTiny families that pace transmission from a hardware
+// timer interrupt: RTL8720C (gtimer) and the BK7231N-style PWM block (BKTIMER1). Everything
+// platform-specific sits behind five hooks implemented in the per-family files -- carrier
+// setup, duty writes, one-shot arming and timer stop. Families without a usable timer keep
+// the generic bit-bang implementation and compile none of this.
+#if defined(USE_LIBRETINY_VARIANT_RTL8720C) || defined(REMOTE_TRANSMITTER_BK_PWM)
+
+namespace esphome::remote_transmitter {
+
+static const char *const TAG = "remote_transmitter";
+
+// Margin past a transmission's expected duration before the chain is declared stalled
+static constexpr uint32_t STALL_MARGIN_MS = 1000;
+// Longest single one-shot armed; longer durations are chained. Both families need the cap:
+// the Beken driver computes period_us * 26 in 32 bits (overflows past ~165s) and the Realtek
+// us->tick conversion lives in mask ROM with unverified headroom.
+static constexpr uint32_t MAX_ONE_SHOT_US = 50000;
+
+// One hardware timer is shared by all instances (MULTI_CONF), so they serialize on this
+// token; the deadline always describes whichever chain currently owns it.
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+static RemoteTransmitterComponent *volatile s_active_transmitter = nullptr;
+static uint32_t s_expected_end_ms = 0;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Entry point for trampolines whose SDK callback carries no user argument
+void IRAM_ATTR RemoteTransmitterComponent::advance_active_isr() {
+  auto *transmitter = s_active_transmitter;
+  if (transmitter != nullptr)
+    transmitter->advance_envelope_isr();
+}
+
+// Arms the envelope timer, chaining durations longer than MAX_ONE_SHOT_US. ISR-safe.
+void IRAM_ATTR RemoteTransmitterComponent::arm_envelope_timer_(uint32_t duration_us) {
+  // clamp to 1us (a zero-length one-shot never fires); the remainder must not underflow
+  const uint32_t chunk = std::max(uint32_t(1), std::min(duration_us, MAX_ONE_SHOT_US));
+  this->isr_wait_remaining_ = duration_us > chunk ? duration_us - chunk : 0;
+  this->arm_one_shot_(chunk);
+}
+
+// Writes the level for one envelope item and arms the timer for its duration.
+// Runs in ISR context (and once from arm_chain_ to kick the chain): no logging, no allocation.
+void IRAM_ATTR RemoteTransmitterComponent::start_isr_item_(size_t index) {
+  const int32_t item = this->isr_data_[index];
+  this->write_envelope_level_(item > 0);
+  this->arm_envelope_timer_(uint32_t(item > 0 ? item : -item));
+}
+
+void IRAM_ATTR RemoteTransmitterComponent::advance_envelope_isr() {
+  if (!this->transmitting_)
+    return;  // chain was aborted; this is a stale one-shot that was already latched
+  if (this->isr_wait_remaining_ > 0) {
+    // continue a duration longer than one hardware one-shot
+    this->arm_envelope_timer_(this->isr_wait_remaining_);
+    return;
+  }
+  if (this->isr_in_gap_) {
+    // inter-repeat gap elapsed; restart the item chain
+    this->isr_in_gap_ = false;
+    this->isr_index_ = 0;
+    this->start_isr_item_(0);
+    return;
+  }
+  this->isr_index_++;
+  if (this->isr_index_ < this->isr_data_.size()) {
+    this->start_isr_item_(this->isr_index_);
+    return;
+  }
+  // end of one repetition
+  this->write_envelope_level_(false);
+  if (this->isr_repeats_left_ > 1) {
+    this->isr_repeats_left_--;
+    this->isr_index_ = 0;
+    if (this->isr_send_wait_ > 0) {
+      this->isr_in_gap_ = true;
+      this->arm_envelope_timer_(this->isr_send_wait_);
+    } else {
+      this->start_isr_item_(0);
+    }
+    return;
+  }
+  this->stop_envelope_timer_();
+  this->transmitting_ = false;
+  s_active_transmitter = nullptr;
+}
+
+// Aborts a chain that stopped advancing: stop the timer, idle the pin, release the token.
+// Every step is a no-op if the chain completed meanwhile. Task context only.
+void RemoteTransmitterComponent::abort_stalled_chain_() {
+  // cleared first so a straggler one-shot bails at the ISR entry check
+  this->transmitting_ = false;
+  this->stop_envelope_timer_();
+  this->write_envelope_level_(false);
+  s_active_transmitter = nullptr;
+  this->stall_aborted_ = true;
+  this->status_set_warning("envelope timer stalled");
+  ESP_LOGE(TAG, "Envelope timer stalled; transmission aborted");
+  delay(1);  // let any already-latched interrupt land while the chain state is safe
+}
+
+// Delivers one deferred completion with its status bookkeeping
+void RemoteTransmitterComponent::deliver_completion_() {
+  if (!this->stall_aborted_)
+    this->status_clear_warning();
+  this->complete_pending_ = false;
+  this->complete_trigger_.trigger();
+}
+
+// Waits until no chain is in flight, delivering any deferred completions; a completion
+// automation may start a new send, so repeat until truly idle. Bounded by the stall deadline.
+void RemoteTransmitterComponent::wait_until_idle_() {
+  while (true) {
+    while (true) {
+      // snapshot: the final ISR can clear the volatile pointer between a check and a use
+      auto *active = s_active_transmitter;
+      if (active == nullptr)
+        break;
+      if ((int32_t) (millis() - s_expected_end_ms) > 0) {
+        active->abort_stalled_chain_();
+        break;
+      }
+      App.feed_wdt();
+      delay(1);
+    }
+    if (!this->complete_pending_)
+      break;
+    this->deliver_completion_();
+  }
+}
+
+// Stages the repeat schedule and stall deadline, then starts the interrupt chain
+void RemoteTransmitterComponent::arm_chain_(uint32_t send_times, uint32_t send_wait) {
+  this->isr_repeats_left_ = send_times;
+  this->isr_send_wait_ = send_wait;
+  this->isr_index_ = 0;
+  this->isr_in_gap_ = false;
+  this->stall_aborted_ = false;
+  uint64_t frame_us = 0;
+  for (int32_t item : this->isr_data_)
+    frame_us += uint32_t(item > 0 ? item : -item);
+  const uint64_t total_us = frame_us * send_times + uint64_t(send_wait) * (send_times - 1);
+  s_expected_end_ms = millis() + uint32_t(total_us / 1000) + STALL_MARGIN_MS;
+  this->transmitting_ = true;
+  s_active_transmitter = this;
+  this->start_isr_item_(0);
+}
+
+void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
+  if (!this->envelope_ready_()) {
+    ESP_LOGW(TAG, "Cannot send: PWM not initialized");
+    return;
+  }
+  this->wait_until_idle_();
+  if (send_times == 0) {
+    // parity with the loop-based implementations: transmit nothing, but both triggers
+    // still fire so an on_complete-sequenced automation does not stall
+    this->transmit_trigger_.trigger();
+    this->deliver_completion_();
+    return;
+  }
+  ESP_LOGD(TAG, "Sending remote code");
+  this->prepare_carrier_(this->temp_.get_carrier_frequency());
+  // own copy: with non_blocking the caller may re-encode temp_ while this frame is in flight
+  this->isr_data_.assign(this->temp_.get_data().begin(), this->temp_.get_data().end());
+  if (this->isr_data_.empty()) {
+    ESP_LOGW(TAG, "Empty data");
+    this->transmit_trigger_.trigger();
+    this->deliver_completion_();
+    return;
+  }
+  // trigger first: the deadline computed in arm_chain_ must not be charged for user code
+  this->transmit_trigger_.trigger();
+  // the automation may have started a send on another instance; let it finish before
+  // claiming the shared timer (a same-instance send remains unsupported here)
+  this->wait_until_idle_();
+  this->arm_chain_(send_times, send_wait);
+  if (this->non_blocking_) {
+    this->complete_pending_ = true;
+    this->enable_loop();
+    return;
+  }
+  // blocking mode: wait out the chain, bounded by the stall deadline
+  while (this->transmitting_) {
+    if ((int32_t) (millis() - s_expected_end_ms) > 0) {
+      this->abort_stalled_chain_();
+      break;
+    }
+    App.feed_wdt();
+    delay(1);
+  }
+  this->deliver_completion_();
+}
+
+void RemoteTransmitterComponent::loop() {
+  if (!this->complete_pending_) {
+    this->disable_loop();
+    return;
+  }
+  if (this->transmitting_) {
+    // non-blocking stall recovery: without this, a dead chain would leave the carrier
+    // driven and on_complete unfired until the next send happened to abort it
+    if ((int32_t) (millis() - s_expected_end_ms) <= 0)
+      return;
+    this->abort_stalled_chain_();
+  }
+  // release the loop before user code runs: the automation may start a new non-blocking
+  // send, and its enable_loop() must be the last writer or its completion would strand
+  this->disable_loop();
+  this->deliver_completion_();
+}
+
+}  // namespace esphome::remote_transmitter
+
+#endif  // USE_LIBRETINY_VARIANT_RTL8720C || REMOTE_TRANSMITTER_BK_PWM

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
@@ -66,7 +66,7 @@ void IRAM_ATTR RemoteTransmitterComponent::advance_envelope_isr() {
     this->start_isr_item_(0);
     return;
   }
-  this->isr_index_++;
+  this->isr_index_ = this->isr_index_ + 1;
   if (this->isr_index_ < this->isr_data_.size()) {
     this->start_isr_item_(this->isr_index_);
     return;
@@ -74,7 +74,7 @@ void IRAM_ATTR RemoteTransmitterComponent::advance_envelope_isr() {
   // end of one repetition
   this->write_envelope_level_(false);
   if (this->isr_repeats_left_ > 1) {
-    this->isr_repeats_left_--;
+    this->isr_repeats_left_ = this->isr_repeats_left_ - 1;
     this->isr_index_ = 0;
     if (this->isr_send_wait_ > 0) {
       this->isr_in_gap_ = true;

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
@@ -84,6 +84,8 @@ void IRAM_ATTR RemoteTransmitterComponent::advance_envelope_isr() {
     }
     return;
   }
+  // required on Beken (its timer reloads); on Realtek this only clears the enable bit of a
+  // one-shot that has already fired
   this->stop_envelope_timer_();
   this->transmitting_ = false;
   s_active_transmitter = nullptr;
@@ -152,7 +154,10 @@ void RemoteTransmitterComponent::arm_chain_(uint32_t send_times, uint32_t send_w
 
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
   if (!this->envelope_ready_()) {
+    // both triggers still fire, so an on_complete-sequenced automation does not stall
     ESP_LOGW(TAG, "Cannot send: PWM not initialized");
+    this->transmit_trigger_.trigger();
+    this->deliver_completion_();
     return;
   }
   this->wait_until_idle_();

--- a/esphome/components/remote_transmitter/remote_transmitter_rtl87xx.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_rtl87xx.cpp
@@ -24,20 +24,13 @@ static const char *const TAG = "remote_transmitter";
 
 #ifdef USE_LIBRETINY_VARIANT_RTL8720C
 static constexpr uint32_t ENVELOPE_TIMER_ID = TIMER6;  // GTimer7
-// Margin past a transmission's expected duration before the chain is declared stalled
-static constexpr uint32_t STALL_MARGIN_MS = 1000;
-// Longest single one-shot armed; longer durations are chained (ROM us->tick headroom unverified)
-static constexpr uint32_t MAX_ONE_SHOT_US = 50000;
 
-// Shared envelope timer: a second gtimer_init on the same id fails silently, so all
-// instances serialize on s_active_transmitter
+// One envelope timer for all instances: a second gtimer_init on the same id fails silently,
+// so the chain serializes them (remote_transmitter_libretiny_isr.cpp)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 static uint8_t s_pwm_tick_sources[] = {GTimer1, GTimer2, GTimer3, GTimer4, GTimer5, GTimer6, 0xff};
 static gtimer_t s_envelope_timer;
 static bool s_envelope_timer_ready = false;
-static RemoteTransmitterComponent *volatile s_active_transmitter = nullptr;
-// Deadline for the in-flight transmission (millis-based); only touched from the main task
-static uint32_t s_expected_end_ms = 0;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 static void IRAM_ATTR envelope_timer_isr(uint32_t arg) {
@@ -104,105 +97,22 @@ void RemoteTransmitterComponent::digital_write(bool value) {
 }
 
 #ifdef USE_LIBRETINY_VARIANT_RTL8720C
-// Arms the shared envelope timer, chaining durations longer than MAX_ONE_SHOT_US. ISR-safe.
-void IRAM_ATTR RemoteTransmitterComponent::arm_envelope_timer_(uint32_t duration_us) {
-  // clamp to 1us (a zero-length one-shot never fires); the remainder must not underflow
-  const uint32_t chunk = std::max(uint32_t(1), std::min(duration_us, MAX_ONE_SHOT_US));
-  this->isr_wait_remaining_ = duration_us > chunk ? duration_us - chunk : 0;
-  gtimer_start_one_shout(&s_envelope_timer, chunk, (void *) envelope_timer_isr, (uint32_t) this);
-}
+// --- envelope chain hooks (see remote_transmitter_libretiny_isr.cpp) ---
 
-// Aborts a chain that stopped advancing: stop the timer, idle the pin, release the token.
-// Every step is a no-op if the chain completed meanwhile. Task context only.
-void RemoteTransmitterComponent::abort_stalled_chain_() {
-  // cleared first so a straggler one-shot bails at the ISR entry check
-  this->transmitting_ = false;
-  gtimer_stop(&s_envelope_timer);
-  pwmout_write(static_cast<pwmout_t *>(this->pwm_), this->isr_space_duty_);
-  s_active_transmitter = nullptr;
-  this->stall_aborted_ = true;
-  this->status_set_warning("envelope timer stalled");
-  ESP_LOGE(TAG, "Envelope timer stalled; transmission aborted");
-  delay(1);  // let any already-latched interrupt land while the chain state is safe
-}
+bool RemoteTransmitterComponent::envelope_ready_() const { return this->pwm_ != nullptr; }
 
-// Delivers one deferred completion with its status bookkeeping
-void RemoteTransmitterComponent::deliver_completion_() {
-  if (!this->stall_aborted_)
-    this->status_clear_warning();
-  this->complete_pending_ = false;
-  this->complete_trigger_.trigger();
-}
-
-// Writes the duty for one envelope item and arms the timer for its duration.
-// Runs in ISR context (and once from send_internal to kick the chain): no logging, no allocation.
-void IRAM_ATTR RemoteTransmitterComponent::start_isr_item_(size_t index) {
-  const int32_t item = this->isr_data_[index];
-  pwmout_write(static_cast<pwmout_t *>(this->pwm_), item > 0 ? this->isr_mark_duty_ : this->isr_space_duty_);
-  this->arm_envelope_timer_(uint32_t(item > 0 ? item : -item));
-}
-
-void IRAM_ATTR RemoteTransmitterComponent::advance_envelope_isr() {
-  if (!this->transmitting_)
-    return;  // chain was aborted; this is a stale one-shot that was already latched
-  if (this->isr_wait_remaining_ > 0) {
-    // continue a duration longer than one hardware one-shot
-    this->arm_envelope_timer_(this->isr_wait_remaining_);
-    return;
+// Retunes the PWM period when the carrier changes and stages the per-item duties;
+// unmodulated protocols (no carrier or 100% duty) drive the pin constantly during marks
+void RemoteTransmitterComponent::prepare_carrier_(uint32_t carrier_frequency) {
+  float mark_duty =
+      (carrier_frequency > 0 && this->carrier_duty_percent_ < 100) ? this->carrier_duty_percent_ / 100.0f : 1.0f;
+  float space_duty = 0.0f;
+  if (this->pin_->is_inverted()) {
+    mark_duty = 1.0f - mark_duty;
+    space_duty = 1.0f;
   }
-  if (this->isr_in_gap_) {
-    // inter-repeat gap elapsed; restart the item chain
-    this->isr_in_gap_ = false;
-    this->isr_index_ = 0;
-    this->start_isr_item_(0);
-    return;
-  }
-  this->isr_index_++;
-  if (this->isr_index_ < this->isr_data_.size()) {
-    this->start_isr_item_(this->isr_index_);
-    return;
-  }
-  // end of one repetition
-  pwmout_write(static_cast<pwmout_t *>(this->pwm_), this->isr_space_duty_);
-  if (this->isr_repeats_left_ > 1) {
-    this->isr_repeats_left_--;
-    this->isr_index_ = 0;
-    if (this->isr_send_wait_ > 0) {
-      this->isr_in_gap_ = true;
-      this->arm_envelope_timer_(this->isr_send_wait_);
-    } else {
-      this->start_isr_item_(0);
-    }
-    return;
-  }
-  this->transmitting_ = false;
-  s_active_transmitter = nullptr;
-}
-
-// Waits until no chain is in flight, delivering any deferred completions; a completion
-// automation may start a new send, so repeat until truly idle. Bounded by the stall deadline.
-void RemoteTransmitterComponent::wait_until_idle_() {
-  while (true) {
-    while (true) {
-      // snapshot: the final ISR can clear the volatile pointer between a check and a use
-      auto *active = s_active_transmitter;
-      if (active == nullptr)
-        break;
-      if ((int32_t) (millis() - s_expected_end_ms) > 0) {
-        active->abort_stalled_chain_();
-        break;
-      }
-      App.feed_wdt();
-      delay(1);
-    }
-    if (!this->complete_pending_)
-      break;
-    this->deliver_completion_();
-  }
-}
-
-// Retunes the PWM period when the carrier changes; the ISR sets duty per item
-void RemoteTransmitterComponent::update_carrier_(uint32_t carrier_frequency) {
+  this->isr_mark_duty_ = mark_duty;
+  this->isr_space_duty_ = space_duty;
   if (carrier_frequency == 0 || carrier_frequency == this->current_carrier_frequency_)
     return;
   // round(1000000/freq), clamped so a bad lambda can't hand the SDK a zero period
@@ -211,97 +121,15 @@ void RemoteTransmitterComponent::update_carrier_(uint32_t carrier_frequency) {
   this->current_carrier_frequency_ = carrier_frequency;
 }
 
-// Stages the repeat schedule and stall deadline, then starts the interrupt chain
-void RemoteTransmitterComponent::arm_chain_(uint32_t send_times, uint32_t send_wait) {
-  this->isr_repeats_left_ = send_times;
-  this->isr_send_wait_ = send_wait;
-  this->isr_index_ = 0;
-  this->isr_in_gap_ = false;
-  this->stall_aborted_ = false;
-  uint64_t frame_us = 0;
-  for (int32_t item : this->isr_data_)
-    frame_us += uint32_t(item > 0 ? item : -item);
-  const uint64_t total_us = frame_us * send_times + uint64_t(send_wait) * (send_times - 1);
-  s_expected_end_ms = millis() + uint32_t(total_us / 1000) + STALL_MARGIN_MS;
-  this->transmitting_ = true;
-  s_active_transmitter = this;
-  this->start_isr_item_(0);
+void IRAM_ATTR RemoteTransmitterComponent::write_envelope_level_(bool mark) {
+  pwmout_write(static_cast<pwmout_t *>(this->pwm_), mark ? this->isr_mark_duty_ : this->isr_space_duty_);
 }
 
-void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
-  if (this->pwm_ == nullptr) {
-    ESP_LOGW(TAG, "Cannot send: PWM not initialized");
-    return;
-  }
-  this->wait_until_idle_();
-  if (send_times == 0) {
-    // parity with the loop-based implementations: transmit nothing, but both triggers
-    // still fire so an on_complete-sequenced automation does not stall
-    this->transmit_trigger_.trigger();
-    this->deliver_completion_();
-    return;
-  }
-  ESP_LOGD(TAG, "Sending remote code");
-  const uint32_t carrier_frequency = this->temp_.get_carrier_frequency();
-  // unmodulated protocols (no carrier or 100% duty) drive the pin constantly during marks
-  float mark_duty =
-      (carrier_frequency > 0 && this->carrier_duty_percent_ < 100) ? this->carrier_duty_percent_ / 100.0f : 1.0f;
-  float space_duty = 0.0f;
-  if (this->pin_->is_inverted()) {
-    mark_duty = 1.0f - mark_duty;
-    space_duty = 1.0f;
-  }
-  this->update_carrier_(carrier_frequency);
-  // own copy: with non_blocking the caller may re-encode temp_ while this frame is in flight
-  this->isr_data_.assign(this->temp_.get_data().begin(), this->temp_.get_data().end());
-  if (this->isr_data_.empty()) {
-    ESP_LOGW(TAG, "Empty data");
-    this->transmit_trigger_.trigger();
-    this->deliver_completion_();
-    return;
-  }
-  this->isr_mark_duty_ = mark_duty;
-  this->isr_space_duty_ = space_duty;
-  // trigger first: the deadline computed in arm_chain_ must not be charged for user code
-  this->transmit_trigger_.trigger();
-  // the automation may have started a send on another instance; let it finish before
-  // claiming the shared timer (a same-instance send remains unsupported here)
-  this->wait_until_idle_();
-  this->arm_chain_(send_times, send_wait);
-  if (this->non_blocking_) {
-    this->complete_pending_ = true;
-    this->enable_loop();
-    return;
-  }
-  // blocking mode: wait out the chain, bounded by the stall deadline
-  while (this->transmitting_) {
-    if ((int32_t) (millis() - s_expected_end_ms) > 0) {
-      this->abort_stalled_chain_();
-      break;
-    }
-    App.feed_wdt();
-    delay(1);
-  }
-  this->deliver_completion_();
+void IRAM_ATTR RemoteTransmitterComponent::arm_one_shot_(uint32_t duration_us) {
+  gtimer_start_one_shout(&s_envelope_timer, duration_us, (void *) envelope_timer_isr, (uint32_t) this);
 }
 
-void RemoteTransmitterComponent::loop() {
-  if (!this->complete_pending_) {
-    this->disable_loop();
-    return;
-  }
-  if (this->transmitting_) {
-    // non-blocking stall recovery: without this, a dead chain would leave the carrier
-    // driven and on_complete unfired until the next send happened to abort it
-    if ((int32_t) (millis() - s_expected_end_ms) <= 0)
-      return;
-    this->abort_stalled_chain_();
-  }
-  // release the loop before user code runs: the automation may start a new non-blocking
-  // send, and its enable_loop() must be the last writer or its completion would strand
-  this->disable_loop();
-  this->deliver_completion_();
-}
+void IRAM_ATTR RemoteTransmitterComponent::stop_envelope_timer_() { gtimer_stop(&s_envelope_timer); }
 
 #else  // !USE_LIBRETINY_VARIANT_RTL8720C -- AmebaZ (RTL8710B): spin-based envelope, per-frame priority boost
 

--- a/tests/component_tests/remote_transmitter/test_non_blocking_gate.py
+++ b/tests/component_tests/remote_transmitter/test_non_blocking_gate.py
@@ -4,6 +4,9 @@ the ISR paths, so this gate is the only CI-reachable coverage for the platform m
 import pytest
 
 from esphome.components.libretiny.const import (
+    FAMILY_BK7231N,
+    FAMILY_BK7231T,
+    FAMILY_BK7238,
     FAMILY_RTL8710B,
     FAMILY_RTL8720C,
     KEY_FAMILY,
@@ -23,6 +26,9 @@ from ..types import SetCoreConfigCallable
         (PlatformFramework.ESP32_IDF, None, True),
         (PlatformFramework.RTL87XX_ARDUINO, FAMILY_RTL8720C, True),
         (PlatformFramework.RTL87XX_ARDUINO, FAMILY_RTL8710B, False),
+        (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7231N, True),
+        (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7238, True),
+        (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7231T, False),
         (PlatformFramework.ESP8266_ARDUINO, None, False),
     ],
 )

--- a/tests/components/remote_transmitter/test.bk72xx-ard.yaml
+++ b/tests/components/remote_transmitter/test.bk72xx-ard.yaml
@@ -2,6 +2,7 @@ remote_transmitter:
   id: xmitr
   pin: GPIO26
   carrier_duty_percent: 50%
+  # non_blocking is bk7231n/bk7238-only; the CI board is a BK7252
 
 packages:
   buttons: !include common-buttons.yaml


### PR DESCRIPTION
# What does this implement/fix?

Builds on #18648 (now merged) — the branch is rebased onto `dev` and the diff is the single BK72xx commit.

This brings the same ISR-driven transmission design to Beken chips with the BK7231N-style PWM block (BK7231N and BK7238): the carrier comes from the PWM peripheral (26MHz clock) and the mark/space envelope is paced by a hardware timer interrupt chain — each interrupt sets the next PWM duty through the block's shadow registers and re-arms the timer for that item's duration. Interrupts stay enabled throughout (no `InterruptLock`), so `remote_receiver` keeps working during transmission and WiFi timing is unaffected. `non_blocking:` is enabled on BK7231N and BK7238, with the same semantics as #18648: `send_internal` returns after arming the chain and `on_complete` fires from `loop()`.

Older Beken SoCs (BK7231T, BK7252, ...) keep the existing bit-bang implementation, literally: they still compile the untouched generic `remote_transmitter.cpp` (their PWM driver lacks the hardware shadow-load mechanism that makes glitch-free per-edge duty updates possible). Both source files ship for `bk72xx` and self-gate on the `REMOTE_TRANSMITTER_BK_PWM` family macro, so there is no duplicated bit-bang copy in this PR.

The envelope chain itself is also shared rather than copied. `remote_transmitter_libretiny_isr.cpp` now holds the logic that is identical on both families — stall deadline and recovery, chunked one-shots, re-entrant completion delivery, `send_internal`, `loop()` — and each family file implements five hooks for the parts that touch hardware: `envelope_ready_`, `prepare_carrier_`, `write_envelope_level_`, `arm_one_shot_`, `stop_envelope_timer_`. Net effect on the RTL8720C side is a 212-line reduction; the ISR chain is still `IRAM_ATTR` there (verified in the linker map after the move, including the two hooks now on the interrupt path). One deliberate behavior change on that family: the end of a chain now calls `stop_envelope_timer_()`, which Beken requires because its timer reloads. On Realtek that resolves to `gtimer_stop`, i.e. `hal_timer_disable`, a single `ctrl_b.en = 0` write against a one-shot that has already fired; the next send re-arms through `hal_timer_start_one_shot`, which reconfigures and re-enables. Bench-checked on an RM4 Pro: five consecutive sends after the change, ten frames, every one decoded by the device's own receiver as NEC `0x5AA5`/`0xED12`. This avoids two copies of concurrency logic that CI cannot compile on either board.

Implementation notes:

- Duty updates write the T1..T4 compare registers directly and toggle the block's `CFG_UPDATA` bit, which latches the new duty glitch-free at the next carrier period. The SDK's staged-update path (`pwm_update_param`) works too but applies via its own ISR and measured slightly worse (~26µs vs ~19µs mean edge latency, measured with a dedicated probe component on real hardware); the direct write also has no driver shared-state handshake to race against. The interrupt-status bits in the same register are write-1-clear and are explicitly not touched.
- BKTIMER1 paces the envelope: TIMER0 is LibreTiny's FreeRTOS tick source, TIMER2 is the SDK's tick-calibration timer, TIMER4 is the watchdog bark timer; TIMER1 is free and sits in the 26MHz group, giving microsecond granularity. The timer is shared across `MULTI_CONF` instances and serialized through the same active-transmitter token as #18648.
- The waits in `send_internal` (cross-instance and blocking-mode) are bounded by the transmission's expected duration plus a generous margin and yield with `delay(1)` while waiting — a stalled timer chain degrades to an aborted send with a logged error and a status warning (cleared by the next successful transmission) instead of wedging the device behind a fed watchdog. `loop()` applies the same deadline in non-blocking mode, so a stall still idles the pin and fires `on_complete`. Degenerate sends (`send_times: 0`, empty data) still fire `on_transmit`/`on_complete` for parity with the loop-based implementations. (These mirror the review feedback addressed on the RTL8720C side in #18648.)
- Durations longer than 50ms (chiefly user-configured repeat gaps, which are unbounded) are chained as consecutive one-shots: the Beken driver computes `period_us * 26` in 32 bits, which would overflow past ~165 seconds. The chunking costs one microsecond-scale interrupt per 50ms of gap. Zero-length timing items are clamped to 1us and behave as no-ops, matching the loop-based implementations. Delivering a deferred completion re-enters the serialization wait afterwards, so an `on_complete` automation that itself transmits cannot have its chain clobbered by the outer send. Aborting a stalled chain is safe against an already-latched timer interrupt (the ISR bails when the chain is no longer marked transmitting), and a stall warning set by another instance's recovery persists until the instance next completes successfully. The ISR chain carries no `IRAM_ATTR` deliberately: `libretiny/hal.h` makes it a no-op on BK72xx because the SDK masks IRQs at the CPU around every flash write, so the flash-stall race the attribute guards against cannot occur on this family. As on the ESP32/RMT non-blocking path, a send that was already encoded and queued behind the serialization wait shares the `temp_` encode buffer, so a transmit issued from a delivered `on_complete` automation replaces the queued frame. An `on_transmit` automation that starts a send on a different instance serializes cleanly (`send_internal` re-enters the idle wait after the trigger); a same-instance send from `on_transmit` remains unsupported as on every non-RMT platform.
- `non_blocking:` validation accepts BK7231N and BK7238 (tested on hardware), which is exactly the set the PWM path compiles for. The channel/pin map is taken from the board variant's own `PIN_PWM0..5` defines rather than a hardcoded family pinout, so an unusual board maps correctly instead of silently driving a different pad.
- CI coverage caveat: the `bk72xx-ard` CI board is a BK7252, so CI compiles the bit-bang `#else` branch of the new file, not the PWM/ISR path. The PWM path was compile-verified locally for BK7238 and BK7231N-style SoCs and runtime-verified on BK7238 hardware. Same harness limitation as #18648's RTL8710B CI board. The `non_blocking` platform gate has direct unit coverage (`tests/component_tests/remote_transmitter/`, extended here with the BK7231N/BK7238 accepts and a BK7231T reject), which runs in CI regardless of build board.
- The per-instance ISR state, the `loop()`/`advance_envelope_isr()` overrides and the BK-specific helpers are guarded by `REMOTE_TRANSMITTER_BK_PWM`, a header macro derived from the `USE_LIBRETINY_VARIANT_*` family flags (same scheme as #18648's RTL8720C guards) — old-driver Beken builds carry none of it: no dead members, no stub definitions, no extra vtable slot.

Verified on an FK UFO-R4 IR blaster (BK7238): Panasonic (36.7kHz) and Pioneer (40kHz) equipment responds; the Pioneer button uses `repeat: times: 2`, exercising the ISR gap chain. Logic-analyzer captures of the IR pin show clean carriers and envelopes; a probe component measured duty-apply latency of 16–30µs and 39/39 bit-perfect NEC envelopes across two PWM channels, confirmed optically by the device's own `remote_receiver` decoding the transmissions from the air.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7252

**Pull request in [developers.esphome.io](https://github.com/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_transmitter:
  id: ir_tx
  pin: 6
  carrier_duty_percent: 50%
  non_blocking: true

button:
  - platform: template
    name: Pioneer Mute
    on_press:
      - remote_transmitter.transmit_pioneer:
          rc_code_1: 0xA512
          repeat:
            times: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
