### PR TITLE
[esp-idf] Never let the size summary fail a linked build

### DIFF
--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -34,8 +34,6 @@ _SIZE_SUFFIXES = {"K": 1024, "M": 1024 * 1024}
 
 def _parse_size(token: str) -> int:
     token = token.strip()
-    if not token:
-        raise ValueError("blank partition size cell")
     if token.startswith(("0x", "0X")):
         return int(token, 16)
     suffix = token[-1].upper()
@@ -53,8 +51,9 @@ def _find_app_partition_size(partitions_csv: Path) -> int | None:
     layouts like Adafruit's ``partitions-4MB-tinyuf2.csv`` repurpose
     ``factory`` for a UF2 bootloader before the real OTA slot, so a
     naive "prefer factory" rule would pick the wrong row. A missing
-    table or no qualifying row is legitimate absence (None); a raise
-    always means a present-but-broken table.
+    table or no qualifying row is legitimate absence (None); malformed
+    tables cannot reach a successful build (gen_esp32part rejects them),
+    so parse failures go to the caller's backstop.
     """
     if not partitions_csv.is_file():
         return None
@@ -64,12 +63,7 @@ def _find_app_partition_size(partitions_csv: Path) -> int | None:
             continue
         ptype, psubtype, psize = cells[1], cells[2], cells[4]
         if ptype in ("app", "0") and psubtype in ("factory", "ota_0"):
-            try:
-                return _parse_size(psize)
-            except ValueError as err:
-                raise ValueError(
-                    f"{err} for partition {cells[0]} in {partitions_csv}"
-                ) from err
+            return _parse_size(psize)
     return None
 
 
@@ -175,20 +169,12 @@ def _flash_line(data: dict, size_json: Path, partitions_csv: Path | None) -> str
         return None
     try:
         app_size = _find_app_partition_size(partitions_csv)
-    except (ValueError, OSError, csv.Error) as e:
-        # The table is there but broken/unreadable: visible, like size 0
+    except OSError as e:
+        # A read race on a table the build just used; visible but non-fatal
         _LOGGER.warning("Skipping Flash summary: %s", e)
         return None
-    if app_size is None:
+    if not app_size:
         # No table or no qualifying row: legitimate for non-app layouts
         _LOGGER.debug("Skipping Flash summary: no app partition in %s", partitions_csv)
-        return None
-    if app_size <= 0:
-        # Skipping also fails CI's Flash extraction, the right outcome here
-        _LOGGER.warning(
-            "Skipping Flash summary: app partition size is %s in %s",
-            app_size,
-            partitions_csv,
-        )
         return None
     return f"Flash: {_format_bar(int(image_size), app_size)}"

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -94,6 +94,12 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.debug("Skipping size summary: %s", e)
         return
 
+    if not isinstance(data, dict):
+        # Valid JSON that is not an object (truncated tool output) must
+        # not raise past a build that already linked
+        _LOGGER.debug("Skipping size summary: unexpected shape in %s", size_json)
+        return
+
     memory_types = data.get("memory_types", {})
     ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
     ram_used = ram_region.get("used")
@@ -106,7 +112,12 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         return
     try:
         app_size = _find_app_partition_size(partitions_csv)
-    except ValueError as e:
+    except (ValueError, OSError) as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)
+        return
+    if app_size <= 0:
+        # A malformed partition row parses to 0; a 0% bar would feed CI's
+        # memory-impact extraction fabricated data
+        _LOGGER.debug("Skipping Flash summary: app partition size is 0")
         return
     print(f"Flash: {_format_bar(image_size, app_size)}")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -53,8 +53,11 @@ def _find_app_partition_size(partitions_csv: Path) -> int | None:
     naive "prefer factory" rule would pick the wrong row. No qualifying
     row is legitimate absence (None); a build cannot succeed with a
     missing or malformed table (gen_esp32part consumes it first), so
-    those states belong to the backstop.
+    those states belong to the backstop -- the missing-file raise just
+    names that one cleanly.
     """
+    if not partitions_csv.is_file():
+        raise ValueError(f"partitions.csv not found at {partitions_csv}")
     for row in csv.reader(partitions_csv.read_text(encoding="utf-8").splitlines()):
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -112,21 +112,26 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.warning("Skipping size summary: unexpected shape in %s", size_json)
         return
 
+    if (ram := _ram_line(data, size_json)) is not None:
+        print(ram)
+    if (flash := _flash_line(data, partitions_csv)) is not None:
+        print(flash)
+
+
+def _dict_get(mapping: object, key: str) -> object:
+    """dict.get that reads None from any non-dict."""
+    return mapping.get(key) if isinstance(mapping, dict) else None
+
+
+def _ram_line(data: dict, size_json: Path) -> str | None:
+    """The formatted RAM line, or None (already logged) to skip it."""
     memory_types = data.get("memory_types")
