### PR TITLE
[ci] Run C++ unit tests when a component's Python or test override changes

### DIFF
--- a/script/build_helpers.py
+++ b/script/build_helpers.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-from helpers import get_all_dependencies, root_path as _root_path
+from helpers import get_all_dependencies, has_cpp_unit_tests, root_path as _root_path
 import yaml
 
 # Ensure the repo root is on sys.path so that ``tests.testing_helpers`` and
@@ -131,14 +131,11 @@ def filter_components_with_files(components: list[str], tests_dir: Path) -> list
     """
     filtered_components: list[str] = []
     for component in components:
-        test_dir = tests_dir / component
-        if test_dir.is_dir() and (
-            any(test_dir.glob("*.cpp")) or any(test_dir.glob("*.h"))
-        ):
+        if has_cpp_unit_tests(component, tests_dir):
             filtered_components.append(component)
         else:
             print(
-                f"WARNING: No files found for component '{component}' in {test_dir}, skipping.",
+                f"WARNING: No files found for component '{component}' in {tests_dir / component}, skipping.",
                 file=sys.stderr,
             )
     return filtered_components

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -620,7 +620,7 @@ def determine_cpp_unit_tests(
 
     C++ unit tests will run when any of the following conditions are met:
 
-    1. Any C++ core source files changed (esphome/core/*), in which case
+    1. Any core C++ or Python files changed (esphome/core/*), in which case
        all cpp unit tests run.
     2. A test file for a component changed, which triggers tests for that
        component.
@@ -628,6 +628,9 @@ def determine_cpp_unit_tests(
        component and all components that depend on it. Python files count
        too: a component's Python decides which sources and defines go into
        the host test build, so a Python-only change can break the link.
+
+    Components without C++ test sources are dropped from the list, so the
+    job is only scheduled when there is something to build.
 
     Args:
         branch: Branch to compare against. If None, uses default.
@@ -641,8 +644,8 @@ def determine_cpp_unit_tests(
     if core_changed(files):
         return (True, [])
 
-    test_files = list(filter(filter_cpp_unit_test_files, files))
-    return (False, get_cpp_changed_components(test_files))
+    relevant_files = list(filter(filter_cpp_unit_test_files, files))
+    return (False, get_cpp_changed_components(relevant_files))
 
 
 # Paths within tests/benchmarks/ that contain component benchmark files

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -66,8 +66,8 @@ from helpers import (
     base_python_changed,
     changed_files,
     core_changed,
-    filter_component_and_test_cpp_files,
     filter_component_and_test_files,
+    filter_cpp_unit_test_files,
     get_changed_components,
     get_component_from_path,
     get_component_test_files,
@@ -625,7 +625,9 @@ def determine_cpp_unit_tests(
     2. A test file for a component changed, which triggers tests for that
        component.
     3. The code for a component changed, which triggers tests for that
-       component and all components that depend on it.
+       component and all components that depend on it. Python files count
+       too: a component's Python decides which sources and defines go into
+       the host test build, so a Python-only change can break the link.
 
     Args:
         branch: Branch to compare against. If None, uses default.
@@ -639,9 +641,8 @@ def determine_cpp_unit_tests(
     if core_changed(files):
         return (True, [])
 
-    # Filter to only C++ files
-    cpp_files = list(filter(filter_component_and_test_cpp_files, files))
-    return (False, get_cpp_changed_components(cpp_files))
+    test_files = list(filter(filter_cpp_unit_test_files, files))
+    return (False, get_cpp_changed_components(test_files))
 
 
 # Paths within tests/benchmarks/ that contain component benchmark files

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -67,7 +67,6 @@ from helpers import (
     changed_files,
     core_changed,
     filter_component_and_test_files,
-    filter_cpp_unit_test_files,
     get_changed_components,
     get_component_from_path,
     get_component_test_files,
@@ -644,8 +643,7 @@ def determine_cpp_unit_tests(
     if core_changed(files):
         return (True, [])
 
-    relevant_files = list(filter(filter_cpp_unit_test_files, files))
-    return (False, get_cpp_changed_components(relevant_files))
+    return (False, get_cpp_changed_components(files))
 
 
 # Paths within tests/benchmarks/ that contain component benchmark files

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -1154,17 +1154,32 @@ def filter_cpp_unit_test_files(file_path: str) -> bool:
     """Check if a file can affect a component's C++ unit test build.
 
     Besides C++ sources, a component's Python code (defines, source file
