### PR TITLE
Add M5STACK-ATOMS3R-ST7735 as a display panel configuration

### DIFF
--- a/esphome/components/mipi_spi/models/ili.py
+++ b/esphome/components/mipi_spi/models/ili.py
@@ -649,7 +649,7 @@ DriverChip(
         (0xF3, 0x52, 0xA4, 0x7F, 0x33, 0x34, 0xDF),
     ),
 )
-DriverChip(
+ST7735 = DriverChip(
     "ST7735",
     color_order=MODE_RGB,
     width=128,

--- a/esphome/components/mipi_spi/models/m5stack.py
+++ b/esphome/components/mipi_spi/models/m5stack.py
@@ -12,7 +12,7 @@ from esphome.components.mipi import (
     DriverChip,
 )
 
-from .ili import ILI9341, ST7789V
+from .ili import ILI9341, ST7735, ST7789V
 
 # fmt: off
 DriverChip(

--- a/esphome/components/mipi_spi/models/m5stack.py
+++ b/esphome/components/mipi_spi/models/m5stack.py
@@ -4,6 +4,7 @@ from esphome.components.mipi import (
     GMCTRP1,
     IDMOFF,
     IFMODE,
+    MODE_BGR,
     PWCTR1,
     PWCTR2,
     SETEXTC,

--- a/esphome/components/mipi_spi/models/m5stack.py
+++ b/esphome/components/mipi_spi/models/m5stack.py
@@ -72,3 +72,23 @@ GC9107.extend(
     cs_pin=14,
     requires={"psram"},
 )
+
+# M5Stack AtomS3R (ST7735 revision - May 14, 2026+)
+ST7735.extend(
+    "M5STACK-ATOMS3R-ST7735",
+    native_width=132,
+    native_height=132,
+    width=128,
+    height=128,
+    offset_width=2,
+    offset_height=1,
+    pad_width=2,
+    pad_height=3,
+    data_rate="40MHz",
+    color_order=MODE_BGR,
+    invert_colors=True,
+    reset_pin=48,
+    dc_pin=42,
+    cs_pin=14,
+    requires={"psram"},
+)


### PR DESCRIPTION
# What does this implement/fix?

Adds the M5STACK-ATOMS3R-ST7735 display model for newer hardware revisions of the M5Stack AtomS3R.

On May 14, 2026, M5Stack changed the AtomS3R display controller IC from GC9107 to ST7735 (saw this at the [bottom of their spec page](https://docs.m5stack.com/en/core/AtomS3R)). So I've added the ST7735 model definition using the hardware offsets and 132×132 memory mapping from their [official M5GFX driver](https://github.com/m5stack/M5GFX/blob/master/src/M5GFX.cpp#L106-L125) and the [panel definition](https://github.com/m5stack/M5GFX/blob/master/src/lgfx/v1/panel/Panel_ST7735.hpp)

## Types of changes

New feature (non-breaking change which adds functionality)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**
n/a

## Test Environment

ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: mipi_spi
  model: M5STACK-ATOMS3R-ST7735
  rotation: 180°
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Tested and verified on physical M5Stack AtomS3R running ESPHome over ESP-IDF. Display alignment, colors, and 180° rotation work without visual artifacts.

<img width="2693" height="2863" alt="PXL_20260823_122726918" src="https://github.com/user-attachments/assets/d0d19a6b-e5b0-411c-bde1-8b69c87fe5ad" />
<img width="2978" height="3375" alt="PXL_20260823_122915878" src="https://github.com/user-attachments/assets/4a22a553-4df7-4d5c-99a6-f2dfcbf6b6a6" />

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
I can submit PR for https://github.com/esphome/esphome.io/blob/current/src/content/docs/components/display/mipi_spi.mdx  if this is approved.