-    ram_region = (
-        memory_types.get("DRAM") or memory_types.get("DIRAM")
-        if isinstance(memory_types, dict)
-        else None
-    )
-    ram_used = ram_region.get("used") if isinstance(ram_region, dict) else None
-    ram_total = ram_region.get("size") if isinstance(ram_region, dict) else None
-    if (
-        isinstance(ram_used, (int, float))
-        and isinstance(ram_total, (int, float))
-        and ram_total > 0
-    ):
-        print(f"RAM:   {_format_bar(int(ram_used), int(ram_total))}")
-    elif (memory_types is not None and not isinstance(memory_types, dict)) or (
+    ram_region = _dict_get(memory_types, "DRAM") or _dict_get(memory_types, "DIRAM")
+    used = _dict_get(ram_region, "used")
+    total = _dict_get(ram_region, "size")
+    if isinstance(used, (int, float)) and isinstance(total, (int, float)) and total > 0:
+        return f"RAM:   {_format_bar(int(used), int(total))}"
+    if (memory_types is not None and not isinstance(memory_types, dict)) or (
         ram_region is not None and not isinstance(ram_region, dict)
     ):
         # A structurally corrupt report, not a variant without the region
@@ -135,9 +140,7 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.warning(
             "Skipping RAM summary: no usable DRAM/DIRAM region in %s", size_json
         )
-
-    if (flash := _flash_line(data, partitions_csv)) is not None:
-        print(flash)
+    return None
 
 
 def _flash_line(data: dict, partitions_csv: Path | None) -> str | None:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -44,6 +44,11 @@ def _parse_size(token: str) -> int:
     return int(token)
 
 
+class _MalformedPartitionRow(ValueError):
+    """A matched app row whose size cell cannot be parsed; warned, since the
+    table is present but broken."""
+
+
 def _find_app_partition_size(partitions_csv: Path) -> int:
     """Return the size of the firmware's app partition.
 
@@ -66,7 +71,7 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
             try:
                 return _parse_size(psize)
             except ValueError as err:
-                raise ValueError(
+                raise _MalformedPartitionRow(
                     f"{err} for partition {cells[0]} in {partitions_csv}"
                 ) from err
     raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
@@ -96,35 +101,69 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
 
 
 def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
+    # The build's own POST_BUILD step writes this file; its absence or an
+    # unexpected shape is a regression signal, so these skips warn
     if not size_json.is_file():
-        _LOGGER.debug("Skipping size summary: %s not found", size_json)
+        _LOGGER.warning("Skipping size summary: %s not found", size_json)
         return
     try:
         data = json.loads(size_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
-        _LOGGER.debug("Skipping size summary: %s", e)
+        _LOGGER.warning("Skipping size summary: %s", e)
         return
-
     if not isinstance(data, dict):
         # Non-object JSON has no .get
-        _LOGGER.debug("Skipping size summary: unexpected shape in %s", size_json)
+        _LOGGER.warning("Skipping size summary: unexpected shape in %s", size_json)
         return
 
-    memory_types = data.get("memory_types", {})
+    # Buffered so a late failure prints nothing instead of half a report
+    lines: list[str] = []
+    memory_types = data.get("memory_types")
+    if not isinstance(memory_types, dict):
+        memory_types = {}
     ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
+    if not isinstance(ram_region, dict):
+        ram_region = {}
     ram_used = ram_region.get("used")
     ram_total = ram_region.get("size")
-    if ram_total and ram_used is not None:
-        print(f"RAM:   {_format_bar(ram_used, ram_total)}")
+    if (
+        isinstance(ram_used, (int, float))
+        and isinstance(ram_total, (int, float))
+        and ram_total > 0
+    ):
+        lines.append(f"RAM:   {_format_bar(int(ram_used), int(ram_total))}")
+    else:
+        _LOGGER.warning(
+            "Skipping RAM summary: no usable DRAM/DIRAM region in %s", size_json
+        )
 
+    app_size = _resolve_app_size(data, partitions_csv)
+    if app_size is not None:
+        lines.append(f"Flash: {_format_bar(data['image_size'], app_size)}")
+    for line in lines:
+        print(line)
+
+
+def _resolve_app_size(data: dict, partitions_csv: Path | None) -> int | None:
+    """The Flash bar's denominator, or None (already logged) to skip it."""
     image_size = data.get("image_size")
-    if image_size is None or partitions_csv is None:
-        return
+    if image_size is None:
+        _LOGGER.warning("Skipping Flash summary: no image_size in the size report")
+        return None
+    if partitions_csv is None:
+        _LOGGER.debug("Skipping Flash summary: no partition table given")
+        return None
     try:
         app_size = _find_app_partition_size(partitions_csv)
-    except (ValueError, OSError) as e:
+    except (_MalformedPartitionRow, OSError) as e:
+        # The table is there but broken/unreadable: visible, like size 0
+        _LOGGER.warning("Skipping Flash summary: %s", e)
+        return None
+    except ValueError as e:
+        # Missing file or no qualifying partition: legitimate for
+        # non-app layouts, keep quiet
         _LOGGER.debug("Skipping Flash summary: %s", e)
-        return
+        return None
     if app_size <= 0:
         # Skipping also fails CI's Flash extraction, the right outcome here
         _LOGGER.warning(
@@ -132,5 +171,5 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
             app_size,
             partitions_csv,
         )
-        return
-    print(f"Flash: {_format_bar(image_size, app_size)}")
+        return None
+    return app_size

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -50,13 +50,11 @@ def _find_app_partition_size(partitions_csv: Path) -> int | None:
     whose subtype is ``factory`` or ``ota_0``. Order matters because
     layouts like Adafruit's ``partitions-4MB-tinyuf2.csv`` repurpose
     ``factory`` for a UF2 bootloader before the real OTA slot, so a
-    naive "prefer factory" rule would pick the wrong row. A missing
-    table or no qualifying row is legitimate absence (None); malformed
-    tables cannot reach a successful build (gen_esp32part rejects them),
-    so parse failures go to the caller's backstop.
+    naive "prefer factory" rule would pick the wrong row. No qualifying
+    row is legitimate absence (None); a build cannot succeed with a
+    missing or malformed table (gen_esp32part consumes it first), so
+    those states belong to the backstop.
     """
-    if not partitions_csv.is_file():
-        return None
     for row in csv.reader(partitions_csv.read_text(encoding="utf-8").splitlines()):
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:
@@ -167,12 +165,7 @@ def _flash_line(data: dict, size_json: Path, partitions_csv: Path | None) -> str
     if partitions_csv is None:
         _LOGGER.debug("Skipping Flash summary: no partition table given")
         return None
-    try:
-        app_size = _find_app_partition_size(partitions_csv)
-    except OSError as e:
-        # A read race on a table the build just used; visible but non-fatal
-        _LOGGER.warning("Skipping Flash summary: %s", e)
-        return None
+    app_size = _find_app_partition_size(partitions_csv)
     if not app_size:
         # No table or no qualifying row: legitimate for non-app layouts
         _LOGGER.debug("Skipping Flash summary: no app partition in %s", partitions_csv)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -35,8 +35,6 @@ _SIZE_SUFFIXES = {"K": 1024, "M": 1024 * 1024}
 def _parse_size(token: str) -> int:
     token = token.strip()
     if not token:
-        # A blank size cell is a malformed row; naming it beats a
-        # meaningless "from 0 bytes" bar downstream
         raise ValueError("blank partition size cell")
     if token.startswith(("0x", "0X")):
         return int(token, 16)
@@ -82,16 +80,11 @@ def _format_bar(used: int, total: int) -> str:
 
 
 def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
-    """Print PlatformIO-shaped RAM and Flash one-liners.
-
-    Failures are non-fatal: the build has already succeeded, we just couldn't
-    summarize. Logs the cause at debug level.
-    """
+    """Print PlatformIO-shaped RAM and Flash one-liners; never fails the build."""
     try:
         _print_summary(size_json, partitions_csv)
     except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # The named guards below cover the known shapes; this net keeps the
-        # promise for the rest (nested non-dict values, non-numeric sizes)
+        # Backstop for shapes the named guards below miss
         _LOGGER.debug("Skipping size summary: %s", e)
 
 
@@ -106,8 +99,7 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         return
 
     if not isinstance(data, dict):
-        # Valid JSON that is not an object (a hand-edited or tool-emitted
-        # array) has no .get; skip with the file named
+        # Non-object JSON has no .get
         _LOGGER.debug("Skipping size summary: unexpected shape in %s", size_json)
         return
 
@@ -127,10 +119,7 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.debug("Skipping Flash summary: %s", e)
         return
     if app_size <= 0:
-        # Defensive backstop behind _parse_size's blank-cell rejection: a
-        # "from 0 bytes" denominator is meaningless to a reader. Note the
-        # skip costs CI's memory-impact extraction its Flash match, which
-        # is the loud outcome a broken partition table deserves.
+        # Skipping also fails CI's Flash extraction, the right outcome here
         _LOGGER.debug("Skipping Flash summary: app partition size is 0")
         return
     print(f"Flash: {_format_bar(image_size, app_size)}")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import math
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         data = json.loads(size_json.read_text(encoding="utf-8"))
     except (OSError, ValueError) as e:
         # ValueError covers JSONDecodeError and a non-UTF-8 (truncated) file
-        _LOGGER.warning("Skipping size summary: %s", e)
+        _LOGGER.warning("Skipping size summary: cannot read %s: %s", size_json, e)
         return
     if not isinstance(data, dict):
         # Non-object JSON has no .get
@@ -127,13 +128,25 @@ def _present_but_not_dict(value: object) -> bool:
 
 
 def _is_number(value: object) -> bool:
-    return isinstance(value, (int, float))
+    # bool subclasses int; NaN/Infinity are valid JSON for json.loads
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
 
 
 def _ram_line(data: dict, size_json: Path) -> str | None:
     """The formatted RAM line, or None (already logged) to skip it."""
     memory_types = data.get("memory_types")
-    ram_region = _dict_get(memory_types, "DRAM") or _dict_get(memory_types, "DIRAM")
+    ram_region = None
+    if isinstance(memory_types, dict):
+        # Key presence, not truthiness: a falsy DRAM value is corrupt, not
+        # absent, and must not fall through to DIRAM
+        for key in ("DRAM", "DIRAM"):
+            if key in memory_types:
+                ram_region = memory_types[key]
+                break
     used = _dict_get(ram_region, "used")
     total = _dict_get(ram_region, "size")
     if _is_number(used) and _is_number(total) and total > 0:
@@ -170,7 +183,8 @@ def _flash_line(data: dict, size_json: Path, partitions_csv: Path | None) -> str
         return None
     app_size = _find_app_partition_size(partitions_csv)
     if not app_size:
-        # No table or no qualifying row: legitimate for non-app layouts
+        # No qualifying row (a zero-size row has nothing to report either):
+        # legitimate for non-app layouts
         _LOGGER.debug("Skipping Flash summary: no app partition in %s", partitions_csv)
         return None
     return f"Flash: {_format_bar(int(image_size), app_size)}"

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -35,7 +35,9 @@ _SIZE_SUFFIXES = {"K": 1024, "M": 1024 * 1024}
 def _parse_size(token: str) -> int:
     token = token.strip()
     if not token:
-        return 0
+        # A blank size cell is a malformed row; naming it beats a
+        # meaningless "from 0 bytes" bar downstream
+        raise ValueError("blank partition size cell")
     if token.startswith(("0x", "0X")):
         return int(token, 16)
     suffix = token[-1].upper()
@@ -85,6 +87,15 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     Failures are non-fatal: the build has already succeeded, we just couldn't
     summarize. Logs the cause at debug level.
     """
+    try:
+        _print_summary(size_json, partitions_csv)
+    except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # The named guards below cover the known shapes; this net keeps the
+        # promise for the rest (nested non-dict values, non-numeric sizes)
+        _LOGGER.debug("Skipping size summary: %s", e)
+
+
+def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     if not size_json.is_file():
         _LOGGER.debug("Skipping size summary: %s not found", size_json)
         return
@@ -95,8 +106,8 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         return
 
     if not isinstance(data, dict):
-        # Valid JSON that is not an object (truncated tool output) must
-        # not raise past a build that already linked
+        # Valid JSON that is not an object (a hand-edited or tool-emitted
+        # array) has no .get; skip with the file named
         _LOGGER.debug("Skipping size summary: unexpected shape in %s", size_json)
         return
 
@@ -116,8 +127,10 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.debug("Skipping Flash summary: %s", e)
         return
     if app_size <= 0:
-        # A malformed partition row parses to 0; a 0% bar would feed CI's
-        # memory-impact extraction fabricated data
+        # Defensive backstop behind _parse_size's blank-cell rejection: a
+        # "from 0 bytes" denominator is meaningless to a reader. Note the
+        # skip costs CI's memory-impact extraction its Flash match, which
+        # is the loud outcome a broken partition table deserves.
         _LOGGER.debug("Skipping Flash summary: app partition size is 0")
         return
     print(f"Flash: {_format_bar(image_size, app_size)}")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -93,9 +93,12 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         # Backstop for shapes the named guards below miss; warning so a
         # regression here cannot go missing indefinitely
         _LOGGER.warning(
-            "Skipping size summary for %s: %s: %s", size_json, type(e).__name__, e
+            "Skipping size summary for %s: %s: %s",
+            size_json,
+            type(e).__name__,
+            e,
+            exc_info=True,
         )
-        _LOGGER.debug("Size summary failure detail", exc_info=True)
 
 
 def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
@@ -114,7 +117,7 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
 
     if (ram := _ram_line(data, size_json)) is not None:
         print(ram)
-    if (flash := _flash_line(data, partitions_csv)) is not None:
+    if (flash := _flash_line(data, size_json, partitions_csv)) is not None:
         print(flash)
 
 
@@ -139,17 +142,24 @@ def _ram_line(data: dict, size_json: Path) -> str | None:
     total = _dict_get(ram_region, "size")
     if _is_number(used) and _is_number(total) and total > 0:
         return f"RAM:   {_format_bar(int(used), int(total))}"
-    if _present_but_not_dict(memory_types) or _present_but_not_dict(ram_region):
+    malformed = (
+        _present_but_not_dict(memory_types)
+        or _present_but_not_dict(ram_region)
+        or any(v is not None and not _is_number(v) for v in (used, total))
+    )
+    if malformed:
         # A structurally corrupt report, not a variant without the region
         _LOGGER.warning("Skipping RAM summary: malformed memory_types in %s", size_json)
     else:
-        _LOGGER.warning(
+        # A variant may name its RAM region differently; healthy builds
+        # must not warn
+        _LOGGER.debug(
             "Skipping RAM summary: no usable DRAM/DIRAM region in %s", size_json
         )
     return None
 
 
-def _flash_line(data: dict, partitions_csv: Path | None) -> str | None:
+def _flash_line(data: dict, size_json: Path, partitions_csv: Path | None) -> str | None:
     """The formatted Flash line, or None (already logged) to skip it.
 
     Owns both sides of the bar, so nothing after a print can raise: the
@@ -157,7 +167,7 @@ def _flash_line(data: dict, partitions_csv: Path | None) -> str | None:
     """
     image_size = data.get("image_size")
     if not _is_number(image_size):
-        _LOGGER.warning("Skipping Flash summary: no usable image_size")
+        _LOGGER.warning("Skipping Flash summary: no usable image_size in %s", size_json)
         return None
     if partitions_csv is None:
         _LOGGER.debug("Skipping Flash summary: no partition table given")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -123,17 +123,23 @@ def _dict_get(mapping: object, key: str) -> object:
     return mapping.get(key) if isinstance(mapping, dict) else None
 
 
+def _present_but_not_dict(value: object) -> bool:
+    return value is not None and not isinstance(value, dict)
+
+
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float))
+
+
 def _ram_line(data: dict, size_json: Path) -> str | None:
     """The formatted RAM line, or None (already logged) to skip it."""
     memory_types = data.get("memory_types")
     ram_region = _dict_get(memory_types, "DRAM") or _dict_get(memory_types, "DIRAM")
     used = _dict_get(ram_region, "used")
     total = _dict_get(ram_region, "size")
