### PR TITLE
[voice_assistant] Make TTS playback start timeout configurable

### DIFF
--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -49,6 +49,7 @@ CONF_MICRO_WAKE_WORD = "micro_wake_word"
 CONF_WAKE_WORD = "wake_word"
 
 CONF_CONVERSATION_TIMEOUT = "conversation_timeout"
+CONF_TTS_PLAYBACK_START_TIMEOUT = "tts_playback_start_timeout"
 
 CONF_ON_TIMER_STARTED = "on_timer_started"
 CONF_ON_TIMER_UPDATED = "on_timer_updated"
@@ -126,6 +127,9 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(
                 CONF_CONVERSATION_TIMEOUT, default="300s"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_TTS_PLAYBACK_START_TIMEOUT, default="2s"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_VOLUME_MULTIPLIER, default=1.0): cv.float_range(
                 min=0.0, min_included=False
@@ -235,6 +239,7 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_auto_gain(config[CONF_AUTO_GAIN]))
     cg.add(var.set_volume_multiplier(config[CONF_VOLUME_MULTIPLIER]))
     cg.add(var.set_conversation_timeout(config[CONF_CONVERSATION_TIMEOUT]))
+    cg.add(var.set_tts_playback_start_timeout(config[CONF_TTS_PLAYBACK_START_TIMEOUT]))
 
     if CONF_ON_LISTENING in config:
         await automation.build_automation(

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -755,7 +755,7 @@ void VoiceAssistant::signal_stop_() {
 }
 
 void VoiceAssistant::start_playback_timeout_() {
-  this->set_timeout("playing", 2000, [this]() {
+  this->set_timeout("playing", this->tts_playback_start_timeout_, [this]() {
     this->cancel_timeout("speaker-timeout");
     this->set_state_(State::RESPONSE_FINISHED, State::RESPONSE_FINISHED);
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -191,6 +191,7 @@ class VoiceAssistant final : public Component {
   void set_auto_gain(uint8_t auto_gain) { this->auto_gain_ = auto_gain; }
   void set_volume_multiplier(float volume_multiplier) { this->volume_multiplier_ = volume_multiplier; }
   void set_conversation_timeout(uint32_t conversation_timeout) { this->conversation_timeout_ = conversation_timeout; }
+  void set_tts_playback_start_timeout(uint32_t timeout) { this->tts_playback_start_timeout_ = timeout; }
   void reset_conversation_id();
 
   Trigger<> *get_intent_end_trigger() { return &this->intent_end_trigger_; }
@@ -327,6 +328,7 @@ class VoiceAssistant final : public Component {
   uint8_t auto_gain_;
   float volume_multiplier_;
   uint32_t conversation_timeout_;
+  uint32_t tts_playback_start_timeout_{2000};
 
   bool continuous_{false};
   bool silence_detection_;

--- a/tests/components/voice_assistant/common-idf.yaml
+++ b/tests/components/voice_assistant/common-idf.yaml
@@ -52,6 +52,7 @@ voice_assistant:
   speaker: va_speaker_id
   micro_wake_word: mww_id
   conversation_timeout: 60s
+  tts_playback_start_timeout: 10s
   on_listening:
     - logger.log: "Voice assistant microphone listening"
   on_start:

--- a/tests/components/voice_assistant/common.yaml
+++ b/tests/components/voice_assistant/common.yaml
@@ -33,6 +33,7 @@ voice_assistant:
     channels: 0
   speaker: va_speaker_id
   conversation_timeout: 60s
+  tts_playback_start_timeout: 10s
   on_listening:
     - logger.log: "Voice assistant microphone listening"
   on_start:


### PR DESCRIPTION
## What does this implement/fix?

The voice assistant currently uses a fixed 2 second timeout while waiting for TTS playback to start. XTTS synthesis can take longer than 2 seconds before playback begins, causing the timeout to expire and the response to be marked as finished before its audio starts.

This adds an optional `tts_playback_start_timeout` setting. The default remains 2 seconds, so existing configurations retain the current behavior.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- No related issue.

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7260

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
voice_assistant:
  microphone: va_mic
  speaker: va_speaker
  tts_playback_start_timeout: 10s
```

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).
- [x] Documentation added/updated in `esphome.io`.

Local validation:

- Component formatting and Python lint passed.
- The isolated `voice_assistant` ESP32 IDF component build passed with ESP-IDF 5.5.5.
- Generated C++ uses 10000 ms for the 10 second test configuration.
