### PR TITLE
[esp32_ble] Skip ble_advertising.cpp when advertising is not used

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -22,6 +22,7 @@ from esphome.components.esp32 import (
     request_bluetooth,
 )
 from esphome.components.esp32.const import VARIANT_ESP32C2
+from esphome.config_helpers import filter_source_files_from_defines
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ENABLE_ON_BOOT,
@@ -637,3 +638,10 @@ async def ble_disable_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     return cg.new_Pvariable(action_id, template_arg)
+
+
+# ble_advertising.cpp is fully #ifdef'd on USE_ESP32_BLE_ADVERTISING, set
+# when advertising is enabled here or by esp32_ble_server / esp32_ble_beacon.
+FILTER_SOURCE_FILES = filter_source_files_from_defines(
+    {"ble_advertising.cpp": "USE_ESP32_BLE_ADVERTISING"}
+)


### PR DESCRIPTION
# What does this implement/fix?

`ble_advertising.cpp` is fully `#ifdef`'d on `USE_ESP32_BLE_ADVERTISING`, set when `advertising: true` is configured or when `esp32_ble_server` or `esp32_ble_beacon` is present. Advertising is off by default, so plain bluetooth proxy and tracker builds compile the file to nothing. This adds a define filter so it is skipped in that case. Uses the `filter_source_files_from_defines` helper from #18602.

Compiled on ESP32 IDF with the feature on and off to confirm the file is kept in one case and skipped in the other.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
