### PR TITLE
[esp32_ble_tracker] Warn when the scan window is above 600ms with wifi

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -220,22 +220,38 @@ def _warn_long_scan_window_with_wifi(config: ConfigType) -> ConfigType:
     """Warn when the scan window is long enough to starve wifi.
 
     Runs after _raise_defaulted_scan_window so it sees the final window.
-    software_coexistence only exists when wifi is configured, so ethernet
-    builds never warn: BLE has the radio to itself there.
+    software_coexistence is only present when wifi is configured, so ethernet
+    builds never warn: BLE has the radio to itself there. Presence is what
+    matters, not the value; with the arbiter disabled a long window starves
+    wifi outright.
     """
-    window = config[CONF_SCAN_PARAMETERS][CONF_WINDOW]
-    if (
-        config.get(CONF_SOFTWARE_COEXISTENCE)
-        and window > MAX_RECOMMENDED_WIFI_SCAN_WINDOW
-    ):
+    params = config[CONF_SCAN_PARAMETERS]
+    window = params[CONF_WINDOW]
+    if CONF_SOFTWARE_COEXISTENCE not in config:
+        return config
+    if window <= MAX_RECOMMENDED_WIFI_SCAN_WINDOW:
+        return config
+    if _get_data().scan_window_defaulted:
+        # The window was raised to match the interval, so point at the key the
+        # user actually set.
         _LOGGER.warning(
-            "BLE scan window of %s with wifi on the same radio starves wifi and "
-            "can cause wifi disconnects depending on the access point; keep the "
-            "window at or below %s (for example interval: 320ms, window: 300ms). "
-            "Long windows are only a problem with wifi, they are fine on ethernet",
-            window,
+            "BLE scan interval of %s sets the scan window to the same value, "
+            "which starves wifi on the same radio and can cause wifi disconnects "
+            "depending on the access point; keep the interval at or below %s "
+            "(for example interval: 320ms). Long windows are only a problem with "
+            "wifi, they are fine on ethernet",
+            params[CONF_INTERVAL],
             MAX_RECOMMENDED_WIFI_SCAN_WINDOW,
         )
+        return config
+    _LOGGER.warning(
+        "BLE scan window of %s with wifi on the same radio starves wifi and "
+        "can cause wifi disconnects depending on the access point; keep the "
+        "window at or below %s (for example interval: 320ms, window: 300ms). "
+        "Long windows are only a problem with wifi, they are fine on ethernet",
+        window,
+        MAX_RECOMMENDED_WIFI_SCAN_WINDOW,
+    )
     return config
 
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -229,7 +229,7 @@ def _warn_long_scan_window_with_wifi(config: ConfigType) -> ConfigType:
     ):
         _LOGGER.warning(
             "BLE scan window of %s with wifi on the same radio starves wifi and "
-            "causes disconnects and crashes; keep the window at or below %s "
+            "causes wifi disconnects; keep the window at or below %s "
             "(for example interval: 320ms, window: 300ms). Long windows are "
             "only a problem with wifi, they are fine on ethernet",
             window,

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -143,6 +143,12 @@ def validate_max_connections_deprecated(config: ConfigType) -> ConfigType:
 # BLE uses the airtime wifi does not claim.
 IDF_SCAN_WINDOW_FIX_VERSION = cv.Version(5, 5, 5)
 
+# Above this the scanner holds the shared radio long enough that wifi drops
+# packets and connections; old proxy configs with 1100 ms windows are a
+# recurring cause of instability (esphome/esphome#18655). Only wifi shares
+# the radio; long windows are fine on ethernet builds.
+MAX_RECOMMENDED_WIFI_SCAN_WINDOW = TimePeriod(milliseconds=600)
+
 
 @dataclass
 class TrackerData:
@@ -209,6 +215,29 @@ def _raise_defaulted_scan_window(config: ConfigType) -> ConfigType:
     return config
 
 
+def _warn_long_scan_window_with_wifi(config: ConfigType) -> ConfigType:
+    """Warn when the scan window is long enough to starve wifi.
+
+    Runs after _raise_defaulted_scan_window so it sees the final window.
+    software_coexistence only exists when wifi is configured, so ethernet
+    builds never warn: BLE has the radio to itself there.
+    """
+    window = config[CONF_SCAN_PARAMETERS][CONF_WINDOW]
+    if (
+        config.get(CONF_SOFTWARE_COEXISTENCE)
+        and window > MAX_RECOMMENDED_WIFI_SCAN_WINDOW
+    ):
+        _LOGGER.warning(
+            "BLE scan window of %s with wifi on the same radio starves wifi and "
+            "causes disconnects and crashes; keep the window at or below %s "
+            "(for example interval: 320ms, window: 300ms). Long windows are "
+            "only a problem with wifi, they are fine on ethernet",
+            window,
+            MAX_RECOMMENDED_WIFI_SCAN_WINDOW,
+        )
+    return config
+
+
 # 320 ms is the ESP-IDF reference scan interval; the shared schema also
 # tightens validation to the controller's 2.5 ms .. 10240 ms range and rejects
 # window/interval pairs that collapse to the same 0.625 ms unit count.
@@ -271,6 +300,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     validate_max_connections_deprecated,
     _raise_defaulted_scan_window,
+    _warn_long_scan_window_with_wifi,
 )
 
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -144,9 +144,10 @@ def validate_max_connections_deprecated(config: ConfigType) -> ConfigType:
 IDF_SCAN_WINDOW_FIX_VERSION = cv.Version(5, 5, 5)
 
 # Above this the scanner holds the shared radio long enough that wifi drops
