### PR TITLE
[time] Throwaway: run the time C++ unit tests against #18680

### DIFF
--- a/tests/components/time/posix_tz.cpp
+++ b/tests/components/time/posix_tz.cpp
@@ -1,7 +1,7 @@
 // Tests for time conversion functions, DST detection, and ESPTime::strptime.
 //
 // These tests cover the permanent timezone functions: epoch_to_local_tm, is_in_dst,
-// calculate_dst_transition, and the internal helper functions they depend on.
+// calculate_dst_transition, and the internal helpers they depend on.
 
 // Enable USE_TIME_TIMEZONE for tests
 #define USE_TIME_TIMEZONE


### PR DESCRIPTION
# What does this implement/fix?

Throwaway PR chained off #18680 to make CI actually run the `time` C++ unit tests. The job is only triggered by C++ file changes, and #18680 only touches Python, so the link failure the bot found (and the fix for it) never got exercised in CI. This PR touches the test source so the job runs against the #18680 branch. Close once the job is green; the gating itself is fixed separately.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
