### PR TITLE
[gpio] Fix one_wire reset busy-waiting with interrupts off when delay wraps

### DIFF
--- a/esphome/components/gpio/one_wire/gpio_one_wire.cpp
+++ b/esphome/components/gpio/one_wire/gpio_one_wire.cpp
@@ -55,8 +55,11 @@ int HOT IRAM_ATTR GPIOOneWireBus::reset_int() {
     delayMicroseconds(1);
   }
 
-  // delay J
-  delayMicroseconds(start + 480 - micros());
+  // delay J: finish the 480us slot, but never spin if it already elapsed
+  // (unsigned wrap here would busy-wait for minutes with interrupts off)
+  uint32_t elapsed = micros() - start;
+  if (elapsed < 480)
+    delayMicroseconds(480 - elapsed);
   this->pin_.digital_write(true);
   this->pin_.pin_mode(gpio::FLAG_OUTPUT);
   return r ? 1 : 0;


### PR DESCRIPTION
# What does this implement/fix?

The delay J at the end of `GPIOOneWireBus::reset_int()` is computed as `start + 480 - micros()` while interrupts are masked. If more than 480us have passed since `start`, the unsigned subtraction wraps and `delayMicroseconds()` spins for about 71 minutes with interrupts off, which trips the hardware WDT.

Normally the presence loop finishes well under 480us, but `InterruptLock` does not block NMIs; the ESP8266 waveform generator used by `esp8266_pwm` runs at NMI level and at 25kHz it fires every 40us, so the window can be stretched past 480us. That matches the reporter's setup in #18606 (one_wire plus 25kHz esp8266_pwm). The backtrace in that issue is stale state from an earlier crash since a hardware WDT never runs the postmortem hook (see #18597).

This computes the elapsed time first and only delays for the remainder when the slot has not already passed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome#18606

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
one_wire:
  - platform: gpio
    pin: GPIO2

sensor:
  - platform: dallas_temp
    name: Temperature

output:
  - platform: esp8266_pwm
    pin: GPIO5
    id: pwm_out
    frequency: 25kHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