-# packets and connections; old proxy configs with 1100 ms windows are a
-# recurring cause of instability (esphome/esphome#18655). Only wifi shares
-# the radio; long windows are fine on ethernet builds.
+# packets and connections on some access points (others cope fine, which is
+# why this is a warning and not an error); old proxy configs with 1100 ms
+# windows are a recurring cause of instability (esphome/esphome#18655). Only
+# wifi shares the radio; long windows are fine on ethernet builds.
 MAX_RECOMMENDED_WIFI_SCAN_WINDOW = TimePeriod(milliseconds=600)
 
 
@@ -229,9 +230,9 @@ def _warn_long_scan_window_with_wifi(config: ConfigType) -> ConfigType:
     ):
         _LOGGER.warning(
             "BLE scan window of %s with wifi on the same radio starves wifi and "
-            "causes wifi disconnects; keep the window at or below %s "
-            "(for example interval: 320ms, window: 300ms). Long windows are "
-            "only a problem with wifi, they are fine on ethernet",
+            "can cause wifi disconnects depending on the access point; keep the "
+            "window at or below %s (for example interval: 320ms, window: 300ms). "
+            "Long windows are only a problem with wifi, they are fine on ethernet",
             window,
             MAX_RECOMMENDED_WIFI_SCAN_WINDOW,
         )

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -225,23 +225,51 @@ def test_connection_scan_window_codegen(
 
 
 @pytest.mark.parametrize(
-    ("wifi", "window", "expect_warning"),
+    ("wifi", "params", "expect_warning"),
     [
-        (True, "1100ms", True),
-        (True, "601ms", True),
-        (True, "600ms", False),
-        (False, "1100ms", False),
+        (True, {"interval": "1100ms", "window": "1100ms"}, True),
+        (True, {"interval": "1100ms", "window": "601ms"}, True),
+        (True, {"interval": "1100ms", "window": "600ms"}, False),
+        (False, {"interval": "1100ms", "window": "1100ms"}, False),
     ],
 )
 def test_long_window_with_wifi_warns(
     stage_esp32: Callable[..., None],
     caplog: pytest.LogCaptureFixture,
     wifi: bool,
-    window: str,
+    params: ConfigType,
     expect_warning: bool,
 ) -> None:
     """A scan window above 600 ms warns only when wifi shares the radio."""
     stage_esp32("5.5.5", wifi=wifi)
     with caplog.at_level(logging.WARNING):
-        _scan_params({"scan_parameters": {"interval": "1100ms", "window": window}})
+        _scan_params({"scan_parameters": params})
     assert ("starves wifi" in caplog.text) is expect_warning
+
+
+def test_long_window_warns_with_coexistence_disabled(
+    stage_esp32: Callable[..., None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Disabling the arbiter is the worst case for a long window, so it still warns."""
+    stage_esp32("5.5.5", wifi=True)
+    with caplog.at_level(logging.WARNING):
+        _scan_params(
+            {
+                CONF_SOFTWARE_COEXISTENCE: False,
+                "scan_parameters": {"interval": "1100ms", "window": "1100ms"},
+            }
+        )
+    assert "BLE scan window of 1100ms" in caplog.text
+
+
+def test_raised_window_warning_points_at_interval(
+    stage_esp32: Callable[..., None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the window was raised to a long interval, the warning names the interval."""
+    stage_esp32("5.5.5", wifi=True)
+    with caplog.at_level(logging.WARNING):
+        _scan_params({"scan_parameters": {"interval": "1s"}})
+    assert "BLE scan interval of 1s" in caplog.text
+    assert "BLE scan window of" not in caplog.text

--- a/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
+++ b/tests/component_tests/esp32_ble_tracker/test_scan_window_default.py
@@ -12,6 +12,7 @@ arbiter a full-duty scan would starve wifi, so the 30 ms default is kept.
 from __future__ import annotations
 
 from collections.abc import Callable
+import logging
 from pathlib import Path
 
 import pytest
@@ -221,3 +222,26 @@ def test_connection_scan_window_codegen(
     assert window_call in main_cpp
     assert ("set_connection_scan_window(48)" in main_cpp) == connection_call
     assert ("'connection_scan_window' has no effect" in caplog.text) == warns
+
+
+@pytest.mark.parametrize(
+    ("wifi", "window", "expect_warning"),
+    [
+        (True, "1100ms", True),
+        (True, "601ms", True),
+        (True, "600ms", False),
+        (False, "1100ms", False),
+    ],
+)
+def test_long_window_with_wifi_warns(
+    stage_esp32: Callable[..., None],
+    caplog: pytest.LogCaptureFixture,
+    wifi: bool,
+    window: str,
+    expect_warning: bool,
+) -> None:
+    """A scan window above 600 ms warns only when wifi shares the radio."""
+    stage_esp32("5.5.5", wifi=wifi)
+    with caplog.at_level(logging.WARNING):
+        _scan_params({"scan_parameters": {"interval": "1100ms", "window": window}})
+    assert ("starves wifi" in caplog.text) is expect_warning


### PR DESCRIPTION
# What does this implement/fix?

Some older bluetooth proxy configs still set `interval: 1100ms` and `window: 1100ms`. With wifi on the same radio the scanner holds the radio for over a second at a time, which starves wifi and can cause wifi disconnects; #18655 is the latest example with exactly that config. Some access points cope with it just fine, which is why this is a warning and not an error.

This adds a config time warning when the scan window is above 600ms and wifi is configured. Nothing is rejected. Ethernet builds never warn since BLE has the radio to itself there, and the message says so.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18655

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wifi:
  ssid: MySSID

esp32_ble_tracker:
  scan_parameters:
    interval: 1100ms
    window: 1100ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).