-    if isinstance(used, (int, float)) and isinstance(total, (int, float)) and total > 0:
+    if _is_number(used) and _is_number(total) and total > 0:
         return f"RAM:   {_format_bar(int(used), int(total))}"
-    if (memory_types is not None and not isinstance(memory_types, dict)) or (
-        ram_region is not None and not isinstance(ram_region, dict)
-    ):
+    if _present_but_not_dict(memory_types) or _present_but_not_dict(ram_region):
         # A structurally corrupt report, not a variant without the region
         _LOGGER.warning("Skipping RAM summary: malformed memory_types in %s", size_json)
     else:
@@ -150,7 +156,7 @@ def _flash_line(data: dict, partitions_csv: Path | None) -> str | None:
     blanket guard is left for genuinely unforeseen shapes.
     """
     image_size = data.get("image_size")
-    if not isinstance(image_size, (int, float)):
+    if not _is_number(image_size):
         _LOGGER.warning("Skipping Flash summary: no usable image_size")
         return None
     if partitions_csv is None:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -107,7 +107,8 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     # FileNotFoundError lands in the OSError arm with the path in its text.
     try:
         data = json.loads(size_json.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as e:
+    except (OSError, ValueError) as e:
+        # ValueError covers JSONDecodeError and a non-UTF-8 (truncated) file
         _LOGGER.warning("Skipping size summary: %s", e)
         return
     if not isinstance(data, dict):

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -92,7 +92,9 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Backstop for shapes the named guards below miss; warning so a
         # regression here cannot go missing indefinitely
-        _LOGGER.warning("Skipping size summary for %s: %s", size_json, e)
+        _LOGGER.warning(
+            "Skipping size summary for %s: %s: %s", size_json, type(e).__name__, e
+        )
         _LOGGER.debug("Size summary failure detail", exc_info=True)
 
 
@@ -111,19 +113,24 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         return
 
     memory_types = data.get("memory_types")
-    if not isinstance(memory_types, dict):
-        memory_types = {}
-    ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM")
-    if not isinstance(ram_region, dict):
-        ram_region = {}
-    ram_used = ram_region.get("used")
-    ram_total = ram_region.get("size")
+    ram_region = (
+        memory_types.get("DRAM") or memory_types.get("DIRAM")
+        if isinstance(memory_types, dict)
+        else None
+    )
+    ram_used = ram_region.get("used") if isinstance(ram_region, dict) else None
+    ram_total = ram_region.get("size") if isinstance(ram_region, dict) else None
     if (
         isinstance(ram_used, (int, float))
         and isinstance(ram_total, (int, float))
         and ram_total > 0
     ):
         print(f"RAM:   {_format_bar(int(ram_used), int(ram_total))}")
+    elif (memory_types is not None and not isinstance(memory_types, dict)) or (
+        ram_region is not None and not isinstance(ram_region, dict)
+    ):
+        # A structurally corrupt report, not a variant without the region
+        _LOGGER.warning("Skipping RAM summary: malformed memory_types in %s", size_json)
     else:
         _LOGGER.warning(
             "Skipping RAM summary: no usable DRAM/DIRAM region in %s", size_json
@@ -148,7 +155,7 @@ def _flash_line(data: dict, partitions_csv: Path | None) -> str | None:
         return None
     try:
         app_size = _find_app_partition_size(partitions_csv)
-    except (ValueError, OSError) as e:
+    except (ValueError, OSError, csv.Error) as e:
         # The table is there but broken/unreadable: visible, like size 0
         _LOGGER.warning("Skipping Flash summary: %s", e)
         return None

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -63,7 +63,12 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
             continue
         ptype, psubtype, psize = cells[1], cells[2], cells[4]
         if ptype in ("app", "0") and psubtype in ("factory", "ota_0"):
-            return _parse_size(psize)
+            try:
+                return _parse_size(psize)
+            except ValueError as err:
+                raise ValueError(
+                    f"{err} for partition {cells[0]} in {partitions_csv}"
+                ) from err
     raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
 
 
@@ -84,8 +89,10 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     try:
         _print_summary(size_json, partitions_csv)
     except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # Backstop for shapes the named guards below miss
-        _LOGGER.debug("Skipping size summary: %s", e)
+        # Backstop for shapes the named guards below miss; warning so a
+        # regression here cannot go missing indefinitely
+        _LOGGER.warning("Skipping size summary for %s: %s", size_json, e)
+        _LOGGER.debug("Size summary failure detail", exc_info=True)
 
 
 def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
@@ -120,6 +127,10 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         return
     if app_size <= 0:
         # Skipping also fails CI's Flash extraction, the right outcome here
-        _LOGGER.debug("Skipping Flash summary: app partition size is 0")
+        _LOGGER.warning(
+            "Skipping Flash summary: app partition size is %s in %s",
+            app_size,
+            partitions_csv,
+        )
         return
     print(f"Flash: {_format_bar(image_size, app_size)}")

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -44,24 +44,20 @@ def _parse_size(token: str) -> int:
     return int(token)
 
 
-class _MalformedPartitionRow(ValueError):
-    """A matched app row whose size cell cannot be parsed; warned, since the
-    table is present but broken."""
-
-
-def _find_app_partition_size(partitions_csv: Path) -> int:
-    """Return the size of the firmware's app partition.
+def _find_app_partition_size(partitions_csv: Path) -> int | None:
+    """The firmware's app partition size; None when there is nothing to find.
 
     Mirrors PlatformIO's ``platform-espressif32/builder/main.py::
     _update_max_upload_size``: take the first ``app``-type partition
     whose subtype is ``factory`` or ``ota_0``. Order matters because
     layouts like Adafruit's ``partitions-4MB-tinyuf2.csv`` repurpose
     ``factory`` for a UF2 bootloader before the real OTA slot, so a
-    naive "prefer factory" rule would pick the wrong row. Raises
-    ``ValueError`` if no qualifying partition is present.
+    naive "prefer factory" rule would pick the wrong row. A missing
+    table or no qualifying row is legitimate absence (None); a raise
+    always means a present-but-broken table.
     """
     if not partitions_csv.is_file():
