### PR TITLE
[api] Treat homeassistant.event variables as lambdas

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -664,7 +664,9 @@ HOMEASSISTANT_EVENT_ACTION_SCHEMA = cv.Schema(
         cv.Required(CONF_EVENT): validate_homeassistant_event,
         cv.Optional(CONF_DATA, default={}): KEY_VALUE_SCHEMA,
         cv.Optional(CONF_DATA_TEMPLATE, default={}): KEY_VALUE_SCHEMA,
-        cv.Optional(CONF_VARIABLES, default={}): KEY_VALUE_SCHEMA,
+        cv.Optional(CONF_VARIABLES, default={}): cv.Schema(
+            {cv.string: cv.returning_lambda}
+        ),
     }
 )
 

--- a/tests/components/api/common-base.yaml
+++ b/tests/components/api/common-base.yaml
@@ -9,6 +9,16 @@ esphome:
           event: esphome.button_pressed
           data:
             message: Button was pressed
+      # variables must be treated as lambdas, like homeassistant.action does.
+      # A plain block scalar was previously kept as a static string, so the C++
+      # source was sent to Home Assistant instead of the value it returns.
+      - homeassistant.event:
+          event: esphome.button_pressed_with_variables
+          data_template:
+            message: Button {{ button_name }} was pressed
+          variables:
+            button_name: |-
+              return std::string("test_button");
       - homeassistant.action:
           action: notify.html5
           data:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`homeassistant.event` and `homeassistant.action` / `homeassistant.service` share the same C++ action (`HomeAssistantServiceCallAction`). Only their config schemas differ, and they disagree about `variables`:

```python
KEY_VALUE_SCHEMA = cv.Schema({cv.string: cv.templatable(cv.string_strict)})

# HOMEASSISTANT_ACTION_ACTION_SCHEMA
cv.Optional(CONF_VARIABLES, default={}): cv.Schema({cv.string: cv.returning_lambda})

# HOMEASSISTANT_EVENT_ACTION_SCHEMA
cv.Optional(CONF_VARIABLES, default={}): KEY_VALUE_SCHEMA
```

So a plain YAML block scalar under `variables` behaves differently depending on which action is used:

* `homeassistant.action` / `.service`: the value is coerced into a lambda, and the value that the lambda returns is sent.
* `homeassistant.event`: the value stays a static string, and the C++ source text is sent to Home Assistant as the variable value.

Config validation and compilation both pass with no error and no warning, so nothing points at the problem. The value only looks wrong once it arrives in Home Assistant.

This PR changes the event schema to use `cv.returning_lambda` for `variables`, so both schemas behave the same. The C++ side needs no change.

It looks like the event schema reuses `KEY_VALUE_SCHEMA` for all three of `data`, `data_template` and `variables`, while the action schema handles `variables` separately.

## Documentation

The documentation already describes `variables` the same way for both actions, as lambdas. The documentation is therefore correct and the event schema is the outlier, so no documentation change is needed.

There was an earlier attempt at a documentation change in esphome/esphome.io#4065. It changed the `homeassistant.service` example to `!lambda`, which is the action that already works, so it would not have helped anyone hitting this. That PR was closed by the stale bot and was never merged. The file it edited (`components/api.rst`) no longer exists either.

## Backwards compatibility

This is a behaviour change. A static string under `event` `variables` is accepted today and becomes a validation error after this change, because `cv.returning_lambda` requires the lambda to return a value:

```yaml
# accepted today, rejected after this change
- homeassistant.event:
    event: esphome.example
    variables:
      value: hello
```

I expect very few configurations to rely on this. `variables` exists to provide values for `data_template`, and static values belong in `data`. It is still a behaviour change, so the maintainers should decide whether it is acceptable.

The alternative is to leave the schema as it is and document the difference between the two actions instead. If you prefer that, I am happy to close this and open a documentation PR in esphome.io.

## How this was found

I decode messages from a 2-wire intercom bus and forward them to Home Assistant as events. The first event I received contained my own C++ source as the field values:

```
msg_type=char b[8];
snprintf(b, sizeof(b), "%02X", x.get_message_type());
return std::string(b);
```

Adding `!lambda` fixed it. Reproduced on ESPHome 2026.8.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#5394

That issue was reported in January 2024, is still open and carries the `stale` label. @ssieb looked at it at the time and wrote: "Looks like a code issue. It appears that the intention was to match the docs, but the implementation isn't quite right." This PR is that code fix.

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- None. The documentation already describes the behaviour this PR implements, see the Documentation section above.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- None. No developer-facing API changes.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

The change is in config validation, so it is not platform specific. I validated and compiled the updated `tests/components/api` config for the `host` platform locally. The test case is in `common-base.yaml`, which every `tests/components/api/test.*.yaml` file includes, so CI covers the esp32-idf, esp8266-ard, rp2040-ard, ln882x-ard and nrf52-adafruit targets as well.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

api:
  actions:
    - action: send_event
      then:
        # Before this change the value below was sent to Home Assistant as the
        # literal text 'return std::string("hello");'.
        # After this change it is compiled as a lambda and 'hello' is sent.
        - homeassistant.event:
            event: esphome.example
            data_template:
              message: "Value is {{ value }}"
            variables:
              value: |-
                return std::string("hello");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