-    filters, libraries) and the ``tests/components/<component>/__init__.py``
-    manifest override decide what the host test binary compiles and links.
+    filters, libraries) and the ``__init__.py`` manifest overrides under
+    ``tests/components/<component>/`` decide what the host test binary
+    compiles and links. Other Python files under ``tests/components/``
+    (pytest conftest.py, fixtures) do not.
 
     Args:
         file_path: Path to check
 
     Returns:
-        True if the file is a C++ or Python file in component or test directories
+        True if the file is a C++ or Python file in a component directory, or
+        a C++ file or ``__init__.py`` in a component test directory
     """
-    return file_path.endswith(CPP_AND_PYTHON_FILE_EXTENSIONS) and file_path.startswith(
-        COMPONENT_AND_TESTS_PATHS
+    if file_path.startswith(ESPHOME_COMPONENTS_PATH):
+        return file_path.endswith(CPP_AND_PYTHON_FILE_EXTENSIONS)
+    if file_path.startswith(ESPHOME_TESTS_COMPONENTS_PATH):
+        return file_path.endswith(CPP_FILE_EXTENSIONS) or file_path.endswith(
+            "/__init__.py"
+        )
+    return False
+
+
+def has_cpp_unit_tests(component: str, tests_dir: Path) -> bool:
+    """Check if a component has C++ unit test sources in ``tests_dir``."""
+    component_dir = tests_dir / component
+    return component_dir.is_dir() and (
+        any(component_dir.glob("*.cpp")) or any(component_dir.glob("*.h"))
     )
 
 
@@ -1505,7 +1520,8 @@ def get_cpp_changed_components(files: list[str]) -> list[str]:
        - This ensures that changes propagate to dependent components
 
     Python files count because a component's Python code decides which
-    sources and defines end up in the host test build.
+    sources and defines end up in the host test build. Components without
+    C++ test sources are dropped so CI does not schedule the job for nothing.
 
     Args:
         files: List of file paths to analyze (C++ and Python files)
@@ -1514,20 +1530,16 @@ def get_cpp_changed_components(files: list[str]) -> list[str]:
         Sorted list of component names that need C++ unit tests run
     """
     components_graph = create_components_graph()
+    tests_dir = Path(root_path) / ESPHOME_TESTS_COMPONENTS_PATH
     affected: set[str] = set()
     for file in files:
-        if not file.endswith(CPP_AND_PYTHON_FILE_EXTENSIONS):
+        if not filter_cpp_unit_test_files(file):
             continue
-        if file.startswith(ESPHOME_TESTS_COMPONENTS_PATH):
-            parts = file.split("/")
-            if len(parts) >= 4:
-                component_dir = Path(ESPHOME_TESTS_COMPONENTS_PATH) / parts[2]
-                if component_dir.is_dir():
-                    affected.add(parts[2])
-        elif file.startswith(ESPHOME_COMPONENTS_PATH):
-            parts = file.split("/")
-            if len(parts) >= 4:
-                component = parts[2]
-                affected.update(find_children_of_component(components_graph, component))
-                affected.add(component)
-    return sorted(affected)
+        parts = file.split("/")
+        if len(parts) < 4:
+            continue
+        component = parts[2]
+        affected.add(component)
+        if file.startswith(ESPHOME_COMPONENTS_PATH):
+            affected.update(find_children_of_component(components_graph, component))
+    return sorted(c for c in affected if has_cpp_unit_tests(c, tests_dir))

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -1150,16 +1150,20 @@ def filter_component_and_test_files(file_path: str) -> bool:
     )
 
 
-def filter_component_and_test_cpp_files(file_path: str) -> bool:
-    """Check if a file is a C++ source file in component or test directories.
+def filter_cpp_unit_test_files(file_path: str) -> bool:
+    """Check if a file can affect a component's C++ unit test build.
+
+    Besides C++ sources, a component's Python code (defines, source file
+    filters, libraries) and the ``tests/components/<component>/__init__.py``
+    manifest override decide what the host test binary compiles and links.
 
     Args:
         file_path: Path to check
 
     Returns:
