### PR TITLE
[light] Skip light_json_schema.cpp when json is not used

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -7,6 +7,7 @@ import esphome.automation as auto
 import esphome.codegen as cg
 from esphome.components import mqtt, power_supply, web_server
 from esphome.components.const import CONF_CHANNEL_COLORS, CONF_IS_WRGB
+from esphome.config_helpers import filter_source_files_from_defines
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BLUE,
@@ -557,3 +558,10 @@ async def new_light(config, *args):
 @coroutine_with_priority(CoroPriority.CORE)
 async def to_code(config):
     cg.add_global(light_ns.using)
+
+
+# light_json_schema.cpp is fully #ifdef'd on USE_JSON; only mqtt and
+# web_server use it.
+FILTER_SOURCE_FILES = filter_source_files_from_defines(
+    {"light_json_schema.cpp": "USE_JSON"}
+)

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -560,8 +560,8 @@ async def to_code(config):
     cg.add_global(light_ns.using)
 
 
-# light_json_schema.cpp is fully #ifdef'd on USE_JSON; only mqtt and
-# web_server use it.
+# light_json_schema.cpp is only used by mqtt and web_server, which both
+# auto load json; USE_JSON alone is too broad since other components load it.
 FILTER_SOURCE_FILES = filter_source_files_from_defines(
-    {"light_json_schema.cpp": "USE_JSON"}
+    {"light_json_schema.cpp": ("USE_MQTT", "USE_WEBSERVER")}
 )


### PR DESCRIPTION
# What does this implement/fix?

`light_json_schema.cpp` is only used by `mqtt_light.cpp` and `web_server.cpp`, so on most builds it is opened and parsed for nothing. This adds a `FILTER_SOURCE_FILES` using the `filter_source_files_from_defines` helper from #18602 so the file is skipped unless `mqtt` or `web_server` is in the build. The file is guarded by `USE_JSON`, but keying on that alone is too broad since `api` and others also load json without needing this file.

Checked with a binary light on ESP32 IDF: the file is excluded without `web_server` and kept once `web_server` is added.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
