### PR TITLE
Add xiaomi MCCGQ02HL sensor

### DIFF
--- a/esphome/components/xiaomi_ble/__init__.py
+++ b/esphome/components/xiaomi_ble/__init__.py
@@ -1,26 +1,22 @@
 import esphome.codegen as cg
-from esphome.components import ble_device_base
+from esphome.components import esp32_ble_tracker
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
-from esphome.types import ConfigType
 
-AUTO_LOAD = ["ble_device_base"]
+DEPENDENCIES = ["esp32_ble_tracker"]
 
 xiaomi_ble_ns = cg.esphome_ns.namespace("xiaomi_ble")
 XiaomiListener = xiaomi_ble_ns.class_(
-    "XiaomiListener", ble_device_base.ESPBTDeviceListener
+    "XiaomiListener", esp32_ble_tracker.ESPBTDeviceListener
 )
 
-CONFIG_SCHEMA = cv.All(
-    ble_device_base.rename_legacy_hub_id("xiaomi_ble"),
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(XiaomiListener),
-        }
-    ).extend(ble_device_base.BLE_DEVICE_SCHEMA),
-)
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(XiaomiListener),
+    }
+).extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
 
 
-async def to_code(config: ConfigType) -> None:
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await ble_device_base.register_ble_device(var, config)
+    await esp32_ble_tracker.register_ble_device(var, config)

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -2,21 +2,14 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#include <vector>
-
-// AES-CCM backend for encrypted-payload (bindkey) decryption:
-//   - ESP32 + ESP-IDF >= 6.0 -> PSA crypto (psa_aead_decrypt), hardware-backed.
-//   - every other platform   -> the portable software AES-CCM in ble_device_base, so
-//     decryption never depends on the SDK exposing mbedtls/PSA to application code.
 #ifdef USE_ESP32