-        True if the file is a C++ source/header file in component or test directories
+        True if the file is a C++ or Python file in component or test directories
     """
-    return file_path.endswith(CPP_FILE_EXTENSIONS) and file_path.startswith(
+    return file_path.endswith(CPP_AND_PYTHON_FILE_EXTENSIONS) and file_path.startswith(
         COMPONENT_AND_TESTS_PATHS
     )
 
@@ -1486,22 +1490,25 @@ def base_python_changed(files: list[str]) -> bool:
 
 
 def get_cpp_changed_components(files: list[str]) -> list[str]:
-    """Get components that have changed C++ files or tests.
+    """Get components whose C++ unit tests are affected by changed files.
 
     This function analyzes a list of changed files and determines which components
     are affected. It handles two scenarios:
 
-    1. Test files changed (tests/components/<component>/*.cpp):
+    1. Test files changed (tests/components/<component>/*.cpp or __init__.py):
        - Adds the component to the affected list
        - Only that component needs to be tested
 
-    2. Component C++ files changed (esphome/components/<component>/*):
+    2. Component files changed (esphome/components/<component>/*.cpp or *.py):
        - Adds the component to the affected list
        - Also adds all components that depend on this component (recursively)
        - This ensures that changes propagate to dependent components
 
+    Python files count because a component's Python code decides which
+    sources and defines end up in the host test build.
+
     Args:
-        files: List of file paths to analyze (should be C++ files)
+        files: List of file paths to analyze (C++ and Python files)
 
     Returns:
         Sorted list of component names that need C++ unit tests run
@@ -1509,7 +1516,7 @@ def get_cpp_changed_components(files: list[str]) -> list[str]:
     components_graph = create_components_graph()
     affected: set[str] = set()
     for file in files:
-        if not file.endswith(CPP_FILE_EXTENSIONS):
+        if not file.endswith(CPP_AND_PYTHON_FILE_EXTENSIONS):
             continue
         if file.startswith(ESPHOME_TESTS_COMPONENTS_PATH):
             parts = file.split("/")

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -1176,7 +1176,12 @@ def filter_cpp_unit_test_files(file_path: str) -> bool:
 
 
 def has_cpp_unit_tests(component: str, tests_dir: Path) -> bool:
-    """Check if a component has C++ unit test sources in ``tests_dir``."""
+    """Check if a component has C++ test or benchmark sources in ``tests_dir``.
+
+    Shared by CI job selection and the build itself
+    (``build_helpers.filter_components_with_files``) so both agree on
+    which components have something to build.
+    """
     component_dir = tests_dir / component
     return component_dir.is_dir() and (
         any(component_dir.glob("*.cpp")) or any(component_dir.glob("*.h"))
@@ -1524,7 +1529,7 @@ def get_cpp_changed_components(files: list[str]) -> list[str]:
     C++ test sources are dropped so CI does not schedule the job for nothing.
 
     Args:
-        files: List of file paths to analyze (C++ and Python files)
+        files: List of changed file paths; irrelevant ones are ignored
 
     Returns:
         Sorted list of component names that need C++ unit tests run

--- a/script/list-components.py
+++ b/script/list-components.py
@@ -3,8 +3,8 @@ import argparse
 
 from helpers import (
     changed_files,
-    filter_component_and_test_cpp_files,
     filter_component_and_test_files,
+    filter_cpp_unit_test_files,
     get_all_component_files,
     get_components_with_dependencies,
     get_cpp_changed_components,
@@ -38,7 +38,7 @@ def main():
     parser.add_argument(
         "--cpp-changed",
         action="store_true",
-        help="List components with changed C++ files",
+        help="List components whose C++ unit tests are affected by changed files",
     )
     args = parser.parse_args()
 
@@ -78,9 +78,9 @@ def main():
         #   Returns: Components with code changes + their dependencies (not infrastructure)
         #   Reason: CI needs to test changed components and their dependents
         #
-        # - --cpp-changed: Used by CI to determine if any C++ files changed (script/determine-jobs.py)
-        #   Returns: Only components with changed C++ files
-        #   Reason: Only components with C++ changes need C++ testing
+        # - --cpp-changed: Mirrors the C++ unit test selection in script/determine-jobs.py
+        #   Returns: Components with changed C++ or Python files (plus dependents)
+        #   Reason: Python decides which sources and defines go into the host test build
 
         base_test_changed = any(
             "tests/test_build_components" in file for file in changed
@@ -115,8 +115,7 @@ def main():
         for c in get_components_with_dependencies(files, False):
             print(c)
     elif args.cpp_changed:
-        # Only look at changed cpp files
-        files = list(filter(filter_component_and_test_cpp_files, changed))
+        files = list(filter(filter_cpp_unit_test_files, changed))
         for c in get_cpp_changed_components(files):
             print(c)
     else:

--- a/script/list-components.py
+++ b/script/list-components.py
@@ -4,7 +4,6 @@ import argparse
 from helpers import (
     changed_files,
     filter_component_and_test_files,
-    filter_cpp_unit_test_files,
     get_all_component_files,
     get_components_with_dependencies,
     get_cpp_changed_components,
@@ -115,8 +114,7 @@ def main():
         for c in get_components_with_dependencies(files, False):
             print(c)
     elif args.cpp_changed:
-        files = list(filter(filter_cpp_unit_test_files, changed))
-        for c in get_cpp_changed_components(files):
+        for c in get_cpp_changed_components(changed):
             print(c)
     else:
         # Return all changed components (with dependencies) - default behavior

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1197,6 +1197,41 @@ def test_count_changed_cpp_files_with_branch() -> None:
         mock_changed.assert_called_once_with("release")
 
 
+@pytest.mark.parametrize(
+    ("changed_files", "expected"),
+    [
+        # Core C++ change runs everything
+        (["esphome/core/helpers.cpp"], (True, [])),
+        # Core Python change runs everything too
+        (["esphome/core/config.py"], (True, [])),
+        # Component C++ change: component plus dependents
+        (["esphome/components/time/posix_tz.cpp"], (False, ["homeassistant", "time"])),
+        # Component Python change shapes the host build (defines, source
+        # filters), so it must trigger the same tests as a C++ change
+        (["esphome/components/time/__init__.py"], (False, ["homeassistant", "time"])),
+        # Test manifest override changes only that component
+        (["tests/components/time/__init__.py"], (False, ["time"])),
+        # Test source change only that component
+        (["tests/components/time/posix_tz.cpp"], (False, ["time"])),
+        # YAML build tests do not affect the C++ unit test binary
+        (["tests/components/time/test.esp32-idf.yaml"], (False, [])),
+        (["README.md", "script/helpers.py"], (False, [])),
+        ([], (False, [])),
+    ],
+)
+def test_determine_cpp_unit_tests(
+    changed_files: list[str], expected: tuple[bool, list[str]]
+) -> None:
+    """Test which C++ unit tests a set of changed files selects."""
+    with (
+        patch.object(determine_jobs, "changed_files", return_value=changed_files),
+        patch.object(
+            helpers, "create_components_graph", return_value={"time": ["homeassistant"]}
+        ),
+    ):
+        assert determine_jobs.determine_cpp_unit_tests() == expected
+
+
 def test_main_filters_components_without_tests(
     mock_determine_integration_tests: Mock,
     mock_should_run_clang_tidy: Mock,

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1204,29 +1204,44 @@ def test_count_changed_cpp_files_with_branch() -> None:
         (["esphome/core/helpers.cpp"], (True, [])),
         # Core Python change runs everything too
         (["esphome/core/config.py"], (True, [])),
-        # Component C++ change: component plus dependents
-        (["esphome/components/time/posix_tz.cpp"], (False, ["homeassistant", "time"])),
+        # Component C++ change: component plus dependents with C++ tests
+        (["esphome/components/time/posix_tz.cpp"], (False, ["sntp", "time"])),
         # Component Python change shapes the host build (defines, source
         # filters), so it must trigger the same tests as a C++ change
-        (["esphome/components/time/__init__.py"], (False, ["homeassistant", "time"])),
+        (["esphome/components/time/__init__.py"], (False, ["sntp", "time"])),
+        # Nothing to build when no selected component has C++ tests
+        (["esphome/components/homeassistant/__init__.py"], (False, [])),
         # Test manifest override changes only that component
         (["tests/components/time/__init__.py"], (False, ["time"])),
         # Test source change only that component
         (["tests/components/time/posix_tz.cpp"], (False, ["time"])),
-        # YAML build tests do not affect the C++ unit test binary
+        # pytest files and YAML build tests do not affect the test binary
+        (["tests/components/socket/conftest.py"], (False, [])),
         (["tests/components/time/test.esp32-idf.yaml"], (False, [])),
         (["README.md", "script/helpers.py"], (False, [])),
         ([], (False, [])),
     ],
 )
 def test_determine_cpp_unit_tests(
-    changed_files: list[str], expected: tuple[bool, list[str]]
+    changed_files: list[str],
+    expected: tuple[bool, list[str]],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test which C++ unit tests a set of changed files selects."""
+    tests_dir = tmp_path / "tests" / "components"
+    for component in ("time", "sntp"):
+        (tests_dir / component).mkdir(parents=True)
+        (tests_dir / component / f"{component}.cpp").write_text("")
+    (tests_dir / "homeassistant").mkdir()
+    (tests_dir / "socket").mkdir()
+    monkeypatch.setattr(helpers, "root_path", str(tmp_path))
     with (
         patch.object(determine_jobs, "changed_files", return_value=changed_files),
         patch.object(
-            helpers, "create_components_graph", return_value={"time": ["homeassistant"]}
+            helpers,
+            "create_components_graph",
+            return_value={"time": ["homeassistant", "sntp"]},
         ),
     ):
         assert determine_jobs.determine_cpp_unit_tests() == expected

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -2039,8 +2039,14 @@ def test_get_changed_files_from_command_gh_failure_keeps_stderr() -> None:
         ("esphome/components/time/posix_tz.cpp", True),
         ("esphome/components/time/posix_tz.h", True),
         ("esphome/components/time/__init__.py", True),
