### PR TITLE
[core] Parse the common on/off spellings in boolean env vars

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -395,6 +395,12 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
 
 
 def get_bool_env(var, default=False):
+    """Read a boolean environment knob.
+
+    Accepts the same spellings as ``cv.boolean`` does in YAML, so the
+    environment speaks the config language's boolean dialect; anything
+    unrecognized falls through to ``bool(value)``.
+    """
     value = os.getenv(var, default)
     if isinstance(value, str):
         value = value.lower()

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -31,6 +31,13 @@ SockAddr = IPv4SockAddr | IPv6SockAddr
 
 _LOGGER = logging.getLogger(__name__)
 
+# cv.boolean's closed spelling tables, shared with the env-knob parsing below
+TRUTHY_BOOL_STRINGS = frozenset({"true", "yes", "on", "enable"})
+FALSY_BOOL_STRINGS = frozenset({"false", "no", "off", "disable"})
+# cv.boolean's spelling tables plus the 1/0 env convention
+TRUTHY_ENV_STRINGS = TRUTHY_BOOL_STRINGS | {"1"}
+FALSY_ENV_STRINGS = FALSY_BOOL_STRINGS | {"0"}
+
 IS_MACOS = platform.system() == "Darwin"
 IS_WINDOWS = platform.system() == "Windows"
 IS_LINUX = platform.system() == "Linux"
@@ -400,9 +407,9 @@ def get_bool_env(var, default=False):
     value = os.getenv(var, default)
     if isinstance(value, str):
         value = value.lower()
-        if value in ("1", "true", "yes", "on", "enable"):
+        if value in TRUTHY_ENV_STRINGS:
             return True
-        if value in ("0", "false", "no", "off", "disable"):
+        if value in FALSY_ENV_STRINGS:
             return False
     return bool(value)
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -395,12 +395,8 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
 
 
 def get_bool_env(var, default=False):
-    """Read a boolean environment knob.
-
-    Accepts the ``cv.boolean`` spellings plus ``1``/``0``, so environment
-    knobs speak the config language's boolean dialect; anything else falls
-    through to ``bool(value)``.
-    """
+    """Read a boolean env var: the ``cv.boolean`` spellings plus ``1``/``0``;
+    anything else falls through to ``bool(value)``."""
     value = os.getenv(var, default)
     if isinstance(value, str):
         value = value.lower()

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -398,9 +398,9 @@ def get_bool_env(var, default=False):
     value = os.getenv(var, default)
     if isinstance(value, str):
         value = value.lower()
-        if value in ["1", "true"]:
+        if value in ("1", "true", "yes", "on", "enable"):
             return True
-        if value in ["0", "false"]:
+        if value in ("0", "false", "no", "off", "disable"):
             return False
     return bool(value)
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -397,9 +397,9 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
 def get_bool_env(var, default=False):
     """Read a boolean environment knob.
 
-    Accepts the same spellings as ``cv.boolean`` does in YAML, so the
-    environment speaks the config language's boolean dialect; anything
-    unrecognized falls through to ``bool(value)``.
+    Accepts the ``cv.boolean`` spellings plus ``1``/``0``, so environment
+    knobs speak the config language's boolean dialect; anything else falls
+    through to ``bool(value)``.
     """
     value = os.getenv(var, default)
     if isinstance(value, str):

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -171,8 +171,7 @@ def test_is_ip_address__valid(value):
         ("FOO", "fAlSe", True, False),
         ("FOO", "Yes", False, True),
         ("FOO", "123", False, True),
-        # cv.boolean's spellings; the True-default falsy rows are the
-        # ESPHOME_LOG_STATES=off shape the old bool(str) fallthrough broke
+        # cv.boolean's spellings; falsy rows use default=True on purpose
         ("FOO", "on", False, True),
         ("FOO", "enable", False, True),
         ("FOO", "no", True, False),

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1124,6 +1124,6 @@ def test_format_duration(seconds: float, expected: str) -> None:
 def test_get_bool_env_common_spellings(
     monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
 ) -> None:
