### PR TITLE
[esp32] Only build the mbedTLS certificate bundle when a component needs it

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -7,6 +7,7 @@ from esphome.components.esp32 import (
     add_idf_component,
     add_idf_sdkconfig_option,
     include_builtin_idf_component,
+    require_certificate_bundle,
 )
 import esphome.config_validation as cv
 from esphome.const import (
@@ -335,6 +336,8 @@ def _emit_memory_pair(value: str | None, psram_key: str, internal_key: str) -> N
 async def to_code(config: ConfigType) -> None:
     # Re-enable ESP-IDF's HTTP client (excluded by default to save compile time)
     include_builtin_idf_component("esp_http_client")
+    # HTTPS streams verify the server against the root certificate bundle
+    require_certificate_bundle()
 
     add_idf_component(
         name="esphome/esp-audio-libs",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -645,6 +645,16 @@ class RawSdkconfigValue:
 SdkconfigValueType = bool | int | HexInt | str | RawSdkconfigValue
 
 
+def set_idf_sdkconfig_default(name: str, value: SdkconfigValueType) -> None:
+    """Set an sdkconfig option unless the user already set it in sdkconfig_options.
+
+    For the FINAL priority reconcile jobs, which run after the user options
+    were applied in to_code and must not override them.
+    """
+    if name not in CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]:
+        add_idf_sdkconfig_option(name, value)
+
+
 def add_idf_sdkconfig_option(name: str, value: SdkconfigValueType):
     """Set an esp-idf sdkconfig value."""
     CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS][name] = value
@@ -1755,7 +1765,7 @@ def require_full_certificate_bundle() -> None:
 
     Call this from components that need to connect to services using uncommon CAs.
     """
-    CORE.data[KEY_ESP32][KEY_CERT_BUNDLE] = True
+    require_certificate_bundle()
     CORE.data[KEY_ESP32][KEY_FULL_CERT_BUNDLE] = True
 
 
@@ -2170,43 +2180,6 @@ def register_exclude_components_cmake_arg() -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
-async def _write_certificate_bundle_sdkconfig() -> None:
-    """Enable the mbedTLS certificate bundle only when a component asked for it.
-
-    Runs at FINAL priority so every require_certificate_bundle() call has
-    happened. Without a request the bundle is disabled, which skips
-    esp_crt_bundle.c, the gen_crt_bundle step and the x509_crt_bundle.S embed.
-    A user-supplied sdkconfig_options value takes precedence.
-    """
-    data = CORE.data[KEY_ESP32]
-    opts = data[KEY_SDKCONFIG_OPTIONS]
-
-    def set_opt(name: str, value: SdkconfigValueType) -> None:
-        # User sdkconfig_options (applied during to_code) win.
-        if name not in opts:
-            add_idf_sdkconfig_option(name, value)
-
-    # A user forcing the bundle on through sdkconfig_options still gets the
-    # CMN variant pinned, as before this job existed.
-    user_value = opts.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE")
-    user_enabled = str(getattr(user_value, "value", user_value)).lower() in (
-        "y",
-        "true",
-    )
-    if not (data.get(KEY_CERT_BUNDLE, False) or user_enabled):
-        set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", False)
-        return
-    set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
-    # Use CMN (common CAs) bundle by default to save ~51KB flash
-    # CMN covers CAs with >1% market share (~99% of websites)
-    # Components needing uncommon CAs can call require_full_certificate_bundle()
-    use_full_bundle = data.get(KEY_FULL_CERT_BUNDLE, False)
-    set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle)
-    if not use_full_bundle:
-        set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
-
-
-@coroutine_with_priority(CoroPriority.FINAL)
 async def _write_exclude_components() -> None:
     """Write EXCLUDE_COMPONENTS cmake arg after all components have registered exclusions."""
     register_exclude_components_cmake_arg()
@@ -2268,6 +2241,31 @@ async def _set_libc_picolibc_newlib_compat() -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
+async def _reconcile_certificate_bundle_sdkconfig() -> None:
+    """Enable the mbedTLS certificate bundle only when something asked for it.
+
+    Runs at FINAL priority so every require_certificate_bundle() call has
+    happened. Without a request the bundle is disabled, which skips
+    esp_crt_bundle.c, the gen_crt_bundle step and the x509_crt_bundle.S embed.
+    A user-supplied sdkconfig_options value takes precedence.
+    """
+    data = CORE.data[KEY_ESP32]
+    enabled = data.get(KEY_CERT_BUNDLE, False)
+    set_idf_sdkconfig_default("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", enabled)
+    if not enabled:
+        return
+    # Use CMN (common CAs) bundle by default to save ~51KB flash
+    # CMN covers CAs with >1% market share (~99% of websites)
+    # Components needing uncommon CAs can call require_full_certificate_bundle()
+    use_full_bundle = data.get(KEY_FULL_CERT_BUNDLE, False)
+    set_idf_sdkconfig_default(
+        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
+    )
+    if not use_full_bundle:
+        set_idf_sdkconfig_default("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
 async def _reconcile_network_sdkconfig() -> None:
     """Reconcile WiFi/Ethernet/Bluetooth/coexistence sdkconfig flags.
 
