### PR TITLE
[core] Register the OTA component in dummy_main like its siblings

### DIFF
--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -29,6 +29,7 @@ void setup() {
 
   auto *ota = new esphome::ESPHomeOTAComponent();  // NOLINT
   ota->set_port(8266);
+  App.register_component_(ota);
 
   App.setup();
 }


### PR DESCRIPTION
# What does this implement/fix?

`tests/dummy_main.cpp` registers its logger and wifi components with `App.register_component_()`, but the OTA component is created and configured without ever being registered. The clang static analyzer correctly reports the pointer as a potential leak (`clang-analyzer-cplusplus.NewDeleteLeaks`), which fails the `clang-tidy for ESP32 IDF 3/3` job on any PR that triggers a full tidy run.

Registering the component like its siblings both silences the analyzer (the pointer escapes into the application) and makes the dummy translation unit internally consistent.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18539

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A, CI-only fixture

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes; CI fixture only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