+
+#include <vector>
 #include <esp_idf_version.h>
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 #include <psa/crypto.h>
-#define XIAOMI_CRYPTO_PSA
-#endif
-#endif
-#ifndef XIAOMI_CRYPTO_PSA
-#include "esphome/components/ble_device_base/ble_aes_ccm.h"
+#else
+#include "mbedtls/ccm.h"
 #endif
 
 namespace esphome::xiaomi_ble {
@@ -92,8 +85,14 @@ bool parse_xiaomi_value(uint16_t value_type, const uint8_t *data, uint8_t value_
     const uint32_t idle_time = encode_uint32(data[3], data[2], data[1], data[0]);
     result.idle_time = idle_time / 60.0f;
     result.has_motion = !idle_time;
-  } else if ((value_type == 0x1018) && (value_length == 1)) {
+  }
+  // light, 1 byte, 0 or 1
+  else if ((value_type == 0x1018) && (value_length == 1)) {
     result.is_light = data[0];
+  }
+  // open/close state, 1 byte, 8-bit unsigned integer, 1:closed or 0,2:opened
+  else if ((value_type == 0x1019) && (value_length == 1)) {
+    result.is_open = data[0] != 0x01;
   }
   // MiaoMiaoce temperature, 4 bytes, float, 0.1 °C
   else if ((value_type == 0x4C01) && (value_length == 4)) {
@@ -173,7 +172,7 @@ bool parse_xiaomi_message(const std::vector<uint8_t> &message, XiaomiParseResult
   return success;
 }
 
-optional<XiaomiParseResult> parse_xiaomi_header(const ble_device_base::ServiceData &service_data) {
+optional<XiaomiParseResult> parse_xiaomi_header(const esp32_ble_tracker::ServiceData &service_data) {
   XiaomiParseResult result;
   if (!service_data.uuid.contains(0x95, 0xFE)) {
     ESP_LOGVV(TAG, "parse_xiaomi_header(): no service data UUID magic bytes.");
@@ -265,6 +264,9 @@ optional<XiaomiParseResult> parse_xiaomi_header(const ble_device_base::ServiceDa
   } else if (device_uuid == 0x0387) {  // square body, e-ink display
     result.type = XiaomiParseResult::TYPE_MHOC401;
     result.name = "MHOC401";
+  } else if (device_uuid == 0x098b) {  // Door sensor
+    result.type = XiaomiParseResult::TYPE_MCCGQ02HL;
+    result.name = "MCCGQ02HL";
   } else if (device_uuid == 0x0A83) {  // Qingping-branded, motion & ambient light sensor
     result.type = XiaomiParseResult::TYPE_CGPR1;
     result.name = "CGPR1";
@@ -293,7 +295,7 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
     return false;
   }
 
-  uint8_t mac_reverse[MAC_ADDRESS_SIZE] = {0};
+  uint8_t mac_reverse[6] = {0};
   mac_reverse[5] = (uint8_t) (address >> 40);
   mac_reverse[4] = (uint8_t) (address >> 32);
   mac_reverse[3] = (uint8_t) (address >> 24);
@@ -325,7 +327,7 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   memcpy(vector.iv + 6, v + 2, 3);               // sensor type (2) + packet id (1)
   memcpy(vector.iv + 9, v + raw.size() - 7, 3);  // payload counter
 
-#ifdef XIAOMI_CRYPTO_PSA
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   // PSA AEAD expects ciphertext + tag concatenated
   uint8_t ct_with_tag[sizeof(vector.ciphertext) + sizeof(vector.tag)];
   memcpy(ct_with_tag, vector.ciphertext, vector.datasize);
@@ -351,14 +353,24 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   psa_destroy_key(key_id);
   bool decrypt_ok = (status == PSA_SUCCESS && plaintext_length == vector.datasize);
 #else
-  // Portable software AES-CCM (ble_device_base) — no SDK mbedtls/PSA dependency.
-  bool decrypt_ok = ble_device_base::aes_ccm_auth_decrypt(vector.key, vector.iv, vector.ivsize, vector.authdata,
-                                                          vector.authsize, vector.ciphertext, vector.datasize,
-                                                          vector.plaintext, vector.tag, vector.tagsize);
+  mbedtls_ccm_context ctx;
+  mbedtls_ccm_init(&ctx);
+
+  int ret = mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, vector.key, vector.keysize * 8);
+  if (ret) {
+    ESP_LOGVV(TAG, "decrypt_xiaomi_payload(): mbedtls_ccm_setkey() failed.");
+    mbedtls_ccm_free(&ctx);
+    return false;
+  }
+
+  ret = mbedtls_ccm_auth_decrypt(&ctx, vector.datasize, vector.iv, vector.ivsize, vector.authdata, vector.authsize,
+                                 vector.ciphertext, vector.plaintext, vector.tag, vector.tagsize);
+  mbedtls_ccm_free(&ctx);
+  bool decrypt_ok = (ret == 0);
 #endif
 
   if (!decrypt_ok) {
-    uint8_t mac_address[MAC_ADDRESS_SIZE] = {0};
+    uint8_t mac_address[6] = {0};
     memcpy(mac_address, mac_reverse + 5, 1);
     memcpy(mac_address + 1, mac_reverse + 4, 1);
     memcpy(mac_address + 2, mac_reverse + 3, 1);
@@ -438,6 +450,9 @@ bool report_xiaomi_results(const optional<XiaomiParseResult> &result, const char
   if (result->is_light.has_value()) {
     ESP_LOGD(TAG, "  Light: %s", (*result->is_light) ? "on" : "off");
   }
+  if (result->is_open.has_value()) {
+    ESP_LOGD(TAG, "  Open:  %s", (*result->is_open) ? "on" : "off");
+  }
   if (result->button_press.has_value()) {
     ESP_LOGD(TAG, "  Button: %s", (*result->button_press) ? "pressed" : "");
   }
@@ -445,7 +460,7 @@ bool report_xiaomi_results(const optional<XiaomiParseResult> &result, const char
   return true;
 }
 
-bool XiaomiListener::parse_device(const ble_device_base::ESPBTDevice &device) {
+bool XiaomiListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   // Previously the message was parsed twice per packet, once by XiaomiListener::parse_device()
   // and then again by the respective device class's parse_device() function. Parsing the header
   // here and then for each device seems to be unnecessary and complicates the duplicate packet filtering.
@@ -457,3 +472,5 @@ bool XiaomiListener::parse_device(const ble_device_base::ESPBTDevice &device) {
 }
 
 }  // namespace esphome::xiaomi_ble
+
+#endif

--- a/esphome/components/xiaomi_ble/xiaomi_ble.h
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "esphome/components/ble_device_base/ble_device.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/core/component.h"
 
 #include <vector>
+
+#ifdef USE_ESP32
 
 namespace esphome::xiaomi_ble {
 
@@ -26,6 +28,7 @@ struct XiaomiParseResult {
     TYPE_MJYD02YLA,
     TYPE_MHOC303,
     TYPE_MHOC401,
+    TYPE_MCCGQ02HL,
     TYPE_CGPR1,
     TYPE_RTCGQ02LM,
   } type;
@@ -42,6 +45,7 @@ struct XiaomiParseResult {
   optional<bool> is_active;
   optional<bool> has_motion;
   optional<bool> is_light;
+  optional<bool> is_open;
   optional<bool> button_press;
   bool has_data;        // 0x40
   bool has_capability;  // 0x20
@@ -66,13 +70,15 @@ struct XiaomiAESVector {
 
 bool parse_xiaomi_value(uint16_t value_type, const uint8_t *data, uint8_t value_length, XiaomiParseResult &result);
 bool parse_xiaomi_message(const std::vector<uint8_t> &message, XiaomiParseResult &result);
-optional<XiaomiParseResult> parse_xiaomi_header(const ble_device_base::ServiceData &service_data);
+optional<XiaomiParseResult> parse_xiaomi_header(const esp32_ble_tracker::ServiceData &service_data);
 bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address);
 bool report_xiaomi_results(const optional<XiaomiParseResult> &result, const char *address);
 
-class XiaomiListener final : public ble_device_base::ESPBTDeviceListener {
+class XiaomiListener final : public esp32_ble_tracker::ESPBTDeviceListener {
  public:
-  bool parse_device(const ble_device_base::ESPBTDevice &device) override;
+  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };
 
 }  // namespace esphome::xiaomi_ble
+
+#endif

--- a/esphome/components/xiaomi_mccgq02hl/__init__.py
+++ b/esphome/components/xiaomi_mccgq02hl/__init__.py
@@ -1,11 +1,7 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import esp32_ble_tracker
-from esphome.const import (
-    CONF_MAC_ADDRESS,
-    CONF_ID,
-    CONF_BINDKEY,
-)
+import esphome.config_validation as cv
+from esphome.const import CONF_BINDKEY, CONF_ID, CONF_MAC_ADDRESS
 
 AUTO_LOAD = ["xiaomi_ble"]
 CODEOWNERS = ["@morph027", "Fabian-Schmidt", "@kabongsteve"]

--- a/esphome/components/xiaomi_mccgq02hl/__init__.py
+++ b/esphome/components/xiaomi_mccgq02hl/__init__.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import esp32_ble_tracker
+from esphome.const import (
+    CONF_MAC_ADDRESS,
+    CONF_ID,
+    CONF_BINDKEY,
+)
+
+AUTO_LOAD = ["xiaomi_ble"]
+CODEOWNERS = ["@morph027", "Fabian-Schmidt", "@kabongsteve"]
+DEPENDENCIES = ["esp32_ble_tracker"]
+MULTI_CONF = True
+
+xiaomi_mccgq02hl_ns = cg.esphome_ns.namespace("xiaomi_mccgq02hl")
+XiaomiMCCGQ02HL = xiaomi_mccgq02hl_ns.class_(
+    "XiaomiMCCGQ02HL",
+    esp32_ble_tracker.ESPBTDeviceListener,
+    cg.Component,
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(XiaomiMCCGQ02HL),
+            cv.Required(CONF_BINDKEY): cv.bind_key,
+            cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+        }
+    )
+    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await esp32_ble_tracker.register_ble_device(var, config)
+
+    cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
+    cg.add(var.set_bindkey(config[CONF_BINDKEY]))

--- a/esphome/components/xiaomi_mccgq02hl/binary_sensor.py
+++ b/esphome/components/xiaomi_mccgq02hl/binary_sensor.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_LIGHT,
+    CONF_TIMEOUT,
+    DEVICE_CLASS_LIGHT,
+    DEVICE_CLASS_OPENING,
+)
+from esphome.core import TimePeriod
+
+from . import XiaomiMCCGQ02HL
+
+DEPENDENCIES = ["xiaomi_mccgq02hl"]
+
+CONF_OPEN = "open"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(XiaomiMCCGQ02HL),
+        cv.Optional(CONF_LIGHT): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_LIGHT
+        ),
+        cv.Optional(CONF_OPEN): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_OPENING
+        )
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ID])
+
+    if CONF_LIGHT in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_LIGHT])
+        cg.add(parent.set_light(sens))
+
+    if CONF_OPEN in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_OPEN])
+        cg.add(parent.set_open(sens))