@@ -2278,37 +2276,31 @@ async def _reconcile_network_sdkconfig() -> None:
     always takes precedence.
     """
     net = CORE.data[KEY_ESP32].get(KEY_NETWORK_SDKCONFIG, NetworkSdkconfigData())
-    opts = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     is_arduino = CORE.using_arduino
-
-    def set_opt(name: str, value: SdkconfigValueType) -> None:
-        # User sdkconfig_options (applied during to_code) win.
-        if name not in opts:
-            add_idf_sdkconfig_option(name, value)
 
     # Bluetooth: only ever enable when requested. The IDF default is off.
     # According to the IDF docs, only one of 4.2 or 5.0 should be enabled.
     if net.bluetooth:
-        set_opt("CONFIG_BT_ENABLED", True)
-        set_opt("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
-        set_opt("CONFIG_BT_BLE_50_FEATURES_SUPPORTED", False)
+        set_idf_sdkconfig_default("CONFIG_BT_ENABLED", True)
+        set_idf_sdkconfig_default("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
+        set_idf_sdkconfig_default("CONFIG_BT_BLE_50_FEATURES_SUPPORTED", False)
 
     # WiFi stack: disable only when Ethernet is present and WiFi is not. WiFi
     # relies on the IDF default (enabled), so it is never written True here.
     wifi_disabled = net.ethernet and not net.wifi
     if wifi_disabled:
-        set_opt("CONFIG_ESP_WIFI_ENABLED", False)
+        set_idf_sdkconfig_default("CONFIG_ESP_WIFI_ENABLED", False)
 
     # Software coexistence: enable when requested (the schema only allows it
     # alongside WiFi). Disable only in the Ethernet-without-WiFi case.
     if net.software_coexistence:
-        set_opt("CONFIG_SW_COEXIST_ENABLE", True)
+        set_idf_sdkconfig_default("CONFIG_SW_COEXIST_ENABLE", True)
     elif wifi_disabled:
-        set_opt("CONFIG_SW_COEXIST_ENABLE", False)
+        set_idf_sdkconfig_default("CONFIG_SW_COEXIST_ENABLE", False)
 
     # SoftAP support: drop it when WiFi is used without AP mode (IDF only).
     if not is_arduino and net.wifi and not net.wifi_ap:
-        set_opt("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
+        set_idf_sdkconfig_default("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
 
     # LWIP DHCP server: a WiFi-AP-mode / enable_lwip_dhcp_server concern (not
     # coexistence). Disable when WiFi has no AP (IDF) or the enable_lwip_dhcp_server
@@ -2319,7 +2311,7 @@ async def _reconcile_network_sdkconfig() -> None:
     if (
         wifi_wants_dhcps_off or dhcp_server_disabled_by_option
     ) and not arduino_eth_exclusion:
-        set_opt("CONFIG_LWIP_DHCPS", False)
+        set_idf_sdkconfig_default("CONFIG_LWIP_DHCPS", False)
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
@@ -2344,29 +2336,24 @@ async def _reconcile_vfs_fatfs_sdkconfig(
     """Reconcile VFS/FATFS sdkconfig flags after all require_*() calls; user sdkconfig_options win."""
     opts = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
 
-    def set_opt(name: str, value: SdkconfigValueType) -> None:
-        # User sdkconfig_options (applied during to_code) win.
-        if name not in opts:
-            add_idf_sdkconfig_option(name, value)
-
     # USB Serial JTAG VFS needs termios (require_vfs_termios(), e.g. logger). ~1.8KB flash when off.
     if CORE.data.get(KEY_VFS_TERMIOS_REQUIRED, False):
-        set_opt("CONFIG_VFS_SUPPORT_TERMIOS", True)
+        set_idf_sdkconfig_default("CONFIG_VFS_SUPPORT_TERMIOS", True)
     else:
-        set_opt("CONFIG_VFS_SUPPORT_TERMIOS", not disable_vfs_termios)
+        set_idf_sdkconfig_default("CONFIG_VFS_SUPPORT_TERMIOS", not disable_vfs_termios)
 
     # VFS select is only needed for UART/eventfd fds (require_vfs_select(), e.g. openthread);
     # sockets use lwip_select() either way. ~2.7KB flash when off.
     if CORE.data.get(KEY_VFS_SELECT_REQUIRED, False):
-        set_opt("CONFIG_VFS_SUPPORT_SELECT", True)
+        set_idf_sdkconfig_default("CONFIG_VFS_SUPPORT_SELECT", True)
     else:
-        set_opt("CONFIG_VFS_SUPPORT_SELECT", not disable_vfs_select)
+        set_idf_sdkconfig_default("CONFIG_VFS_SUPPORT_SELECT", not disable_vfs_select)
 
     # Directory functions: opendir/readdir/mkdir etc. (require_vfs_dir()). ~0.5KB flash when off.
     if CORE.data.get(KEY_VFS_DIR_REQUIRED, False):
-        set_opt("CONFIG_VFS_SUPPORT_DIR", True)
+        set_idf_sdkconfig_default("CONFIG_VFS_SUPPORT_DIR", True)
     else:
-        set_opt("CONFIG_VFS_SUPPORT_DIR", not disable_vfs_dir)
+        set_idf_sdkconfig_default("CONFIG_VFS_SUPPORT_DIR", not disable_vfs_dir)
 
     # FATFS (require_fatfs()): LFN + one volume per esp_vfs_fat mount. Defaults only;
     # sdkconfig_options override. FATFS_LONG_FILENAMES is a Kconfig choice -- if the user set
@@ -2379,15 +2366,15 @@ async def _reconcile_vfs_fatfs_sdkconfig(
     user_picked_lfn = any(k in opts for k in lfn_keys)
     if CORE.data[KEY_ESP32].get(KEY_FATFS_REQUIRED, False):
         if not user_picked_lfn:
-            set_opt("CONFIG_FATFS_LFN_NONE", False)
-            set_opt("CONFIG_FATFS_LFN_HEAP", True)
-            set_opt("CONFIG_FATFS_MAX_LFN", 255)
-        set_opt("CONFIG_FATFS_VOLUME_COUNT", 4)
+            set_idf_sdkconfig_default("CONFIG_FATFS_LFN_NONE", False)
+            set_idf_sdkconfig_default("CONFIG_FATFS_LFN_HEAP", True)
+            set_idf_sdkconfig_default("CONFIG_FATFS_MAX_LFN", 255)
+        set_idf_sdkconfig_default("CONFIG_FATFS_VOLUME_COUNT", 4)
     elif disable_fatfs:
         if not user_picked_lfn:
-            set_opt("CONFIG_FATFS_LFN_NONE", True)
+            set_idf_sdkconfig_default("CONFIG_FATFS_LFN_NONE", True)
         # Kconfig range is [1,10]; 0 gets clamped to the default.
-        set_opt("CONFIG_FATFS_VOLUME_COUNT", 1)
+        set_idf_sdkconfig_default("CONFIG_FATFS_VOLUME_COUNT", 1)
 
 
 @coroutine_with_priority(CoroPriority.FINAL - 1)
@@ -2968,6 +2955,9 @@ async def to_code(config):
     # FINAL priority: runs after every network/coexistence request_*() call
     CORE.add_job(_reconcile_network_sdkconfig)
 
+    # FINAL priority: runs after every require_certificate_bundle() call
+    CORE.add_job(_reconcile_certificate_bundle_sdkconfig)
+
     # FINAL: require_*() calls can come from to_code at or below this priority, so an
     # inline read would be iteration-order-dependent; reconcile once after every job ran.
     CORE.add_job(
@@ -2995,6 +2985,19 @@ async def to_code(config):
 
     for name, value in conf[CONF_SDKCONFIG_OPTIONS].items():
         add_idf_sdkconfig_option(name, RawSdkconfigValue(value))
+    # A bundle forced on through sdkconfig_options is a request like any other,
+    # so it still gets the CMN variant pinned.
+    if (
+        _format_sdkconfig_val(
+            RawSdkconfigValue(
+                conf[CONF_SDKCONFIG_OPTIONS].get(
+                    "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", "n"
+                )
+            )
+        )
+        == "y"
+    ):
+        require_certificate_bundle()
 
     # Components from YAML are added in a separate coroutine with FINAL priority
     # Schedule it to run after all other components
@@ -3005,7 +3008,6 @@ async def to_code(config):
     # a chance to call include_builtin_idf_component() to re-enable components they need.
     # Default exclusions are added in set_core_data() during config validation.
     CORE.add_job(_write_exclude_components)
-    CORE.add_job(_write_certificate_bundle_sdkconfig)
 
     # Write Arduino selective compilation sdkconfig at FINAL priority after all
     # components have had a chance to call cg.add_library() to enable libraries they need.

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -344,6 +344,10 @@ ARDUINO_LIBRARY_IDF_COMPONENTS: dict[str, tuple[str, ...]] = {
     "Zigbee": ("espressif__esp-zigbee-lib", "espressif__esp-zboss-lib"),
 }
 
+# Arduino libraries whose sources reference esp_crt_bundle_attach without a
+# CONFIG_MBEDTLS_CERTIFICATE_BUNDLE guard, so enabling them needs the bundle.
+ARDUINO_LIBRARIES_NEEDING_CERT_BUNDLE = frozenset({"NetworkClientSecure"})
+
 # Arduino library to Arduino library dependencies
 # When enabling one library, also enable its dependencies
 # Kconfig "select" statements don't work with CONFIG_ARDUINO_SELECTIVE_COMPILATION
@@ -800,8 +804,9 @@ def _enable_arduino_library(name: str) -> None:
     # Also enable any required IDF components
     for idf_component in ARDUINO_LIBRARY_IDF_COMPONENTS.get(name, ()):
         include_builtin_idf_component(idf_component)
-    # ssl_client.cpp references esp_crt_bundle_attach without a guard
-    if name == "NetworkClientSecure":
+    if not ARDUINO_LIBRARIES_NEEDING_CERT_BUNDLE.isdisjoint(
+        {name, *ARDUINO_LIBRARY_DEPENDENCIES.get(name, ())}
+    ):
         require_certificate_bundle()
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2186,7 +2186,14 @@ async def _write_certificate_bundle_sdkconfig() -> None:
         if name not in opts:
             add_idf_sdkconfig_option(name, value)
 
-    if not data.get(KEY_CERT_BUNDLE, False):
+    # A user forcing the bundle on through sdkconfig_options still gets the
+    # CMN variant pinned, as before this job existed.
+    user_value = opts.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE")
+    user_enabled = str(getattr(user_value, "value", user_value)).lower() in (
+        "y",
+        "true",
+    )
+    if not (data.get(KEY_CERT_BUNDLE, False) or user_enabled):
         set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", False)
         return
     set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -65,6 +65,7 @@ from .boards import BOARDS, STANDARD_BOARDS
 from .const import (
     KEY_ARDUINO_LIBRARIES,
     KEY_BOARD,
+    KEY_CERT_BUNDLE,
     KEY_COMPONENTS,
     KEY_ESP32,
     KEY_EXCLUDE_COMPONENTS,
@@ -1735,6 +1736,16 @@ def require_vfs_termios() -> None:
     CORE.data[KEY_VFS_TERMIOS_REQUIRED] = True
 
 
+def require_certificate_bundle() -> None:
+    """Enable the mbedTLS root certificate bundle for this build.
+
+    The bundle is off by default; components that verify TLS server
+    certificates (http_request, audio streaming) call this so the bundle is
+    compiled and gen_crt_bundle runs only when something uses it.
+    """
+    CORE.data[KEY_ESP32][KEY_CERT_BUNDLE] = True
+
+
 def require_full_certificate_bundle() -> None:
     """Request the full certificate bundle instead of the common-CAs-only bundle.
 
