### PR TITLE
[modbus_controller] Brace poll-refused log to fix -Wempty-body warning

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -218,8 +218,9 @@ void ModbusController::update() {
     for (auto &cmd : this->polling_command_items_) {
       ESP_LOGVV(TAG, "Updating range 0x%X", cmd.register_address());
       // A refusal is already logged by the hub; note the affected range for controller-level diagnostics.
-      if (!cmd.send())
+      if (!cmd.send()) {
         ESP_LOGD(TAG, "Poll refused by hub for range 0x%X", cmd.register_address());
+      }
     }
   }
   this->update_counter_++;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a `-Wempty-body` compiler warning in `modbus_controller`.

The polling loop in `ModbusController::update()` logs a refused poll with an un-braced `if`:

```cpp
if (!cmd.send())
  ESP_LOGD(TAG, "Poll refused by hub for range 0x%X", cmd.register_address());
```

When the build's compile-time log level is below `DEBUG`, `ESP_LOGD` expands to nothing, so the `if` is left with an empty body (`if (!cmd.send()) ;`) and the compiler warns:

```
modbus_controller.cpp:...: warning: suggest braces around empty body in an 'if' statement [-Wempty-body]
```

Adding braces resolves it, and it is harmless at higher log levels too. The sibling offline-probe log a few lines up is already braced, so this brings the two in line.

The issue reported two occurrences on 2026.8.x (in `update_range_()` and `update()`); on `dev`, `update_range_()` has since been removed and the probe log already braced, leaving only this one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18711

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; existing modbus_controller configs are unaffected.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
