### PR TITLE
[core] Replace a damaged existing file in write_file_if_changed

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -550,18 +550,22 @@ def write_file_if_changed(path: Path, text: str) -> bool:
 
     Returns true if the file was changed.
     """
-    from esphome.core import EsphomeError
-
     src_content = None
     if path.is_file():
         try:
-            src_content = read_file(path)
-        except EsphomeError as err:
-            # read_file wraps OSError and UnicodeDecodeError alike
-            # A damaged existing file (unreadable, non-UTF-8) must be
-            # replaced, not abort the regeneration that would fix it
+            src_content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as err:
+            # A damaged existing file must be replaced, not abort the very
+            # regeneration that would fix it. Only decode failures recover:
+            # an OSError (permissions, I/O) may hide an intact file and
+            # propagates below like it always did.
             _LOGGER.warning("Replacing damaged file %s: %s", path, err)
-            path.unlink(missing_ok=True)
+            with suppress(OSError):
+                path.unlink(missing_ok=True)
+        except OSError as err:
+            from esphome.core import EsphomeError
+
+            raise EsphomeError(f"Error reading file {path}: {err}") from err
     if src_content == text:
         return False
     write_file(path, text)

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -550,9 +550,17 @@ def write_file_if_changed(path: Path, text: str) -> bool:
 
     Returns true if the file was changed.
     """
+    from esphome.core import EsphomeError
+
     src_content = None
     if path.is_file():
-        src_content = read_file(path)
+        try:
+            src_content = read_file(path)
+        except (EsphomeError, UnicodeDecodeError) as err:
+            # A damaged existing file (unreadable, non-UTF-8) must be
+            # replaced, not abort the regeneration that would fix it
+            _LOGGER.warning("Replacing damaged file %s: %s", path, err)
+            path.unlink(missing_ok=True)
     if src_content == text:
         return False
     write_file(path, text)

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -556,7 +556,8 @@ def write_file_if_changed(path: Path, text: str) -> bool:
     if path.is_file():
         try:
             src_content = read_file(path)
-        except (EsphomeError, UnicodeDecodeError) as err:
+        except EsphomeError as err:
+            # read_file wraps OSError and UnicodeDecodeError alike
             # A damaged existing file (unreadable, non-UTF-8) must be
             # replaced, not abort the regeneration that would fix it
             _LOGGER.warning("Replacing damaged file %s: %s", path, err)

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -555,10 +555,8 @@ def write_file_if_changed(path: Path, text: str) -> bool:
         try:
             src_content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError as err:
-            # A damaged existing file must be replaced, not abort the very
-            # regeneration that would fix it. Only decode failures recover:
-            # an OSError (permissions, I/O) may hide an intact file and
-            # propagates below like it always did.
+            # Replace a damaged file rather than abort the regeneration that
+            # fixes it; an OSError may hide an intact file, so it still raises
             _LOGGER.warning("Replacing damaged file %s: %s", path, err)
             with suppress(OSError):
                 path.unlink(missing_ok=True)

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1108,3 +1108,15 @@ def test_progressbar_enabled_on_pipe_with_dashboard(monkeypatch) -> None:
 def test_format_duration(seconds: float, expected: str) -> None:
     """Test that durations are rendered as short human-readable strings."""
     assert helpers.format_duration(seconds) == expected
+
+
+def test_write_file_if_changed_replaces_damaged_file(tmp_path, caplog) -> None:
+    """A non-UTF-8 or unreadable existing file is logged and overwritten;
+    aborting would block the very regeneration that fixes it."""
+    from esphome.helpers import write_file_if_changed
+
+    target = tmp_path / "generated.txt"
+    target.write_bytes(b"\xff\xfe")
+    assert write_file_if_changed(target, "fresh content") is True
+    assert target.read_text(encoding="utf-8") == "fresh content"
+    assert "Replacing damaged file" in caplog.text

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -256,8 +256,7 @@ class Test_write_file_if_changed:
     def test_damaged_existing_file_is_replaced(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ):
-        """A non-UTF-8 existing file is logged and overwritten; aborting
-        would block the very regeneration that fixes it."""
+        """A non-UTF-8 existing file is logged and overwritten."""
         dst = tmp_path / "generated.txt"
         dst.write_bytes(b"\xff\xfe")
 
@@ -267,8 +266,7 @@ class Test_write_file_if_changed:
         assert "Replacing damaged file" in caplog.text
 
     def test_unreadable_existing_file_still_raises(self, tmp_path: Path):
-        """An OSError on the comparison read may hide an intact file, so it
-        propagates as EsphomeError instead of unlinking."""
+        """An OSError on the comparison read still raises EsphomeError."""
         dst = tmp_path / "generated.txt"
         dst.write_text("intact")
 

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -253,6 +253,33 @@ class Test_write_file_if_changed:
 
         assert dst.read_text() == text
 
+    def test_damaged_existing_file_is_replaced(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """A non-UTF-8 existing file is logged and overwritten; aborting
+        would block the very regeneration that fixes it."""
+        dst = tmp_path / "generated.txt"
+        dst.write_bytes(b"\xff\xfe")
+
+        assert helpers.write_file_if_changed(dst, "fresh content") is True
+
+        assert dst.read_text(encoding="utf-8") == "fresh content"
+        assert "Replacing damaged file" in caplog.text
+
+    def test_unreadable_existing_file_still_raises(self, tmp_path: Path):
+        """An OSError on the comparison read may hide an intact file, so it
+        propagates as EsphomeError instead of unlinking."""
+        dst = tmp_path / "generated.txt"
+        dst.write_text("intact")
+
+        with (
+            patch.object(Path, "read_text", side_effect=OSError("permission denied")),
+            pytest.raises(EsphomeError, match="Error reading file"),
+        ):
+            helpers.write_file_if_changed(dst, "fresh content")
+
+        assert dst.exists()
+
     def test_dst_does_not_exist(self, tmp_path: Path):
         text = "A files are unique.\n"
         dst = tmp_path / "file-a.txt"
@@ -1108,15 +1135,3 @@ def test_progressbar_enabled_on_pipe_with_dashboard(monkeypatch) -> None:
 def test_format_duration(seconds: float, expected: str) -> None:
     """Test that durations are rendered as short human-readable strings."""
     assert helpers.format_duration(seconds) == expected
-
-
-def test_write_file_if_changed_replaces_damaged_file(tmp_path, caplog) -> None:
-    """A non-UTF-8 or unreadable existing file is logged and overwritten;
-    aborting would block the very regeneration that fixes it."""
-    from esphome.helpers import write_file_if_changed
-
-    target = tmp_path / "generated.txt"
-    target.write_bytes(b"\xff\xfe")
-    assert write_file_if_changed(target, "fresh content") is True
-    assert target.read_text(encoding="utf-8") == "fresh content"
-    assert "Replacing damaged file" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

`write_file_if_changed` reads the existing file to compare contents, and that read raises on a non-UTF-8 file. That aborts exactly the regeneration that would fix the damaged file: a corrupted generated linker script, `main.cpp`, or CMake file leaves the build failing until the file is deleted by hand.

The comparison read now treats a decode failure as "content differs": it logs a warning naming the file and cause, unlinks it (best effort), and writes the fresh content. An `OSError` on the read still raises as before, since a permissions or I/O fault may hide an intact file, and a genuine write failure still raises.

Split out of the ESP8266 native-toolchain chain (#18539), where the generated linker-script cache first hit this; every `write_file_if_changed` caller (main.cpp writer, espidf CMake files) gets the same recovery.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18539

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A, no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes; internal build-file writing only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

