### PR TITLE
[wifi] libretiny: reset the STA state on synchronous connect failure

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -952,6 +952,14 @@ class WiFiComponent final : public Component {
   // uint8_t writes are atomic on Xtensa LX106 so no synchronization is needed.
   uint8_t sta_state_{0};
 #endif
+#ifdef USE_LIBRETINY
+  // First attempt since STA-up (re-armed on every STA off->on); the
+  // pre-attempt teardown is skipped then.
+  bool lt_first_connect_attempt_{true};
+  // A self-inflicted disconnect from that teardown is pending; it must not
+  // consume an ignored-disconnect slot.
+  bool lt_teardown_event_pending_{false};
+#endif
   RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
   RoamingState roaming_state_{RoamingState::IDLE};
   bssid_t roaming_target_bssid_{};  // BSSID of the AP we're trying to roam to

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -115,6 +115,8 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
 
   if (enable_sta && !current_sta) {
     ESP_LOGV(TAG, "Enabling STA");
+    // Fresh STA stack: skip the pre-attempt teardown again.
+    this->lt_first_connect_attempt_ = true;
   } else if (!enable_sta && current_sta) {
     ESP_LOGV(TAG, "Disabling STA");
   }
@@ -202,10 +204,21 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   if (!this->wifi_mode_(true, {}))
     return false;
 
-  String ssid = WiFi.SSID();
-  if (ssid && strcmp(ssid.c_str(), ap.ssid_.c_str()) != 0) {
-    WiFi.disconnect();
+  // Tear down any live session so begin() re-fires its events; skipped on the
+  // first attempt after STA-up (nothing to tear down, and BK7231N on the older
+  // Beken SDK did not come back from it). The flag is per-attempt and armed
+  // only for a live session: an idle disconnect may emit no event, and a stale
+  // flag would swallow this attempt's first real failure.
+  this->lt_teardown_event_pending_ = false;
+  if (!this->lt_first_connect_attempt_) {
+    const bool was_live = WiFi.status() == WL_CONNECTED;
+    if (WiFi.disconnect()) {
+      this->lt_teardown_event_pending_ = was_live;
+    } else {
+      ESP_LOGD(TAG, "Pre-connect teardown returned false");
+    }
   }
+  this->lt_first_connect_attempt_ = false;
 
 #ifdef USE_WIFI_MANUAL_IP
   if (!this->wifi_sta_ip_config_(ap.get_manual_ip())) {
@@ -227,7 +240,10 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
                                  ap.get_channel(),  // 0 = auto
                                  ap.has_bssid() ? ap.get_bssid().data() : NULL);
   if (status != WL_CONNECTED) {
-    ESP_LOGW(TAG, "esp_wifi_connect failed: %d", status);
+    ESP_LOGW(TAG, "WiFi.begin failed: %d", status);
+    // Without this reset the state machine stays at CONNECTING and each retry
+    // stalls for the full connect timeout (46 s).
+    this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::ERROR_FAILED);
     return false;
   }
 
@@ -455,6 +471,9 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_CONNECTED: {
+      // Processed in queue order, so a teardown event still ahead of this
+      // CONNECTED was already consumed; a leftover flag is stale.
+      this->lt_teardown_event_pending_ = false;
       auto &it = event->data.sta_connected;
       char bssid_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       format_mac_addr_upper(it.bssid, bssid_buf);
@@ -481,6 +500,14 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
     }
     case ESPHOME_EVENT_ID_WIFI_STA_DISCONNECTED: {
       auto &it = event->data.sta_disconnected;
+
+      // Consume the disconnect our own teardown queued, without spending an
+      // ignore slot. Ungated on SSID and state: the flag is armed only for this
+      // attempt's teardown of a live session.
+      if (this->lt_teardown_event_pending_ && it.reason != WIFI_REASON_NO_AP_FOUND) {
+        this->lt_teardown_event_pending_ = false;
+        break;
+      }
 
       // LibreTiny can send spurious disconnect events with empty ssid/bssid during connection.
       // These are typically "Association Leave" events that don't indicate actual failures:


### PR DESCRIPTION
# What does this implement/fix?

On LibreTiny, a `WiFi.begin()` that fails synchronously left the state machine at `CONNECTING`, and the retry path skipped `WiFi.disconnect()` when the SSID matched — while the driver keeps auto-reconnecting in the background. The next `begin()` then lands on an already-live driver session and completes without re-firing the events the state machine waits for: the driver is connected (the device pings) but ESPHome stalls for the full 46 s connect timeout per attempt, with the API and OTA down.

Two changes, one per half of the trap:

- On a synchronous `begin()` failure, set `ERROR_FAILED` so `check_connecting_finished()` takes its connect-failed branch and retries after one cooldown instead of stalling.
- `WiFi.disconnect()` before every attempt except the first since STA-up, so each retry starts from a torn-down session and the full event sequence re-fires. The teardown is expected to queue one `STA_DISCONNECTED`; a flag scoped to that attempt consumes it, and it is armed only when a session was actually live, so an ordinary reject-and-retry keeps its fast fail.

Behavior change beyond the failure path: post-connect roaming becomes break-before-make — the association is dropped before re-associating to the roam target. Under the old code that roam `begin()` landed on a live session, which is the same no-events trap this PR fixes, so it most likely stalled to the timeout anyway.

This code path is shared by all LibreTiny targets (BK72xx, LN882x, RTL87xx).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a (found on the bench; no open issue)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a (no user-facing configuration change)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration change: the existing wifi block exercises the fixed path.
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Testing detail: reproduced repeatedly on an RTL8720DN losing its AP (with the fix it reassociates reliably); BK7231N on the older Beken SDK boots clean with the first-attempt teardown skip and survives OTA plus forced-reboot cycles, back on WiFi in seconds with the API up; LN882H likewise. No attempt is burned by the pre-connect teardown on any of them.

No test was added: the change is in `wifi_component_libretiny.cpp`, which is `USE_LIBRETINY`-gated and cannot run under the host test harness, and the behaviour depends on driver event timing. `tests/unit_tests` + `tests/component_tests` pass, and `wifi` compiles for `bk72xx-ard`.
