### PR TITLE
[audio_http] Add persistent ring buffer option

### DIFF
--- a/esphome/components/audio_http/audio_http_media_source.cpp
+++ b/esphome/components/audio_http/audio_http_media_source.cpp
@@ -30,8 +30,9 @@ void AudioHTTPMediaSource::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Audio HTTP Media Source:\n"
                 "  Buffer Size: %zu bytes\n"
+                "  Persistent Ring Buffer: %s\n"
                 "  Decoder Task Stack in PSRAM: %s",
-                this->buffer_size_, YESNO(this->decoder_task_stack_in_psram_));
+                this->buffer_size_, YESNO(this->persistent_ring_buffer_), YESNO(this->decoder_task_stack_in_psram_));
 }
 
 void AudioHTTPMediaSource::setup() {
@@ -39,6 +40,7 @@ void AudioHTTPMediaSource::setup() {
 
   micro_decoder::DecoderConfig config;
   config.ring_buffer_size = this->buffer_size_;
+  config.persistent_ring_buffer = this->persistent_ring_buffer_;
   // Keep the transfer buffer smaller than the ring buffer so the reader can top up the ring
   // while the decoder is still draining it, instead of oscillating between empty and full.
   config.transfer_buffer_size = std::min(DEFAULT_TRANSFER_BUFFER_SIZE, this->buffer_size_ / 2);

--- a/esphome/components/audio_http/audio_http_media_source.h
+++ b/esphome/components/audio_http/audio_http_media_source.h
@@ -33,6 +33,7 @@ class AudioHTTPMediaSource final : public Component,
 
   void set_buffer_size(size_t buffer_size) { this->buffer_size_ = buffer_size; }
   void set_task_stack_in_psram(bool task_stack_in_psram) { this->decoder_task_stack_in_psram_ = task_stack_in_psram; }
+  void set_persistent_ring_buffer(bool persistent) { this->persistent_ring_buffer_ = persistent; }
 
   // MediaSource interface implementation
   bool play_uri(const std::string &uri) override;
@@ -54,6 +55,7 @@ class AudioHTTPMediaSource final : public Component,
   // on_audio_write(). Must be atomic to avoid a data race.
   std::atomic<bool> pause_{false};
   bool decoder_task_stack_in_psram_{false};
+  bool persistent_ring_buffer_{false};
 };
 
 }  // namespace esphome::audio_http

--- a/esphome/components/audio_http/media_source.py
+++ b/esphome/components/audio_http/media_source.py
@@ -7,6 +7,8 @@ from esphome.types import ConfigType
 CODEOWNERS = ["@kahrendt"]
 AUTO_LOAD = ["audio"]
 
+CONF_PERSISTENT_RING_BUFFER = "persistent_ring_buffer"
+
 audio_http_ns = cg.esphome_ns.namespace("audio_http")
 AudioHTTPMediaSource = audio_http_ns.class_(
     "AudioHTTPMediaSource", cg.Component, media_source.MediaSource
@@ -28,6 +30,7 @@ CONFIG_SCHEMA = cv.All(
                 min=5000, max=1000000
             ),
             cv.Optional(CONF_TASK_STACK_IN_PSRAM): psram.validate_task_stack_in_psram,
+            cv.Optional(CONF_PERSISTENT_RING_BUFFER, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA),
@@ -45,3 +48,4 @@ async def to_code(config: ConfigType) -> None:
         cg.add(var.set_task_stack_in_psram(True))
         psram.request_external_task_stack()
     cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))
+    cg.add(var.set_persistent_ring_buffer(config[CONF_PERSISTENT_RING_BUFFER]))

--- a/tests/components/audio_http/common.yaml
+++ b/tests/components/audio_http/common.yaml
@@ -4,4 +4,5 @@ media_source:
   - platform: audio_http
     id: audio_http_source
     buffer_size: 100000
+    persistent_ring_buffer: true
     task_stack_in_psram: true


### PR DESCRIPTION
# What does this implement/fix?

This exposes the `micro-decoder` `persistent_ring_buffer` setting through the
`audio_http` media source.

By default, `micro-decoder` allocates the HTTP decoder ring buffer when URL
playback starts and releases it after playback stops. On devices running
multiple memory-intensive components, a later playback can fail if the heap no
longer has a sufficiently large contiguous block.

Setting `persistent_ring_buffer: true` asks `micro-decoder` to allocate the
configured ring buffer when the decoder source is created and retain it between
URL playback sessions. This trades persistent RAM use for stable buffer
ownership and avoids repeated allocation and release. If preallocation fails,
the library retains its existing fallback and retries when playback starts.

The option defaults to `false`, so existing configurations keep their current
memory use and lifecycle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) - [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) - [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) - [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7261

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- Not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tests performed:

- ESPHome component compile test for `audio_http` with ESP-IDF 5.5.5
- Real ESP32-S3 Spotpear firmware using two persistent 32 KiB HTTP decoder rings
- Sendspin playback during direct bidirectional VoIP calls between two ESP32-S3 devices
- A real FLAC xTTS stream during the concurrent Sendspin and VoIP load
- Additional FLAC xTTS cycles, with observed `idle`, `playing`, `idle` transitions, to exercise buffer reuse
- Return to idle without ring buffer allocation errors, SPI errors, watchdogs, panics, or resets

## Example entry for `config.yaml`:

```yaml
media_source:
  - platform: audio_http
    id: http_source
    buffer_size: 32768
    persistent_ring_buffer: true
```

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