+        ("esphome/components/sntp/time.py", True),
         ("tests/components/time/posix_tz.cpp", True),
         ("tests/components/time/__init__.py", True),
+        # Platform override: tests/components/<component>/<domain>/__init__.py
+        ("tests/components/template/sensor/__init__.py", True),
+        # pytest-only files do not shape the C++ test binary
+        ("tests/components/socket/conftest.py", False),
+        ("tests/components/socket/test_socket.py", False),
         ("tests/components/time/test.esp32-idf.yaml", False),
         ("esphome/core/time.cpp", False),
         ("esphome/config.py", False),
@@ -2053,24 +2059,64 @@ def test_filter_cpp_unit_test_files(file_path: str, expected: bool) -> None:
     assert helpers.filter_cpp_unit_test_files(file_path) is expected
 
 
+@pytest.fixture
+def cpp_unit_test_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fake repo root where time, sntp and api have C++ unit tests.
+
+    homeassistant depends on time but has no C++ tests, so it must be
+    dropped from the selection; socket has only pytest files.
+    """
+    tests_dir = tmp_path / "tests" / "components"
+    for component in ("time", "sntp", "api"):
+        (tests_dir / component).mkdir(parents=True)
+        (tests_dir / component / f"{component}.cpp").write_text("")
+    (tests_dir / "homeassistant").mkdir()
+    (tests_dir / "homeassistant" / "__init__.py").write_text("")
+    (tests_dir / "socket").mkdir()
+    (tests_dir / "socket" / "conftest.py").write_text("")
+    monkeypatch.setattr(helpers, "root_path", str(tmp_path))
+    monkeypatch.setattr(
+        helpers,
+        "create_components_graph",
+        lambda: {"time": ["homeassistant", "sntp"]},
+    )
+    return tmp_path
+
+
 @pytest.mark.parametrize(
     ("files", "expected"),
     [
-        (["esphome/components/time/posix_tz.cpp"], ["homeassistant", "time"]),
-        (["esphome/components/time/__init__.py"], ["homeassistant", "time"]),
+        # Component changes expand to dependents with C++ tests
+        (["esphome/components/time/posix_tz.cpp"], ["sntp", "time"]),
+        (["esphome/components/time/__init__.py"], ["sntp", "time"]),
+        # Dependent without C++ tests is dropped
+        (["esphome/components/homeassistant/__init__.py"], []),
+        # Test changes select only that component
         (["tests/components/time/posix_tz.cpp"], ["time"]),
         (["tests/components/time/__init__.py"], ["time"]),
+        (["tests/components/homeassistant/__init__.py"], []),
+        (["tests/components/socket/conftest.py"], []),
         (["tests/components/time/test.esp32-idf.yaml"], []),
         (
             ["esphome/components/time/__init__.py", "tests/components/api/api.cpp"],
-            ["api", "homeassistant", "time"],
+            ["api", "sntp", "time"],
         ),
         ([], []),
     ],
 )
+@pytest.mark.usefixtures("cpp_unit_test_tree")
 def test_get_cpp_changed_components(files: list[str], expected: list[str]) -> None:
     """Test that C++ and Python component changes select the right unit tests."""
-    with patch.object(
-        helpers, "create_components_graph", return_value={"time": ["homeassistant"]}
-    ):
-        assert helpers.get_cpp_changed_components(files) == expected
+    assert helpers.get_cpp_changed_components(files) == expected
+
+
+def test_get_cpp_changed_components_independent_of_cwd(
+    cpp_unit_test_tree: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test directories resolve against root_path, not the current directory."""
+    monkeypatch.chdir(tmp_path_factory.mktemp("elsewhere"))
+    assert helpers.get_cpp_changed_components(
+        ["tests/components/time/__init__.py"]
+    ) == ["time"]

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -2031,3 +2031,46 @@ def test_get_changed_files_from_command_gh_failure_keeps_stderr() -> None:
         pytest.raises(Exception, match="maximum number of changed files"),
     ):
         _get_changed_files_from_command(["gh", "pr", "diff", "123", "--name-only"])