--- a/esphome/components/xiaomi_mccgq02hl/binary_sensor.py
+++ b/esphome/components/xiaomi_mccgq02hl/binary_sensor.py
@@ -1,14 +1,7 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import binary_sensor
-from esphome.const import (
-    CONF_ID,
-    CONF_LIGHT,
-    CONF_TIMEOUT,
-    DEVICE_CLASS_LIGHT,
-    DEVICE_CLASS_OPENING,
-)
-from esphome.core import TimePeriod
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_LIGHT, DEVICE_CLASS_LIGHT, DEVICE_CLASS_OPENING
 
 from . import XiaomiMCCGQ02HL
 
@@ -24,7 +17,7 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_OPEN): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_OPENING
-        )
+        ),
     }
 )
 

--- a/esphome/components/xiaomi_mccgq02hl/sensor.py
+++ b/esphome/components/xiaomi_mccgq02hl/sensor.py
@@ -1,0 +1,37 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    CONF_BATTERY_LEVEL,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PERCENT,
+    CONF_ID,
+    DEVICE_CLASS_BATTERY,
+)
+
+from . import XiaomiMCCGQ02HL
+
+DEPENDENCIES = ["xiaomi_mccgq02hl"]
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(XiaomiMCCGQ02HL),
+        cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_BATTERY,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ID])
+
+    if CONF_BATTERY_LEVEL in config:
+        sens = await sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+        cg.add(parent.set_battery_level(sens))

