### PR TITLE
[core] Treat a malformed build_info.json as stale instead of crashing

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -343,7 +343,8 @@ def copy_src_tree():
             ):
                 # Non-object JSON is stale like every other damage case
                 sources_changed = True
-        except (json.JSONDecodeError, OSError):
+        except (ValueError, OSError):
+            # ValueError covers both JSONDecodeError and UnicodeDecodeError
             sources_changed = True
 
     # Write build_info header and JSON metadata

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -337,14 +337,14 @@ def copy_src_tree():
     else:
         try:
             existing = json.loads(build_info_json_path.read_text(encoding="utf-8"))
-            if (
+            if not isinstance(existing, dict) or (
                 existing.get("config_hash") != config_hash
                 or existing.get("esphome_version") != __version__
             ):
+                # Valid JSON that is not an object (truncated or
+                # hand-edited) is stale like every other damage case
                 sources_changed = True
-        except (json.JSONDecodeError, AttributeError, KeyError, OSError):
-            # AttributeError: valid JSON that is not an object (truncated
-            # or hand-edited) has no .get; treat it as stale like the rest
+        except (json.JSONDecodeError, OSError):
             sources_changed = True
 
     # Write build_info header and JSON metadata

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -348,15 +348,17 @@ def copy_src_tree():
             sources_changed = True
         except (ValueError, OSError) as err:
             # ValueError covers both JSONDecodeError and UnicodeDecodeError;
-            # unlink so the regenerating write never re-reads the damage
-            _LOGGER.warning("Replacing damaged build_info.json: %s", err)
+            # unlink so the regenerating write never re-reads the bad copy.
+            # "Unreadable" not "damaged": EACCES/EISDIR land here too
+            _LOGGER.warning("Regenerating unreadable build_info.json: %s", err)
             try:
-                build_info_json_path.unlink()
+                # missing_ok: a concurrent clean may have removed it already
+                build_info_json_path.unlink(missing_ok=True)
             except OSError as unlink_err:
-                # The later write re-reads the file, so a kept damaged copy
+                # The later write re-reads the file, so a kept unreadable copy
                 # fails again with a misattributed error; name the real cause
                 _LOGGER.warning(
-                    "Could not remove damaged build_info.json: %s", unlink_err
+                    "Could not remove unreadable build_info.json: %s", unlink_err
                 )
             sources_changed = True
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 import importlib
 import json
 import logging
@@ -343,8 +344,12 @@ def copy_src_tree():
             ):
                 # Non-object JSON is stale like every other damage case
                 sources_changed = True
-        except (ValueError, OSError):
-            # ValueError covers both JSONDecodeError and UnicodeDecodeError
+        except (ValueError, OSError) as err:
+            # ValueError covers both JSONDecodeError and UnicodeDecodeError;
+            # unlink so the regenerating write never re-reads the damage
+            _LOGGER.warning("Replacing damaged build_info.json: %s", err)
+            with suppress(OSError):
+                build_info_json_path.unlink(missing_ok=True)
             sources_changed = True
 
     # Write build_info header and JSON metadata

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -341,8 +341,7 @@ def copy_src_tree():
                 existing.get("config_hash") != config_hash
                 or existing.get("esphome_version") != __version__
             ):
-                # Valid JSON that is not an object (truncated or
-                # hand-edited) is stale like every other damage case
+                # Non-object JSON is stale like every other damage case
                 sources_changed = True
         except (json.JSONDecodeError, OSError):
             sources_changed = True

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -342,7 +342,9 @@ def copy_src_tree():
                 or existing.get("esphome_version") != __version__
             ):
                 sources_changed = True
-        except (json.JSONDecodeError, KeyError, OSError):
+        except (json.JSONDecodeError, AttributeError, KeyError, OSError):
+            # AttributeError: valid JSON that is not an object (truncated
+            # or hand-edited) has no .get; treat it as stale like the rest
             sources_changed = True
 
     # Write build_info header and JSON metadata

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -1,4 +1,3 @@
-from contextlib import suppress
 import importlib
 import json
 import logging
@@ -344,12 +343,21 @@ def copy_src_tree():
             ):
                 # Non-object JSON is stale like every other damage case
                 sources_changed = True