@@ -1744,6 +1755,7 @@ def require_full_certificate_bundle() -> None:
 
     Call this from components that need to connect to services using uncommon CAs.
     """
+    CORE.data[KEY_ESP32][KEY_CERT_BUNDLE] = True
     CORE.data[KEY_ESP32][KEY_FULL_CERT_BUNDLE] = True
 
 
@@ -2158,6 +2170,30 @@ def register_exclude_components_cmake_arg() -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
+async def _write_certificate_bundle_sdkconfig() -> None:
+    """Enable the mbedTLS certificate bundle only when a component asked for it.
+
+    Runs at FINAL priority so every require_certificate_bundle() call has
+    happened. Without a request the bundle is disabled, which skips
+    esp_crt_bundle.c, the gen_crt_bundle step and the x509_crt_bundle.S embed.
+    """
+    data = CORE.data[KEY_ESP32]
+    if not data.get(KEY_CERT_BUNDLE, False):
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", False)
+        return
+    add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+    # Use CMN (common CAs) bundle by default to save ~51KB flash
+    # CMN covers CAs with >1% market share (~99% of websites)
+    # Components needing uncommon CAs can call require_full_certificate_bundle()
+    use_full_bundle = data.get(KEY_FULL_CERT_BUNDLE, False)
+    add_idf_sdkconfig_option(
+        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
+    )
+    if not use_full_bundle:
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
 async def _write_exclude_components() -> None:
     """Write EXCLUDE_COMPONENTS cmake arg after all components have registered exclusions."""
     register_exclude_components_cmake_arg()
@@ -2525,21 +2561,11 @@ async def to_code(config):
         )
 
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PSK_MODES", True)
-        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
 
     cg.add_build_flag("-Wno-nonnull-compare")
 
-    # Use CMN (common CAs) bundle by default to save ~51KB flash
-    # CMN covers CAs with >1% market share (~99% of websites)
-    # Components needing uncommon CAs can call require_full_certificate_bundle()
-    use_full_bundle = conf[CONF_ADVANCED].get(
-        CONF_USE_FULL_CERTIFICATE_BUNDLE, False
-    ) or CORE.data[KEY_ESP32].get(KEY_FULL_CERT_BUNDLE, False)
-    add_idf_sdkconfig_option(
-        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
-    )
-    if not use_full_bundle:
-        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
+    if conf[CONF_ADVANCED].get(CONF_USE_FULL_CERTIFICATE_BUNDLE, False):
+        require_full_certificate_bundle()
 
     add_idf_sdkconfig_option(f"CONFIG_IDF_TARGET_{variant}", True)
     add_idf_sdkconfig_option(
@@ -2966,6 +2992,7 @@ async def to_code(config):
     # a chance to call include_builtin_idf_component() to re-enable components they need.
     # Default exclusions are added in set_core_data() during config validation.
     CORE.add_job(_write_exclude_components)
+    CORE.add_job(_write_certificate_bundle_sdkconfig)
 
     # Write Arduino selective compilation sdkconfig at FINAL priority after all
     # components have had a chance to call cg.add_library() to enable libraries they need.

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2176,21 +2176,27 @@ async def _write_certificate_bundle_sdkconfig() -> None:
     Runs at FINAL priority so every require_certificate_bundle() call has
     happened. Without a request the bundle is disabled, which skips
     esp_crt_bundle.c, the gen_crt_bundle step and the x509_crt_bundle.S embed.
+    A user-supplied sdkconfig_options value takes precedence.
     """
     data = CORE.data[KEY_ESP32]
