### PR TITLE
[uart] Delete ESP32 UART driver on shutdown to keep ROM output off the bus

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -393,5 +393,7 @@ void IRAM_ATTR IDFUARTComponent::uart_rx_isr_callback(uart_port_t uart_num, uart
 }
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
+void IDFUARTComponent::on_shutdown() { uart_driver_delete(uart_num_); }
+
 }  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -393,7 +393,16 @@ void IRAM_ATTR IDFUARTComponent::uart_rx_isr_callback(uart_port_t uart_num, uart
 }
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
-void IDFUARTComponent::on_shutdown() { uart_driver_delete(this->uart_num_); }
+void IDFUARTComponent::on_shutdown() {
+  if (this->uart_num_ == UART_NUM_MAX || !uart_is_driver_installed(this->uart_num_))
+    return;
+  uart_wait_tx_done(this->uart_num_, pdMS_TO_TICKS(100));
+  // Keep the peripheral quiet across a soft reset so ROM output does not reach the attached device (#15472)
+  esp_err_t err = uart_driver_delete(this->uart_num_);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_driver_delete failed: %s", esp_err_to_name(err));
+  }
+}
 
 }  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -393,7 +393,7 @@ void IRAM_ATTR IDFUARTComponent::uart_rx_isr_callback(uart_port_t uart_num, uart
 }
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
-void IDFUARTComponent::on_shutdown() { uart_driver_delete(uart_num_); }
+void IDFUARTComponent::on_shutdown() { uart_driver_delete(this->uart_num_); }
 
 }  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -56,7 +56,7 @@ class IDFUARTComponent final : public UARTComponent, public Component {
 
  protected:
   void check_logger_conflict() override;
-  uart_port_t uart_num_;
+  uart_port_t uart_num_{UART_NUM_MAX};
   uart_config_t get_config_();
 
   bool has_peek_{false};

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -52,6 +52,8 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   void load_settings(bool dump_config) override;
   using UARTComponent::load_settings;  // also bring in the no-arg overload for convenience
 
+  void on_shutdown() override;
+
  protected:
   void check_logger_conflict() override;
   uart_port_t uart_num_;


### PR DESCRIPTION
# What does this implement/fix?

After a soft reboot the ESP32 ROM can print boot output on a UART that is not the logger UART, and the device attached to that UART then receives unexpected bytes; in the linked issue this crashed an LD2420. The UART driver is now deleted in `on_shutdown()`, after a short bounded wait for the TX FIFO to drain, so the peripheral is quiet across the restart.

The hook skips components whose `setup()` failed before a port was assigned, and logs if the delete fails.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15472

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
logger:
  hardware_uart: USB_SERIAL_JTAG

uart:
  - id: ld2420_uart
    rx_pin: 13
    tx_pin: 12
    baud_rate: 115200

ld2420:

switch:
  - platform: restart
    name: Restart
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
