### PR TITLE
[noise] Declare libsodium as a direct dependency

### DIFF
--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -64,6 +64,11 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
     cg.add_library("esphome/noise-c", "0.1.21")
+    # noise-c depends on libsodium, but declaring it here too lets the
+    # library manager see the full set up front instead of discovering
+    # libsodium only after noise-c has downloaded, so the two can download
+    # in parallel. The version must match noise-c's library.json.
+    cg.add_library("esphome/libsodium", "1.10021.4")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")


### PR DESCRIPTION
# What does this implement/fix?

noise-c depends on libsodium, but the library manager only learns that after it has downloaded noise-c and read its library.json, so the two archives download serially. Declaring libsodium directly in the noise component's to_code puts both libraries in lib_deps up front, letting them download in parallel once the parallel downloader lands. The version pin matches noise-c's library.json, so the resolved tree is unchanged.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