+
+
+@pytest.mark.parametrize(
+    ("file_path", "expected"),
+    [
+        ("esphome/components/time/posix_tz.cpp", True),
+        ("esphome/components/time/posix_tz.h", True),
+        ("esphome/components/time/__init__.py", True),
+        ("tests/components/time/posix_tz.cpp", True),
+        ("tests/components/time/__init__.py", True),
+        ("tests/components/time/test.esp32-idf.yaml", False),
+        ("esphome/core/time.cpp", False),
+        ("esphome/config.py", False),
+        ("script/helpers.py", False),
+        ("README.md", False),
+    ],
+)
+def test_filter_cpp_unit_test_files(file_path: str, expected: bool) -> None:
+    """Test which changed files can affect a component's C++ unit test build."""
+    assert helpers.filter_cpp_unit_test_files(file_path) is expected
+
+
+@pytest.mark.parametrize(
+    ("files", "expected"),
+    [
+        (["esphome/components/time/posix_tz.cpp"], ["homeassistant", "time"]),
+        (["esphome/components/time/__init__.py"], ["homeassistant", "time"]),
+        (["tests/components/time/posix_tz.cpp"], ["time"]),
+        (["tests/components/time/__init__.py"], ["time"]),
+        (["tests/components/time/test.esp32-idf.yaml"], []),
+        (
+            ["esphome/components/time/__init__.py", "tests/components/api/api.cpp"],
+            ["api", "homeassistant", "time"],
+        ),
+        ([], []),
+    ],
+)
+def test_get_cpp_changed_components(files: list[str], expected: list[str]) -> None:
+    """Test that C++ and Python component changes select the right unit tests."""
+    with patch.object(
+        helpers, "create_components_graph", return_value={"time": ["homeassistant"]}
+    ):
+        assert helpers.get_cpp_changed_components(files) == expected


### PR DESCRIPTION
# What does this implement/fix?

The C++ unit test job was only selected when a `.cpp`/`.h` file changed. A component's Python code also shapes the host test build: it emits defines and `FILTER_SOURCE_FILES`, and `tests/components/<component>/__init__.py` overrides the manifest used for the test binary. #18680 only touched those two Python files, broke the `time` unit test link, and CI never ran the job to notice; the follow-up fix could not be verified in CI either.

`determine_cpp_unit_tests` and `list-components.py --cpp-changed` now also count Python files under `esphome/components/` and `tests/components/`, using the same component and dependents expansion as C++ changes. Components without C++ tests are still dropped by `filter_components_with_files` before anything is built, so wide Python-only PRs only run the tests that actually exist.

Tests added for `filter_cpp_unit_test_files`, `get_cpp_changed_components` and `determine_cpp_unit_tests`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