+        except FileNotFoundError:
+            # An absent build_info.json is stale, not damaged; rebuild quietly
+            sources_changed = True
         except (ValueError, OSError) as err:
             # ValueError covers both JSONDecodeError and UnicodeDecodeError;
             # unlink so the regenerating write never re-reads the damage
             _LOGGER.warning("Replacing damaged build_info.json: %s", err)
-            with suppress(OSError):
-                build_info_json_path.unlink(missing_ok=True)
+            try:
+                build_info_json_path.unlink()
+            except OSError as unlink_err:
+                # The later write re-reads the file, so a kept damaged copy
+                # fails again with a misattributed error; name the real cause
+                _LOGGER.warning(
+                    "Could not remove damaged build_info.json: %s", unlink_err
+                )
             sources_changed = True
 
     # Write build_info header and JSON metadata

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2072,8 +2072,7 @@ def test_copy_src_tree_detects_config_hash_change(
         )
     )
 
-    # Create both existing build_info sources so the staleness decision
-    # reaches the JSON comparison instead of the missing-file branch
+    # Both sources must exist to reach the JSON comparison branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
     (esphome_core_path / "build_info_data.cpp").write_text("// old")
@@ -2138,8 +2137,7 @@ def test_copy_src_tree_detects_version_change(
         )
     )
 
-    # Create both existing build_info sources so the staleness decision
-    # reaches the JSON comparison instead of the missing-file branch
+    # Both sources must exist to reach the JSON comparison branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
     (esphome_core_path / "build_info_data.cpp").write_text("// old")
