### PR TITLE
[speaker] Report how much audio is buffered, not just whether any is

### DIFF
--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -276,6 +276,12 @@ bool RingBufferAudioSource::has_buffered_data() const {
   return (this->current_available_ > 0) || (this->queued_length_ > 0) || (this->ring_buffer_->available() > 0);
 }
 
+size_t RingBufferAudioSource::buffered_bytes() const {
+  // Same three terms as has_buffered_data(), and splice_length_ is excluded for the same reason: those
+  // bytes are still to arrive through the ring buffer and are already counted in its available().
+  return this->current_available_ + this->queued_length_ + this->ring_buffer_->available();
+}
+
 size_t RingBufferAudioSource::fill(TickType_t ticks_to_wait, bool /*pre_shift*/) {
   if (this->current_available_ > 0) {
     // Caller has not finished consuming the current exposure

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -246,6 +246,11 @@ class RingBufferAudioSource : public AudioReadableBuffer {
   size_t available() const override { return this->current_available_; }
   void consume(size_t bytes) override;
   bool has_buffered_data() const override;
+  /// @brief Total buffered audio in bytes, across the exposed region, the queued item, and the ring
+  /// buffer. Same accounting as has_buffered_data() but keeping the count instead of collapsing it to
+  /// a bool -- a consumer that needs to know HOW FAR BEHIND the audio it hands over will be played
+  /// cannot work from "some" versus "none".
+  size_t buffered_bytes() const;
   /// pre_shift is ignored: there is no intermediate transfer buffer to compact, so an unconsumed
   /// exposure stays in place and fill() returns 0 until it is fully consumed.
   size_t fill(TickType_t ticks_to_wait, bool pre_shift) override;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -218,6 +218,33 @@ bool I2SAudioSpeakerBase::has_buffered_data() const {
   return false;
 }
 
+bool I2SAudioSpeakerBase::buffered_bytes(size_t &bytes) const {
+  // Ring buffer PLUS the DMA descriptors' full occupancy, so this answers "how long until audio
+  // handed over now reaches the pin".
+  //
+  // The DMA term must include silence padding, and that is the whole point. Lockstep write records
+  // count only REAL frames per descriptor, so the played-frames callback never reports padding --
+  // yet padding still takes time to clock out. A consumer that schedules playback from the callback
+  // therefore underestimates its own latency by exactly the padding, and renders that much late.
+  // Measured across four synchronised clients: devices whose DMA had refilled with padding after a
+  // starvation reported 30-57 ms of real DMA content against a healthy 110 ms, and played 50-80 ms
+  // behind their peers -- persistently, and invisibly to every frame-based metric on the device.
+  const size_t dma = this->dma_resident_bytes_.load(std::memory_order_relaxed);
+  if (this->audio_ring_buffer_.use_count() > 0) {
+    std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->audio_ring_buffer_.lock();
+    if (temp_ring_buffer != nullptr) {
+      bytes = temp_ring_buffer->available() + dma;
+      return true;
+    }
+  }
+  if (dma > 0) {
+    // Task running with no ring yet: the DMA still holds (padded) audio
+    bytes = dma;
+    return true;
+  }
+  return false;
+}
+
 void I2SAudioSpeakerBase::speaker_task(void *params) {
   I2SAudioSpeakerBase *this_speaker = (I2SAudioSpeakerBase *) params;
   this_speaker->run_speaker_task();
@@ -296,6 +323,8 @@ esp_err_t I2SAudioSpeakerBase::init_i2s_channel_(const i2s_chan_config_t &chan_c
 }
 
 void I2SAudioSpeakerBase::stop_i2s_driver_() {
+  // Descriptors go away with the channel; stop claiming their latency
+  this->dma_resident_bytes_.store(0, std::memory_order_relaxed);
   if (this->tx_handle_ != nullptr) {
     i2s_channel_disable(this->tx_handle_);
     i2s_del_channel(this->tx_handle_);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -10,6 +10,8 @@
 
 #include "esphome/components/audio/audio.h"
 #include "esphome/components/ring_buffer/ring_buffer.h"
+
+#include <atomic>
 #include "esphome/components/speaker/speaker.h"
 
 #include "esphome/core/component.h"
@@ -76,6 +78,7 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   size_t play(const uint8_t *data, size_t length) override { return play(data, length, 0); }
 
   bool has_buffered_data() const override;
+  bool buffered_bytes(size_t &bytes) const override;
 
   /// @brief Sets the volume of the speaker. Uses the speaker's configured audio dac component. If unavailble, it is
   /// implemented as a software volume control. Overrides the default setter to convert the floating point volume to a
@@ -150,6 +153,12 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   std::weak_ptr<ring_buffer::RingBuffer> audio_ring_buffer_;
 
   uint32_t buffer_duration_ms_;
+  // Total bytes resident in the I2S DMA descriptors, INCLUDING silence padding. The lockstep write
+  // records count only REAL frames, so the played-frames callback -- and any accounting built on it --
+  // cannot see padding, even though padding still costs time to render. Published so buffered_bytes()
+  // can answer "how long until audio handed over now reaches the pin" rather than "how many real
+  // frames are outstanding". Set once the DMA geometry is known; 0 while the task is not running.
+  std::atomic<size_t> dma_resident_bytes_{0};
 
   optional<uint32_t> timeout_;
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
@@ -103,9 +103,12 @@ void I2SAudioSpeaker::run_speaker_task() {
   if (i2s_channel_get_info(this->tx_handle_, &chan_info) == ESP_OK && chan_info.total_dma_buf_size > 0) {
     // total_dma_buf_size spans all DMA_BUFFERS_COUNT descriptors and is an exact multiple of the count.
     dma_buffer_bytes = chan_info.total_dma_buf_size / DMA_BUFFERS_COUNT;
+    // Descriptors are preloaded and kept full for the task's lifetime, so occupancy is the whole span
+    this->dma_resident_bytes_.store(chan_info.total_dma_buf_size, std::memory_order_relaxed);
   } else {
     // Should not happen for a READY channel; fall back to the requested size.
     dma_buffer_bytes = this->output_stream_info_.frames_to_bytes(dma_buffer_frames(this->output_stream_info_));
+    this->dma_resident_bytes_.store(dma_buffer_bytes * DMA_BUFFERS_COUNT, std::memory_order_relaxed);
   }
   // dma_buffer_bytes counts output-format bytes; convert with the output stream info.
   const uint32_t frames_per_dma_buffer = this->output_stream_info_.bytes_to_frames(dma_buffer_bytes);

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -62,6 +62,20 @@ class Speaker {
 
   virtual bool has_buffered_data() const = 0;
 
+  /// @brief Bytes of audio buffered between this speaker's input and the point it is actually
+  /// rendered, if the platform can report it.
+  ///
+  /// has_buffered_data() answers "any or none", which is enough to drain but not enough to know WHEN
+  /// audio handed over now will be heard. A synchronised consumer needs the depth: it can count what
+  /// it pushed and be told what was played, but the fill sitting between those two points is
+  /// otherwise invisible, so a pipeline restart at an unobserved fill level leaves playback offset by
+  /// that amount with every other metric reading nominal.
+  ///
+  /// @param bytes Set to the buffered byte count on success. Untouched on failure.
+  /// @return false when the platform cannot report a count -- distinct from reporting zero, which
+  /// means genuinely empty.
+  virtual bool buffered_bytes(size_t & /*bytes*/) const { return false; }
+
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 


### PR DESCRIPTION
# What does this implement/fix?

`Speaker::has_buffered_data()` answers "any or none", which is enough to drain a pipeline but not enough to know **when** audio handed over now will actually be heard. Every layer already computes the count and then discards it at the API boundary:

```cpp
I2SAudioSpeakerBase::has_buffered_data()
    return temp_ring_buffer->available() > 0;
RingBufferAudioSource::has_buffered_data()
    return current_available_ > 0 || queued_length_ > 0 || ring_buffer_->available() > 0;
```

This adds `virtual bool buffered_bytes(size_t &bytes) const`, defaulting to `false`, and implements it for `i2s_audio` and `RingBufferAudioSource`. `has_buffered_data()` is untouched.

**Why a second method rather than changing the existing one.** `has_buffered_data()` is pure virtual, so changing its signature breaks every out-of-tree speaker platform. More importantly a bool cannot distinguish *"this platform cannot report a count"* from *"the buffer is genuinely empty"*, and that distinction is what makes the value safe to act on — a caller that treats "unknown" as "zero" will confidently mis-schedule. Defaulting to `false` keeps every existing platform compiling unchanged.

**Why the DMA descriptors are included for i2s_audio.** The lockstep write records added in #16317 count only *real* frames per descriptor, so silence padding never reaches the played-frames callback — yet it still takes time to clock out. A consumer scheduling from that callback underestimates its own latency by exactly the padding and renders that much late, with nothing in its frame accounting able to show it.

Measured across four synchronised clients on one AP: devices whose DMA had refilled with padding after a starvation reported 30–57 ms of real DMA content where healthy peers reported 110 ms, and played 50–80 ms behind those peers. Persistently — the fill settles at its new level and stays — and invisibly, because every frame-based metric agreed the devices were aligned to under a millisecond. It was audible to a listener long before it was measurable, which is the point: the quantity was structurally unobservable.

## Who this is for

Two open items in this repo are working around the absence of a count:

- **#16512** waits for a media player to finish playing buffered audio before reopening the mic, and can only poll the bool. A count gives the remaining time directly.
- **#18404** loses roughly a syllable off the end of every TTS response on a shared-bus S3 — the class of symptom that appears when a stage is torn down while audio is still in flight downstream of the last thing anyone can see.

It also came out of an external Snapcast client, where an unobserved fill at pipeline restart left playback 100–250 ms offset with every on-device metric reading nominal. That is corroboration rather than the motivation; the two above are in-tree.

## Types of changes

- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)

**Related issue or feature (if applicable):**

- Related: #16512, #18404
- Builds on: #16317 (the lockstep write records this reads)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Not applicable — no YAML surface changes.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- Happy to open one if a new `Speaker` virtual warrants an entry — say the word and I'll follow up.

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration change. Compiled against an unmodified i2s_audio + mixer chain:
i2s_audio:
  - id: i2s_out
    i2s_lrclk_pin: GPIO5
    i2s_bclk_pin: GPIO6

speaker:
  - platform: i2s_audio
    id: dac_speaker
    i2s_audio_id: i2s_out
    dac_type: external
    i2s_dout_pin: GPIO7
    sample_rate: 48000
    channel: stereo
  - platform: mixer
    output_speaker: dac_speaker
    num_channels: 2
    source_speakers:
      - id: mix_a
      - id: mix_b
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Notes on the checklist: compiled for ESP32-S3 with esp-idf against `mixer`, `media_source` and `speaker_source` in their **unmodified** state, to confirm the defaulted virtual is genuinely backward compatible. The reported values were then exercised on a four-device fleet over several days, which is where the figures above come from.

No test config added — `tests/components/speaker/` already compiles the i2s_audio chain, and this adds no configuration to exercise. Glad to add one if you would rather see the method covered explicitly.

Two follow-ups are open and chained on this one, each reviewable on its own and neither needed for this to be useful:

- **#18754** — `mixer` sums its source queue, output transfer buffer and output speaker. This is where the accounting becomes complete: the transfer buffer is a task-local `unique_ptr` no caller could reach, and it is exactly the +52/+55 ms residual left after counting the DMA descriptors.
- **#18755** — a `media_source` query carrying the value across the listener boundary, so a component feeding audio in can see what is still in flight.

Both target `dev` and therefore carry this commit as well, since an outside contributor cannot base a PR on a branch in their own fork. Their diffs collapse as this one lands.