-        raise ValueError(f"partitions.csv not found at {partitions_csv}")
+        return None
     for row in csv.reader(partitions_csv.read_text(encoding="utf-8").splitlines()):
         cells = [c.strip() for c in row]
         if not cells or cells[0].startswith("#") or len(cells) < 5:
@@ -71,10 +67,10 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
             try:
                 return _parse_size(psize)
             except ValueError as err:
-                raise _MalformedPartitionRow(
+                raise ValueError(
                     f"{err} for partition {cells[0]} in {partitions_csv}"
                 ) from err
-    raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
+    return None
 
 
 def _format_bar(used: int, total: int) -> str:
@@ -102,10 +98,8 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
 
 def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
     # The build's own POST_BUILD step writes this file; its absence or an
-    # unexpected shape is a regression signal, so these skips warn
-    if not size_json.is_file():
-        _LOGGER.warning("Skipping size summary: %s not found", size_json)
-        return
+    # unexpected shape is a regression signal, so these skips warn.
+    # FileNotFoundError lands in the OSError arm with the path in its text.
     try:
         data = json.loads(size_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:
@@ -116,12 +110,10 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.warning("Skipping size summary: unexpected shape in %s", size_json)
         return
 
-    # Buffered so a late failure prints nothing instead of half a report
-    lines: list[str] = []
     memory_types = data.get("memory_types")
     if not isinstance(memory_types, dict):
         memory_types = {}
-    ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
+    ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM")
     if not isinstance(ram_region, dict):
         ram_region = {}
     ram_used = ram_region.get("used")
@@ -131,38 +123,38 @@ def _print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         and isinstance(ram_total, (int, float))
         and ram_total > 0
     ):
-        lines.append(f"RAM:   {_format_bar(int(ram_used), int(ram_total))}")
+        print(f"RAM:   {_format_bar(int(ram_used), int(ram_total))}")
     else:
         _LOGGER.warning(
             "Skipping RAM summary: no usable DRAM/DIRAM region in %s", size_json
         )
 
-    app_size = _resolve_app_size(data, partitions_csv)
-    if app_size is not None:
-        lines.append(f"Flash: {_format_bar(data['image_size'], app_size)}")
-    for line in lines:
-        print(line)
+    if (flash := _flash_line(data, partitions_csv)) is not None:
+        print(flash)
 
 
-def _resolve_app_size(data: dict, partitions_csv: Path | None) -> int | None:
-    """The Flash bar's denominator, or None (already logged) to skip it."""
+def _flash_line(data: dict, partitions_csv: Path | None) -> str | None:
+    """The formatted Flash line, or None (already logged) to skip it.
+
+    Owns both sides of the bar, so nothing after a print can raise: the
+    blanket guard is left for genuinely unforeseen shapes.
+    """
     image_size = data.get("image_size")
-    if image_size is None:
-        _LOGGER.warning("Skipping Flash summary: no image_size in the size report")
+    if not isinstance(image_size, (int, float)):
+        _LOGGER.warning("Skipping Flash summary: no usable image_size")
         return None
     if partitions_csv is None:
         _LOGGER.debug("Skipping Flash summary: no partition table given")
         return None
     try:
         app_size = _find_app_partition_size(partitions_csv)
-    except (_MalformedPartitionRow, OSError) as e:
+    except (ValueError, OSError) as e:
         # The table is there but broken/unreadable: visible, like size 0
         _LOGGER.warning("Skipping Flash summary: %s", e)
         return None
-    except ValueError as e:
-        # Missing file or no qualifying partition: legitimate for
-        # non-app layouts, keep quiet
-        _LOGGER.debug("Skipping Flash summary: %s", e)
+    if app_size is None:
+        # No table or no qualifying row: legitimate for non-app layouts
+        _LOGGER.debug("Skipping Flash summary: no app partition in %s", partitions_csv)
         return None
     if app_size <= 0:
         # Skipping also fails CI's Flash extraction, the right outcome here
@@ -172,4 +164,4 @@ def _resolve_app_size(data: dict, partitions_csv: Path | None) -> int | None:
             partitions_csv,
         )
         return None