@@ -2190,8 +2188,7 @@ def test_copy_src_tree_handles_invalid_build_info_json(
     build_info_json_path = build_path / "build_info.json"
     build_info_json_path.write_text("invalid json {{{")
 
-    # Create both existing build_info sources so the staleness decision
-    # reaches the JSON comparison instead of the missing-file branch
+    # Both sources must exist to reach the JSON comparison branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
     (esphome_core_path / "build_info_data.cpp").write_text("// old")
@@ -2238,12 +2235,10 @@ def test_copy_src_tree_handles_non_dict_build_info_json(
     build_path = tmp_path / "build"
     build_path.mkdir()
 
-    # Valid JSON that is not an object: no .get, must read as stale
     build_info_json_path = build_path / "build_info.json"
     build_info_json_path.write_text("[]")
 
-    # Create both existing build_info sources so the staleness decision
-    # reaches the JSON comparison instead of the missing-file branch
+    # Both sources must exist to reach the JSON comparison branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
     (esphome_core_path / "build_info_data.cpp").write_text("// old")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2232,7 +2232,7 @@ def test_copy_src_tree_handles_non_dict_build_info_json(
     build_path = tmp_path / "build"
     build_path.mkdir()
 
-    # Create invalid build_info.json
+    # Valid JSON that is not an object: no .get, must read as stale
     build_info_json_path = build_path / "build_info.json"
     build_info_json_path.write_text("[]")
 

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2072,9 +2072,11 @@ def test_copy_src_tree_detects_config_hash_change(
         )
     )
 
-    # Create existing build_info_data.h
+    # Create both existing build_info sources so the staleness decision
+    # reaches the JSON comparison instead of the missing-file branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
+    (esphome_core_path / "build_info_data.cpp").write_text("// old")
 
     # Setup mocks
     mock_core.relative_src_path.side_effect = src_path.joinpath
@@ -2136,9 +2138,11 @@ def test_copy_src_tree_detects_version_change(
         )
     )
 
-    # Create existing build_info_data.h
+    # Create both existing build_info sources so the staleness decision
+    # reaches the JSON comparison instead of the missing-file branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
+    (esphome_core_path / "build_info_data.cpp").write_text("// old")
 
     # Setup mocks
     mock_core.relative_src_path.side_effect = src_path.joinpath
@@ -2186,9 +2190,11 @@ def test_copy_src_tree_handles_invalid_build_info_json(
     build_info_json_path = build_path / "build_info.json"
     build_info_json_path.write_text("invalid json {{{")
 
-    # Create existing build_info_data.h
+    # Create both existing build_info sources so the staleness decision
+    # reaches the JSON comparison instead of the missing-file branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
+    (esphome_core_path / "build_info_data.cpp").write_text("// old")
 
     # Setup mocks
     mock_core.relative_src_path.side_effect = src_path.joinpath
@@ -2236,9 +2242,11 @@ def test_copy_src_tree_handles_non_dict_build_info_json(
     build_info_json_path = build_path / "build_info.json"
     build_info_json_path.write_text("[]")
 
-    # Create existing build_info_data.h
+    # Create both existing build_info sources so the staleness decision
+    # reaches the JSON comparison instead of the missing-file branch
     build_info_h_path = esphome_core_path / "build_info_data.h"
     build_info_h_path.write_text("// old build_info_data.h")
+    (esphome_core_path / "build_info_data.cpp").write_text("// old")
 
     # Setup mocks
     mock_core.relative_src_path.side_effect = src_path.joinpath

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2146,6 +2146,56 @@ def test_copy_src_tree_regenerates_damaged_build_info(
 @patch("esphome.writer.CORE")
 @patch("esphome.writer.iter_components")
 @patch("esphome.writer.walk_files")
+def test_copy_src_tree_missing_build_info_rebuilds_quietly(
+    mock_walk_files: MagicMock,
+    mock_iter_components: MagicMock,
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An absent build_info.json regenerates without claiming damage."""
+    build_info_json_path = _setup_build_info_mocks(
+        mock_core, mock_iter_components, mock_walk_files, tmp_path
+    )
+    _run_copy_src_tree()
+    build_info_json_path.unlink()
+    _run_copy_src_tree()
+    assert json.loads(build_info_json_path.read_text())["config_hash"] == 0xDEADBEEF
+    assert "damaged" not in caplog.text
+
+
+@patch("esphome.writer.CORE")
+@patch("esphome.writer.iter_components")
+@patch("esphome.writer.walk_files")
+def test_copy_src_tree_unremovable_damaged_build_info_is_logged(
+    mock_walk_files: MagicMock,
+    mock_iter_components: MagicMock,
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed unlink of the damaged file names the real cause."""
+    build_info_json_path = _setup_build_info_mocks(
+        mock_core, mock_iter_components, mock_walk_files, tmp_path
+    )
+    _run_copy_src_tree()
+    build_info_json_path.write_text("invalid json {{{")
+    real_unlink = Path.unlink
+
+    def fail_on_build_info(self: Path, missing_ok: bool = False) -> None:
+        if self.name == "build_info.json":
+            raise OSError("simulated EACCES")
+        real_unlink(self, missing_ok=missing_ok)
+
+    with patch.object(Path, "unlink", fail_on_build_info):
+        _run_copy_src_tree()
+    assert "Could not remove damaged build_info.json" in caplog.text
+    assert json.loads(build_info_json_path.read_text())["config_hash"] == 0xDEADBEEF
+
+
+@patch("esphome.writer.CORE")
+@patch("esphome.writer.iter_components")
+@patch("esphome.writer.walk_files")
 def test_copy_src_tree_build_info_timestamp_behavior(
     mock_walk_files: MagicMock,
     mock_iter_components: MagicMock,

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2118,8 +2118,8 @@ def test_copy_src_tree_detects_version_change(
 
 @pytest.mark.parametrize(
     "damage",
-    (b"invalid json {{{", b"[]"),
-    ids=("invalid-json", "non-object"),
+    (b"invalid json {{{", b"[]", b'\xff{"config_hash": 1}'),
+    ids=("invalid-json", "non-object", "non-utf8"),
 )
 @patch("esphome.writer.CORE")
 @patch("esphome.writer.iter_components")
@@ -2141,35 +2141,6 @@ def test_copy_src_tree_regenerates_damaged_build_info(
     _run_copy_src_tree()
     new_json = json.loads(build_info_json_path.read_text())
     assert new_json["config_hash"] == 0xDEADBEEF
-
-
-@patch("esphome.writer.write_file_if_changed", return_value=False)
-@patch("esphome.writer.CORE")
-@patch("esphome.writer.iter_components")
-@patch("esphome.writer.walk_files")
-def test_copy_src_tree_non_utf8_build_info_reads_as_stale(
-    mock_walk_files: MagicMock,
-    mock_iter_components: MagicMock,
-    mock_core: MagicMock,
-    mock_write: MagicMock,
-    tmp_path: Path,
-) -> None:
-    """Non-UTF-8 build_info.json fires the staleness branch instead of raising.
-
-    Writes are stubbed (returning False, so nothing else can set
-    sources_changed): regenerating over the damaged file needs
-    write_file_if_changed's own recovery, which lands separately.
-    """
-    build_info_json_path = _setup_build_info_mocks(
-        mock_core, mock_iter_components, mock_walk_files, tmp_path
-    )
-    core_path = tmp_path / "src" / "esphome" / "core"
-    (core_path / "build_info_data.h").write_text("// old")
-    (core_path / "build_info_data.cpp").write_text("// old")
-    build_info_json_path.write_bytes(b'\xff{"config_hash": 1}')
-    _run_copy_src_tree()
-    written = [call.args[0] for call in mock_write.call_args_list]
-    assert build_info_json_path in written
 
 
 @patch("esphome.writer.CORE")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2217,6 +2217,56 @@ def test_copy_src_tree_handles_invalid_build_info_json(
 @patch("esphome.writer.CORE")
 @patch("esphome.writer.iter_components")
 @patch("esphome.writer.walk_files")
+def test_copy_src_tree_handles_non_dict_build_info_json(
+    mock_walk_files: MagicMock,
+    mock_iter_components: MagicMock,
+    mock_core: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Valid JSON that is not an object (no .get) is treated as stale."""
+    # Setup directory structure
+    src_path = tmp_path / "src"
+    src_path.mkdir()
+    esphome_core_path = src_path / "esphome" / "core"
+    esphome_core_path.mkdir(parents=True)
+    build_path = tmp_path / "build"
+    build_path.mkdir()
+
+    # Create invalid build_info.json
+    build_info_json_path = build_path / "build_info.json"
+    build_info_json_path.write_text("[]")
+
+    # Create existing build_info_data.h
+    build_info_h_path = esphome_core_path / "build_info_data.h"
+    build_info_h_path.write_text("// old build_info_data.h")
+
+    # Setup mocks
+    mock_core.relative_src_path.side_effect = src_path.joinpath
+    mock_core.relative_build_path.side_effect = build_path.joinpath
+    mock_core.defines = []
+    mock_core.config_hash = 0xDEADBEEF
+    mock_core.comment = ""
+    mock_core.target_platform = "test_platform"
+    mock_core.config = {}
+    mock_iter_components.return_value = []
+    mock_walk_files.return_value = []
+
+    with (
+        patch("esphome.writer.__version__", "2025.1.0-dev"),
+        patch("esphome.writer.importlib.import_module") as mock_import,
+    ):
+        mock_import.side_effect = AttributeError
+        copy_src_tree()
+
+    # Verify build_info files were created despite invalid JSON
+    assert build_info_h_path.exists()
+    new_json = json.loads(build_info_json_path.read_text())
+    assert new_json["config_hash"] == 0xDEADBEEF
+
+
+@patch("esphome.writer.CORE")
+@patch("esphome.writer.iter_components")
+@patch("esphome.writer.walk_files")
 def test_copy_src_tree_build_info_timestamp_behavior(
     mock_walk_files: MagicMock,
     mock_iter_components: MagicMock,

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2161,7 +2161,7 @@ def test_copy_src_tree_missing_build_info_rebuilds_quietly(
     build_info_json_path.unlink()
     _run_copy_src_tree()
     assert json.loads(build_info_json_path.read_text())["config_hash"] == 0xDEADBEEF
-    assert "damaged" not in caplog.text
+    assert "unreadable" not in caplog.text
 
 
 @patch("esphome.writer.CORE")
@@ -2189,7 +2189,7 @@ def test_copy_src_tree_unremovable_damaged_build_info_is_logged(
 
     with patch.object(Path, "unlink", fail_on_build_info):
         _run_copy_src_tree()
-    assert "Could not remove damaged build_info.json" in caplog.text
+    assert "Could not remove unreadable build_info.json" in caplog.text
     assert json.loads(build_info_json_path.read_text())["config_hash"] == 0xDEADBEEF
 
 

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2041,6 +2041,38 @@ def test_copy_src_tree_writes_build_info_files(
     assert build_info_json["esphome_version"] == "2025.1.0-dev"
 
 
+def _setup_build_info_mocks(
+    mock_core: MagicMock,
+    mock_iter_components: MagicMock,
+    mock_walk_files: MagicMock,
+    tmp_path: Path,
+) -> Path:
+    """Point CORE at tmp_path and return the build_info.json path."""
+    src_path = tmp_path / "src"
+    (src_path / "esphome" / "core").mkdir(parents=True)
+    build_path = tmp_path / "build"
+    build_path.mkdir()
+    mock_core.relative_src_path.side_effect = src_path.joinpath
+    mock_core.relative_build_path.side_effect = build_path.joinpath
+    mock_core.defines = []
+    mock_core.config_hash = 0xDEADBEEF
+    mock_core.comment = ""
+    mock_core.target_platform = "test_platform"
+    mock_core.config = {}
+    mock_iter_components.return_value = []
+    mock_walk_files.return_value = []
+    return build_path / "build_info.json"
+
+
+def _run_copy_src_tree(version: str = "2025.1.0-dev") -> None:
+    with (
+        patch("esphome.writer.__version__", version),
+        patch("esphome.writer.importlib.import_module") as mock_import,
+    ):
+        mock_import.side_effect = AttributeError
+        copy_src_tree()
+
+
 @patch("esphome.writer.CORE")
 @patch("esphome.writer.iter_components")
 @patch("esphome.writer.walk_files")
@@ -2050,60 +2082,17 @@ def test_copy_src_tree_detects_config_hash_change(
     mock_core: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """Test copy_src_tree detects when config_hash changes."""
-    # Setup directory structure
-    src_path = tmp_path / "src"
-    src_path.mkdir()
-    esphome_core_path = src_path / "esphome" / "core"
-    esphome_core_path.mkdir(parents=True)
-    build_path = tmp_path / "build"
-    build_path.mkdir()
-
-    # Create existing build_info.json with different config_hash
-    build_info_json_path = build_path / "build_info.json"
-    build_info_json_path.write_text(
-        json.dumps(
-            {
-                "config_hash": 0x12345678,  # Different from current
-                "build_time": 1700000000,
-                "build_time_str": "2023-11-14 22:13:20 +0000",
-                "esphome_version": "2025.1.0-dev",
-            }
-        )
+    """A changed config_hash regenerates build_info after a steady-state run."""
+    build_info_json_path = _setup_build_info_mocks(
+        mock_core, mock_iter_components, mock_walk_files, tmp_path
     )
+    _run_copy_src_tree()
+    assert json.loads(build_info_json_path.read_text())["config_hash"] == 0xDEADBEEF
 
-    # Both sources must exist to reach the JSON comparison branch
-    build_info_h_path = esphome_core_path / "build_info_data.h"
-    build_info_h_path.write_text("// old build_info_data.h")
-    (esphome_core_path / "build_info_data.cpp").write_text("// old")
-
-    # Setup mocks
-    mock_core.relative_src_path.side_effect = src_path.joinpath
-    mock_core.relative_build_path.side_effect = build_path.joinpath
-    mock_core.defines = []
-    mock_core.config_hash = 0xDEADBEEF  # Different from existing
-    mock_core.comment = ""
-    mock_core.target_platform = "test_platform"
-    mock_core.config = {}
-    mock_iter_components.return_value = []
-    mock_walk_files.return_value = []
-
-    with (
-        patch("esphome.writer.__version__", "2025.1.0-dev"),
-        patch("esphome.writer.importlib.import_module") as mock_import,
-    ):
-        mock_import.side_effect = AttributeError
-        copy_src_tree()
-
-    # Verify build_info files were updated due to config_hash change
-    assert build_info_h_path.exists()
-    build_info_cpp_path = esphome_core_path / "build_info_data.cpp"
-    assert build_info_cpp_path.exists()
-    new_content = build_info_cpp_path.read_text()
-    assert "0xdeadbeef" in new_content.lower()
-
-    new_json = json.loads(build_info_json_path.read_text())
-    assert new_json["config_hash"] == 0xDEADBEEF
+    # Second run only regenerates if the hash comparison detects the change
+    mock_core.config_hash = 0xC0FFEE
+    _run_copy_src_tree()
+    assert json.loads(build_info_json_path.read_text())["config_hash"] == 0xC0FFEE
 
 
 @patch("esphome.writer.CORE")
@@ -2115,156 +2104,72 @@ def test_copy_src_tree_detects_version_change(
     mock_core: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """Test copy_src_tree detects when esphome_version changes."""
-    # Setup directory structure
-    src_path = tmp_path / "src"
-    src_path.mkdir()
-    esphome_core_path = src_path / "esphome" / "core"
-    esphome_core_path.mkdir(parents=True)
-    build_path = tmp_path / "build"
-    build_path.mkdir()
-
-    # Create existing build_info.json with different version
-    build_info_json_path = build_path / "build_info.json"
-    build_info_json_path.write_text(
-        json.dumps(
-            {
-                "config_hash": 0xDEADBEEF,
-                "build_time": 1700000000,
-                "build_time_str": "2023-11-14 22:13:20 +0000",
-                "esphome_version": "2024.12.0",  # Old version
-            }
-        )
+    """A changed esphome_version regenerates build_info after a steady-state run."""
+    build_info_json_path = _setup_build_info_mocks(
+        mock_core, mock_iter_components, mock_walk_files, tmp_path
     )
-
-    # Both sources must exist to reach the JSON comparison branch
-    build_info_h_path = esphome_core_path / "build_info_data.h"
-    build_info_h_path.write_text("// old build_info_data.h")
-    (esphome_core_path / "build_info_data.cpp").write_text("// old")
-
-    # Setup mocks
-    mock_core.relative_src_path.side_effect = src_path.joinpath
-    mock_core.relative_build_path.side_effect = build_path.joinpath
-    mock_core.defines = []
-    mock_core.config_hash = 0xDEADBEEF
-    mock_core.comment = ""
-    mock_core.target_platform = "test_platform"
-    mock_core.config = {}
-    mock_iter_components.return_value = []
-    mock_walk_files.return_value = []
-
-    with (
-        patch("esphome.writer.__version__", "2025.1.0-dev"),  # New version
-        patch("esphome.writer.importlib.import_module") as mock_import,
-    ):
-        mock_import.side_effect = AttributeError
-        copy_src_tree()
-
-    # Verify build_info files were updated due to version change
-    assert build_info_h_path.exists()
+    # Pin version.h so only the build_info comparison can see the bump
+    with patch("esphome.writer.generate_version_h", return_value="// version.h\n"):
+        _run_copy_src_tree(version="2024.12.0")
+        _run_copy_src_tree(version="2025.1.0-dev")
     new_json = json.loads(build_info_json_path.read_text())
     assert new_json["esphome_version"] == "2025.1.0-dev"
 
 
+@pytest.mark.parametrize(
+    "damage",
+    (b"invalid json {{{", b"[]"),
+    ids=("invalid-json", "non-object"),
+)
 @patch("esphome.writer.CORE")
 @patch("esphome.writer.iter_components")
 @patch("esphome.writer.walk_files")
-def test_copy_src_tree_handles_invalid_build_info_json(
+def test_copy_src_tree_regenerates_damaged_build_info(
     mock_walk_files: MagicMock,
     mock_iter_components: MagicMock,
     mock_core: MagicMock,
     tmp_path: Path,
+    damage: bytes,
 ) -> None:
-    """Test copy_src_tree handles invalid build_info.json gracefully."""
-    # Setup directory structure
-    src_path = tmp_path / "src"
-    src_path.mkdir()
-    esphome_core_path = src_path / "esphome" / "core"
-    esphome_core_path.mkdir(parents=True)
-    build_path = tmp_path / "build"
-    build_path.mkdir()
-
-    # Create invalid build_info.json
-    build_info_json_path = build_path / "build_info.json"
-    build_info_json_path.write_text("invalid json {{{")
-
-    # Both sources must exist to reach the JSON comparison branch
-    build_info_h_path = esphome_core_path / "build_info_data.h"
-    build_info_h_path.write_text("// old build_info_data.h")
-    (esphome_core_path / "build_info_data.cpp").write_text("// old")
-
-    # Setup mocks
-    mock_core.relative_src_path.side_effect = src_path.joinpath
-    mock_core.relative_build_path.side_effect = build_path.joinpath
-    mock_core.defines = []
-    mock_core.config_hash = 0xDEADBEEF
-    mock_core.comment = ""
-    mock_core.target_platform = "test_platform"
-    mock_core.config = {}
-    mock_iter_components.return_value = []
-    mock_walk_files.return_value = []
-
-    with (
-        patch("esphome.writer.__version__", "2025.1.0-dev"),
-        patch("esphome.writer.importlib.import_module") as mock_import,
-    ):
-        mock_import.side_effect = AttributeError
-        copy_src_tree()
-
-    # Verify build_info files were created despite invalid JSON
-    assert build_info_h_path.exists()
+    """A damaged build_info.json reads as stale and is regenerated, not left in place."""
+    build_info_json_path = _setup_build_info_mocks(
+        mock_core, mock_iter_components, mock_walk_files, tmp_path
+    )
+    _run_copy_src_tree()
+    build_info_json_path.write_bytes(damage)
+    # Second run only rewrites the file if the damage branch fires
+    _run_copy_src_tree()
     new_json = json.loads(build_info_json_path.read_text())
     assert new_json["config_hash"] == 0xDEADBEEF
 
 
+@patch("esphome.writer.write_file_if_changed", return_value=False)
 @patch("esphome.writer.CORE")
 @patch("esphome.writer.iter_components")
 @patch("esphome.writer.walk_files")
-def test_copy_src_tree_handles_non_dict_build_info_json(
+def test_copy_src_tree_non_utf8_build_info_reads_as_stale(
     mock_walk_files: MagicMock,
     mock_iter_components: MagicMock,
     mock_core: MagicMock,
+    mock_write: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """Valid JSON that is not an object (no .get) is treated as stale."""
-    # Setup directory structure
-    src_path = tmp_path / "src"
-    src_path.mkdir()
-    esphome_core_path = src_path / "esphome" / "core"
-    esphome_core_path.mkdir(parents=True)
-    build_path = tmp_path / "build"
-    build_path.mkdir()
+    """Non-UTF-8 build_info.json fires the staleness branch instead of raising.
 
-    build_info_json_path = build_path / "build_info.json"
-    build_info_json_path.write_text("[]")
-
-    # Both sources must exist to reach the JSON comparison branch
-    build_info_h_path = esphome_core_path / "build_info_data.h"
-    build_info_h_path.write_text("// old build_info_data.h")
-    (esphome_core_path / "build_info_data.cpp").write_text("// old")
-
-    # Setup mocks
-    mock_core.relative_src_path.side_effect = src_path.joinpath
-    mock_core.relative_build_path.side_effect = build_path.joinpath
-    mock_core.defines = []
-    mock_core.config_hash = 0xDEADBEEF
-    mock_core.comment = ""
-    mock_core.target_platform = "test_platform"
-    mock_core.config = {}
-    mock_iter_components.return_value = []
-    mock_walk_files.return_value = []
-
-    with (
-        patch("esphome.writer.__version__", "2025.1.0-dev"),
-        patch("esphome.writer.importlib.import_module") as mock_import,
-    ):
-        mock_import.side_effect = AttributeError
-        copy_src_tree()
-
-    # Verify build_info files were created despite invalid JSON
-    assert build_info_h_path.exists()
-    new_json = json.loads(build_info_json_path.read_text())
-    assert new_json["config_hash"] == 0xDEADBEEF
+    Writes are stubbed (returning False, so nothing else can set
+    sources_changed): regenerating over the damaged file needs
+    write_file_if_changed's own recovery, which lands separately.
+    """
+    build_info_json_path = _setup_build_info_mocks(
+        mock_core, mock_iter_components, mock_walk_files, tmp_path
+    )
+    core_path = tmp_path / "src" / "esphome" / "core"
+    (core_path / "build_info_data.h").write_text("// old")
+    (core_path / "build_info_data.cpp").write_text("// old")
+    build_info_json_path.write_bytes(b'\xff{"config_hash": 1}')
+    _run_copy_src_tree()
+    written = [call.args[0] for call in mock_write.call_args_list]
+    assert build_info_json_path in written
 
 
 @patch("esphome.writer.CORE")


### PR DESCRIPTION
# What does this implement/fix?

The build-info staleness check reads `build_info.json` and calls `.get` on the parsed value. The except clause covers `JSONDecodeError`, `KeyError`, and `OSError`, but valid JSON that is not an object (a truncated or hand-edited file like `[]`) raises `AttributeError` and crashes the compile instead of regenerating the file.

The parsed value's shape is now checked explicitly: anything that is not an object counts as stale and regenerates like the other damage cases. The except tuple widens to `(ValueError, OSError)` so non-UTF-8 damage is caught too (`UnicodeDecodeError` is a `ValueError`), the damaged file is unlinked with a warning so the regenerating write never re-reads it, and the never-raised `KeyError` leaves the tuple.

Review hardening also restructured the staleness tests into a two-run steady-state shape, so each assertion only passes when the comparison under test actually fires.

Split out of the ESP8266 native-toolchain chain (#18539), where review hardening found it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18539

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [x] ESP8266
- [ ] ESP32
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes; build metadata handling only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


