### PR TITLE
[api] Use C++20 bit-field initializers instead of nested flag structs

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -251,10 +251,10 @@ void APIConnection::begin_iterator_(ActiveIterator type) {
 }
 
 void APIConnection::loop() {
-  if (this->flags_.next_close) {
+  if (this->next_close_) {
     // requested a disconnect - don't close socket here, let APIServer::loop() do it
     // so getpeername() still works for the disconnect trigger
-    this->flags_.remove = true;
+    this->remove_ = true;
     return;
   }
 
@@ -271,8 +271,8 @@ void APIConnection::loop() {
   // messages share a TCP segment, the last message's data stays in LWIP's
   // lastdata cache after rcvevent hits 0, making is_socket_ready() return false
   // even though data remains.
-  if (this->helper_->is_socket_ready() || this->flags_.may_have_remaining_data) {
-    this->flags_.may_have_remaining_data = false;
+  if (this->helper_->is_socket_ready() || this->may_have_remaining_data_) {
+    this->may_have_remaining_data_ = false;
     // Read up to MAX_MESSAGES_PER_LOOP messages per loop to improve throughput
     uint8_t message_count = 0;
     for (; message_count < MAX_MESSAGES_PER_LOOP; message_count++) {
@@ -302,19 +302,19 @@ void APIConnection::loop() {
         }
         // read a packet
         this->read_message_(buffer.data_len, buffer.type, buffer.data);
-        if (this->flags_.remove)
+        if (this->remove_)
           return;
       }
     }
     // If we hit the limit, there may be more data remaining in LWIP's
     // lastdata cache that rcvevent doesn't account for.
     if (message_count == MAX_MESSAGES_PER_LOOP) {
-      this->flags_.may_have_remaining_data = true;
+      this->may_have_remaining_data_ = true;
     }
   }
 
   // Process deferred batch if scheduled and timer has expired
-  if (this->flags_.batch_scheduled && now - this->deferred_batch_.batch_start_time >= this->get_batch_delay_ms_()) {
+  if (this->batch_scheduled_ && now - this->deferred_batch_.batch_start_time >= this->get_batch_delay_ms_()) {
     this->process_batch_();
   }
 
@@ -353,23 +353,23 @@ void APIConnection::loop() {
 
 void APIConnection::check_keepalive_(uint32_t now) {
   // Caller guarantees: now - last_traffic_ > KEEPALIVE_TIMEOUT_MS
-  if (this->flags_.sent_ping) {
+  if (this->sent_ping_) {
     // Disconnect if not responded within 2.5*keepalive
     if (now - this->last_traffic_ > KEEPALIVE_DISCONNECT_TIMEOUT) {
       on_fatal_error();
       this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("is unresponsive; disconnecting"));
     }
-  } else if (!this->flags_.remove) {
+  } else if (!this->remove_) {
     // Only send ping if we're not disconnecting
     ESP_LOGVV(TAG, "Sending keepalive PING");
     PingRequest req;
-    this->flags_.sent_ping = this->send_message(req);
-    if (!this->flags_.sent_ping) {
+    this->sent_ping_ = this->send_message(req);
+    if (!this->sent_ping_) {
       // If we can't send the ping request directly (tx_buffer full),
       // schedule it at the front of the batch so it will be sent with priority
       ESP_LOGW(TAG, "Buffer full, ping queued");
       this->schedule_message_front_(nullptr, PingRequest::MESSAGE_TYPE, PingRequest::ESTIMATED_SIZE);
-      this->flags_.sent_ping = true;  // Mark as sent to avoid scheduling multiple pings
+      this->sent_ping_ = true;  // Mark as sent to avoid scheduling multiple pings
     }
   }
 }
@@ -379,7 +379,7 @@ void APIConnection::process_active_iterator_() {
   if (this->active_iterator_ == ActiveIterator::LIST_ENTITIES) {
     if (this->iterator_storage_.list_entities.completed()) {
       this->destroy_active_iterator_();
-      if (this->flags_.state_subscription) {
+      if (this->state_subscription_) {
         this->begin_iterator_(ActiveIterator::INITIAL_STATE);
       } else {
         this->finalize_iterator_sync_();
@@ -405,7 +405,7 @@ void APIConnection::finalize_iterator_sync_() {
     this->process_batch_();
   }
   // Enable immediate sending for future state changes
-  this->flags_.should_try_send_immediately = true;
+  this->should_try_send_immediately_ = true;
   // Release excess memory from buffers that grew during initial sync
   this->deferred_batch_.release_buffer();
   this->helper_->release_buffers();
@@ -430,14 +430,14 @@ bool APIConnection::send_disconnect_response_() {
   // don't close yet, we still need to send the disconnect response
   // close will happen on next loop
   this->log_client_(ESPHOME_LOG_LEVEL_DEBUG, LOG_STR("disconnected"));
-  this->flags_.next_close = true;
+  this->next_close_ = true;
   DisconnectResponse resp;
   return this->send_message(resp);
 }
 void APIConnection::on_disconnect_response() {
   // Don't close socket here, let APIServer::loop() do it
   // so getpeername() still works for the disconnect trigger
-  this->flags_.remove = true;
+  this->remove_ = true;
 }
 
 uint16_t APIConnection::fill_and_encode_entity_state(EntityBase *entity, StateResponseProtoMessage &msg,
@@ -1163,7 +1163,7 @@ void APIConnection::try_send_camera_image_() {
   }
 }
 void APIConnection::set_camera_state(std::shared_ptr<camera::CameraImage> image) {
-  if (!this->flags_.state_subscription)
+  if (!this->state_subscription_)
     return;
   if (this->image_reader_ && this->image_reader_->available())
     return;
@@ -1719,11 +1719,11 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
 
 void APIConnection::complete_authentication_() {
   // Early return if already authenticated
-  if (this->flags_.connection_state == static_cast<uint8_t>(ConnectionState::AUTHENTICATED)) {
+  if (this->is_authenticated()) {
     return;
   }
 
-  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
+  this->connection_state_ = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
   // Reset traffic timer so keepalive starts from authentication, not connection start
   this->last_traffic_ = App.get_loop_component_start_time();
   this->log_client_(ESPHOME_LOG_LEVEL_DEBUG, LOG_STR("connected"));
@@ -2082,7 +2082,7 @@ void APIConnection::send_execute_service_response(uint32_t call_id, bool success
 
 #ifdef USE_API_HOMEASSISTANT_SERVICES
 bool APIConnection::send_homeassistant_action(const HomeassistantActionRequest &call) {
-  if (!this->flags_.service_call_subscription)
+  if (!this->service_call_subscription_)
     return false;
   if (!this->send_message(call)) {
     API_LOG_MSG_DROPPED(TAG, "Action request");
@@ -2237,7 +2237,7 @@ void APIConnection::on_no_setup_connection() {
 void APIConnection::on_fatal_error() {
   // Don't close socket here - keep it open so getpeername() works for logging
   // Socket will be closed when client is removed from the list in APIServer::loop()
-  this->flags_.remove = true;
+  this->remove_ = true;
 }
 
 bool APIConnection::schedule_message_front_(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
@@ -2263,8 +2263,8 @@ bool APIConnection::send_message_smart_(EntityBase *entity, uint8_t message_type
 }
 
 bool APIConnection::schedule_batch_() {
-  if (!this->flags_.batch_scheduled) {
-    this->flags_.batch_scheduled = true;
+  if (!this->batch_scheduled_) {
+    this->batch_scheduled_ = true;
     this->deferred_batch_.batch_start_time = App.get_loop_component_start_time();
   }
   return true;
@@ -2272,7 +2272,7 @@ bool APIConnection::schedule_batch_() {
 
 void APIConnection::process_batch_() {
   if (this->deferred_batch_.empty()) {
-    this->flags_.batch_scheduled = false;
+    this->batch_scheduled_ = false;
     return;
   }
 
@@ -2422,7 +2422,7 @@ void APIConnection::process_batch_multi_(APIBuffer &shared_buf, size_t num_items
 // Switch assigns function pointer, single call site for smaller code size
 uint16_t APIConnection::dispatch_message_(const DeferredBatch::BatchItem &item, uint32_t remaining_size,
                                           bool batch_first) {
-  this->flags_.batch_first_message = batch_first;
+  this->batch_first_message_ = batch_first;
   this->batch_message_type_ = item.message_type;
 #ifdef USE_EVENT
   // Events need aux_data_index to look up event type from entity

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -736,21 +736,21 @@ class APIConnection final : public APIServerConnectionBase {
   };
 
   // Group 5: bit-packed small state (2 bytes), followed by the 2-byte and 1-byte members
-  uint8_t connection_state_ : 2 {0};  // ConnectionState, 3 values
+  uint8_t connection_state_ : 2 {0};  // ConnectionState
   uint8_t log_subscription_ : 3 {0};  // log levels 0-7
-  bool remove_ : 1 {false};
-  bool state_subscription_ : 1 {false};
-  bool sent_ping_ : 1 {false};
-  bool service_call_subscription_ : 1 {false};
-  bool next_close_ : 1 {false};
-  bool batch_scheduled_ : 1 {false};
-  bool batch_first_message_ : 1 {false};          // For batch buffer allocation
-  bool should_try_send_immediately_ : 1 {false};  // True after initial states are sent
-  bool may_have_remaining_data_ : 1 {false};      // Read loop hit limit, retry without ready check
+  uint8_t remove_ : 1 {0};
+  uint8_t state_subscription_ : 1 {0};
+  uint8_t sent_ping_ : 1 {0};
+  uint8_t service_call_subscription_ : 1 {0};
+  uint8_t next_close_ : 1 {0};
+  uint8_t batch_scheduled_ : 1 {0};
+  uint8_t batch_first_message_ : 1 {0};          // For batch buffer allocation
+  uint8_t should_try_send_immediately_ : 1 {0};  // True after initial states are sent
+  uint8_t may_have_remaining_data_ : 1 {0};      // Read loop hit limit, retry without ready check
   // reserved_ keeps every bit of the flag word owned by a member so constructors zero it with
   // a plain store instead of a read-modify-write that preserves unowned padding bits
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  bool log_only_mode_ : 1 {false};
+  uint8_t log_only_mode_ : 1 {0};
   uint8_t reserved_ : 1 {0};
 #else
   uint8_t reserved_ : 2 {0};

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -259,7 +259,7 @@ class APIConnection final : public APIServerConnectionBase {
   void on_disconnect_response();
   void on_ping_response() {
     // we initiated ping
-    this->flags_.sent_ping = false;
+    this->sent_ping_ = false;
   }
 #ifdef USE_API_HOMEASSISTANT_STATES
   void on_home_assistant_state_response(const HomeAssistantStateResponse &msg);
@@ -274,7 +274,7 @@ class APIConnection final : public APIServerConnectionBase {
   void on_device_capabilities_request();
   void on_list_entities_request() { this->begin_iterator_(ActiveIterator::LIST_ENTITIES); }
   void on_subscribe_states_request() {
-    this->flags_.state_subscription = true;
+    this->state_subscription_ = true;
     // Start initial state iterator only if no iterator is active
     // If list_entities is running, we'll start initial_state when it completes
     if (this->active_iterator_ == ActiveIterator::NONE) {
@@ -282,7 +282,7 @@ class APIConnection final : public APIServerConnectionBase {
     }
   }
   void on_subscribe_logs_request(const SubscribeLogsRequest &msg) {
-    this->flags_.log_subscription = msg.level;
+    this->log_subscription_ = msg.level;
     if (msg.dump_config)
       App.schedule_dump_config();
 #ifdef USE_ESP32_CRASH_HANDLER
@@ -297,7 +297,7 @@ class APIConnection final : public APIServerConnectionBase {
 #endif
   }
 #ifdef USE_API_HOMEASSISTANT_SERVICES
-  void on_subscribe_homeassistant_services_request() { this->flags_.service_call_subscription = true; }
+  void on_subscribe_homeassistant_services_request() { this->service_call_subscription_ = true; }
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
   void on_subscribe_home_assistant_states_request();
@@ -317,14 +317,14 @@ class APIConnection final : public APIServerConnectionBase {
 #endif
 
   bool is_authenticated() {
-    return static_cast<ConnectionState>(this->flags_.connection_state) == ConnectionState::AUTHENTICATED;
+    return static_cast<ConnectionState>(this->connection_state_) == ConnectionState::AUTHENTICATED;
   }
   bool is_connection_setup() {
-    return static_cast<ConnectionState>(this->flags_.connection_state) == ConnectionState::CONNECTED ||
+    return static_cast<ConnectionState>(this->connection_state_) == ConnectionState::CONNECTED ||
            this->is_authenticated();
   }
-  bool is_marked_for_removal() const { return this->flags_.remove; }
-  uint8_t get_log_subscription_level() const { return this->flags_.log_subscription; }
+  bool is_marked_for_removal() const { return this->remove_; }
+  uint8_t get_log_subscription_level() const { return this->log_subscription_; }
 
   // Get client API version for feature detection
   bool client_supports_api_version(uint16_t major, uint16_t minor) const {
@@ -368,7 +368,7 @@ class APIConnection final : public APIServerConnectionBase {
   }
 
   bool try_to_clear_buffer(bool log_out_of_space) {
-    if (this->flags_.remove)
+    if (this->remove_)
       return false;
     if (this->helper_->can_write_without_blocking())
       return true;
@@ -735,36 +735,29 @@ class APIConnection final : public APIServerConnectionBase {
     AUTHENTICATED = 2,
   };
 
-  // Group 5: Pack all small members together to minimize padding
-  // This group starts at a 4-byte boundary after DeferredBatch
-  struct APIFlags {
-    // Connection state only needs 2 bits (3 states)
-    uint8_t connection_state : 2;
-    // Log subscription needs 3 bits (log levels 0-7)
-    uint8_t log_subscription : 3;
-    // Boolean flags (1 bit each)
-    uint8_t remove : 1;
-    uint8_t state_subscription : 1;
-    uint8_t sent_ping : 1;
-
-    uint8_t service_call_subscription : 1;
-    uint8_t next_close : 1;
-    uint8_t batch_scheduled : 1;
-    uint8_t batch_first_message : 1;          // For batch buffer allocation
-    uint8_t should_try_send_immediately : 1;  // True after initial states are sent
-    uint8_t may_have_remaining_data : 1;      // Read loop hit limit, retry without ready check
+  // Group 5: bit-packed small state (2 bytes), followed by the 2-byte and 1-byte members
+  uint8_t connection_state_ : 2 {0};  // ConnectionState, 3 values
+  uint8_t log_subscription_ : 3 {0};  // log levels 0-7
+  bool remove_ : 1 {false};
+  bool state_subscription_ : 1 {false};
+  bool sent_ping_ : 1 {false};
+  bool service_call_subscription_ : 1 {false};
+  bool next_close_ : 1 {false};
+  bool batch_scheduled_ : 1 {false};
+  bool batch_first_message_ : 1 {false};          // For batch buffer allocation
+  bool should_try_send_immediately_ : 1 {false};  // True after initial states are sent
+  bool may_have_remaining_data_ : 1 {false};      // Read loop hit limit, retry without ready check
 #ifdef HAS_PROTO_MESSAGE_DUMP
-    uint8_t log_only_mode : 1;
+  bool log_only_mode_ : 1 {false};
 #endif
-  } flags_{};  // 2 bytes total
 
-  // 2-byte types immediately after flags_ (no padding between them)
+  // 2-byte types immediately after the bit-fields (no padding between them)
   uint16_t client_api_version_major_{0};
   uint16_t client_api_version_minor_{0};
   // 1-byte types to fill remaining space before next 4-byte boundary
   ActiveIterator active_iterator_{ActiveIterator::NONE};
   uint8_t batch_message_type_{0};  // Current message type during batch encoding
-  // Total: 2 (flags) + 2 + 2 + 1 + 1 = 8 bytes, aligned to 4-byte boundary
+  // Total: 2 (bit-fields) + 2 + 2 + 1 + 1 = 8 bytes, aligned to 4-byte boundary
 
   // Actual header size used by encode_to_buffer for the current message.
   // Read by process_batch_multi_ to pass into MessageInfo.
@@ -791,7 +784,7 @@ class APIConnection final : public APIServerConnectionBase {
       __attribute__((noinline));
   void clear_batch_() {
     this->deferred_batch_.clear();
-    this->flags_.batch_scheduled = false;
+    this->batch_scheduled_ = false;
   }
 
   // Dispatch message encoding based on message_type - replaces function pointer storage
@@ -800,9 +793,9 @@ class APIConnection final : public APIServerConnectionBase {
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void log_batch_item_(const DeferredBatch::BatchItem &item) {
-    this->flags_.log_only_mode = true;
+    this->log_only_mode_ = true;
     this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true);
-    this->flags_.log_only_mode = false;
+    this->log_only_mode_ = false;
   }
 #endif
 
@@ -821,7 +814,7 @@ class APIConnection final : public APIServerConnectionBase {
 #ifdef USE_EVENT
         message_type == EventResponse::MESSAGE_TYPE ||
 #endif
-        (this->flags_.should_try_send_immediately && this->get_batch_delay_ms_() == 0));
+        (this->should_try_send_immediately_ && this->get_batch_delay_ms_() == 0));
   }
 
   // Helper method to send a message either immediately or via batching

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -747,8 +747,13 @@ class APIConnection final : public APIServerConnectionBase {
   bool batch_first_message_ : 1 {false};          // For batch buffer allocation
   bool should_try_send_immediately_ : 1 {false};  // True after initial states are sent
   bool may_have_remaining_data_ : 1 {false};      // Read loop hit limit, retry without ready check
+  // reserved_ keeps every bit of the flag word owned by a member so constructors zero it with
+  // a plain store instead of a read-modify-write that preserves unowned padding bits
 #ifdef HAS_PROTO_MESSAGE_DUMP
   bool log_only_mode_ : 1 {false};
+  uint8_t reserved_ : 1 {0};
+#else
+  uint8_t reserved_ : 2 {0};
 #endif
 
   // 2-byte types immediately after the bit-fields (no padding between them)

--- a/esphome/components/api/api_connection_buffer.h
+++ b/esphome/components/api/api_connection_buffer.h
@@ -15,7 +15,7 @@ inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t c
                                                                       MessageEncodeFn encode_fn, const void *msg,
                                                                       APIConnection *conn, uint32_t remaining_size) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  if (conn->flags_.log_only_mode) {
+  if (conn->log_only_mode_) {
     auto *proto_msg = static_cast<const ProtoMessage *>(msg);
     DumpBuffer dump_buf;
     conn->log_send_message_(proto_msg->message_name(), proto_msg->dump_to(dump_buf));
@@ -26,8 +26,8 @@ inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t c
 
   // First message uses max padding (already in buffer), subsequent use exact header size
   size_t to_add;
-  if (conn->flags_.batch_first_message) {
-    conn->flags_.batch_first_message = false;
+  if (conn->batch_first_message_) {
+    conn->batch_first_message_ = false;
     conn->batch_header_size_ = conn->helper_->frame_header_padding();
     to_add = calculated_size;
   } else {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -174,12 +174,12 @@ void APIServer::loop() {
     auto &client = this->clients_[client_index];
 
     // Common case: process active client
-    if (!client->flags_.remove) {
+    if (!client->remove_) {
       client->loop();
     }
     // Handle disconnection promptly - close socket to free LWIP PCB
     // resources and prevent retransmit crashes on ESP8266.
-    if (client->flags_.remove) {
+    if (client->remove_) {
       // Rare case: handle disconnection (don't increment - swapped element needs processing)
       this->remove_client_(client_index);
     } else {
@@ -292,7 +292,7 @@ void APIServer::handle_disconnect(APIConnection *conn) {}
     if (obj->is_internal()) \
       return; \
     for (auto &c : this->active_clients()) { \
-      if (c->flags_.state_subscription) \
+      if (c->state_subscription_) \
         c->send_##entity_name##_state(obj); \
     } \
   }
@@ -374,7 +374,7 @@ void APIServer::on_event(event::Event *obj) {
   if (obj->is_internal())
     return;
   for (auto &c : this->active_clients()) {
-    if (c->flags_.state_subscription)
+    if (c->state_subscription_)
       c->send_event(obj);
   }
 }
@@ -386,7 +386,7 @@ void APIServer::on_update(update::UpdateEntity *obj) {
   if (obj->is_internal())
     return;
   for (auto &c : this->active_clients()) {
-    if (c->flags_.state_subscription)
+    if (c->state_subscription_)
       c->send_update_state(obj);
   }
 }
@@ -639,7 +639,7 @@ bool APIServer::clear_noise_psk(bool make_active) {
 #ifdef USE_HOMEASSISTANT_TIME
 void APIServer::request_time() {
   for (auto &client : this->active_clients()) {
-    if (!client->flags_.remove && client->is_authenticated()) {
+    if (!client->remove_ && client->is_authenticated()) {
       client->send_time_request();
       return;  // Only request from one client to avoid clock conflicts
     }
@@ -649,7 +649,7 @@ void APIServer::request_time() {
 
 bool APIServer::is_connected_with_state_subscription() const {
   for (uint8_t i = 0; i < this->api_connection_count_; i++) {
-    if (this->clients_[i]->flags_.state_subscription) {
+    if (this->clients_[i]->state_subscription_) {
       return true;
     }
   }
@@ -665,7 +665,7 @@ void APIServer::on_log(uint8_t level, const char *tag, const char *message, size
     return;
   }
   for (auto &c : this->active_clients()) {
-    if (!c->flags_.remove && c->get_log_subscription_level() >= level)
+    if (!c->remove_ && c->get_log_subscription_level() >= level)
       c->try_send_log_message(level, tag, message, message_len);
   }
 }
@@ -674,7 +674,7 @@ void APIServer::on_log(uint8_t level, const char *tag, const char *message, size
 #ifdef USE_CAMERA
 void APIServer::on_camera_image(const std::shared_ptr<camera::CameraImage> &image) {
   for (auto &c : this->active_clients()) {
-    if (!c->flags_.remove)
+    if (!c->remove_)
       c->set_camera_state(image);
   }
 }

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -298,10 +298,10 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
   Trigger<std::string, Ts...> error_trigger_;
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
-  bool is_event_ : 1 {false};
-  bool wants_status_ : 1 {false};
-  bool wants_response_ : 1 {false};
-  bool has_response_template_ : 1 {false};
+  uint8_t is_event_ : 1 {0};
+  uint8_t wants_status_ : 1 {0};
+  uint8_t wants_response_ : 1 {0};
+  uint8_t has_response_template_ : 1 {0};
   uint8_t reserved_ : 4 {0};  // keep the byte fully owned, see APIConnection
 };
 

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -302,6 +302,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
   bool wants_status_ : 1 {false};
   bool wants_response_ : 1 {false};
   bool has_response_template_ : 1 {false};
+  uint8_t reserved_ : 4 {0};  // keep the byte fully owned, see APIConnection
 };
 
 }  // namespace esphome::api

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -106,9 +106,7 @@ template<typename... Ts> using ActionResponseCallback = std::function<void(const
 
 template<typename... Ts> class HomeAssistantServiceCallAction final : public Action<Ts...> {
  public:
-  explicit HomeAssistantServiceCallAction(APIServer *parent, bool is_event) : parent_(parent) {
-    this->flags_.is_event = is_event;
-  }
+  explicit HomeAssistantServiceCallAction(APIServer *parent, bool is_event) : parent_(parent), is_event_(is_event) {}
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
@@ -148,11 +146,11 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
   template<typename T> void set_response_template(T response_template) {
     this->response_template_ = response_template;
-    this->flags_.has_response_template = true;
+    this->has_response_template_ = true;
   }
 
-  void set_wants_status() { this->flags_.wants_status = true; }
-  void set_wants_response() { this->flags_.wants_response = true; }
+  void set_wants_status() { this->wants_status_ = true; }
+  void set_wants_response() { this->wants_response_ = true; }
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   Trigger<JsonObjectConst, Ts...> *get_success_trigger_with_response() { return &this->success_trigger_with_response_; }
@@ -165,7 +163,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
     HomeassistantActionRequest resp;
     std::string service_value = this->service_.value(x...);
     resp.service = StringRef(service_value);
-    resp.is_event = this->flags_.is_event;
+    resp.is_event = this->is_event_;
 
     // Local storage for lambda-evaluated strings - lives until after send
     FixedVector<std::string> data_storage;
@@ -181,16 +179,16 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
     // IMPORTANT: Declare at outer scope so it lives until send_homeassistant_action returns.
     std::string response_template_value;
 #endif
-    if (this->flags_.wants_status) {
+    if (this->wants_status_) {
       // Generate a unique call ID for this service call
       static uint32_t call_id_counter = 1;
       uint32_t call_id = call_id_counter++;
       resp.call_id = call_id;
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-      if (this->flags_.wants_response) {
+      if (this->wants_response_) {
         resp.wants_response = true;
         // Set response template if provided
-        if (this->flags_.has_response_template) {
+        if (this->has_response_template_) {
           response_template_value = this->response_template_.value(x...);
           resp.response_template = StringRef(response_template_value);
         }
@@ -203,7 +201,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
             [this, &response](auto &&...args) {
               if (response.is_success()) {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-                if (this->flags_.wants_response) {
+                if (this->wants_response_) {
                   this->success_trigger_with_response_.trigger(response.get_json(), args...);
                 } else
 #endif
@@ -300,13 +298,10 @@ template<typename... Ts> class HomeAssistantServiceCallAction final : public Act
   Trigger<std::string, Ts...> error_trigger_;
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
-  struct Flags {
-    uint8_t is_event : 1;
-    uint8_t wants_status : 1;
-    uint8_t wants_response : 1;
-    uint8_t has_response_template : 1;
-    uint8_t reserved : 5;
-  } flags_{0};
+  bool is_event_ : 1 {false};
+  bool wants_status_ : 1 {false};
+  bool wants_response_ : 1 {false};
+  bool has_response_template_ : 1 {false};
 };
 
 }  // namespace esphome::api

--- a/tests/benchmarks/components/api/bench_send_sensor_state.cpp
+++ b/tests/benchmarks/components/api/bench_send_sensor_state.cpp
@@ -12,7 +12,7 @@
 namespace esphome::api {
 
 // Friend functions declared in APIConnection for benchmark access.
-void bench_enable_immediate_send(APIConnection *conn) { conn->flags_.should_try_send_immediately = true; }
+void bench_enable_immediate_send(APIConnection *conn) { conn->should_try_send_immediately_ = true; }
 void bench_clear_batch(APIConnection *conn) { conn->clear_batch_(); }
 void bench_process_batch(APIConnection *conn) { conn->process_batch_(); }
 


### PR DESCRIPTION
# What does this implement/fix?

The API connection kept its small per connection state in a nested `APIFlags` struct, and the Home Assistant action kept a similar nested `Flags` struct. The wrapper only existed because bit-fields could not carry a default member initializer before C++20, so the struct was the way to zero everything at once. We build with gnu++20 now, so the bit-fields can be declared directly on the class with `: 1 {0}` and the `flags_.` indirection goes away.

Layout is unchanged; the connection still packs the same bits into the same 2 bytes. Every bit of each flag word stays owned by a member (`reserved_`), because unowned padding bits force the compiler to preserve them with a read-modify-write in constructors instead of a plain zero store. The bit-field types stay `uint8_t` as before; `bool` bit-fields changed codegen in a few hot functions on esp8266. With both of those in place the esp8266 memory impact build (`test_build_components.py -c api -t esp8266-ard`) is the same size as dev, 439979 bytes. The action struct had `reserved : 5`, which pushed it to 9 bits and 2 bytes, so that one shrinks to a single byte.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