--- a/esphome/components/xiaomi_mccgq02hl/sensor.py
+++ b/esphome/components/xiaomi_mccgq02hl/sensor.py
@@ -1,13 +1,13 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import sensor
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_BATTERY_LEVEL,
+    CONF_ID,
+    DEVICE_CLASS_BATTERY,
     ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_CLASS_MEASUREMENT,
     UNIT_PERCENT,
-    CONF_ID,
-    DEVICE_CLASS_BATTERY,
 )
 
 from . import XiaomiMCCGQ02HL

--- a/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.cpp
+++ b/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.cpp
@@ -14,11 +14,11 @@ void XiaomiMCCGQ02HL::dump_config() {
 #ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "Open", this->is_open_);
   LOG_BINARY_SENSOR("  ", "Light", this->is_light_);
-#endif // USE_BINARY_SENSOR
+#endif  // USE_BINARY_SENSOR
 
 #ifdef USE_SENSOR
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
-#endif // USE_SENSOR
+#endif  // USE_SENSOR
 }
 
 bool XiaomiMCCGQ02HL::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
@@ -56,12 +56,12 @@ bool XiaomiMCCGQ02HL::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
       this->is_light_->publish_state(*res->is_light);
     if (res->is_open.has_value() && this->is_open_ != nullptr)
       this->is_open_->publish_state(*res->is_open);
-#endif // USE_BINARY_SENSOR
+#endif  // USE_BINARY_SENSOR
 
 #ifdef USE_SENSOR
     if (res->battery_level.has_value() && this->battery_level_ != nullptr)
       this->battery_level_->publish_state(*res->battery_level);
-#endif // USE_SENSOR
+#endif  // USE_SENSOR
 
     success = true;
   }