-    return app_size
+    return f"Flash: {_format_bar(int(image_size), app_size)}"

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -456,8 +456,8 @@ def run_compile(config, verbose: bool) -> int:
     rc = run_idf_py(*args, jobs=config[CONF_ESPHOME].get(CONF_COMPILE_PROCESS_LIMIT))
     if rc == 0:
         size_json = CORE.relative_build_path("build", "esp_idf_size.json")
-        partitions = CORE.relative_build_path("partitions.csv")
-        print_summary(size_json, partitions if partitions.is_file() else None)
+        # size_summary owns the missing-table policy
+        print_summary(size_json, CORE.relative_build_path("partitions.csv"))
     return rc
 
 

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -174,17 +174,6 @@ def test_print_summary_unreadable_partitions_is_skipped(
     assert "RAM:" in out and "Flash:" not in out
 
 
-def test_print_summary_zero_app_partition_is_skipped(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A 0-size app partition drops the Flash bar instead of rendering 0%."""
-    size_json = _write_size_json(tmp_path, _dram_size_data())
-    partitions = _write_partitions(tmp_path, "0")
-    print_summary(size_json, partitions)
-    out = capsys.readouterr().out
-    assert "RAM:" in out and "Flash:" not in out
-
-
 def test_print_summary_happy_path_prints_both_bars(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -271,32 +260,16 @@ def test_print_summary_blanket_guard_catches_the_rest(
     assert "Skipping size summary for" in caplog.text
 
 
-@pytest.mark.parametrize("cell", ["", "1.5M", "abc"], ids=["blank", "float", "junk"])
-def test_print_summary_blank_size_cell_names_the_row(
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-    caplog: pytest.LogCaptureFixture,
-    cell: str,
-) -> None:
-    """An unparseable size cell raises ValueError instead of parsing to 0."""
-    size_json = _write_size_json(tmp_path, _dram_size_data())
-    partitions = _write_partitions(tmp_path, cell)
-    print_summary(size_json, partitions)
-    out = capsys.readouterr().out
-    assert "RAM:" in out and "Flash:" not in out
-    # Pins the ValueError path: pre-diff, "" parsed to 0 and the size-0
-    # warning fired instead
-    assert "Skipping Flash summary" in caplog.text
-    assert "app0" in caplog.text and str(partitions) in caplog.text
-
-
+@pytest.mark.parametrize("cell", ["1M", "1048576"], ids=["suffixed", "decimal"])
 def test_print_summary_suffixed_size_cell(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], cell: str
 ) -> None:
-    """K/M suffixes parse like PlatformIO's rule (1M = 1048576 bytes)."""
+    """K/M suffixes and plain decimals parse like PlatformIO's rule."""
     size_json = _write_size_json(tmp_path, _dram_size_data())
     partitions = tmp_path / "partitions.csv"
-    partitions.write_text("# comment row\nshort,row\napp0, app, ota_0, 0x10000, 1M,\n")
+    partitions.write_text(
+        f"# comment row\nshort,row\napp0, app, ota_0, 0x10000, {cell},\n"
+    )
     print_summary(size_json, partitions)
     assert "from 1048576 bytes" in capsys.readouterr().out
 

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -125,11 +126,14 @@ def test_print_summary_skips_when_diram_total_collapses(
 
 
 def test_print_summary_handles_missing_json(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Missing size json is non-fatal and prints nothing."""
     print_summary(tmp_path / "does_not_exist.json", partitions_csv=None)
     assert capsys.readouterr().out == ""
+    assert "Skipping size summary" in caplog.text
 
 
 def test_print_summary_handles_no_memory_types(
@@ -250,20 +254,22 @@ def test_print_summary_blanket_guard_catches_the_rest(
     assert "Skipping size summary for" in caplog.text
 
 
+@pytest.mark.parametrize("cell", ["", "1.5M", "abc"], ids=["blank", "float", "junk"])
 def test_print_summary_blank_size_cell_names_the_row(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
+    cell: str,
 ) -> None:
-    """A blank size cell raises ValueError instead of parsing to 0."""
+    """An unparseable size cell raises ValueError instead of parsing to 0."""
     size_json = _write_size_json(tmp_path, _dram_size_data())
-    partitions = _write_partitions(tmp_path, "")
+    partitions = _write_partitions(tmp_path, cell)
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out
     # Pins the ValueError path: pre-diff, "" parsed to 0 and the size-0
     # warning fired instead
-    assert "blank partition size cell" in caplog.text
+    assert "Skipping Flash summary" in caplog.text
     assert "app0" in caplog.text and str(partitions) in caplog.text
 
 
@@ -286,12 +292,17 @@ def test_print_summary_missing_or_appless_partitions_stay_quiet(
     """A missing table or one without a qualifying app row is a legitimate
     layout: the Flash line drops at debug, never at warning."""
     size_json = _write_size_json(tmp_path, _dram_size_data())
-    print_summary(size_json, tmp_path / "nope.csv")
-    partitions = _write_partitions(tmp_path, "0x1000", ptype="data", subtype="spiffs")
-    print_summary(size_json, partitions)
+    with caplog.at_level(logging.DEBUG, logger="esphome.espidf.size_summary"):
+        print_summary(size_json, tmp_path / "nope.csv")
+        partitions = _write_partitions(
+            tmp_path, "0x1000", ptype="data", subtype="spiffs"
+        )
+        print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "Flash:" not in out
-    assert "Skipping Flash summary" not in caplog.text
+    # Quiet means debug-logged, not unlogged
+    assert caplog.text.count("Skipping Flash summary: no app partition") == 2
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 def test_print_summary_corrupt_size_json_warns(

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -201,17 +201,42 @@ def test_print_summary_happy_path_prints_both_bars(
     ],
 )
 def test_print_summary_nested_bad_shapes_never_raise(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str], payload: dict
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+    payload: dict,
 ) -> None:
-    """The blanket guard keeps unexpected nested shapes from raising."""
+    """Bad nested shapes hit the named RAM guard, not the blanket backstop."""
     size_json = _write_size_json(tmp_path, payload)
     print_summary(size_json, None)
     # No half-formed bar for CI to scrape; every payload fails before printing
     assert capsys.readouterr().out == ""
+    assert "Skipping RAM summary" in caplog.text
+    assert "Skipping size summary for" not in caplog.text
+
+
+def test_print_summary_blanket_guard_catches_the_rest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Shapes the named guards miss (non-numeric image_size) warn via the
+    blanket backstop, and the buffered report prints nothing at all."""
+    size_json = _write_size_json(
+        tmp_path,
+        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": "x"},
+    )
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("app0, app, ota_0, 0x10000, 0x100000,\n")
+    print_summary(size_json, partitions)
+    assert capsys.readouterr().out == ""
+    assert "Skipping size summary for" in caplog.text
 
 
 def test_print_summary_blank_size_cell_names_the_row(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A blank size cell raises ValueError instead of parsing to 0."""
     size_json = _write_size_json(
@@ -223,3 +248,7 @@ def test_print_summary_blank_size_cell_names_the_row(
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out
+    # Pins the ValueError path: pre-diff, "" parsed to 0 and the size-0
+    # warning fired instead
+    assert "blank partition size cell" in caplog.text
+    assert "app0" in caplog.text and str(partitions) in caplog.text

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -142,8 +142,7 @@ def test_print_summary_non_dict_json_is_skipped(
 def test_print_summary_unreadable_partitions_is_skipped(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """An OSError reading the partition table skips the summary, never the
-    build (a missing file takes the ValueError path instead)."""
+    """An OSError reading the partition table skips the summary, not the build."""
     size_json = tmp_path / "size.json"
     size_json.write_text(
         '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
@@ -166,8 +165,7 @@ def test_print_summary_unreadable_partitions_is_skipped(
 def test_print_summary_zero_app_partition_is_skipped(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A partition row parsing to size 0 must not render a 0% bar for CI's
-    memory-impact extraction to ingest."""
+    """A 0-size app partition drops the Flash bar instead of rendering 0%."""
     size_json = tmp_path / "size.json"
     size_json.write_text(
         '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
@@ -205,8 +203,7 @@ def test_print_summary_happy_path_prints_both_bars(
 def test_print_summary_nested_bad_shapes_never_raise(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], payload: dict
 ) -> None:
-    """The blanket guard keeps nested non-dict values and non-numeric sizes
-    from raising past a linked build."""
+    """The blanket guard keeps unexpected nested shapes from raising."""
     size_json = _write_size_json(tmp_path, payload)
     print_summary(size_json, None)
     assert "Traceback" not in capsys.readouterr().err
@@ -215,8 +212,7 @@ def test_print_summary_nested_bad_shapes_never_raise(
 def test_print_summary_blank_size_cell_names_the_row(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A blank size cell is reported as the malformed input it is, via the
-    ValueError path, instead of parsing to 0."""
+    """A blank size cell raises ValueError instead of parsing to 0."""
     size_json = _write_size_json(
         tmp_path,
         {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -213,13 +213,30 @@ def test_print_summary_nested_bad_shapes_never_raise(
     caplog: pytest.LogCaptureFixture,
     payload: dict,
 ) -> None:
-    """Bad nested shapes hit the named RAM guard, not the blanket backstop."""
+    """Corrupt nested shapes hit the named malformed guard, not the blanket."""
     size_json = _write_size_json(tmp_path, payload)
     print_summary(size_json, None)
     # No half-formed bar for CI to scrape; every payload fails before printing
     assert capsys.readouterr().out == ""
-    assert "Skipping RAM summary" in caplog.text
+    assert "malformed memory_types" in caplog.text
     assert "Skipping size summary for" not in caplog.text
+
+
+def test_print_summary_absent_region_stays_quiet(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A well-shaped report without DRAM/DIRAM is a variant difference, not
+    a broken artifact: debug, never a per-build warning."""
+    size_json = _write_size_json(tmp_path, {"memory_types": {}, "image_size": 1})
+    with caplog.at_level(logging.DEBUG, logger="esphome.espidf.size_summary"):
+        print_summary(size_json, None)
+    assert "RAM:" not in capsys.readouterr().out
+    assert "no usable DRAM/DIRAM region" in caplog.text
+    assert not [
+        r for r in caplog.records if r.levelno >= logging.WARNING and "RAM" in r.message
+    ]
 
 
 def test_print_summary_non_numeric_image_size_warns_by_name(

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -133,7 +133,8 @@ def test_print_summary_handles_missing_json(
     """Missing size json is non-fatal and prints nothing."""
     print_summary(tmp_path / "does_not_exist.json", partitions_csv=None)
     assert capsys.readouterr().out == ""
-    assert "Skipping size summary" in caplog.text
+    assert "cannot read" in caplog.text
+    assert "Skipping size summary for" not in caplog.text
 
 
 def test_print_summary_handles_no_memory_types(
@@ -196,6 +197,8 @@ def test_print_summary_happy_path_prints_both_bars(
         {"memory_types": []},
         {"memory_types": {"DRAM": 5}},
         {"memory_types": {"DRAM": {"used": "x", "size": "y"}}, "image_size": 1},
+        {"memory_types": {"DRAM": []}},
+        {"memory_types": {"DRAM": {"used": True, "size": True}}},
     ],
 )
 def test_print_summary_nested_bad_shapes_never_raise(
@@ -303,8 +306,12 @@ def test_print_summary_corrupt_size_json_warns(
     size_json = tmp_path / "size.json"
     size_json.write_text("not json {{{")
     print_summary(size_json, None)
+    size_json.write_bytes(b"\xff\xfe\x00")
+    print_summary(size_json, None)
     assert capsys.readouterr().out == ""
-    assert "Skipping size summary" in caplog.text
+    # The named arm, not the blanket, for both damage classes
+    assert caplog.text.count("cannot read") == 2
+    assert "Skipping size summary for" not in caplog.text
 
 
 def test_print_summary_missing_partitions_named_in_backstop(

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -126,3 +126,38 @@ def test_print_summary_handles_no_memory_types(
     size_json = _write_size_json(tmp_path, {"image_size": 0})
     print_summary(size_json, partitions_csv=None)
     assert capsys.readouterr().out == ""
+
+
+def test_print_summary_non_dict_json_is_skipped(tmp_path, capsys) -> None:
+    """Valid JSON that is not an object must not raise past a build that
+    already linked."""
+    size_json = tmp_path / "size.json"
+    size_json.write_text("[]")
+    print_summary(size_json, tmp_path / "partitions.csv")
+    assert capsys.readouterr().out == ""
+
+
+def test_print_summary_unreadable_partitions_is_skipped(tmp_path, capsys) -> None:
+    """An OSError reading the partition table is a skipped summary, not a
+    failed build."""
+    size_json = tmp_path / "size.json"
+    size_json.write_text(
+        '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
+    )
+    print_summary(size_json, tmp_path / "missing" / "partitions.csv")
+    out = capsys.readouterr().out
+    assert "RAM:" in out and "Flash:" not in out
+
+
+def test_print_summary_zero_app_partition_is_skipped(tmp_path, capsys) -> None:
+    """A malformed partition row parsing to 0 must not render a 0% bar for
+    CI's memory-impact extraction to ingest."""
+    size_json = tmp_path / "size.json"
+    size_json.write_text(
+        '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
+    )
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("app0, app, ota_0, 0x10000, ,\n")
+    print_summary(size_json, partitions)
+    out = capsys.readouterr().out
+    assert "RAM:" in out and "Flash:" not in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -156,7 +156,7 @@ def test_print_summary_non_dict_json_is_skipped(
 
 
 def test_print_summary_unreadable_partitions_is_skipped(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
 ) -> None:
     """An OSError reading the partition table skips the summary, not the build."""
     size_json = _write_size_json(tmp_path, _dram_size_data())
@@ -170,8 +170,10 @@ def test_print_summary_unreadable_partitions_is_skipped(
 
     with patch.object(Path, "read_text", fail_partitions_read):
         print_summary(size_json, partitions)
+    # An impossible post-build state is the backstop's business
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out
+    assert "Skipping size summary for" in caplog.text
 
 
 def test_print_summary_happy_path_prints_both_bars(
@@ -279,19 +281,16 @@ def test_print_summary_missing_or_appless_partitions_stay_quiet(
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A missing table or one without a qualifying app row is a legitimate
-    layout: the Flash line drops at debug, never at warning."""
+    """A table without a qualifying app row is a legitimate layout: the
+    Flash line drops at debug, never at warning."""
     size_json = _write_size_json(tmp_path, _dram_size_data())
+    partitions = _write_partitions(tmp_path, "0x1000", ptype="data", subtype="spiffs")
     with caplog.at_level(logging.DEBUG, logger="esphome.espidf.size_summary"):
-        print_summary(size_json, tmp_path / "nope.csv")
-        partitions = _write_partitions(
-            tmp_path, "0x1000", ptype="data", subtype="spiffs"
-        )
         print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "Flash:" not in out
     # Quiet means debug-logged, not unlogged
-    assert caplog.text.count("Skipping Flash summary: no app partition") == 2
+    assert "Skipping Flash summary: no app partition" in caplog.text
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -305,3 +305,16 @@ def test_print_summary_corrupt_size_json_warns(
     print_summary(size_json, None)
     assert capsys.readouterr().out == ""
     assert "Skipping size summary" in caplog.text
+
+
+def test_print_summary_missing_partitions_named_in_backstop(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A vanished table is an impossible post-build state; the backstop
+    reports it by name instead of a bare FileNotFoundError."""
+    size_json = _write_size_json(tmp_path, _dram_size_data())
+    print_summary(size_json, tmp_path / "nope.csv")
+    assert "Flash:" not in capsys.readouterr().out
+    assert "partitions.csv not found" in caplog.text

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -252,3 +252,50 @@ def test_print_summary_blank_size_cell_names_the_row(
     # warning fired instead
     assert "blank partition size cell" in caplog.text
     assert "app0" in caplog.text and str(partitions) in caplog.text
+
+
+def test_print_summary_suffixed_size_cell(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """K/M suffixes parse like PlatformIO's rule (1M = 1048576 bytes)."""
+    size_json = _write_size_json(
+        tmp_path,
+        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},
+    )
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("# comment row\nshort,row\napp0, app, ota_0, 0x10000, 1M,\n")
+    print_summary(size_json, partitions)
+    assert "from 1048576 bytes" in capsys.readouterr().out
+
+
+def test_print_summary_missing_or_appless_partitions_stay_quiet(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A missing table or one without a qualifying app row is a legitimate
+    layout: the Flash line drops at debug, never at warning."""
+    size_json = _write_size_json(
+        tmp_path,
+        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},
+    )
+    print_summary(size_json, tmp_path / "nope.csv")
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("st0, data, spiffs, 0x10000, 0x1000,\n")
+    print_summary(size_json, partitions)
+    out = capsys.readouterr().out
+    assert "Flash:" not in out
+    assert "Skipping Flash summary" not in caplog.text
+
+
+def test_print_summary_corrupt_size_json_warns(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The build's own size report failing to parse is a regression signal."""
+    size_json = tmp_path / "size.json"
+    size_json.write_text("not json {{{")
+    print_summary(size_json, None)
+    assert capsys.readouterr().out == ""
+    assert "Skipping size summary" in caplog.text

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -177,3 +177,52 @@ def test_print_summary_zero_app_partition_is_skipped(
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out
+
+
+def test_print_summary_happy_path_prints_both_bars(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A well-formed size report and partition table print both bars."""
+    size_json = tmp_path / "size.json"
+    size_json.write_text(
+        '{"memory_types": {"DRAM": {"used": 1000, "size": 2000}}, "image_size": 100000}'
+    )
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("app0, app, ota_0, 0x10000, 0x180000,\n")
+    print_summary(size_json, partitions)
+    out = capsys.readouterr().out
+    assert "RAM:" in out and "Flash:" in out
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"memory_types": []},
+        {"memory_types": {"DRAM": 5}},
+        {"memory_types": {"DRAM": {"used": "x", "size": "y"}}, "image_size": 1},
+    ],
+)
+def test_print_summary_nested_bad_shapes_never_raise(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], payload: dict
+) -> None:
+    """The blanket guard keeps nested non-dict values and non-numeric sizes
+    from raising past a linked build."""
+    size_json = _write_size_json(tmp_path, payload)
+    print_summary(size_json, None)
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_print_summary_blank_size_cell_names_the_row(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A blank size cell is reported as the malformed input it is, via the
+    ValueError path, instead of parsing to 0."""
+    size_json = _write_size_json(
+        tmp_path,
+        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},
+    )
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("app0, app, ota_0, 0x10000, ,\n")
+    print_summary(size_json, partitions)
+    out = capsys.readouterr().out
+    assert "RAM:" in out and "Flash:" not in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -206,7 +206,8 @@ def test_print_summary_nested_bad_shapes_never_raise(
     """The blanket guard keeps unexpected nested shapes from raising."""
     size_json = _write_size_json(tmp_path, payload)
     print_summary(size_json, None)
-    assert "Traceback" not in capsys.readouterr().err
+    # No half-formed bar for CI to scrape; every payload fails before printing
+    assert capsys.readouterr().out == ""
 
 
 def test_print_summary_blank_size_cell_names_the_row(

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -128,36 +129,51 @@ def test_print_summary_handles_no_memory_types(
     assert capsys.readouterr().out == ""
 
 
-def test_print_summary_non_dict_json_is_skipped(tmp_path, capsys) -> None:
-    """Valid JSON that is not an object must not raise past a build that
-    already linked."""
+def test_print_summary_non_dict_json_is_skipped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Valid JSON that is not an object must not raise past a linked build."""
     size_json = tmp_path / "size.json"
     size_json.write_text("[]")
     print_summary(size_json, tmp_path / "partitions.csv")
     assert capsys.readouterr().out == ""
 
 
-def test_print_summary_unreadable_partitions_is_skipped(tmp_path, capsys) -> None:
-    """An OSError reading the partition table is a skipped summary, not a
-    failed build."""
-    size_json = tmp_path / "size.json"
-    size_json.write_text(
-        '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
-    )
-    print_summary(size_json, tmp_path / "missing" / "partitions.csv")
-    out = capsys.readouterr().out
-    assert "RAM:" in out and "Flash:" not in out
-
-
-def test_print_summary_zero_app_partition_is_skipped(tmp_path, capsys) -> None:
-    """A malformed partition row parsing to 0 must not render a 0% bar for
-    CI's memory-impact extraction to ingest."""
+def test_print_summary_unreadable_partitions_is_skipped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An OSError reading the partition table skips the summary, never the
+    build (a missing file takes the ValueError path instead)."""
     size_json = tmp_path / "size.json"
     size_json.write_text(
         '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
     )
     partitions = tmp_path / "partitions.csv"
-    partitions.write_text("app0, app, ota_0, 0x10000, ,\n")
+    partitions.write_text("app0, app, ota_0, 0x10000, 1M,\n")
+    real_read_text = Path.read_text
+
+    def fail_partitions_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self == partitions:
+            raise OSError("permission denied")
+        return real_read_text(self, *args, **kwargs)
+
+    with patch.object(Path, "read_text", fail_partitions_read):
+        print_summary(size_json, partitions)
+    out = capsys.readouterr().out
+    assert "RAM:" in out and "Flash:" not in out
+
+
+def test_print_summary_zero_app_partition_is_skipped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A partition row parsing to size 0 must not render a 0% bar for CI's
+    memory-impact extraction to ingest."""
+    size_json = tmp_path / "size.json"
+    size_json.write_text(
+        '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
+    )
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text("app0, app, ota_0, 0x10000, 0,\n")
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -70,6 +70,18 @@ def _s3_size_data() -> dict:
     }
 
 
+def _dram_size_data(image_size: int = 100) -> dict:
+    return {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": image_size}
+
+
+def _write_partitions(
+    tmp_path: Path, size: str, ptype: str = "app", subtype: str = "ota_0"
+) -> Path:
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text(f"app0, {ptype}, {subtype}, 0x10000, {size},\n")
+    return partitions
+
+
 def test_print_summary_esp32_uses_dram(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -143,12 +155,8 @@ def test_print_summary_unreadable_partitions_is_skipped(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """An OSError reading the partition table skips the summary, not the build."""
-    size_json = tmp_path / "size.json"
-    size_json.write_text(
-        '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
-    )
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text("app0, app, ota_0, 0x10000, 1M,\n")
+    size_json = _write_size_json(tmp_path, _dram_size_data())
+    partitions = _write_partitions(tmp_path, "1M")
     real_read_text = Path.read_text
 
     def fail_partitions_read(self: Path, *args: object, **kwargs: object) -> str:
@@ -166,12 +174,8 @@ def test_print_summary_zero_app_partition_is_skipped(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A 0-size app partition drops the Flash bar instead of rendering 0%."""
-    size_json = tmp_path / "size.json"
-    size_json.write_text(
-        '{"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100}'
-    )
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text("app0, app, ota_0, 0x10000, 0,\n")
+    size_json = _write_size_json(tmp_path, _dram_size_data())
+    partitions = _write_partitions(tmp_path, "0")
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out
@@ -185,8 +189,7 @@ def test_print_summary_happy_path_prints_both_bars(
     size_json.write_text(
         '{"memory_types": {"DRAM": {"used": 1000, "size": 2000}}, "image_size": 100000}'
     )
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text("app0, app, ota_0, 0x10000, 0x180000,\n")
+    partitions = _write_partitions(tmp_path, "0x180000")
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" in out
@@ -215,21 +218,35 @@ def test_print_summary_nested_bad_shapes_never_raise(
     assert "Skipping size summary for" not in caplog.text
 
 
+def test_print_summary_non_numeric_image_size_warns_by_name(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-numeric image_size hits the named guard, not the blanket."""
+    size_json = _write_size_json(
+        tmp_path,
+        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": "x"},
+    )
+    print_summary(size_json, _write_partitions(tmp_path, "0x100000"))
+    assert "Flash:" not in capsys.readouterr().out
+    assert "no usable image_size" in caplog.text
+    assert "Skipping size summary for" not in caplog.text
+
+
 def test_print_summary_blanket_guard_catches_the_rest(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Shapes the named guards miss (non-numeric image_size) warn via the
-    blanket backstop, and the buffered report prints nothing at all."""
-    size_json = _write_size_json(
-        tmp_path,
-        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": "x"},
-    )
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text("app0, app, ota_0, 0x10000, 0x100000,\n")
-    print_summary(size_json, partitions)
-    assert capsys.readouterr().out == ""
+    """A genuinely unforeseen failure warns via the blanket backstop and
+    never raises past a linked build."""
+    size_json = _write_size_json(tmp_path, _dram_size_data())
+    with patch(
+        "esphome.espidf.size_summary._flash_line",
+        side_effect=RuntimeError("unforeseen"),
+    ):
+        print_summary(size_json, None)
     assert "Skipping size summary for" in caplog.text
 
 
@@ -239,12 +256,8 @@ def test_print_summary_blank_size_cell_names_the_row(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A blank size cell raises ValueError instead of parsing to 0."""
-    size_json = _write_size_json(
-        tmp_path,
-        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},
-    )
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text("app0, app, ota_0, 0x10000, ,\n")
+    size_json = _write_size_json(tmp_path, _dram_size_data())
+    partitions = _write_partitions(tmp_path, "")
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "RAM:" in out and "Flash:" not in out
@@ -258,10 +271,7 @@ def test_print_summary_suffixed_size_cell(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """K/M suffixes parse like PlatformIO's rule (1M = 1048576 bytes)."""
-    size_json = _write_size_json(
-        tmp_path,
-        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},
-    )
+    size_json = _write_size_json(tmp_path, _dram_size_data())
     partitions = tmp_path / "partitions.csv"
     partitions.write_text("# comment row\nshort,row\napp0, app, ota_0, 0x10000, 1M,\n")
     print_summary(size_json, partitions)
@@ -275,13 +285,9 @@ def test_print_summary_missing_or_appless_partitions_stay_quiet(
 ) -> None:
     """A missing table or one without a qualifying app row is a legitimate
     layout: the Flash line drops at debug, never at warning."""
-    size_json = _write_size_json(
-        tmp_path,
-        {"memory_types": {"DRAM": {"used": 1, "size": 2}}, "image_size": 100},
-    )
+    size_json = _write_size_json(tmp_path, _dram_size_data())
     print_summary(size_json, tmp_path / "nope.csv")
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text("st0, data, spiffs, 0x10000, 0x1000,\n")
+    partitions = _write_partitions(tmp_path, "0x1000", ptype="data", subtype="spiffs")
     print_summary(size_json, partitions)
     out = capsys.readouterr().out
     assert "Flash:" not in out


### PR DESCRIPTION
# What does this implement/fix?

The size-summary code will soon be shared with the ESP8266 native toolchain (#18539), which needs it hardened first: `print_summary` promises failures are non-fatal after a successful build, but several inputs break that: valid JSON that is not an object raises `AttributeError` from `.get`, and an unreadable partition table raises `OSError` past the linked build.

Every failure now skips instead of raising, with one visibility rule: skips caused by the build's own artifacts (missing or misshapen size report) warn, while variant differences (absent RAM region, no table, no qualifying app row) stay at debug. The size report is the one input nothing upstream validates; malformed partition tables cannot reach a successful build (IDF's `gen_esp32part.py` rejects them first), so the table handling stays minimal: a read race warns, everything else is the backstop's business.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18539

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes; build size reporting only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