-    """The common on/off spellings parse instead of reading as truthy."""
+    """The cv.boolean spellings parse instead of reading as truthy."""
     monkeypatch.setenv("SOME_KNOB", value)
     assert helpers.get_bool_env("SOME_KNOB") is expected

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1124,8 +1124,6 @@ def test_format_duration(seconds: float, expected: str) -> None:
 def test_get_bool_env_common_spellings(
     monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
 ) -> None:
-    """The common on/off spellings parse instead of falling through to
-    bool(str), which read "off" as enabled (e.g. IDF_CCACHE_ENABLE=off
-    left ccache on)."""
+    """The common on/off spellings parse instead of reading as truthy."""
     monkeypatch.setenv("SOME_KNOB", value)
     assert helpers.get_bool_env("SOME_KNOB") is expected

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -1108,3 +1108,24 @@ def test_progressbar_enabled_on_pipe_with_dashboard(monkeypatch) -> None:
 def test_format_duration(seconds: float, expected: str) -> None:
     """Test that durations are rendered as short human-readable strings."""
     assert helpers.format_duration(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("yes", True),
+        ("on", True),
+        ("enable", True),
+        ("no", False),
+        ("off", False),
+        ("disable", False),
+    ],
+)
+def test_get_bool_env_common_spellings(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
+) -> None:
+    """The common on/off spellings parse instead of falling through to
+    bool(str), which read "off" as enabled (e.g. IDF_CCACHE_ENABLE=off
+    left ccache on)."""
+    monkeypatch.setenv("SOME_KNOB", value)
+    assert helpers.get_bool_env("SOME_KNOB") is expected

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -171,6 +171,14 @@ def test_is_ip_address__valid(value):
         ("FOO", "fAlSe", True, False),
         ("FOO", "Yes", False, True),
         ("FOO", "123", False, True),
+        # cv.boolean's spellings; the True-default falsy rows are the
+        # ESPHOME_LOG_STATES=off shape the old bool(str) fallthrough broke
+        ("FOO", "on", False, True),
+        ("FOO", "enable", False, True),
+        ("FOO", "no", True, False),
+        ("FOO", "off", True, False),
+        ("FOO", "OFF", True, False),
+        ("FOO", "Disable", True, False),
     ),
 )
 def test_get_bool_env(monkeypatch, var, value, default, expected):
@@ -1108,22 +1116,3 @@ def test_progressbar_enabled_on_pipe_with_dashboard(monkeypatch) -> None:
 def test_format_duration(seconds: float, expected: str) -> None:
     """Test that durations are rendered as short human-readable strings."""
     assert helpers.format_duration(seconds) == expected
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("yes", True),
-        ("on", True),
-        ("enable", True),
-        ("no", False),
-        ("off", False),
-        ("disable", False),
-    ],
-)
-def test_get_bool_env_common_spellings(
-    monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
-) -> None:
-    """The cv.boolean spellings parse instead of reading as truthy."""
-    monkeypatch.setenv("SOME_KNOB", value)
-    assert helpers.get_bool_env("SOME_KNOB") is expected


### PR DESCRIPTION
# What does this implement/fix?

`get_bool_env` recognizes only `1`/`true`/`0`/`false`; any other string falls through to `bool(value)`, which is truthy. So the common opt-out spellings do the opposite of what they say: `IDF_CCACHE_ENABLE=off` (or `no`) leaves ccache enabled, and the same applies to every boolean env knob read through this helper.

The truthy and falsy lists gain exactly the spellings `cv.boolean` accepts in YAML (`yes`/`on`/`enable`, `no`/`off`/`disable`), so environment knobs speak the same boolean dialect as the config language; anything else keeps today's fallthrough.

Split out of the ESP8266 native-toolchain chain (#18539), which hit this in the ccache gates.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18539

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes; environment variable parsing only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

