### PR TITLE
[espidf] Cache the discovered component list to skip the discovery configure

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -57,9 +57,10 @@ def get_available_components_with_dirs() -> dict[str, str] | None:
         root = (Path(data["idf_path"]) / "components").resolve()
 
         result = {
-            name: info["dir"]
+            name: comp_dir
             for name, info in component_info.items()
-            if Path(info.get("dir", "")).resolve().is_relative_to(root)
+            if (comp_dir := info.get("dir"))
+            and Path(comp_dir).resolve().is_relative_to(root)
         }
         if not result:
             _LOGGER.warning("No ESP-IDF components found under %s", root)

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -1,6 +1,7 @@
 """ESP-IDF direct build generator for ESPHome."""
 
 import json
+import logging
 from pathlib import Path
 
 from esphome.components.esp32 import (
@@ -19,6 +20,8 @@ from esphome.framework_helpers import (
 )
 from esphome.helpers import mkdir_p, write_file_if_changed
 
+_LOGGER = logging.getLogger(__name__)
+
 # Replaces the IDF default C++ standard (-std=gnu++2b appended to
 # CXX_COMPILE_OPTIONS by project.cmake's __build_init) with the one set via
 # cg.set_cpp_standard(). Emitted between include(project.cmake) and project(),
@@ -31,16 +34,13 @@ list(APPEND esphome_cxx_compile_options "-std={standard}")
 idf_build_set_property(CXX_COMPILE_OPTIONS "${{esphome_cxx_compile_options}}")"""
 
 
-def get_available_components_with_dirs(
-    root: Path | None = None,
-) -> dict[str, str] | None:
+def get_available_components_with_dirs() -> dict[str, str] | None:
     """Map built-in ESP-IDF component names to their source directories.
 
-    Read from ``project_description.json``. Excludes ``src``, IDF-managed
-    components (``managed_components/``), and converted PIO libs
-    (``pio_components/``). With ``root`` only components below that
-    directory are kept, which drops project local ones such as the Arduino
-    ``component_stubs``. Returns ``None`` if the build dir or
+    Read from ``project_description.json``; only components below its
+    ``idf_path/components`` count, which leaves out ``src``, IDF-managed
+    components, converted PIO libs and project local ones such as the
+    Arduino ``component_stubs``. Returns ``None`` if the build dir or
     ``project_description.json`` isn't ready yet.
     """
     if CORE.build_path is None:
@@ -54,24 +54,17 @@ def get_available_components_with_dirs(
             data = json.load(f)
 
         component_info = data.get("build_component_info", {})
+        root = (Path(data["idf_path"]) / "components").resolve()
 
-        result: dict[str, str] = {}
-        for name, info in component_info.items():
-            # Exclude our own src component
-            if name == "src":
-                continue
-
-            # Exclude IDF-managed and converted-PIO components (external).
-            comp_dir = info.get("dir", "")
-            if "managed_components" in comp_dir or "pio_components" in comp_dir:
-                continue
-            if root is not None and not Path(comp_dir).resolve().is_relative_to(root):
-                continue
-
-            result[name] = comp_dir
-
+        result = {
+            name: info["dir"]
+            for name, info in component_info.items()
+            if Path(info.get("dir", "")).resolve().is_relative_to(root)
+        }
+        if not result:
+            _LOGGER.warning("No ESP-IDF components found under %s", root)
         return result
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, KeyError, OSError):
         return None
 
 

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -34,14 +34,13 @@ list(APPEND esphome_cxx_compile_options "-std={standard}")
 idf_build_set_property(CXX_COMPILE_OPTIONS "${{esphome_cxx_compile_options}}")"""
 
 
-def get_available_components_with_dirs() -> dict[str, str] | None:
-    """Map built-in ESP-IDF component names to their source directories.
+def get_available_components() -> list[str] | None:
+    """List the built-in ESP-IDF components from ``project_description.json``.
 
-    Read from ``project_description.json``; only components below its
-    ``idf_path/components`` count, which leaves out ``src``, IDF-managed
-    components, converted PIO libs and project local ones such as the
-    Arduino ``component_stubs``. Returns ``None`` if the build dir or
-    ``project_description.json`` isn't ready yet.
+    Only components below its ``idf_path/components`` count, which leaves out
+    ``src``, IDF-managed components, converted PIO libs and project local
+    ones such as the Arduino ``component_stubs``. Returns ``None`` if the
+    build dir or ``project_description.json`` isn't ready yet.
     """
     if CORE.build_path is None:
         return None
@@ -52,35 +51,24 @@ def get_available_components_with_dirs() -> dict[str, str] | None:
     try:
         with project_desc.open(encoding="utf-8") as f:
             data = json.load(f)
-
-        component_info = data.get("build_component_info", {})
         root = (Path(data["idf_path"]) / "components").resolve()
-
-        result = {
-            name: comp_dir
-            for name, info in component_info.items()
+        result = [
+            name
+            for name, info in data.get("build_component_info", {}).items()
             if (comp_dir := info.get("dir"))
             and Path(comp_dir).resolve().is_relative_to(root)
-        }
-        if not result:
-            _LOGGER.warning("No ESP-IDF components found under %s", root)
-        return result
-    except (json.JSONDecodeError, KeyError, OSError):
+        ]
+    except (json.JSONDecodeError, KeyError, OSError) as err:
+        _LOGGER.debug("Could not read %s: %s", project_desc, err)
         return None
-
-
-def get_available_components() -> list[str] | None:
-    """Get list of built-in ESP-IDF components from project_description.json.
-
-    See ``get_available_components_with_dirs``; returns ``None`` when that does.
-    """
-    components = get_available_components_with_dirs()
-    return None if components is None else list(components)
+    if not result:
+        _LOGGER.warning("No ESP-IDF components found under %s", root)
+    return result
 
 
 def has_discovered_components() -> bool:
-    """Check if we have discovered components from a previous configure."""
-    return get_available_components_with_dirs() is not None
+    """Check if a previous configure discovered any built-in components."""
+    return bool(get_available_components())
 
 
 def _cmake_quote(value: str) -> str:

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -31,12 +31,16 @@ list(APPEND esphome_cxx_compile_options "-std={standard}")
 idf_build_set_property(CXX_COMPILE_OPTIONS "${{esphome_cxx_compile_options}}")"""
 
 
-def get_available_components_with_dirs() -> dict[str, str] | None:
+def get_available_components_with_dirs(
+    root: Path | None = None,
+) -> dict[str, str] | None:
     """Map built-in ESP-IDF component names to their source directories.
 
     Read from ``project_description.json``. Excludes ``src``, IDF-managed
     components (``managed_components/``), and converted PIO libs
-    (``pio_components/``). Returns ``None`` if the build dir or
+    (``pio_components/``). With ``root`` only components below that
+    directory are kept, which drops project local ones such as the Arduino
+    ``component_stubs``. Returns ``None`` if the build dir or
     ``project_description.json`` isn't ready yet.
     """
     if CORE.build_path is None:
@@ -61,6 +65,8 @@ def get_available_components_with_dirs() -> dict[str, str] | None:
             comp_dir = info.get("dir", "")
             if "managed_components" in comp_dir or "pio_components" in comp_dir:
                 continue
+            if root is not None and not Path(comp_dir).resolve().is_relative_to(root):
+                continue
 
             result[name] = comp_dir
 
@@ -80,7 +86,7 @@ def get_available_components() -> list[str] | None:
 
 def has_discovered_components() -> bool:
     """Check if we have discovered components from a previous configure."""
-    return get_available_components() is not None
+    return get_available_components_with_dirs() is not None
 
 
 def _cmake_quote(value: str) -> str:
@@ -100,8 +106,6 @@ def get_project_cmakelists(
     ``builtin_components`` supplies the discovered list (from the cache)
     instead of reading it from ``project_description.json``.
     """
-    if builtin_components is None:
-        builtin_components = get_available_components()
     idf_target = variant_to_idf_target(get_esp32_variant())
 
     # esp_idf_size 2.x (bundled with IDF >=6.0) made NG the default and
@@ -177,9 +181,11 @@ def get_project_cmakelists(
         else "\n".join(
             f"idf_build_set_property(ESPHOME_PROJECT_BUILTIN_COMPONENTS {name} APPEND)"
             for name in sorted(
-                set(builtin_components or []).difference(
-                    CORE.cmake_args.get("EXCLUDE_COMPONENTS", "").split(";")
-                )
+                set(
+                    builtin_components
+                    if builtin_components is not None
+                    else get_available_components() or []
+                ).difference(CORE.cmake_args.get("EXCLUDE_COMPONENTS", "").split(";"))
             )
         )
     )

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -11,6 +11,7 @@ from esphome.components.esp32 import (
 )
 import esphome.config_validation as cv
 from esphome.core import CORE
+from esphome.espidf import variant_to_idf_target
 from esphome.framework_helpers import (
     get_project_compile_flags,
     get_project_cxx_compile_flags,
@@ -30,12 +31,13 @@ list(APPEND esphome_cxx_compile_options "-std={standard}")
 idf_build_set_property(CXX_COMPILE_OPTIONS "${{esphome_cxx_compile_options}}")"""
 
 
-def get_available_components() -> list[str] | None:
-    """Get list of built-in ESP-IDF components from project_description.json.
+def get_available_components_with_dirs() -> dict[str, str] | None:
+    """Map built-in ESP-IDF component names to their source directories.
 
-    Excludes ``src``, IDF-managed components (``managed_components/``), and
-    converted PIO libs (``pio_components/``). Returns ``None`` if the build
-    dir or ``project_description.json`` isn't ready yet.
+    Read from ``project_description.json``. Excludes ``src``, IDF-managed
+    components (``managed_components/``), and converted PIO libs
+    (``pio_components/``). Returns ``None`` if the build dir or
+    ``project_description.json`` isn't ready yet.
     """
     if CORE.build_path is None:
         return None
@@ -49,7 +51,7 @@ def get_available_components() -> list[str] | None:
 
         component_info = data.get("build_component_info", {})
 
-        result = []
+        result: dict[str, str] = {}
         for name, info in component_info.items():
             # Exclude our own src component
             if name == "src":
@@ -60,11 +62,20 @@ def get_available_components() -> list[str] | None:
             if "managed_components" in comp_dir or "pio_components" in comp_dir:
                 continue
 
-            result.append(name)
+            result[name] = comp_dir
 
         return result
     except (json.JSONDecodeError, OSError):
         return None
+
+
+def get_available_components() -> list[str] | None:
+    """Get list of built-in ESP-IDF components from project_description.json.
+
+    See ``get_available_components_with_dirs``; returns ``None`` when that does.
+    """
+    components = get_available_components_with_dirs()
+    return None if components is None else list(components)
 
 
 def has_discovered_components() -> bool:
@@ -79,15 +90,19 @@ def _cmake_quote(value: str) -> str:
     return f'"{escaped}"'
 
 
-def get_project_cmakelists(minimal: bool = False) -> str:
+def get_project_cmakelists(
+    minimal: bool = False, builtin_components: list[str] | None = None
+) -> str:
     """Generate the top-level CMakeLists.txt for ESP-IDF project.
 
     When ``minimal`` is true, omit ``ESPHOME_PROJECT_BUILTIN_COMPONENTS``
     since ``project_description.json`` may be stale on the first write.
+    ``builtin_components`` supplies the discovered list (from the cache)
+    instead of reading it from ``project_description.json``.
     """
-    # Get IDF target from ESP32 variant (e.g., ESP32S3 -> esp32s3)
-    variant = get_esp32_variant()
-    idf_target = variant.lower().replace("-", "")
+    if builtin_components is None:
+        builtin_components = get_available_components()
+    idf_target = variant_to_idf_target(get_esp32_variant())
 
     # esp_idf_size 2.x (bundled with IDF >=6.0) made NG the default and
     # removed the --ng flag; on 1.x (IDF 5.5) --ng is required to get
@@ -162,7 +177,7 @@ def get_project_cmakelists(minimal: bool = False) -> str:
         else "\n".join(
             f"idf_build_set_property(ESPHOME_PROJECT_BUILTIN_COMPONENTS {name} APPEND)"
             for name in sorted(
-                set(get_available_components() or []).difference(
+                set(builtin_components or []).difference(
                     CORE.cmake_args.get("EXCLUDE_COMPONENTS", "").split(";")
                 )
             )
@@ -279,7 +294,9 @@ target_link_options(${{COMPONENT_LIB}} PUBLIC
 """
 
 
-def write_project(minimal: bool = False) -> None:
+def write_project(
+    minimal: bool = False, builtin_components: list[str] | None = None
+) -> None:
     """Write ESP-IDF project files."""
     mkdir_p(CORE.build_path)
     mkdir_p(CORE.relative_src_path())
@@ -287,7 +304,7 @@ def write_project(minimal: bool = False) -> None:
     # Write top-level CMakeLists.txt
     write_file_if_changed(
         CORE.relative_build_path("CMakeLists.txt"),
-        get_project_cmakelists(minimal=minimal),
+        get_project_cmakelists(minimal=minimal, builtin_components=builtin_components),
     )
 
     # Write component CMakeLists.txt in src/

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -298,27 +298,14 @@ def load_cached_builtin_components() -> list[str] | None:
     return None
 
 
-def save_cached_builtin_components() -> list[str] | None:
-    """Store the components discovered by the last configure and return them.
-
-    Only components under ``$IDF_PATH/components`` are kept; project local
-    ones (Arduino ``component_stubs``, ``override_path`` entries) are
-    reachable through the manifest and must not leak into other builds.
-    """
-    from esphome.build_gen.espidf import get_available_components_with_dirs
-
-    if (path := _builtin_component_cache_path()) is None:
-        return None
-    root = (path.parents[1] / "components").resolve()
-    components = get_available_components_with_dirs(root)
-    if not components:
-        return None
-    builtin = sorted(components)
+def save_cached_builtin_components(components: list[str]) -> None:
+    """Store a built-in component list that just configured successfully."""
+    if not components or (path := _builtin_component_cache_path()) is None:
+        return
     try:
-        write_file(path, json.dumps(builtin, separators=(",", ":")))
+        write_file(path, json.dumps(components, separators=(",", ":")))
     except EsphomeError as err:
-        _LOGGER.debug("Could not write component list cache %s: %s", path, err)
-    return builtin
+        _LOGGER.warning("Could not write component list cache %s: %s", path, err)
 
 
 def _write_project_and_reconfigure(builtin_components: list[str] | None) -> int:
@@ -338,14 +325,14 @@ def _configure_project() -> int:
     """Configure the project, discovering the built-in components if needed.
 
     A cached component list skips the discovery configure. If the configure
-    with a cached list fails the entry is dropped and discovery runs once, so
-    a bad entry never poisons later builds.
+    with a cached list fails the entry is dropped and discovery runs once; a
+    list is only cached after it configured successfully.
     """
-    from esphome.build_gen.espidf import write_project
+    from esphome.build_gen.espidf import get_available_components, write_project
 
     if (cached := load_cached_builtin_components()) is not None:
         _LOGGER.info("Using cached ESP-IDF component list")
-        if (rc := _write_project_and_reconfigure(cached)) == 0:
+        if _write_project_and_reconfigure(cached) == 0:
             return 0
         _LOGGER.warning("Cached component list failed; rediscovering")
         _builtin_component_cache_path().unlink(missing_ok=True)
@@ -354,9 +341,12 @@ def _configure_project() -> int:
     if (rc := run_reconfigure()) != 0:
         _LOGGER.error("Component discovery failed")
         return rc
-    if (rc := _write_project_and_reconfigure(save_cached_builtin_components())) != 0:
+    discovered = get_available_components()
+    if (rc := _write_project_and_reconfigure(discovered)) != 0:
         _LOGGER.error("Reconfigure with discovered components failed")
-    return rc
+        return rc
+    save_cached_builtin_components(discovered or [])
+    return 0
 
 
 def has_outdated_files():

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -287,7 +287,11 @@ def load_cached_builtin_components() -> list[str] | None:
         return None
     try:
         components = json.loads(path.read_text(encoding="utf-8"))
-        present = {entry.name for entry in (path.parents[1] / "components").iterdir()}
+        present = {
+            entry.name
+            for entry in (path.parents[1] / "components").iterdir()
+            if entry.is_dir()
+        }
     except (OSError, ValueError):
         return None
     if (
@@ -343,8 +347,8 @@ def _configure_project() -> int:
         _LOGGER.error("Component discovery failed")
         return rc
     discovered = get_available_components()
-    if discovered is None:
-        _LOGGER.error("Component discovery produced no project_description.json")
+    if not discovered:
+        _LOGGER.error("Component discovery found no built-in ESP-IDF components")
         return 1
     if (rc := _write_project_and_reconfigure(discovered)) != 0:
         _LOGGER.error("Reconfigure with discovered components failed")

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -301,7 +301,9 @@ def load_cached_builtin_components() -> list[str] | None:
     components_dir = _get_idf_path(_get_core_framework_version()) / "components"
     if not (
         isinstance(components, list)
-        and all(isinstance(c, str) and (components_dir / c).is_dir() for c in components)
+        and all(
+            isinstance(c, str) and (components_dir / c).is_dir() for c in components
+        )
     ):
         return None
     return components

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -262,9 +262,10 @@ def _builtin_component_cache_path() -> Path | None:
 
     The file lives inside the extracted framework directory so it is
     discarded together with that exact checkout (re-extract, source
-    override, clean); the target and the EXCLUDE_COMPONENTS set name it. A
-    checkout supplied through IDF_PATH is not managed by ESPHome and is never
-    cached.
+    override, clean-all); the target and the EXCLUDE_COMPONENTS set name it.
+    The sdkconfig is not part of the key: IDF components register regardless
+    of CONFIG_* options and only gate their sources on them. A checkout
+    supplied through IDF_PATH is not managed by ESPHome and is never cached.
     """
     if "IDF_PATH" in os.environ:
         return None
@@ -312,7 +313,7 @@ def _write_project_and_reconfigure(builtin_components: list[str] | None) -> int:
     """Write the full CMakeLists.txt and run the configure for it."""
     from esphome.build_gen.espidf import write_project
 
-    _LOGGER.info("Regenerating CMakeLists.txt with discovered components...")
+    _LOGGER.info("Writing CMakeLists.txt with the built-in component list...")
     write_project(minimal=False, builtin_components=builtin_components)
     # Explicit reconfigure: ninja only re-runs cmake when CMakeLists.txt
     # is strictly newer than build.ninja, which fails on coarse-mtime
@@ -342,10 +343,13 @@ def _configure_project() -> int:
         _LOGGER.error("Component discovery failed")
         return rc
     discovered = get_available_components()
+    if discovered is None:
+        _LOGGER.error("Component discovery produced no project_description.json")
+        return 1
     if (rc := _write_project_and_reconfigure(discovered)) != 0:
         _LOGGER.error("Reconfigure with discovered components failed")
         return rc
-    save_cached_builtin_components(discovered or [])
+    save_cached_builtin_components(discovered)
     return 0
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -262,30 +262,23 @@ def run_reconfigure() -> int:
 
 
 def _builtin_component_cache_path() -> Path | None:
-    """Cache file for this build's built-in component list, or ``None`` when
-    IDF_PATH is unknown.
+    """Cache file for this build's built-in component list.
 
-    The discovered list is a function of the IDF checkout, the target and the
-    EXCLUDE_COMPONENTS set, so those form the key, together with the mtime of
-    ``$IDF_PATH/components`` so an added or removed component directory
-    invalidates the entry.
+    The discovered list depends on the IDF version, the target and the
+    EXCLUDE_COMPONENTS set, so those name the file. A checkout supplied
+    through IDF_PATH is not managed by ESPHome and is never cached.
     """
-    version = _get_core_framework_version()
-    idf_path = _get_idf_path(version)
-    if idf_path is None or not (components_dir := idf_path / "components").is_dir():
+    if "IDF_PATH" in os.environ:
         return None
-    key = hashlib.sha256(
-        json.dumps(
-            [
-                str(idf_path.resolve()),
-                version,
-                variant_to_idf_target(CORE.data[KEY_ESP32][KEY_VARIANT]),
-                CORE.cmake_args.get("EXCLUDE_COMPONENTS", ""),
-                components_dir.stat().st_mtime_ns,
-            ]
-        ).encode()
-    ).hexdigest()[:16]
-    return get_idf_tools_path() / "component_lists" / f"{key}.json"
+    version = _get_core_framework_version()
+    target = variant_to_idf_target(CORE.data[KEY_ESP32][KEY_VARIANT])
+    excluded = CORE.cmake_args.get("EXCLUDE_COMPONENTS", "")
+    excluded_key = hashlib.sha256(excluded.encode()).hexdigest()[:12]
+    return (
+        get_idf_tools_path()
+        / "component_lists"
+        / f"{version}-{target}-{excluded_key}.json"
+    )
 
 
 def load_cached_builtin_components() -> list[str] | None:

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -321,6 +321,9 @@ def save_cached_builtin_components() -> list[str] | None:
         for name, comp_dir in components.items()
         if any(Path(comp_dir).is_relative_to(root) for root in roots)
     )
+    if not builtin:
+        _LOGGER.debug("No components found under %s; not caching", roots)
+        return None
     try:
         write_file(path, json.dumps(builtin, separators=(",", ":")))
     except EsphomeError as err:
@@ -462,26 +465,34 @@ def run_compile(config, verbose: bool) -> int:
     """
     from esphome.build_gen.espidf import write_project
 
-    # Check if we need to do discovery phase
-    if need_reconfigure():
-        builtin_components = load_cached_builtin_components()
-        if builtin_components is None:
-            _LOGGER.info("Discovering available ESP-IDF components...")
-            write_project(minimal=True)
-            rc = run_reconfigure()
-            if rc != 0:
-                _LOGGER.error("Component discovery failed")
-                return rc
-            builtin_components = save_cached_builtin_components()
-        else:
-            _LOGGER.info("Using cached ESP-IDF component list")
+    def configure_with(builtin_components: list[str] | None) -> int:
         _LOGGER.info("Regenerating CMakeLists.txt with discovered components...")
         write_project(minimal=False, builtin_components=builtin_components)
         # Explicit reconfigure: ninja only re-runs cmake when CMakeLists.txt
         # is strictly newer than build.ninja, which fails on coarse-mtime
         # filesystems (#18682). Also keeps idf.py from regenerating memory.ld
         # in testing mode.
-        rc = run_reconfigure()
+        return run_reconfigure()
+
+    # Check if we need to do discovery phase
+    if need_reconfigure():
+        cached = load_cached_builtin_components()
+        rc = 1
+        if cached is not None:
+            _LOGGER.info("Using cached ESP-IDF component list")
+            rc = configure_with(cached)
+            if rc != 0:
+                # Never leave a poisoned entry behind: drop it and discover again.
+                _LOGGER.warning("Cached component list failed; rediscovering")
+                _builtin_component_cache_path().unlink(missing_ok=True)
+        if rc != 0:
+            _LOGGER.info("Discovering available ESP-IDF components...")
+            write_project(minimal=True)
+            rc = run_reconfigure()
+            if rc != 0:
+                _LOGGER.error("Component discovery failed")
+                return rc
+            rc = configure_with(save_cached_builtin_components())
         if rc != 0:
             _LOGGER.error("Reconfigure with discovered components failed")
             return rc

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -1,6 +1,7 @@
 """ESP-IDF direct build API for ESPHome."""
 
 from dataclasses import dataclass, field
+import hashlib
 import json
 import logging
 import os
@@ -23,7 +24,7 @@ from esphome.core import CORE, EsphomeError
 from esphome.espidf import variant_to_idf_target
 from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
-from esphome.helpers import add_git_ceiling_directory
+from esphome.helpers import add_git_ceiling_directory, write_file
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -256,6 +257,83 @@ def run_reconfigure() -> int:
     return run_idf_py(*_get_sdkconfig_args(), "reconfigure")
 
 
+def _builtin_component_cache_path() -> Path | None:
+    """Cache file for this build's built-in component list, or ``None`` when
+    IDF_PATH is unknown.
+
+    The discovered list is a function of the IDF checkout, the target and the
+    EXCLUDE_COMPONENTS set, so those form the key, together with the mtime of
+    ``$IDF_PATH/components`` so an added or removed component directory
+    invalidates the entry.
+    """
+    from esphome.espidf.framework import get_idf_tools_path
+
+    version = _get_core_framework_version()
+    idf_path = _get_idf_path(version)
+    if idf_path is None or not (components_dir := idf_path / "components").is_dir():
+        return None
+    key = hashlib.sha256(
+        json.dumps(
+            [
+                str(idf_path.resolve()),
+                version,
+                variant_to_idf_target(CORE.data[KEY_ESP32][KEY_VARIANT]),
+                CORE.cmake_args.get("EXCLUDE_COMPONENTS", ""),
+                components_dir.stat().st_mtime_ns,
+            ]
+        ).encode()
+    ).hexdigest()[:16]
+    return get_idf_tools_path() / "component_lists" / f"{key}.json"
+
+
+def load_cached_builtin_components() -> list[str] | None:
+    """Return the cached built-in component list for this build, if valid.
+
+    Every name must still be a directory under ``$IDF_PATH/components`` so a
+    stale entry is treated as a miss instead of failing the configure.
+    """
+    if (path := _builtin_component_cache_path()) is None:
+        return None
+    try:
+        components = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    components_dir = _get_idf_path(_get_core_framework_version()) / "components"
+    if not (
+        isinstance(components, list)
+        and all(isinstance(c, str) and (components_dir / c).is_dir() for c in components)
+    ):
+        return None
+    return components
+
+
+def save_cached_builtin_components() -> list[str] | None:
+    """Store the components discovered by the last configure and return them.
+
+    Only components that live in ``$IDF_PATH/components`` are kept; project
+    local ones (Arduino ``component_stubs``, ``override_path`` entries) are
+    reachable through the manifest and must not leak into other builds.
+    """
+    from esphome.build_gen.espidf import get_available_components_with_dirs
+
+    if (path := _builtin_component_cache_path()) is None:
+        return None
+    if (components := get_available_components_with_dirs()) is None:
+        return None
+    idf_path = _get_idf_path(_get_core_framework_version())
+    roots = {idf_path / "components", idf_path.resolve() / "components"}
+    builtin = sorted(
+        name
+        for name, comp_dir in components.items()
+        if any(Path(comp_dir).is_relative_to(root) for root in roots)
+    )
+    try:
+        write_file(path, json.dumps(builtin, separators=(",", ":")))
+    except EsphomeError as err:
+        _LOGGER.debug("Could not write component list cache %s: %s", path, err)
+    return builtin
+
+
 def has_outdated_files():
     """Check if the build configuration is stale.
 
@@ -382,7 +460,9 @@ def run_compile(config, verbose: bool) -> int:
     """Compile the ESP-IDF project.
 
     Uses two-phase configure to auto-discover available components:
-    1. If no previous build, configure with minimal REQUIRES to discover components
+    1. If no previous build, configure with minimal REQUIRES to discover
+       components (skipped when a cached list for this IDF/target/exclusion
+       set exists)
     2. Regenerate CMakeLists.txt with discovered components
     3. Run full build
     """
@@ -390,14 +470,19 @@ def run_compile(config, verbose: bool) -> int:
 
     # Check if we need to do discovery phase
     if need_reconfigure():
-        _LOGGER.info("Discovering available ESP-IDF components...")
-        write_project(minimal=True)
-        rc = run_reconfigure()
-        if rc != 0:
-            _LOGGER.error("Component discovery failed")
-            return rc
+        builtin_components = load_cached_builtin_components()
+        if builtin_components is None:
+            _LOGGER.info("Discovering available ESP-IDF components...")
+            write_project(minimal=True)
+            rc = run_reconfigure()
+            if rc != 0:
+                _LOGGER.error("Component discovery failed")
+                return rc
+            builtin_components = save_cached_builtin_components()
+        else:
+            _LOGGER.info("Using cached ESP-IDF component list")
         _LOGGER.info("Regenerating CMakeLists.txt with discovered components...")
-        write_project(minimal=False)
+        write_project(minimal=False, builtin_components=builtin_components)
         # Explicit reconfigure: ninja only re-runs cmake when CMakeLists.txt
         # is strictly newer than build.ninja, which fails on coarse-mtime
         # filesystems (#18682). Also keeps idf.py from regenerating memory.ld

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -22,11 +22,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, EsphomeError
 from esphome.espidf import variant_to_idf_target
-from esphome.espidf.framework import (
-    check_esp_idf_install,
-    get_framework_env,
-    get_idf_tools_path,
-)
+from esphome.espidf.framework import check_esp_idf_install, get_framework_env
 from esphome.espidf.size_summary import print_summary
 from esphome.helpers import add_git_ceiling_directory, write_file
 
@@ -264,20 +260,21 @@ def run_reconfigure() -> int:
 def _builtin_component_cache_path() -> Path | None:
     """Cache file for this build's built-in component list.
 
-    The discovered list depends on the IDF version, the target and the
-    EXCLUDE_COMPONENTS set, so those name the file. A checkout supplied
-    through IDF_PATH is not managed by ESPHome and is never cached.
+    The file lives inside the extracted framework directory so it is
+    discarded together with that exact checkout (re-extract, source
+    override, clean); the target and the EXCLUDE_COMPONENTS set name it. A
+    checkout supplied through IDF_PATH is not managed by ESPHome and is never
+    cached.
     """
     if "IDF_PATH" in os.environ:
         return None
-    version = _get_core_framework_version()
     target = variant_to_idf_target(CORE.data[KEY_ESP32][KEY_VARIANT])
     excluded = CORE.cmake_args.get("EXCLUDE_COMPONENTS", "")
     excluded_key = hashlib.sha256(excluded.encode()).hexdigest()[:12]
     return (
-        get_idf_tools_path()
-        / "component_lists"
-        / f"{version}-{target}-{excluded_key}.json"
+        _get_idf_path(_get_core_framework_version())
+        / ".esphome_component_lists"
+        / f"{target}-{excluded_key}.json"
     )
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -272,63 +272,91 @@ def _builtin_component_cache_path() -> Path | None:
     excluded = CORE.cmake_args.get("EXCLUDE_COMPONENTS", "")
     excluded_key = hashlib.sha256(excluded.encode()).hexdigest()[:12]
     return (
-        _get_idf_path(_get_core_framework_version())
-        / ".esphome_component_lists"
-        / f"{target}-{excluded_key}.json"
+        _get_idf_path() / ".esphome_component_lists" / f"{target}-{excluded_key}.json"
     )
 
 
 def load_cached_builtin_components() -> list[str] | None:
     """Return the cached built-in component list for this build, if valid.
 
-    Every name must still be a directory under ``$IDF_PATH/components`` so a
-    stale entry is treated as a miss instead of failing the configure.
+    Every name must still exist under ``$IDF_PATH/components`` so a stale
+    entry is treated as a miss instead of failing the configure.
     """
     if (path := _builtin_component_cache_path()) is None:
         return None
     try:
         components = json.loads(path.read_text(encoding="utf-8"))
+        present = {entry.name for entry in (path.parents[1] / "components").iterdir()}
     except (OSError, ValueError):
         return None
-    components_dir = _get_idf_path(_get_core_framework_version()) / "components"
-    if not (
+    if (
         isinstance(components, list)
-        and all(
-            isinstance(c, str) and (components_dir / c).is_dir() for c in components
-        )
+        and all(isinstance(c, str) for c in components)
+        and present.issuperset(components)
     ):
-        return None
-    return components
+        return components
+    return None
 
 
 def save_cached_builtin_components() -> list[str] | None:
     """Store the components discovered by the last configure and return them.
 
-    Only components that live in ``$IDF_PATH/components`` are kept; project
-    local ones (Arduino ``component_stubs``, ``override_path`` entries) are
+    Only components under ``$IDF_PATH/components`` are kept; project local
+    ones (Arduino ``component_stubs``, ``override_path`` entries) are
     reachable through the manifest and must not leak into other builds.
     """
     from esphome.build_gen.espidf import get_available_components_with_dirs
 
     if (path := _builtin_component_cache_path()) is None:
         return None
-    if (components := get_available_components_with_dirs()) is None:
+    root = (path.parents[1] / "components").resolve()
+    components = get_available_components_with_dirs(root)
+    if not components:
         return None
-    idf_path = _get_idf_path(_get_core_framework_version())
-    roots = {idf_path / "components", idf_path.resolve() / "components"}
-    builtin = sorted(
-        name
-        for name, comp_dir in components.items()
-        if any(Path(comp_dir).is_relative_to(root) for root in roots)
-    )
-    if not builtin:
-        _LOGGER.debug("No components found under %s; not caching", roots)
-        return None
+    builtin = sorted(components)
     try:
         write_file(path, json.dumps(builtin, separators=(",", ":")))
     except EsphomeError as err:
         _LOGGER.debug("Could not write component list cache %s: %s", path, err)
     return builtin
+
+
+def _write_project_and_reconfigure(builtin_components: list[str] | None) -> int:
+    """Write the full CMakeLists.txt and run the configure for it."""
+    from esphome.build_gen.espidf import write_project
+
+    _LOGGER.info("Regenerating CMakeLists.txt with discovered components...")
+    write_project(minimal=False, builtin_components=builtin_components)
+    # Explicit reconfigure: ninja only re-runs cmake when CMakeLists.txt
+    # is strictly newer than build.ninja, which fails on coarse-mtime
+    # filesystems (#18682). Also keeps idf.py from regenerating memory.ld
+    # in testing mode.
+    return run_reconfigure()
+
+
+def _configure_project() -> int:
+    """Configure the project, discovering the built-in components if needed.
+
+    A cached component list skips the discovery configure. If the configure
+    with a cached list fails the entry is dropped and discovery runs once, so
+    a bad entry never poisons later builds.
+    """
+    from esphome.build_gen.espidf import write_project
+
+    if (cached := load_cached_builtin_components()) is not None:
+        _LOGGER.info("Using cached ESP-IDF component list")
+        if (rc := _write_project_and_reconfigure(cached)) == 0:
+            return 0
+        _LOGGER.warning("Cached component list failed; rediscovering")
+        _builtin_component_cache_path().unlink(missing_ok=True)
+    _LOGGER.info("Discovering available ESP-IDF components...")
+    write_project(minimal=True)
+    if (rc := run_reconfigure()) != 0:
+        _LOGGER.error("Component discovery failed")
+        return rc
+    if (rc := _write_project_and_reconfigure(save_cached_builtin_components())) != 0:
+        _LOGGER.error("Reconfigure with discovered components failed")
+    return rc
 
 
 def has_outdated_files():
@@ -463,38 +491,9 @@ def run_compile(config, verbose: bool) -> int:
     2. Regenerate CMakeLists.txt with discovered components
     3. Run full build
     """
-    from esphome.build_gen.espidf import write_project
-
-    def configure_with(builtin_components: list[str] | None) -> int:
-        _LOGGER.info("Regenerating CMakeLists.txt with discovered components...")
-        write_project(minimal=False, builtin_components=builtin_components)
-        # Explicit reconfigure: ninja only re-runs cmake when CMakeLists.txt
-        # is strictly newer than build.ninja, which fails on coarse-mtime
-        # filesystems (#18682). Also keeps idf.py from regenerating memory.ld
-        # in testing mode.
-        return run_reconfigure()
-
     # Check if we need to do discovery phase
     if need_reconfigure():
-        cached = load_cached_builtin_components()
-        rc = 1
-        if cached is not None:
-            _LOGGER.info("Using cached ESP-IDF component list")
-            rc = configure_with(cached)
-            if rc != 0:
-                # Never leave a poisoned entry behind: drop it and discover again.
-                _LOGGER.warning("Cached component list failed; rediscovering")
-                _builtin_component_cache_path().unlink(missing_ok=True)
-        if rc != 0:
-            _LOGGER.info("Discovering available ESP-IDF components...")
-            write_project(minimal=True)
-            rc = run_reconfigure()
-            if rc != 0:
-                _LOGGER.error("Component discovery failed")
-                return rc
-            rc = configure_with(save_cached_builtin_components())
-        if rc != 0:
-            _LOGGER.error("Reconfigure with discovered components failed")
+        if (rc := _configure_project()) != 0:
             return rc
         # cmake does not rewrite CMakeCache.txt when only properties change,
         # so restamp it or every build repeats discovery. Only after success,

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -22,7 +22,11 @@ from esphome.const import (
 )
 from esphome.core import CORE, EsphomeError
 from esphome.espidf import variant_to_idf_target
-from esphome.espidf.framework import check_esp_idf_install, get_framework_env
+from esphome.espidf.framework import (
+    check_esp_idf_install,
+    get_framework_env,
+    get_idf_tools_path,
+)
 from esphome.espidf.size_summary import print_summary
 from esphome.helpers import add_git_ceiling_directory, write_file
 
@@ -266,8 +270,6 @@ def _builtin_component_cache_path() -> Path | None:
     ``$IDF_PATH/components`` so an added or removed component directory
     invalidates the entry.
     """
-    from esphome.espidf.framework import get_idf_tools_path
-
     version = _get_core_framework_version()
     idf_path = _get_idf_path(version)
     if idf_path is None or not (components_dir := idf_path / "components").is_dir():

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -492,7 +492,9 @@ def run_compile(config, verbose: bool) -> int:
     3. Run full build
     """
     # Check if we need to do discovery phase
-    if need_reconfigure():
+    if not need_reconfigure():
+        _LOGGER.info("Build configuration is up to date")
+    else:
         if (rc := _configure_project()) != 0:
             return rc
         # cmake does not rewrite CMakeCache.txt when only properties change,

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -35,16 +35,19 @@ def _reset_core(tmp_path: Path) -> None:
     }
 
 
-def _write_project_description(tmp_path: Path, components: dict[str, str]) -> None:
+def _write_project_description(
+    tmp_path: Path, components: dict[str, str], idf_path: str = "/idf"
+) -> None:
     """Stub a project_description.json with the given component_name -> dir map."""
     build_dir = tmp_path / "build"
     build_dir.mkdir(exist_ok=True)
     (build_dir / "project_description.json").write_text(
         json.dumps(
             {
+                "idf_path": idf_path,
                 "build_component_info": {
                     name: {"dir": dir_} for name, dir_ in components.items()
-                }
+                },
             }
         )
     )
@@ -79,8 +82,11 @@ def test_get_available_components_returns_none_without_project_description(
     assert get_available_components() is None
 
 
-def test_get_available_components_filters_src_managed_and_pio(tmp_path: Path) -> None:
-    """Built-ins are returned; src/, managed_components/, pio_components/ skipped."""
+def test_get_available_components_keeps_only_idf_tree_components(
+    tmp_path: Path,
+) -> None:
+    """Only components under idf_path/components are built-ins: src, managed,
+    converted PIO libs and Arduino component_stubs are all left out."""
     _write_project_description(
         tmp_path,
         {
@@ -88,6 +94,7 @@ def test_get_available_components_filters_src_managed_and_pio(tmp_path: Path) ->
             "esp_lcd": "/idf/components/esp_lcd",
             "espressif__arduino-esp32": f"{tmp_path}/managed_components/arduino",
             "JPEGDEC": f"{tmp_path}/pio_components/arduino/abc/bitbank2/JPEGDEC",
+            "cbor": f"{tmp_path}/component_stubs/cbor",
             "freertos": "/idf/components/freertos",
         },
     )
@@ -110,22 +117,32 @@ def test_get_available_components_with_dirs_maps_names_to_dirs(tmp_path: Path) -
     assert get_available_components_with_dirs() == {"lwip": "/idf/components/lwip"}
 
 
-def test_get_available_components_with_dirs_filters_by_root(tmp_path: Path) -> None:
-    """With a root only components below it are kept; Arduino stubs and
-    override_path components outside the IDF tree drop out."""
-    idf = tmp_path / "idf"
-    (idf / "components" / "lwip").mkdir(parents=True)
+def test_codegen_and_configure_writes_render_the_same_cmakelists(
+    tmp_path: Path,
+) -> None:
+    """write_project() at codegen time (no list) and the configure-time write
+    (discovered list) must agree, or ninja re-runs cmake on every build."""
     _write_project_description(
         tmp_path,
         {
-            "lwip": str(idf / "components" / "lwip"),
-            "cbor": str(tmp_path / "build" / "component_stubs" / "cbor"),
+            "lwip": "/idf/components/lwip",
+            "cbor": f"{tmp_path}/component_stubs/cbor",
         },
     )
-    from esphome.build_gen.espidf import get_available_components_with_dirs
+    from esphome.build_gen.espidf import get_available_components
 
-    assert list(get_available_components_with_dirs(idf / "components")) == ["lwip"]
-    assert sorted(get_available_components_with_dirs()) == ["cbor", "lwip"]
+    assert _render() == _render(builtin_components=get_available_components())
+    assert "ESPHOME_PROJECT_BUILTIN_COMPONENTS cbor" not in _render()
+
+
+def test_get_available_components_warns_when_nothing_is_under_idf_path(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write_project_description(tmp_path, {"cbor": f"{tmp_path}/component_stubs/cbor"})
+    from esphome.build_gen.espidf import get_available_components
+
+    assert get_available_components() == []
+    assert "No ESP-IDF components found under" in caplog.text
 
 
 def test_get_available_components_with_dirs_ignores_corrupt_file(

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -103,20 +104,6 @@ def test_get_available_components_keeps_only_idf_tree_components(
     assert sorted(get_available_components()) == ["esp_lcd", "freertos"]
 
 
-def test_get_available_components_with_dirs_maps_names_to_dirs(tmp_path: Path) -> None:
-    _write_project_description(
-        tmp_path,
-        {
-            "src": f"{tmp_path}/src",
-            "lwip": "/idf/components/lwip",
-            "espressif__mdns": f"{tmp_path}/managed_components/mdns",
-        },
-    )
-    from esphome.build_gen.espidf import get_available_components_with_dirs
-
-    assert get_available_components_with_dirs() == {"lwip": "/idf/components/lwip"}
-
-
 def test_codegen_and_configure_writes_render_the_same_cmakelists(
     tmp_path: Path,
 ) -> None:
@@ -139,25 +126,34 @@ def test_get_available_components_warns_when_nothing_is_under_idf_path(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     _write_project_description(tmp_path, {"cbor": f"{tmp_path}/component_stubs/cbor"})
-    from esphome.build_gen.espidf import get_available_components
-
-    assert get_available_components() == []
-    assert "No ESP-IDF components found under" in caplog.text
-
-
-def test_get_available_components_with_dirs_ignores_corrupt_file(
-    tmp_path: Path,
-) -> None:
-    build_dir = tmp_path / "build"
-    build_dir.mkdir()
-    (build_dir / "project_description.json").write_text("{not json")
     from esphome.build_gen.espidf import (
-        get_available_components_with_dirs,
+        get_available_components,
         has_discovered_components,
     )
 
-    assert get_available_components_with_dirs() is None
+    assert get_available_components() == []
+    assert "No ESP-IDF components found under" in caplog.text
+    # An empty discovery must not count as configured, or it would be latched in.
     assert not has_discovered_components()
+
+
+def test_get_available_components_ignores_corrupt_or_unexpected_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    from esphome.build_gen.espidf import (
+        get_available_components,
+        has_discovered_components,
+    )
+
+    (build_dir / "project_description.json").write_text("{not json")
+    assert get_available_components() is None
+    assert not has_discovered_components()
+    (build_dir / "project_description.json").write_text('{"build_component_info": {}}')
+    with caplog.at_level(logging.DEBUG, logger="esphome.build_gen.espidf"):
+        assert get_available_components() is None
+    assert "Could not read" in caplog.text
 
 
 def test_has_discovered_components_after_configure(tmp_path: Path) -> None:

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -110,6 +110,24 @@ def test_get_available_components_with_dirs_maps_names_to_dirs(tmp_path: Path) -
     assert get_available_components_with_dirs() == {"lwip": "/idf/components/lwip"}
 
 
+def test_get_available_components_with_dirs_filters_by_root(tmp_path: Path) -> None:
+    """With a root only components below it are kept; Arduino stubs and
+    override_path components outside the IDF tree drop out."""
+    idf = tmp_path / "idf"
+    (idf / "components" / "lwip").mkdir(parents=True)
+    _write_project_description(
+        tmp_path,
+        {
+            "lwip": str(idf / "components" / "lwip"),
+            "cbor": str(tmp_path / "build" / "component_stubs" / "cbor"),
+        },
+    )
+    from esphome.build_gen.espidf import get_available_components_with_dirs
+
+    assert list(get_available_components_with_dirs(idf / "components")) == ["lwip"]
+    assert sorted(get_available_components_with_dirs()) == ["cbor", "lwip"]
+
+
 def test_get_available_components_with_dirs_ignores_corrupt_file(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -50,7 +50,7 @@ def _write_project_description(tmp_path: Path, components: dict[str, str]) -> No
     )
 
 
-def _render(minimal: bool = False) -> str:
+def _render(minimal: bool = False, builtin_components: list[str] | None = None) -> str:
     """Render the top-level CMakeLists with the standard variant/name patches."""
     with (
         patch("esphome.build_gen.espidf.get_esp32_variant", return_value="ESP32"),
@@ -58,7 +58,9 @@ def _render(minimal: bool = False) -> str:
     ):
         from esphome.build_gen.espidf import get_project_cmakelists
 
-        return get_project_cmakelists(minimal=minimal)
+        return get_project_cmakelists(
+            minimal=minimal, builtin_components=builtin_components
+        )
 
 
 def test_get_available_components_returns_none_without_build_path() -> None:
@@ -92,6 +94,30 @@ def test_get_available_components_filters_src_managed_and_pio(tmp_path: Path) ->
     from esphome.build_gen.espidf import get_available_components
 
     assert sorted(get_available_components()) == ["esp_lcd", "freertos"]
+
+
+def test_get_available_components_with_dirs_maps_names_to_dirs(tmp_path: Path) -> None:
+    _write_project_description(
+        tmp_path,
+        {
+            "src": f"{tmp_path}/src",
+            "lwip": "/idf/components/lwip",
+            "espressif__mdns": f"{tmp_path}/managed_components/mdns",
+        },
+    )
+    from esphome.build_gen.espidf import get_available_components_with_dirs
+
+    assert get_available_components_with_dirs() == {"lwip": "/idf/components/lwip"}
+
+
+def test_get_project_cmakelists_uses_supplied_builtin_components() -> None:
+    """A cached list replaces project_description.json and is still filtered
+    by EXCLUDE_COMPONENTS."""
+    with patch.dict(CORE.cmake_args, {"EXCLUDE_COMPONENTS": "fatfs;unity"}):
+        content = _render(builtin_components=["lwip", "fatfs", "esp_timer"])
+    assert "ESPHOME_PROJECT_BUILTIN_COMPONENTS esp_timer APPEND" in content
+    assert "ESPHOME_PROJECT_BUILTIN_COMPONENTS lwip APPEND" in content
+    assert "ESPHOME_PROJECT_BUILTIN_COMPONENTS fatfs APPEND" not in content
 
 
 def test_get_project_cmakelists_minimal_omits_builtin_components_property(

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -110,6 +110,28 @@ def test_get_available_components_with_dirs_maps_names_to_dirs(tmp_path: Path) -
     assert get_available_components_with_dirs() == {"lwip": "/idf/components/lwip"}
 
 
+def test_get_available_components_with_dirs_ignores_corrupt_file(
+    tmp_path: Path,
+) -> None:
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    (build_dir / "project_description.json").write_text("{not json")
+    from esphome.build_gen.espidf import (
+        get_available_components_with_dirs,
+        has_discovered_components,
+    )
+
+    assert get_available_components_with_dirs() is None
+    assert not has_discovered_components()
+
+
+def test_has_discovered_components_after_configure(tmp_path: Path) -> None:
+    _write_project_description(tmp_path, {"lwip": "/idf/components/lwip"})
+    from esphome.build_gen.espidf import has_discovered_components
+
+    assert has_discovered_components()
+
+
 def test_get_project_cmakelists_uses_supplied_builtin_components() -> None:
     """A cached list replaces project_description.json and is still filtered
     by EXCLUDE_COMPONENTS."""

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -412,9 +412,8 @@ def _record_compile_calls(
     def record_write(minimal: bool = False, builtin_components=None) -> None:
         calls.append(("write_project", minimal, builtin_components))
 
-    def record_save() -> list[str] | None:
-        calls.append(("save",))
-        return saved
+    def record_save(components: list[str]) -> None:
+        calls.append(("save", components))
 
     with (
         patch.object(toolchain, "need_reconfigure", return_value=True),
@@ -422,6 +421,7 @@ def _record_compile_calls(
         patch.object(
             toolchain, "save_cached_builtin_components", side_effect=record_save
         ),
+        patch("esphome.build_gen.espidf.get_available_components", return_value=saved),
         patch("esphome.build_gen.espidf.write_project", side_effect=record_write),
         patch.object(toolchain, "run_reconfigure", side_effect=record_reconfigure),
         patch.object(
@@ -456,25 +456,25 @@ def test_run_compile_poisoned_cache_is_dropped_and_rediscovered(
         ("run_reconfigure",),
         ("write_project", True, None),
         ("run_reconfigure",),
-        ("save",),
         ("write_project", False, ["lwip"]),
         ("run_reconfigure",),
+        ("save", ["lwip"]),
         ("build",),
     ]
 
 
 def test_run_compile_cache_miss_discovers_and_saves(setup_core: Path) -> None:
-    """Without a cached list the discovery configure runs, its result is saved
-    and the same filtered list feeds the full write."""
+    """Without a cached list the discovery configure runs, the discovered list
+    feeds the full write and is cached only after that configure succeeds."""
     _setup_build(setup_core)
     rc, calls = _record_compile_calls(None, saved=["lwip"])
     assert rc == 0
     assert calls == [
         ("write_project", True, None),
         ("run_reconfigure",),
-        ("save",),
         ("write_project", False, ["lwip"]),
         ("run_reconfigure",),
+        ("save", ["lwip"]),
         ("build",),
     ]
 
@@ -488,6 +488,16 @@ def test_run_compile_discovery_failure_stops_before_full_write(
     rc, calls = _record_compile_calls(None, reconfigure_rcs=(2,))
     assert rc == 2
     assert calls == [("write_project", True, None), ("run_reconfigure",)]
+
+
+def test_run_compile_does_not_cache_a_list_that_failed_to_configure(
+    setup_core: Path,
+) -> None:
+    _setup_build(setup_core)
+    rc, calls = _record_compile_calls(None, saved=["lwip"], reconfigure_rcs=(0, 3))
+    assert rc == 3
+    assert ("save", ["lwip"]) not in calls
+    assert ("build",) not in calls
 
 
 def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:
@@ -517,25 +527,17 @@ def _cache_env(tmp_path: Path, excluded: str) -> Iterator[Path]:
         yield idf_path
 
 
-def test_component_cache_round_trip_keeps_only_idf_components(
-    setup_core: Path, tmp_path: Path
-) -> None:
+def test_component_cache_round_trip(setup_core: Path, tmp_path: Path) -> None:
     """A saved list is read back until it is dropped."""
     _setup_build(setup_core)
     with _cache_env(tmp_path, "fatfs") as idf_path:
         for name in ("lwip", "esp_timer"):
             (idf_path / "components" / name).mkdir()
-        components = {
-            "lwip": str(idf_path / "components" / "lwip"),
-            "esp_timer": str(idf_path / "components" / "esp_timer"),
-        }
-        with patch(
-            "esphome.build_gen.espidf.get_available_components_with_dirs",
-            return_value=components,
-        ):
-            assert toolchain.load_cached_builtin_components() is None
-            assert toolchain.save_cached_builtin_components() == ["esp_timer", "lwip"]
+        assert toolchain.load_cached_builtin_components() is None
+        toolchain.save_cached_builtin_components(["esp_timer", "lwip"])
         assert toolchain.load_cached_builtin_components() == ["esp_timer", "lwip"]
+        toolchain._builtin_component_cache_path().unlink()
+        assert toolchain.load_cached_builtin_components() is None
 
 
 def test_component_cache_misses_on_key_change_or_missing_component(
@@ -547,11 +549,7 @@ def test_component_cache_misses_on_key_change_or_missing_component(
     _setup_build(setup_core)
     with _cache_env(tmp_path, "fatfs") as idf_path:
         (idf_path / "components" / "lwip").mkdir()
-        with patch(
-            "esphome.build_gen.espidf.get_available_components_with_dirs",
-            return_value={"lwip": str(idf_path / "components" / "lwip")},
-        ):
-            toolchain.save_cached_builtin_components()
+        toolchain.save_cached_builtin_components(["lwip"])
         path = toolchain._builtin_component_cache_path()
         assert path.parent == idf_path / ".esphome_component_lists"
         assert path.name.startswith("esp32-")
@@ -565,51 +563,28 @@ def test_component_cache_misses_on_key_change_or_missing_component(
         assert toolchain.load_cached_builtin_components() is None
 
 
-def test_component_cache_save_skips_without_key_or_discovery(
+def test_component_cache_save_skips_empty_list_or_custom_idf_path(
     setup_core: Path, tmp_path: Path
 ) -> None:
-    """Nothing is written for a custom IDF_PATH checkout or before a configure
-    has produced project_description.json."""
     _setup_build(setup_core)
     with _cache_env(tmp_path, "") as idf_path:
+        toolchain.save_cached_builtin_components([])
         with patch.dict(os.environ, {"IDF_PATH": str(idf_path)}):
-            assert toolchain.save_cached_builtin_components() is None
-        assert toolchain.save_cached_builtin_components() is None
+            toolchain.save_cached_builtin_components(["lwip"])
         assert not (idf_path / ".esphome_component_lists").exists()
 
 
-def test_component_cache_never_stores_an_empty_list(
-    setup_core: Path, tmp_path: Path
+def test_component_cache_write_failure_is_logged(
+    setup_core: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """When no component resolves under $IDF_PATH/components nothing is cached
-    and the full write falls back to project_description.json."""
     _setup_build(setup_core)
     with (
-        _cache_env(tmp_path, "") as idf_path,
-        patch(
-            "esphome.build_gen.espidf.get_available_components_with_dirs",
-            return_value={},
-        ),
-    ):
-        assert toolchain.save_cached_builtin_components() is None
-        assert not (idf_path / ".esphome_component_lists").exists()
-
-
-def test_component_cache_write_failure_still_returns_list(
-    setup_core: Path, tmp_path: Path
-) -> None:
-    """A cache write error is logged and the discovered list is still used."""
-    _setup_build(setup_core)
-    with (
-        _cache_env(tmp_path, "") as idf_path,
-        patch(
-            "esphome.build_gen.espidf.get_available_components_with_dirs",
-            return_value={"lwip": str(idf_path / "components" / "lwip")},
-        ),
+        _cache_env(tmp_path, ""),
         patch.object(toolchain, "write_file", side_effect=EsphomeError("disk full")),
     ):
-        assert toolchain.save_cached_builtin_components() == ["lwip"]
+        toolchain.save_cached_builtin_components(["lwip"])
         assert toolchain.load_cached_builtin_components() is None
+    assert "Could not write component list cache" in caplog.text
 
 
 def test_component_cache_ignores_corrupt_file(setup_core: Path, tmp_path: Path) -> None:

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -499,6 +499,19 @@ def test_run_compile_discovery_failure_stops_before_full_write(
     assert calls == [("write_project", True, None), ("run_reconfigure",)]
 
 
+@pytest.mark.parametrize("discovered", [None, []], ids=["no_manifest", "empty"])
+def test_run_compile_fails_when_discovery_finds_nothing(
+    setup_core: Path,
+    caplog: pytest.LogCaptureFixture,
+    discovered: list[str] | None,
+) -> None:
+    _setup_build(setup_core)
+    rc, calls = _record_compile_calls(None, saved=discovered)
+    assert rc == 1
+    assert calls == [("write_project", True, None), ("run_reconfigure",)]
+    assert "found no built-in ESP-IDF components" in caplog.text
+
+
 def test_run_compile_does_not_cache_a_list_that_failed_to_configure(
     setup_core: Path,
 ) -> None:
@@ -507,16 +520,6 @@ def test_run_compile_does_not_cache_a_list_that_failed_to_configure(
     assert rc == 3
     assert ("save", ["lwip"]) not in calls
     assert ("build",) not in calls
-
-
-def test_run_compile_fails_when_discovery_leaves_no_manifest(
-    setup_core: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    _setup_build(setup_core)
-    rc, calls = _record_compile_calls(None, saved=None)
-    assert rc == 1
-    assert calls == [("write_project", True, None), ("run_reconfigure",)]
-    assert "produced no project_description.json" in caplog.text
 
 
 def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:
@@ -577,8 +580,11 @@ def test_component_cache_misses_on_key_change_or_missing_component(
             assert toolchain.load_cached_builtin_components() is None
     with _cache_env(tmp_path, "fatfs;unity"):
         assert toolchain.load_cached_builtin_components() is None
-    with _cache_env(tmp_path, "fatfs"):
+    with _cache_env(tmp_path, "fatfs") as idf_path:
         path.write_text(json.dumps(["lwip", "gone"]))
+        assert toolchain.load_cached_builtin_components() is None
+        # A plain file with the right name is not a component directory.
+        (idf_path / "components" / "gone").write_text("not a directory")
         assert toolchain.load_cached_builtin_components() is None
 
 

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -461,7 +461,7 @@ def _cache_env(tmp_path: Path, excluded: str) -> Iterator[Path]:
         patch.object(toolchain, "_get_idf_path", return_value=idf_path),
         patch.dict(CORE.data, {KEY_ESP32: {KEY_VARIANT: "ESP32"}}),
         patch.dict(CORE.cmake_args, {"EXCLUDE_COMPONENTS": excluded}),
-        patch("esphome.espidf.framework.get_idf_tools_path", return_value=tmp_path),
+        patch.object(toolchain, "get_idf_tools_path", return_value=tmp_path),
     ):
         yield idf_path
 

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -489,12 +489,12 @@ def test_component_cache_round_trip_keeps_only_idf_components(
         assert toolchain.load_cached_builtin_components() == ["esp_timer", "lwip"]
 
 
-def test_component_cache_misses_on_key_or_checkout_change(
+def test_component_cache_misses_on_key_change_or_missing_component(
     setup_core: Path, tmp_path: Path
 ) -> None:
-    """A different exclusion set uses another entry, touching the IDF
-    components directory invalidates one, and an entry naming a component
-    that no longer exists is ignored."""
+    """A different exclusion set uses another entry, an entry naming a
+    component that no longer exists is ignored, and a custom IDF_PATH is
+    never cached."""
     _setup_build(setup_core)
     with _cache_env(tmp_path, "fatfs") as idf_path:
         (idf_path / "components" / "lwip").mkdir()
@@ -504,16 +504,15 @@ def test_component_cache_misses_on_key_or_checkout_change(
         ):
             toolchain.save_cached_builtin_components()
         path = toolchain._builtin_component_cache_path()
+        assert path.name.startswith("5.5.5-esp32-")
         assert toolchain.load_cached_builtin_components() == ["lwip"]
+        with patch.dict(os.environ, {"IDF_PATH": str(idf_path)}):
+            assert toolchain.load_cached_builtin_components() is None
     with _cache_env(tmp_path, "fatfs;unity"):
         assert toolchain.load_cached_builtin_components() is None
-    with _cache_env(tmp_path, "fatfs") as idf_path:
+    with _cache_env(tmp_path, "fatfs"):
         path.write_text(json.dumps(["lwip", "gone"]))
         assert toolchain.load_cached_builtin_components() is None
-        components_dir = idf_path / "components"
-        old = components_dir.stat().st_mtime - 100
-        os.utime(components_dir, (old, old))
-        assert toolchain._builtin_component_cache_path() != path
 
 
 def test_component_cache_ignores_corrupt_file(setup_core: Path, tmp_path: Path) -> None:

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -313,6 +313,9 @@ def test_run_compile_restamps_cmakecache_after_discovery(setup_core: Path) -> No
         patch.object(toolchain, "need_reconfigure", return_value=True),
         patch.object(toolchain, "load_cached_builtin_components", return_value=None),
         patch.object(toolchain, "save_cached_builtin_components"),
+        patch(
+            "esphome.build_gen.espidf.get_available_components", return_value=["lwip"]
+        ),
         patch("esphome.build_gen.espidf.write_project"),
         patch.object(toolchain, "run_reconfigure", return_value=0),
         patch.object(toolchain, "run_idf_py", return_value=0),
@@ -335,6 +338,9 @@ def test_run_compile_discovery_without_cmakecache(setup_core: Path) -> None:
         patch.object(toolchain, "need_reconfigure", return_value=True),
         patch.object(toolchain, "load_cached_builtin_components", return_value=None),
         patch.object(toolchain, "save_cached_builtin_components"),
+        patch(
+            "esphome.build_gen.espidf.get_available_components", return_value=["lwip"]
+        ),
         patch("esphome.build_gen.espidf.write_project"),
         patch.object(toolchain, "run_reconfigure", return_value=0),
         patch.object(toolchain, "run_idf_py", return_value=0),
@@ -373,6 +379,9 @@ def test_run_compile_reconfigures_after_full_write_outside_testing_mode(
         patch.object(toolchain, "need_reconfigure", return_value=True),
         patch.object(toolchain, "load_cached_builtin_components", return_value=None),
         patch.object(toolchain, "save_cached_builtin_components"),
+        patch(
+            "esphome.build_gen.espidf.get_available_components", return_value=["lwip"]
+        ),
         patch("esphome.build_gen.espidf.write_project", side_effect=record_write),
         patch.object(toolchain, "run_reconfigure", side_effect=record_reconfigure),
         patch.object(toolchain, "run_idf_py", return_value=0) as mock_build,
@@ -498,6 +507,16 @@ def test_run_compile_does_not_cache_a_list_that_failed_to_configure(
     assert rc == 3
     assert ("save", ["lwip"]) not in calls
     assert ("build",) not in calls
+
+
+def test_run_compile_fails_when_discovery_leaves_no_manifest(
+    setup_core: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _setup_build(setup_core)
+    rc, calls = _record_compile_calls(None, saved=None)
+    assert rc == 1
+    assert calls == [("write_project", True, None), ("run_reconfigure",)]
+    assert "produced no project_description.json" in caplog.text
 
 
 def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -438,6 +438,33 @@ def test_run_compile_cache_miss_discovers_and_saves(setup_core: Path) -> None:
     ]
 
 
+def test_run_compile_discovery_failure_stops_before_full_write(
+    setup_core: Path,
+) -> None:
+    """A failed discovery configure returns its exit code and never writes
+    the full CMakeLists or a cache entry."""
+    _setup_build(setup_core)
+    calls: list[tuple] = []
+    with (
+        patch.object(toolchain, "need_reconfigure", return_value=True),
+        patch.object(toolchain, "load_cached_builtin_components", return_value=None),
+        patch.object(toolchain, "save_cached_builtin_components") as save,
+        patch(
+            "esphome.build_gen.espidf.write_project",
+            side_effect=lambda minimal=False, builtin_components=None: calls.append(
+                ("write_project", minimal)
+            ),
+        ),
+        patch.object(toolchain, "run_reconfigure", return_value=2),
+        patch.object(toolchain, "run_idf_py", return_value=0) as build,
+        patch.object(toolchain, "print_summary"),
+    ):
+        assert toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False) == 2
+    assert calls == [("write_project", True)]
+    save.assert_not_called()
+    build.assert_not_called()
+
+
 def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:
     """A cached list goes straight to the full write; the explicit reconfigure
     after it (#18730) still runs."""

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=protected-access
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import json
 import os
 from pathlib import Path
@@ -309,6 +311,8 @@ def test_run_compile_restamps_cmakecache_after_discovery(setup_core: Path) -> No
 
     with (
         patch.object(toolchain, "need_reconfigure", return_value=True),
+        patch.object(toolchain, "load_cached_builtin_components", return_value=None),
+        patch.object(toolchain, "save_cached_builtin_components"),
         patch("esphome.build_gen.espidf.write_project"),
         patch.object(toolchain, "run_reconfigure", return_value=0),
         patch.object(toolchain, "run_idf_py", return_value=0),
@@ -329,6 +333,8 @@ def test_run_compile_discovery_without_cmakecache(setup_core: Path) -> None:
 
     with (
         patch.object(toolchain, "need_reconfigure", return_value=True),
+        patch.object(toolchain, "load_cached_builtin_components", return_value=None),
+        patch.object(toolchain, "save_cached_builtin_components"),
         patch("esphome.build_gen.espidf.write_project"),
         patch.object(toolchain, "run_reconfigure", return_value=0),
         patch.object(toolchain, "run_idf_py", return_value=0),
@@ -354,7 +360,7 @@ def test_run_compile_reconfigures_after_full_write_outside_testing_mode(
     calls: list[tuple] = []
     reconfigures = 0
 
-    def record_write(minimal: bool = False) -> None:
+    def record_write(minimal: bool = False, builtin_components=None) -> None:
         calls.append(("write_project", minimal))
 
     def record_reconfigure() -> int:
@@ -365,6 +371,8 @@ def test_run_compile_reconfigures_after_full_write_outside_testing_mode(
 
     with (
         patch.object(toolchain, "need_reconfigure", return_value=True),
+        patch.object(toolchain, "load_cached_builtin_components", return_value=None),
+        patch.object(toolchain, "save_cached_builtin_components"),
         patch("esphome.build_gen.espidf.write_project", side_effect=record_write),
         patch.object(toolchain, "run_reconfigure", side_effect=record_reconfigure),
         patch.object(toolchain, "run_idf_py", return_value=0) as mock_build,
@@ -381,6 +389,142 @@ def test_run_compile_reconfigures_after_full_write_outside_testing_mode(
     ]
     mock_build.assert_not_called()
     assert cmakecache.stat().st_mtime == old
+
+
+def _record_compile_calls(
+    cached: list[str] | None, saved: list[str] | None = None
+) -> tuple[int, list[tuple]]:
+    """Run run_compile with a stubbed cache and return (rc, call log)."""
+    calls: list[tuple] = []
+
+    def record_write(minimal: bool = False, builtin_components=None) -> None:
+        calls.append(("write_project", minimal, builtin_components))
+
+    def record_save() -> list[str] | None:
+        calls.append(("save",))
+        return saved
+
+    with (
+        patch.object(toolchain, "need_reconfigure", return_value=True),
+        patch.object(toolchain, "load_cached_builtin_components", return_value=cached),
+        patch.object(
+            toolchain, "save_cached_builtin_components", side_effect=record_save
+        ),
+        patch("esphome.build_gen.espidf.write_project", side_effect=record_write),
+        patch.object(
+            toolchain,
+            "run_reconfigure",
+            side_effect=lambda: calls.append(("run_reconfigure",)) or 0,
+        ),
+        patch.object(toolchain, "run_idf_py", return_value=0),
+        patch.object(toolchain, "print_summary"),
+    ):
+        rc = toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
+    return rc, calls
+
+
+def test_run_compile_cache_miss_discovers_and_saves(setup_core: Path) -> None:
+    """Without a cached list the discovery configure runs, its result is saved
+    and the same filtered list feeds the full write."""
+    _setup_build(setup_core)
+    rc, calls = _record_compile_calls(None, saved=["lwip"])
+    assert rc == 0
+    assert calls == [
+        ("write_project", True, None),
+        ("run_reconfigure",),
+        ("save",),
+        ("write_project", False, ["lwip"]),
+        ("run_reconfigure",),
+    ]
+
+
+def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:
+    """A cached list goes straight to the full write; the explicit reconfigure
+    after it (#18730) still runs."""
+    _setup_build(setup_core)
+    rc, calls = _record_compile_calls(["esp_timer", "lwip"])
+    assert rc == 0
+    assert calls == [
+        ("write_project", False, ["esp_timer", "lwip"]),
+        ("run_reconfigure",),
+    ]
+
+
+@contextmanager
+def _cache_env(tmp_path: Path, excluded: str) -> Iterator[Path]:
+    """Patch everything the cache key derives from onto a temp IDF tree and
+    yield that tree's path."""
+    idf_path = tmp_path / "idf"
+    (idf_path / "components").mkdir(parents=True, exist_ok=True)
+    with (
+        patch.object(toolchain, "_get_core_framework_version", return_value="5.5.5"),
+        patch.object(toolchain, "_get_idf_path", return_value=idf_path),
+        patch.dict(CORE.data, {KEY_ESP32: {KEY_VARIANT: "ESP32"}}),
+        patch.dict(CORE.cmake_args, {"EXCLUDE_COMPONENTS": excluded}),
+        patch("esphome.espidf.framework.get_idf_tools_path", return_value=tmp_path),
+    ):
+        yield idf_path
+
+
+def test_component_cache_round_trip_keeps_only_idf_components(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    """Saved lists hold only components under $IDF_PATH/components; Arduino
+    stubs and local override_path components stay out."""
+    _setup_build(setup_core)
+    with _cache_env(tmp_path, "fatfs") as idf_path:
+        for name in ("lwip", "esp_timer"):
+            (idf_path / "components" / name).mkdir()
+        components = {
+            "lwip": str(idf_path / "components" / "lwip"),
+            "esp_timer": str(idf_path / "components" / "esp_timer"),
+            "cbor": str(setup_core / "build" / "test" / "component_stubs" / "cbor"),
+        }
+        with patch(
+            "esphome.build_gen.espidf.get_available_components_with_dirs",
+            return_value=components,
+        ):
+            assert toolchain.load_cached_builtin_components() is None
+            assert toolchain.save_cached_builtin_components() == ["esp_timer", "lwip"]
+        assert toolchain.load_cached_builtin_components() == ["esp_timer", "lwip"]
+
+
+def test_component_cache_misses_on_key_or_checkout_change(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    """A different exclusion set uses another entry, touching the IDF
+    components directory invalidates one, and an entry naming a component
+    that no longer exists is ignored."""
+    _setup_build(setup_core)
+    with _cache_env(tmp_path, "fatfs") as idf_path:
+        (idf_path / "components" / "lwip").mkdir()
+        with patch(
+            "esphome.build_gen.espidf.get_available_components_with_dirs",
+            return_value={"lwip": str(idf_path / "components" / "lwip")},
+        ):
+            toolchain.save_cached_builtin_components()
+        path = toolchain._builtin_component_cache_path()
+        assert toolchain.load_cached_builtin_components() == ["lwip"]
+    with _cache_env(tmp_path, "fatfs;unity"):
+        assert toolchain.load_cached_builtin_components() is None
+    with _cache_env(tmp_path, "fatfs") as idf_path:
+        path.write_text(json.dumps(["lwip", "gone"]))
+        assert toolchain.load_cached_builtin_components() is None
+        components_dir = idf_path / "components"
+        old = components_dir.stat().st_mtime - 100
+        os.utime(components_dir, (old, old))
+        assert toolchain._builtin_component_cache_path() != path
+
+
+def test_component_cache_ignores_corrupt_file(setup_core: Path, tmp_path: Path) -> None:
+    _setup_build(setup_core)
+    with _cache_env(tmp_path, ""):
+        path = toolchain._builtin_component_cache_path()
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json")
+        assert toolchain.load_cached_builtin_components() is None
+        path.write_text(json.dumps({"components": ["lwip"]}))
+        assert toolchain.load_cached_builtin_components() is None
 
 
 def test_run_compile_passes_compile_process_limit(setup_core: Path) -> None:

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -488,7 +488,6 @@ def _cache_env(tmp_path: Path, excluded: str) -> Iterator[Path]:
         patch.object(toolchain, "_get_idf_path", return_value=idf_path),
         patch.dict(CORE.data, {KEY_ESP32: {KEY_VARIANT: "ESP32"}}),
         patch.dict(CORE.cmake_args, {"EXCLUDE_COMPONENTS": excluded}),
-        patch.object(toolchain, "get_idf_tools_path", return_value=tmp_path),
     ):
         yield idf_path
 
@@ -531,7 +530,8 @@ def test_component_cache_misses_on_key_change_or_missing_component(
         ):
             toolchain.save_cached_builtin_components()
         path = toolchain._builtin_component_cache_path()
-        assert path.name.startswith("5.5.5-esp32-")
+        assert path.parent == idf_path / ".esphome_component_lists"
+        assert path.name.startswith("esp32-")
         assert toolchain.load_cached_builtin_components() == ["lwip"]
         with patch.dict(os.environ, {"IDF_PATH": str(idf_path)}):
             assert toolchain.load_cached_builtin_components() is None
@@ -552,7 +552,7 @@ def test_component_cache_save_skips_without_key_or_discovery(
         with patch.dict(os.environ, {"IDF_PATH": str(idf_path)}):
             assert toolchain.save_cached_builtin_components() is None
         assert toolchain.save_cached_builtin_components() is None
-        assert not (tmp_path / "component_lists").exists()
+        assert not (idf_path / ".esphome_component_lists").exists()
 
 
 def test_component_cache_write_failure_still_returns_list(

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -394,16 +394,20 @@ def test_run_compile_reconfigures_after_full_write_outside_testing_mode(
 def _record_compile_calls(
     cached: list[str] | None,
     saved: list[str] | None = None,
-    reconfigure_rcs: tuple[int, ...] = (0, 0, 0),
+    reconfigure_rcs: tuple[int, ...] = (),
     cache_file: Path | None = None,
 ) -> tuple[int, list[tuple]]:
-    """Run run_compile with a stubbed cache and return (rc, call log)."""
+    """Run run_compile with a stubbed cache and return (rc, call log).
+
+    ``reconfigure_rcs`` overrides the exit codes of the first reconfigures;
+    later ones succeed.
+    """
     calls: list[tuple] = []
     rcs = iter(reconfigure_rcs)
 
     def record_reconfigure() -> int:
         calls.append(("run_reconfigure",))
-        return next(rcs)
+        return next(rcs, 0)
 
     def record_write(minimal: bool = False, builtin_components=None) -> None:
         calls.append(("write_project", minimal, builtin_components))
@@ -423,7 +427,11 @@ def _record_compile_calls(
         patch.object(
             toolchain, "_builtin_component_cache_path", return_value=cache_file
         ),
-        patch.object(toolchain, "run_idf_py", return_value=0),
+        patch.object(
+            toolchain,
+            "run_idf_py",
+            side_effect=lambda *a, **kw: calls.append(("build",)) or 0,
+        ),
         patch.object(toolchain, "print_summary"),
     ):
         rc = toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
@@ -439,7 +447,7 @@ def test_run_compile_poisoned_cache_is_dropped_and_rediscovered(
     cache_file = tmp_path / "esp32-abc.json"
     cache_file.write_text("[]")
     rc, calls = _record_compile_calls(
-        ["stale"], saved=["lwip"], reconfigure_rcs=(1, 0, 0), cache_file=cache_file
+        ["stale"], saved=["lwip"], reconfigure_rcs=(1,), cache_file=cache_file
     )
     assert rc == 0
     assert not cache_file.exists()
@@ -451,6 +459,7 @@ def test_run_compile_poisoned_cache_is_dropped_and_rediscovered(
         ("save",),
         ("write_project", False, ["lwip"]),
         ("run_reconfigure",),
+        ("build",),
     ]
 
 
@@ -466,6 +475,7 @@ def test_run_compile_cache_miss_discovers_and_saves(setup_core: Path) -> None:
         ("save",),
         ("write_project", False, ["lwip"]),
         ("run_reconfigure",),
+        ("build",),
     ]
 
 
@@ -473,27 +483,11 @@ def test_run_compile_discovery_failure_stops_before_full_write(
     setup_core: Path,
 ) -> None:
     """A failed discovery configure returns its exit code and never writes
-    the full CMakeLists or a cache entry."""
+    the full CMakeLists, a cache entry or a build."""
     _setup_build(setup_core)
-    calls: list[tuple] = []
-    with (
-        patch.object(toolchain, "need_reconfigure", return_value=True),
-        patch.object(toolchain, "load_cached_builtin_components", return_value=None),
-        patch.object(toolchain, "save_cached_builtin_components") as save,
-        patch(
-            "esphome.build_gen.espidf.write_project",
-            side_effect=lambda minimal=False, builtin_components=None: calls.append(
-                ("write_project", minimal)
-            ),
-        ),
-        patch.object(toolchain, "run_reconfigure", return_value=2),
-        patch.object(toolchain, "run_idf_py", return_value=0) as build,
-        patch.object(toolchain, "print_summary"),
-    ):
-        assert toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False) == 2
-    assert calls == [("write_project", True)]
-    save.assert_not_called()
-    build.assert_not_called()
+    rc, calls = _record_compile_calls(None, reconfigure_rcs=(2,))
+    assert rc == 2
+    assert calls == [("write_project", True, None), ("run_reconfigure",)]
 
 
 def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:
@@ -505,6 +499,7 @@ def test_run_compile_cache_hit_skips_discovery(setup_core: Path) -> None:
     assert calls == [
         ("write_project", False, ["esp_timer", "lwip"]),
         ("run_reconfigure",),
+        ("build",),
     ]
 
 
@@ -515,7 +510,6 @@ def _cache_env(tmp_path: Path, excluded: str) -> Iterator[Path]:
     idf_path = tmp_path / "idf"
     (idf_path / "components").mkdir(parents=True, exist_ok=True)
     with (
-        patch.object(toolchain, "_get_core_framework_version", return_value="5.5.5"),
         patch.object(toolchain, "_get_idf_path", return_value=idf_path),
         patch.dict(CORE.data, {KEY_ESP32: {KEY_VARIANT: "ESP32"}}),
         patch.dict(CORE.cmake_args, {"EXCLUDE_COMPONENTS": excluded}),
@@ -526,8 +520,7 @@ def _cache_env(tmp_path: Path, excluded: str) -> Iterator[Path]:
 def test_component_cache_round_trip_keeps_only_idf_components(
     setup_core: Path, tmp_path: Path
 ) -> None:
-    """Saved lists hold only components under $IDF_PATH/components; Arduino
-    stubs and local override_path components stay out."""
+    """A saved list is read back until it is dropped."""
     _setup_build(setup_core)
     with _cache_env(tmp_path, "fatfs") as idf_path:
         for name in ("lwip", "esp_timer"):
@@ -535,7 +528,6 @@ def test_component_cache_round_trip_keeps_only_idf_components(
         components = {
             "lwip": str(idf_path / "components" / "lwip"),
             "esp_timer": str(idf_path / "components" / "esp_timer"),
-            "cbor": str(setup_core / "build" / "test" / "component_stubs" / "cbor"),
         }
         with patch(
             "esphome.build_gen.espidf.get_available_components_with_dirs",
@@ -596,7 +588,7 @@ def test_component_cache_never_stores_an_empty_list(
         _cache_env(tmp_path, "") as idf_path,
         patch(
             "esphome.build_gen.espidf.get_available_components_with_dirs",
-            return_value={"cbor": str(setup_core / "component_stubs" / "cbor")},
+            return_value={},
         ),
     ):
         assert toolchain.save_cached_builtin_components() is None

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -515,6 +515,36 @@ def test_component_cache_misses_on_key_change_or_missing_component(
         assert toolchain.load_cached_builtin_components() is None
 
 
+def test_component_cache_save_skips_without_key_or_discovery(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    """Nothing is written for a custom IDF_PATH checkout or before a configure
+    has produced project_description.json."""
+    _setup_build(setup_core)
+    with _cache_env(tmp_path, "") as idf_path:
+        with patch.dict(os.environ, {"IDF_PATH": str(idf_path)}):
+            assert toolchain.save_cached_builtin_components() is None
+        assert toolchain.save_cached_builtin_components() is None
+        assert not (tmp_path / "component_lists").exists()
+
+
+def test_component_cache_write_failure_still_returns_list(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    """A cache write error is logged and the discovered list is still used."""
+    _setup_build(setup_core)
+    with (
+        _cache_env(tmp_path, "") as idf_path,
+        patch(
+            "esphome.build_gen.espidf.get_available_components_with_dirs",
+            return_value={"lwip": str(idf_path / "components" / "lwip")},
+        ),
+        patch.object(toolchain, "write_file", side_effect=EsphomeError("disk full")),
+    ):
+        assert toolchain.save_cached_builtin_components() == ["lwip"]
+        assert toolchain.load_cached_builtin_components() is None
+
+
 def test_component_cache_ignores_corrupt_file(setup_core: Path, tmp_path: Path) -> None:
     _setup_build(setup_core)
     with _cache_env(tmp_path, ""):

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -392,10 +392,18 @@ def test_run_compile_reconfigures_after_full_write_outside_testing_mode(
 
 
 def _record_compile_calls(
-    cached: list[str] | None, saved: list[str] | None = None
+    cached: list[str] | None,
+    saved: list[str] | None = None,
+    reconfigure_rcs: tuple[int, ...] = (0, 0, 0),
+    cache_file: Path | None = None,
 ) -> tuple[int, list[tuple]]:
     """Run run_compile with a stubbed cache and return (rc, call log)."""
     calls: list[tuple] = []
+    rcs = iter(reconfigure_rcs)
+
+    def record_reconfigure() -> int:
+        calls.append(("run_reconfigure",))
+        return next(rcs)
 
     def record_write(minimal: bool = False, builtin_components=None) -> None:
         calls.append(("write_project", minimal, builtin_components))
@@ -411,16 +419,39 @@ def _record_compile_calls(
             toolchain, "save_cached_builtin_components", side_effect=record_save
         ),
         patch("esphome.build_gen.espidf.write_project", side_effect=record_write),
+        patch.object(toolchain, "run_reconfigure", side_effect=record_reconfigure),
         patch.object(
-            toolchain,
-            "run_reconfigure",
-            side_effect=lambda: calls.append(("run_reconfigure",)) or 0,
+            toolchain, "_builtin_component_cache_path", return_value=cache_file
         ),
         patch.object(toolchain, "run_idf_py", return_value=0),
         patch.object(toolchain, "print_summary"),
     ):
         rc = toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
     return rc, calls
+
+
+def test_run_compile_poisoned_cache_is_dropped_and_rediscovered(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    """A cached list that fails the configure is deleted and discovery runs
+    once more instead of every later build failing the same way."""
+    _setup_build(setup_core)
+    cache_file = tmp_path / "esp32-abc.json"
+    cache_file.write_text("[]")
+    rc, calls = _record_compile_calls(
+        ["stale"], saved=["lwip"], reconfigure_rcs=(1, 0, 0), cache_file=cache_file
+    )
+    assert rc == 0
+    assert not cache_file.exists()
+    assert calls == [
+        ("write_project", False, ["stale"]),
+        ("run_reconfigure",),
+        ("write_project", True, None),
+        ("run_reconfigure",),
+        ("save",),
+        ("write_project", False, ["lwip"]),
+        ("run_reconfigure",),
+    ]
 
 
 def test_run_compile_cache_miss_discovers_and_saves(setup_core: Path) -> None:
@@ -551,6 +582,23 @@ def test_component_cache_save_skips_without_key_or_discovery(
     with _cache_env(tmp_path, "") as idf_path:
         with patch.dict(os.environ, {"IDF_PATH": str(idf_path)}):
             assert toolchain.save_cached_builtin_components() is None
+        assert toolchain.save_cached_builtin_components() is None
+        assert not (idf_path / ".esphome_component_lists").exists()
+
+
+def test_component_cache_never_stores_an_empty_list(
+    setup_core: Path, tmp_path: Path
+) -> None:
+    """When no component resolves under $IDF_PATH/components nothing is cached
+    and the full write falls back to project_description.json."""
+    _setup_build(setup_core)
+    with (
+        _cache_env(tmp_path, "") as idf_path,
+        patch(
+            "esphome.build_gen.espidf.get_available_components_with_dirs",
+            return_value={"cbor": str(setup_core / "component_stubs" / "cbor")},
+        ),
+    ):
         assert toolchain.save_cached_builtin_components() is None
         assert not (idf_path / ".esphome_component_lists").exists()
 


### PR DESCRIPTION
# What does this implement/fix?

Every fresh native ESP-IDF build, and every build after a sdkconfig, manifest or exclusion change, runs CMake twice: a discovery configure with a minimal `CMakeLists.txt` whose only purpose is to produce `project_description.json`, then the real configure with `ESPHOME_PROJECT_BUILTIN_COMPONENTS` filled in from that file. The discovered list is a pure function of the IDF checkout, the target and the `EXCLUDE_COMPONENTS` set, so this caches it inside the extracted framework directory (`frameworks/<version>/.esphome_component_lists/<target>-<hash of the exclusion set>.json`) and skips the discovery configure when an entry exists. Keeping the file inside the checkout means it is discarded together with that exact extraction, so a re-extract, a `framework: source:` override or a clean can never leave a list from a different checkout behind; a checkout supplied through `IDF_PATH` is not managed by ESPHome and is never cached. Only components under `$IDF_PATH/components` are stored; project local ones such as the Arduino `component_stubs` are reachable through the manifest and are no longer added to the `src` REQUIRES on either path. A cached entry is validated on load (every name must still be a directory under `$IDF_PATH/components`) and a corrupt or stale file just falls back to discovery. The explicit reconfigure after the full write from #18730 is unchanged, so a cache hit removes exactly one configure and nothing else.

Measured cold on an Apple Silicon Mac (no ccache, fresh build dir each run, three runs each): `gatetrigger.yaml` (ESP32 IDF, Ethernet) went from 24.3s with the discovery pass to 21.7s without it, the discovery configure costing 2.2s plus its generate step; `ratgdo32disco-3111b4.yaml` (Arduino 3.3.11) drops a 3.7s discovery configure. On a Raspberry Pi or Home Assistant Green a CMake configure is several times slower, so the saving there is larger. Verified end to end: miss then hit on both configs, a corrupt cache file, and a stale entry naming a component that does not exist, all of which build successfully.

Empirical matrix, run on this branch with ccache off, each step checking the exit code, which path ran, the number of CMake configures, CMake re-runs inside ninja and that the firmware linked. ESP32 IDF (Ethernet base, one build directory driven through config changes, plus fresh directories): fresh with no cache discovers; rebuild is up to date; adding `web_server`, `http_request` or `mqtt` (each changes the exclusion set) discovers once and removing them hits the earlier entry; a `time:` addition (sdkconfig changes, key does not) hits; a raw `sdkconfig_options` change hits; switching Ethernet to WiFi discovers, then hits on a fresh directory; switching the target to ESP32-C3 discovers, hits on a fresh directory, rebuilds up to date, and switching back to ESP32 in that same directory hits. Arduino (ratgdo32disco as a package): fresh discovers, rebuild up to date, fresh directory hits, adding `http_request` discovers, removing it hits, a raw `sdkconfig_options` change hits, and no stub component ever appears in the CMakeLists. 31 steps, all as expected, no CMake re-run inside ninja in any step. A checkout supplied through `IDF_PATH` is never cached; on this machine that override fails in the discovery configure on `dev` as well (`esp_idf_monitor` missing because ESPHome's IDF environment is skipped), which is unrelated to this change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


