### PR TITLE
[mixer] Report the whole chain in buffered_bytes, not just the source queue

### DIFF
--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -276,6 +276,12 @@ bool RingBufferAudioSource::has_buffered_data() const {
   return (this->current_available_ > 0) || (this->queued_length_ > 0) || (this->ring_buffer_->available() > 0);
 }
 
+size_t RingBufferAudioSource::buffered_bytes() const {
+  // Same three terms as has_buffered_data(), and splice_length_ is excluded for the same reason: those
+  // bytes are still to arrive through the ring buffer and are already counted in its available().
+  return this->current_available_ + this->queued_length_ + this->ring_buffer_->available();
+}
+
 size_t RingBufferAudioSource::fill(TickType_t ticks_to_wait, bool /*pre_shift*/) {
   if (this->current_available_ > 0) {
     // Caller has not finished consuming the current exposure

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -246,6 +246,11 @@ class RingBufferAudioSource : public AudioReadableBuffer {
   size_t available() const override { return this->current_available_; }
   void consume(size_t bytes) override;
   bool has_buffered_data() const override;
+  /// @brief Total buffered audio in bytes, across the exposed region, the queued item, and the ring
+  /// buffer. Same accounting as has_buffered_data() but keeping the count instead of collapsing it to
+  /// a bool -- a consumer that needs to know HOW FAR BEHIND the audio it hands over will be played
+  /// cannot work from "some" versus "none".
+  size_t buffered_bytes() const;
   /// pre_shift is ignored: there is no intermediate transfer buffer to compact, so an unconsumed
   /// exposure stays in place and fill() returns 0 until it is fully consumed.
   size_t fill(TickType_t ticks_to_wait, bool pre_shift) override;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -218,6 +218,33 @@ bool I2SAudioSpeakerBase::has_buffered_data() const {
   return false;
 }
 
+bool I2SAudioSpeakerBase::buffered_bytes(size_t &bytes) const {
+  // Ring buffer PLUS the DMA descriptors' full occupancy, so this answers "how long until audio
+  // handed over now reaches the pin".
+  //
+  // The DMA term must include silence padding, and that is the whole point. Lockstep write records
+  // count only REAL frames per descriptor, so the played-frames callback never reports padding --
+  // yet padding still takes time to clock out. A consumer that schedules playback from the callback
+  // therefore underestimates its own latency by exactly the padding, and renders that much late.
+  // Measured across four synchronised clients: devices whose DMA had refilled with padding after a
+  // starvation reported 30-57 ms of real DMA content against a healthy 110 ms, and played 50-80 ms
+  // behind their peers -- persistently, and invisibly to every frame-based metric on the device.
+  const size_t dma = this->dma_resident_bytes_.load(std::memory_order_relaxed);
+  if (this->audio_ring_buffer_.use_count() > 0) {
+    std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->audio_ring_buffer_.lock();
+    if (temp_ring_buffer != nullptr) {
+      bytes = temp_ring_buffer->available() + dma;
+      return true;
+    }
+  }
+  if (dma > 0) {
+    // Task running with no ring yet: the DMA still holds (padded) audio
+    bytes = dma;
+    return true;
+  }
+  return false;
+}
+
 void I2SAudioSpeakerBase::speaker_task(void *params) {
   I2SAudioSpeakerBase *this_speaker = (I2SAudioSpeakerBase *) params;
   this_speaker->run_speaker_task();
@@ -296,6 +323,8 @@ esp_err_t I2SAudioSpeakerBase::init_i2s_channel_(const i2s_chan_config_t &chan_c
 }
 
 void I2SAudioSpeakerBase::stop_i2s_driver_() {
+  // Descriptors go away with the channel; stop claiming their latency
+  this->dma_resident_bytes_.store(0, std::memory_order_relaxed);
   if (this->tx_handle_ != nullptr) {
     i2s_channel_disable(this->tx_handle_);
     i2s_del_channel(this->tx_handle_);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -10,6 +10,8 @@
 
 #include "esphome/components/audio/audio.h"
 #include "esphome/components/ring_buffer/ring_buffer.h"
+
+#include <atomic>
 #include "esphome/components/speaker/speaker.h"
 
 #include "esphome/core/component.h"
@@ -76,6 +78,7 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   size_t play(const uint8_t *data, size_t length) override { return play(data, length, 0); }
 
   bool has_buffered_data() const override;
+  bool buffered_bytes(size_t &bytes) const override;
 
   /// @brief Sets the volume of the speaker. Uses the speaker's configured audio dac component. If unavailble, it is
   /// implemented as a software volume control. Overrides the default setter to convert the floating point volume to a
@@ -150,6 +153,12 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   std::weak_ptr<ring_buffer::RingBuffer> audio_ring_buffer_;
 
   uint32_t buffer_duration_ms_;
+  // Total bytes resident in the I2S DMA descriptors, INCLUDING silence padding. The lockstep write
+  // records count only REAL frames, so the played-frames callback -- and any accounting built on it --
+  // cannot see padding, even though padding still costs time to render. Published so buffered_bytes()
+  // can answer "how long until audio handed over now reaches the pin" rather than "how many real
+  // frames are outstanding". Set once the DMA geometry is known; 0 while the task is not running.
+  std::atomic<size_t> dma_resident_bytes_{0};
 
   optional<uint32_t> timeout_;
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
@@ -103,9 +103,12 @@ void I2SAudioSpeaker::run_speaker_task() {
   if (i2s_channel_get_info(this->tx_handle_, &chan_info) == ESP_OK && chan_info.total_dma_buf_size > 0) {
     // total_dma_buf_size spans all DMA_BUFFERS_COUNT descriptors and is an exact multiple of the count.
     dma_buffer_bytes = chan_info.total_dma_buf_size / DMA_BUFFERS_COUNT;
+    // Descriptors are preloaded and kept full for the task's lifetime, so occupancy is the whole span
+    this->dma_resident_bytes_.store(chan_info.total_dma_buf_size, std::memory_order_relaxed);
   } else {
     // Should not happen for a READY channel; fall back to the requested size.
     dma_buffer_bytes = this->output_stream_info_.frames_to_bytes(dma_buffer_frames(this->output_stream_info_));
+    this->dma_resident_bytes_.store(dma_buffer_bytes * DMA_BUFFERS_COUNT, std::memory_order_relaxed);
   }
   // dma_buffer_bytes counts output-format bytes; convert with the output stream info.
   const uint32_t frames_per_dma_buffer = this->output_stream_info_.bytes_to_frames(dma_buffer_bytes);

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -281,6 +281,65 @@ bool SourceSpeaker::has_buffered_data() const {
   return ((this->audio_source_.use_count() > 0) && this->audio_source_->has_buffered_data());
 }
 
+bool SourceSpeaker::buffered_bytes(size_t &bytes) const {
+  // TOTAL latency from this source's input to the output speaker's input: this source's own queue
+  // PLUS whatever the mixer has already combined and handed downstream.
+  //
+  // Reporting only the source queue was wrong precisely when the value matters. After a starvation
+  // the source ring is genuinely empty while the output speaker still holds a few hundred ms, so a
+  // caller anchoring its accounting to "0" believes the pipeline is empty when it is not, predicts
+  // playout that much too early, and delays real audio to compensate. Measured: a device logging
+  // "measured fill: 0 frames" settled with 69 ms accounted against a ~269 ms true fill and played
+  // ~200 ms behind its peers.
+  //
+  // The two queues are in series and hold different audio (pre- and post-mix), so summing them is
+  // correct and does not double count.
+  //
+  // Gate on the RING BUFFER, not on audio_source_. play() writes into ring_buffer_, while
+  // audio_source_ is the consumer-side wrapper the mixer task constructs in start_() -- so a
+  // writer can legitimately have queued audio before audio_source_ exists. Gating on the latter
+  // reported "cannot tell" while the ring held data, which reads identically to an empty pipeline
+  // at the call site.
+  size_t own = 0;
+  bool have_own = false;
+  if (this->audio_source_.use_count() > 0) {
+    // RingBufferAudioSource::buffered_bytes() already includes ring_buffer_->available() alongside
+    // its own in-flight exposure and queued item, so that must not be added to it.
+    own = this->audio_source_->buffered_bytes();
+    have_own = true;
+  } else {
+    std::shared_ptr<ring_buffer::RingBuffer> temp_ring_buffer = this->ring_buffer_.lock();
+    if (temp_ring_buffer != nullptr) {
+      // No consumer wrapper yet, so nothing can be in flight beyond the ring itself
+      own = temp_ring_buffer->available();
+      have_own = true;
+    }
+  }
+  if (!have_own) {
+    return false;
+  }
+
+  // Downstream is optional: a platform that cannot report it leaves the caller with the source
+  // queue alone, which is strictly better than nothing and no worse than the previous behaviour.
+  size_t downstream = 0;
+  if (this->parent_ != nullptr) {
+    // The mixer task's own output transfer buffer sits between the source rings and the output
+    // speaker, and holds up to TRANSFER_BUFFER_DURATION_MS. It is task-local, so it was the last
+    // unreachable stage of the chain: a caller summing only the layers it could see under-reported
+    // its latency by ~50 ms, which is exactly the residual that remained after the DMA was counted.
+    downstream += this->parent_->output_transfer_bytes();
+    speaker::Speaker *out = this->parent_->get_output_speaker();
+    if (out != nullptr) {
+      size_t out_bytes = 0;
+      if (out->buffered_bytes(out_bytes)) {
+        downstream += out_bytes;
+      }
+    }
+  }
+  bytes = own + downstream;
+  return true;
+}
+
 void SourceSpeaker::set_mute_state(bool mute_state) {
   this->mute_state_ = mute_state;
   this->parent_->get_output_speaker()->set_mute_state(mute_state);
@@ -485,6 +544,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
 
       // Never shift the data in the output transfer buffer to avoid unnecessary, slow data moves
       output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS), false);
+      this_mixer->output_transfer_bytes_.store(output_transfer_buffer->available(), std::memory_order_relaxed);
 
       const uint32_t output_frames_free =
           this_mixer->audio_stream_info_.value().bytes_to_frames(output_transfer_buffer->free());
@@ -552,6 +612,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
 
           // Update output transfer buffer length and pipeline frame count
           output_transfer_buffer->increase_buffer_length(output_info.frames_to_bytes(frames_to_mix));
+          this_mixer->output_transfer_bytes_.store(output_transfer_buffer->available(), std::memory_order_relaxed);
           this_mixer->frames_in_pipeline_.fetch_add(frames_to_mix, std::memory_order_release);
         } else {
           // Speaker's stream info doesn't match the output speaker's, so it's a new source speaker
@@ -616,6 +677,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
 
         // Update output transfer buffer length and pipeline frame count (once, not per source)
         output_transfer_buffer->increase_buffer_length(output_info.frames_to_bytes(frames_to_mix));
+        this_mixer->output_transfer_bytes_.store(output_transfer_buffer->available(), std::memory_order_relaxed);
         this_mixer->frames_in_pipeline_.fetch_add(frames_to_mix, std::memory_order_release);
       }
     }
@@ -626,6 +688,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
   // Reset pipeline frame count since the task is stopping
   this_mixer->frames_in_pipeline_.store(0, std::memory_order_release);
 
+  this_mixer->output_transfer_bytes_.store(0, std::memory_order_relaxed);
   xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STOPPED);
 
   vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -58,6 +58,7 @@ class SourceSpeaker final : public speaker::Speaker, public Component {
   void finish() override;
 
   bool has_buffered_data() const override;
+  bool buffered_bytes(size_t &bytes) const override;
 
   /// @brief Mute state changes are passed to the parent's output speaker
   void set_mute_state(bool mute_state) override;
@@ -143,6 +144,10 @@ class MixerSpeaker final : public Component {
 
   speaker::Speaker *get_output_speaker() const { return this->output_speaker_; }
 
+  /// @brief Bytes held in the mixer task's output transfer buffer: mixed audio past the source rings
+  /// but not yet at the output speaker. Part of a source's true latency to the pin.
+  size_t output_transfer_bytes() const { return this->output_transfer_bytes_.load(std::memory_order_relaxed); }
+
   /// @brief Returns the current number of frames in the output pipeline (written but not yet played)
   uint32_t get_frames_in_pipeline() const { return this->frames_in_pipeline_.load(std::memory_order_acquire); }
 
@@ -153,6 +158,11 @@ class MixerSpeaker final : public Component {
 
   FixedVector<SourceSpeaker *> source_speakers_;
   speaker::Speaker *output_speaker_{nullptr};
+  // Bytes currently held in the mixer task's output transfer buffer -- mixed audio that has left the
+  // source rings but not yet reached the output speaker. The buffer itself is task-local, so without
+  // publishing it this stage of the pipeline is unreachable and a caller summing the layers it CAN
+  // see under-reports its true latency by up to TRANSFER_BUFFER_DURATION_MS.
+  std::atomic<size_t> output_transfer_bytes_{0};
 
   uint8_t output_bits_per_sample_;
   uint8_t output_channels_;

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -62,6 +62,20 @@ class Speaker {
 
   virtual bool has_buffered_data() const = 0;
 
+  /// @brief Bytes of audio buffered between this speaker's input and the point it is actually
+  /// rendered, if the platform can report it.
+  ///
+  /// has_buffered_data() answers "any or none", which is enough to drain but not enough to know WHEN
+  /// audio handed over now will be heard. A synchronised consumer needs the depth: it can count what
+  /// it pushed and be told what was played, but the fill sitting between those two points is
+  /// otherwise invisible, so a pipeline restart at an unobserved fill level leaves playback offset by
+  /// that amount with every other metric reading nominal.
+  ///
+  /// @param bytes Set to the buffered byte count on success. Untouched on failure.
+  /// @return false when the platform cannot report a count -- distinct from reporting zero, which
+  /// means genuinely empty.
+  virtual bool buffered_bytes(size_t & /*bytes*/) const { return false; }
+
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 


### PR DESCRIPTION
# What does this implement/fix?

> **Chained on top of #18753**, which adds `Speaker::buffered_bytes()`. GitHub will not let an outside contributor base a PR on a branch in their own fork, so this targets `dev` and carries #18753's commit as well. **Only the second commit — `[mixer] Report the whole chain…` — is the subject of this PR**; the diff collapses once #18753 lands. Happy to rebase or split differently if you would rather review it another way.

Three stages sat between a `SourceSpeaker`'s ring buffer and the pin that no caller could see, and each was wrong precisely when the value mattered.

**Gate on the ring, not the consumer wrapper.** `play()` writes into `ring_buffer_`, while `audio_source_` is the consumer-side wrapper the mixer task constructs in `start_()`. A writer can have queued audio before `audio_source_` exists, so gating on the latter reported "cannot tell" while the ring held data — indistinguishable, at the call site, from an empty pipeline. In the field every one of ~120 starvations across four devices took the caller's fallback path, so the query never once returned a real number.

**Include the output speaker.** After a starvation the source ring is genuinely empty while the output speaker still holds a few hundred ms, so a caller anchoring to "0" believes the pipeline is empty when it is not. Measured: a device logged `measured fill: 0 frames` on five consecutive re-baselines, then settled with 69 ms accounted against a ~269 ms true fill and played ~200 ms behind its peers — its own sync error reading ~0, because that error is computed against a prediction built from the same accounting. Peers that never drained that far stayed aligned at 264–272 ms.

**Publish the output transfer buffer.** It holds up to `TRANSFER_BUFFER_DURATION_MS` (50 ms) of mixed audio between the source rings and the output speaker, and is a task-local `unique_ptr` — so nothing outside the mixer task could reach it. It is exactly the residual that survived counting the DMA descriptors: freshly-started clients measured accounted-minus-reported at **+52 and +55 ms** against a 50 ms buffer.

With all three the chain is fully accounted — source ring, transfer buffer, output speaker ring, DMA descriptors — and that changes what a discrepancy *means*. The difference between what a consumer has accounted and what the pipeline reports is no longer a mix of "real audio we cannot see" and "frames that do not exist"; it is only the latter. That makes it a self-contained invariant rather than something needing a fleet to diagnose.

The source queue is pre-mix and the output speaker's is post-mix, so they are in series and hold different audio — summing is correct and does not double count. Downstream reporting stays optional: a platform that cannot report leaves the caller with the source queue alone, no worse than before.

## Types of changes

- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)

**Related issue or feature (if applicable):**

- Chained on: #18753 (review that one first)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Not applicable — no YAML surface changes.

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration change; compiled against the mixer chain from #18753's test config.
speaker:
  - platform: mixer
    output_speaker: dac_speaker
    num_channels: 2
    source_speakers:
      - id: mix_a
      - id: mix_b
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Compiled for ESP32-S3 with esp-idf on top of #18753. The figures above come from a four-device fleet run over several days.