--- a/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.cpp
+++ b/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.cpp
@@ -1,0 +1,87 @@
+#include "xiaomi_mccgq02hl.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace xiaomi_mccgq02hl {
+
+static const char *const TAG = "xiaomi_mccgq02hl";
+
+void XiaomiMCCGQ02HL::dump_config() {
+  ESP_LOGCONFIG(TAG, "Xiaomi MCCGQ02HL");
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+#ifdef USE_BINARY_SENSOR
+  LOG_BINARY_SENSOR("  ", "Open", this->is_open_);
+  LOG_BINARY_SENSOR("  ", "Light", this->is_light_);
+#endif // USE_BINARY_SENSOR
+
+#ifdef USE_SENSOR
+  LOG_SENSOR("  ", "Battery Level", this->battery_level_);
+#endif // USE_SENSOR
+}
+
+bool XiaomiMCCGQ02HL::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  if (device.address_uint64() != this->address_) {
+    ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
+    return false;
+  }
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  const char *addr_str = device.address_str_to(addr_buf);
+  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", addr_str);
+
+  bool success = false;
+  for (auto &service_data : device.get_service_datas()) {
+    auto res = xiaomi_ble::parse_xiaomi_header(service_data);
+    if (!res.has_value()) {
+      continue;
+    }
+    if (res->is_duplicate) {
+      continue;
+    }
+    if (res->has_encryption &&
+        (!(xiaomi_ble::decrypt_xiaomi_payload(const_cast<std::vector<uint8_t> &>(service_data.data), this->bindkey_,
+                                              this->address_)))) {
+      continue;
+    }
+    if (!(xiaomi_ble::parse_xiaomi_message(service_data.data, *res))) {
+      continue;
+    }
+    if (!(xiaomi_ble::report_xiaomi_results(res, addr_str))) {
+      continue;
+    }
+
+#ifdef USE_BINARY_SENSOR
+    if (res->is_light.has_value() && this->is_light_ != nullptr)
+      this->is_light_->publish_state(*res->is_light);
+    if (res->is_open.has_value() && this->is_open_ != nullptr)
+      this->is_open_->publish_state(*res->is_open);
+#endif // USE_BINARY_SENSOR
+
+#ifdef USE_SENSOR
+    if (res->battery_level.has_value() && this->battery_level_ != nullptr)
+      this->battery_level_->publish_state(*res->battery_level);
+#endif // USE_SENSOR
+
+    success = true;
+  }
+
+  return success;
+}
+
+void XiaomiMCCGQ02HL::set_bindkey(const std::string &bindkey) {
+  memset(bindkey_, 0, 16);
+  if (bindkey.size() != 32) {
+    return;
+  }
+  char temp[3] = {0};
+  for (int i = 0; i < 16; i++) {
+    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
+    bindkey_[i] = std::strtoul(temp, nullptr, 16);
+  }
+}
+
+}  // namespace xiaomi_mccgq02hl
+}  // namespace esphome
+
+#endif

--- a/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.h
+++ b/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/core/defines.h"
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif // USE_BINARY_SENSOR
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif // USE_SENSOR
+#include "esphome/components/xiaomi_ble/xiaomi_ble.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace xiaomi_mccgq02hl {
+
+class XiaomiMCCGQ02HL : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
+ public:
+  void set_address(uint64_t address) { address_ = address; };
+  void set_bindkey(const std::string &bindkey);
+
+  bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+#ifdef USE_BINARY_SENSOR
+  void set_light(binary_sensor::BinarySensor *is_light) { is_light_ = is_light; }
+  void set_open(binary_sensor::BinarySensor *is_open) { is_open_ = is_open; }
+#endif  // USE_BINARY_SENSOR
+
+#ifdef USE_SENSOR
+  void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
+#endif  // USE_SENSOR
+
+ protected:
+  uint64_t address_;
+  uint8_t bindkey_[16];
+
+#ifdef USE_BINARY_SENSOR
+  binary_sensor::BinarySensor *is_light_{nullptr};
+  binary_sensor::BinarySensor *is_open_{nullptr};
+#endif  // USE_BINARY_SENSOR
+
+#ifdef USE_SENSOR
+  sensor::Sensor *battery_level_{nullptr};
+#endif  // USE_SENSOR
+};
+
+}  // namespace xiaomi_mccgq02hl
+}  // namespace esphome
+
+#endif

--- a/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.h
+++ b/esphome/components/xiaomi_mccgq02hl/xiaomi_mccgq02hl.h
@@ -5,10 +5,10 @@
 #include "esphome/core/defines.h"
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
-#endif // USE_BINARY_SENSOR
+#endif  // USE_BINARY_SENSOR
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
-#endif // USE_SENSOR
+#endif  // USE_SENSOR
 #include "esphome/components/xiaomi_ble/xiaomi_ble.h"
 
 #ifdef USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?
Adds Xiaomi MCCGQ02HL Door/Window sensor


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7262

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

xiaomi_ble:

xiaomi_mccgq02hl:
  - id: window
    mac_address: ${window_mac}
    bindkey: ${window_key}

binary_sensor:
  - platform: xiaomi_mccgq02hl
    open:
      name: "MCCGQ02HL Open"
    light:
      name: "MCCGQ02HL Light"

sensor:
  - platform: xiaomi_mccgq02hl
    battery_level:
      name: "MCCGQ02HL Battery Level"


```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
