### PR TITLE
[tests] Fix flaky pty log probe test on macOS

### DIFF
--- a/tests/unit_tests/test_log.py
+++ b/tests/unit_tests/test_log.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-import errno
 import io
 import logging
 import os
@@ -189,32 +188,21 @@ def _run_probe_on_pty(
         # the controller is drained: macOS discards buffered pty output once
         # the last follower closes, so closing it early loses the probe's
         # output whenever the child finishes before the first read.
-        while True:
-            timeout = deadline - time.monotonic()
-            if timeout <= 0:
+        while proc.poll() is None:
+            if time.monotonic() > deadline:
                 pytest.fail(f"pty probe did not exit in time; got {output!r}")
-            exited = proc.poll() is not None
-            # After exit everything the child wrote is already buffered, so a
-            # zero timeout drains it without blocking.
-            wait = 0 if exited else min(timeout, 0.1)
-            if select.select([controller], [], [], wait)[0]:
-                try:
-                    chunk = os.read(controller, 4096)
-                except OSError as err:
-                    # EIO means the pty is gone; treat it as end of stream.
-                    if err.errno != errno.EIO:
-                        raise
-                    break
-                if chunk:
-                    output += chunk
-                    continue
-            if exited:
-                break
+            if select.select([controller], [], [], 0.01)[0]:
+                output += os.read(controller, 4096)
+        # Everything the child wrote is already buffered, so drain without waiting.
+        while select.select([controller], [], [], 0)[0] and (
+            chunk := os.read(controller, 4096)
+        ):
+            output += chunk
         stderr_text = ""
         if proc.stderr is not None:
             stderr_text = proc.stderr.read().decode(errors="replace")
             proc.stderr.close()
-        assert proc.wait(60) == 0, stderr_text
+        assert proc.returncode == 0, stderr_text
     finally:
         os.close(follower)
         os.close(controller)

--- a/tests/unit_tests/test_log.py
+++ b/tests/unit_tests/test_log.py
@@ -178,37 +178,45 @@ def _run_probe_on_pty(
     output = b""
     deadline = time.monotonic() + 60
     try:
-        try:
-            proc = subprocess.Popen(
-                _probe_command(fixture_path),
-                stdout=follower,
-                stderr=follower if stderr_to_pty else subprocess.PIPE,
-                stdin=follower,
-                env=probe_env,
-            )
-        finally:
-            os.close(follower)
+        proc = subprocess.Popen(
+            _probe_command(fixture_path),
+            stdout=follower,
+            stderr=follower if stderr_to_pty else subprocess.PIPE,
+            stdin=follower,
+            env=probe_env,
+        )
+        # The parent keeps the follower open until the child has exited and
+        # the controller is drained: macOS discards buffered pty output once
+        # the last follower closes, so closing it early loses the probe's
+        # output whenever the child finishes before the first read.
         while True:
             timeout = deadline - time.monotonic()
-            if timeout <= 0 or not select.select([controller], [], [], timeout)[0]:
-                pytest.fail(f"pty probe produced no EOF in time; got {output!r}")
-            try:
-                chunk = os.read(controller, 1024)
-            except OSError as err:
-                # macOS raises EIO once the child closes its end of the pty;
-                # anything else is a real failure, not end-of-stream.
-                if err.errno != errno.EIO:
-                    raise
+            if timeout <= 0:
+                pytest.fail(f"pty probe did not exit in time; got {output!r}")
+            exited = proc.poll() is not None
+            # After exit everything the child wrote is already buffered, so a
+            # zero timeout drains it without blocking.
+            wait = 0 if exited else min(timeout, 0.1)
+            if select.select([controller], [], [], wait)[0]:
+                try:
+                    chunk = os.read(controller, 4096)
+                except OSError as err:
+                    # EIO means the pty is gone; treat it as end of stream.
+                    if err.errno != errno.EIO:
+                        raise
+                    break
+                if chunk:
+                    output += chunk
+                    continue
+            if exited:
                 break
-            if not chunk:
-                break
-            output += chunk
         stderr_text = ""
         if proc.stderr is not None:
             stderr_text = proc.stderr.read().decode(errors="replace")
             proc.stderr.close()
         assert proc.wait(60) == 0, stderr_text
     finally:
+        os.close(follower)
         os.close(controller)
         if proc is not None and proc.poll() is None:
             proc.kill()


### PR DESCRIPTION
# What does this implement/fix?

`test_setup_log_tty_skips_colorama` fails now and then on the macOS runner with `assert 'colorama_loaded=False' in ''`, for example in https://github.com/esphome/esphome/actions/runs/32648195869/job/97215695561.

The helper closes the follower end of the pty in the parent right after spawning the probe. On macOS the pty discards any buffered output once the last follower closes, and the next read on the controller raises `EIO`. If the probe writes its two lines and exits before the parent gets to its first read, which happens on a busy runner, the output is gone and the test sees an empty string.

The helper now keeps the follower open in the parent until the child has exited and the controller has been drained, so the buffer is never dropped. The read loop polls the child and uses a zero timeout once it has exited, since everything it wrote is already buffered at that point.

Reproduced locally on macOS by injecting a one second delay after `Popen`: the old helper loses the output every time in both stream modes, the new helper returns it every time. The test file also passed 30 consecutive runs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