+    opts = data[KEY_SDKCONFIG_OPTIONS]
+
+    def set_opt(name: str, value: SdkconfigValueType) -> None:
+        # User sdkconfig_options (applied during to_code) win.
+        if name not in opts:
+            add_idf_sdkconfig_option(name, value)
+
     if not data.get(KEY_CERT_BUNDLE, False):
-        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", False)
+        set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", False)
         return
-    add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+    set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
     # Use CMN (common CAs) bundle by default to save ~51KB flash
     # CMN covers CAs with >1% market share (~99% of websites)
     # Components needing uncommon CAs can call require_full_certificate_bundle()
     use_full_bundle = data.get(KEY_FULL_CERT_BUNDLE, False)
-    add_idf_sdkconfig_option(
-        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
-    )
+    set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle)
     if not use_full_bundle:
-        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
+        set_opt("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
 
 
 @coroutine_with_priority(CoroPriority.FINAL)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -646,10 +646,11 @@ SdkconfigValueType = bool | int | HexInt | str | RawSdkconfigValue
 
 
 def set_idf_sdkconfig_default(name: str, value: SdkconfigValueType) -> None:
-    """Set an sdkconfig option unless the user already set it in sdkconfig_options.
+    """Set an sdkconfig option unless it is already set.
 
-    For the FINAL priority reconcile jobs, which run after the user options
-    were applied in to_code and must not override them.
+    For the FINAL priority reconcile jobs: they run after every to_code,
+    including the user's sdkconfig_options, and must not override an
+    existing value.
     """
     if name not in CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]:
         add_idf_sdkconfig_option(name, value)
@@ -799,6 +800,9 @@ def _enable_arduino_library(name: str) -> None:
     # Also enable any required IDF components
     for idf_component in ARDUINO_LIBRARY_IDF_COMPONENTS.get(name, ()):
         include_builtin_idf_component(idf_component)
+    # ssl_client.cpp references esp_crt_bundle_attach without a guard
+    if name == "NetworkClientSecure":
+        require_certificate_bundle()
 
 
 def add_extra_script(stage: str, filename: str, path: Path):

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2987,16 +2987,7 @@ async def to_code(config):
         add_idf_sdkconfig_option(name, RawSdkconfigValue(value))
     # A bundle forced on through sdkconfig_options is a request like any other,
     # so it still gets the CMN variant pinned.
-    if (
-        _format_sdkconfig_val(
-            RawSdkconfigValue(
-                conf[CONF_SDKCONFIG_OPTIONS].get(
-                    "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", "n"
-                )
-            )
-        )
-        == "y"
-    ):
+    if conf[CONF_SDKCONFIG_OPTIONS].get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE") == "y":
         require_certificate_bundle()
 
     # Components from YAML are added in a separate coroutine with FINAL priority

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -27,6 +27,7 @@ KEY_REFRESH = "refresh"
 KEY_PATH = "path"
 KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
+KEY_CERT_BUNDLE = "cert_bundle"
 KEY_FULL_CERT_BUNDLE = "full_cert_bundle"
 KEY_NETWORK_SDKCONFIG = "network_sdkconfig"
 

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -196,9 +196,7 @@ async def to_code(config: ConfigType) -> None:
                 #     framework:
                 #       advanced:
                 #         use_full_certificate_bundle: true
-                esp32.add_idf_sdkconfig_option(
-                    "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True
-                )
+                esp32.require_certificate_bundle()
 
         esp32.add_idf_sdkconfig_option(
             "CONFIG_ESP_TLS_INSECURE",

--- a/tests/component_tests/esp32/config/certificate_bundle_arduino_tls.yaml
+++ b/tests/component_tests/esp32/config/certificate_bundle_arduino_tls.yaml
@@ -1,0 +1,9 @@
+esphome:
+  name: test
+  libraries:
+    - NetworkClientSecure
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino

--- a/tests/component_tests/esp32/config/certificate_bundle_full.yaml
+++ b/tests/component_tests/esp32/config/certificate_bundle_full.yaml
@@ -1,0 +1,9 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    advanced:
+      use_full_certificate_bundle: true

--- a/tests/component_tests/esp32/config/certificate_bundle_http_request.yaml
+++ b/tests/component_tests/esp32/config/certificate_bundle_http_request.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+http_request:
+  verify_ssl: true

--- a/tests/component_tests/esp32/config/certificate_bundle_sdkconfig.yaml
+++ b/tests/component_tests/esp32/config/certificate_bundle_sdkconfig.yaml
@@ -1,0 +1,9 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_MBEDTLS_CERTIFICATE_BUNDLE: y

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -344,6 +344,10 @@ def test_user_sdkconfig_certificate_bundle_wins(
     ]
     assert isinstance(value, RawSdkconfigValue)
     assert value.value == "y"
+    # The variant choice is still pinned to CMN for a user-forced bundle.
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN") is True
+    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL") is False
 
 
 def test_execute_from_psram_s3_sdkconfig(

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -293,59 +293,54 @@ def test_default_exclusions_reincluded_by_owning_components(
     assert "fatfs" in excluded
 
 
+_BUNDLE_OPTIONS = (
+    "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE",
+    "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN",
+    "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL",
+)
+
+
 @pytest.mark.parametrize(
-    ("config_file", "enabled"),
+    ("config_file", "expected"),
     [
-        pytest.param("exclusion_reincludes.yaml", False, id="no_tls_client"),
-        pytest.param("certificate_bundle_http_request.yaml", True, id="http_request"),
+        pytest.param("exclusion_reincludes.yaml", (False, None, None), id="no_tls"),
+        pytest.param(
+            "certificate_bundle_http_request.yaml",
+            (True, True, False),
+            id="http_request",
+        ),
         pytest.param(
             "exclusion_reincludes_http_request.yaml",
-            False,
+            (False, None, None),
             id="http_request_no_verify",
+        ),
+        pytest.param(
+            "certificate_bundle_full.yaml", (True, None, True), id="full_option"
         ),
     ],
 )
-def test_certificate_bundle_only_when_requested(
+def test_certificate_bundle_sdkconfig(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
     config_file: str,
-    enabled: bool,
+    expected: tuple[bool | None, ...],
 ) -> None:
-    """The mbedTLS certificate bundle is compiled only when a component asks for it."""
+    """The bundle and its CMN/FULL variant are written only when requested."""
     generate_main(component_config_path(config_file))
     sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
-    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE") is enabled
-    if enabled:
-        assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN") is True
-    else:
-        assert "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN" not in sdkconfig
-
-
-def test_full_certificate_bundle_option_enables_bundle(
-    generate_main: Callable[[str | Path], str],
-    component_config_path: Callable[[str], Path],
-) -> None:
-    """use_full_certificate_bundle turns the bundle on and selects the full variant."""
-    generate_main(component_config_path("certificate_bundle_full.yaml"))
-    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
-    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE") is True
-    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL") is True
-    assert "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN" not in sdkconfig
+    assert tuple(sdkconfig.get(name) for name in _BUNDLE_OPTIONS) == expected
 
 
 def test_user_sdkconfig_certificate_bundle_wins(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
 ) -> None:
-    """A raw sdkconfig_options bundle setting is not overridden by the FINAL job."""
+    """A raw sdkconfig_options bundle setting is kept and still pins CMN."""
     generate_main(component_config_path("certificate_bundle_sdkconfig.yaml"))
-    value = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS][
-        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE"
-    ]
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    value = sdkconfig["CONFIG_MBEDTLS_CERTIFICATE_BUNDLE"]
     assert isinstance(value, RawSdkconfigValue)
     assert value.value == "y"
-    # The variant choice is still pinned to CMN for a user-forced bundle.
-    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN") is True
     assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL") is False
 

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -317,6 +317,11 @@ _BUNDLE_OPTIONS = (
         pytest.param(
             "certificate_bundle_full.yaml", (True, None, True), id="full_option"
         ),
+        pytest.param(
+            "certificate_bundle_arduino_tls.yaml",
+            (True, True, False),
+            id="arduino_network_client_secure",
+        ),
     ],
 )
 def test_certificate_bundle_sdkconfig(

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -292,6 +292,34 @@ def test_default_exclusions_reincluded_by_owning_components(
     assert "fatfs" in excluded
 
 
+@pytest.mark.parametrize(
+    ("config_file", "enabled"),
+    [
+        pytest.param("exclusion_reincludes.yaml", False, id="no_tls_client"),
+        pytest.param("certificate_bundle_http_request.yaml", True, id="http_request"),
+        pytest.param(
+            "exclusion_reincludes_http_request.yaml",
+            False,
+            id="http_request_no_verify",
+        ),
+    ],
+)
+def test_certificate_bundle_only_when_requested(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+    config_file: str,
+    enabled: bool,
+) -> None:
+    """The mbedTLS certificate bundle is compiled only when a component asks for it."""
+    generate_main(component_config_path(config_file))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE") is enabled
+    if enabled:
+        assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN") is True
+    else:
+        assert "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN" not in sdkconfig
+
+
 def test_execute_from_psram_s3_sdkconfig(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -17,6 +17,7 @@ from esphome.components.esp32 import (
     VARIANT_ESP32,
     VARIANTS,
     NetworkSdkconfigData,
+    RawSdkconfigValue,
     _ota_downgrade_protection_errors,
     _reconcile_network_sdkconfig,
     _reconcile_vfs_fatfs_sdkconfig,
@@ -318,6 +319,31 @@ def test_certificate_bundle_only_when_requested(
         assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN") is True
     else:
         assert "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN" not in sdkconfig
+
+
+def test_full_certificate_bundle_option_enables_bundle(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """use_full_certificate_bundle turns the bundle on and selects the full variant."""
+    generate_main(component_config_path("certificate_bundle_full.yaml"))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE") is True
+    assert sdkconfig.get("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL") is True
+    assert "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN" not in sdkconfig
+
+
+def test_user_sdkconfig_certificate_bundle_wins(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """A raw sdkconfig_options bundle setting is not overridden by the FINAL job."""
+    generate_main(component_config_path("certificate_bundle_sdkconfig.yaml"))
+    value = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS][
+        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE"
+    ]
+    assert isinstance(value, RawSdkconfigValue)
+    assert value.value == "y"
 
 
 def test_execute_from_psram_s3_sdkconfig(

--- a/tests/components/esp32/test.esp32-idf.yaml
+++ b/tests/components/esp32/test.esp32-idf.yaml
@@ -7,7 +7,7 @@ esp32:
       enable_lwip_mdns_queries: true
       enable_lwip_bridge_interface: true
       disable_libc_locks_in_iram: false  # Test explicit opt-out of RAM optimization
-      use_full_certificate_bundle: false  # Test CMN bundle (default)
+      use_full_certificate_bundle: false  # Bundle stays off without a component that needs it
       include_builtin_idf_components:
         - freertos  # Test escape hatch (freertos is always included anyway)
       enable_full_printf: false


### PR DESCRIPTION
# What does this implement/fix?

Every ESP32 build had the root certificate bundle enabled: IDF's Kconfig default turns it on for esp-idf builds and the esp32 component forced `CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y` for Arduino builds. That compiles `esp_crt_bundle.c`, runs `gen_crt_bundle.py` and assembles the `x509_crt_bundle.S` embed even when nothing in the firmware verifies a TLS server. Only `http_request` (with `verify_ssl`) and the `audio` HTTP reader use the bundle, and both already guard their use with `#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE`.

The bundle is now off unless a component asks for it: a new `esp32.require_certificate_bundle()` helper sets it, `require_full_certificate_bundle()` and `use_full_certificate_bundle: true` imply it, and `http_request` and `audio` call it. The sdkconfig options are written by a FINAL priority job so every request is seen before the CMN or full bundle choice is made. A value set through `sdkconfig_options` still wins, like the other FINAL reconcile jobs.

Measured on a cold ESP32 IDF build of an Ethernet config without `http_request` (`gatetrigger.yaml`, no ccache): 2 fewer files, 820 to 818 (`esp_crt_bundle.c` and `x509_crt_bundle.S`), plus the bundle generation step, saving about 0.4s of compile time per `.ninja_log`. These times are from an Apple Silicon Mac; on a Raspberry Pi or Home Assistant Green each file costs 3 to 8 times as much, so the saving there is larger. A grouped esp32-idf compile of `http_request`, `web_server` and `esp32_camera_web_server` still passes with the bundle enabled.

External components that call `esp_crt_bundle_attach()` need to call `esp32.require_certificate_bundle()` in their `to_code`, or guard the call with `#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


