### PR TITLE
[core] Fix false-positive readability-non-const-parameter in string_ref.h

### DIFF
--- a/esphome/core/string_ref.h
+++ b/esphome/core/string_ref.h
@@ -239,7 +239,7 @@ template<typename R, typename F> inline R parse_number(const StringRef &str, siz
 }
 // NOLINTEND(google-runtime-int)
 }  // namespace internal
-// NOLINTBEGIN(readability-identifier-naming,google-runtime-int)
+// NOLINTBEGIN(readability-identifier-naming,google-runtime-int,readability-non-const-parameter)
 inline int stoi(const StringRef &str, size_t *pos = nullptr, int base = 10) {
   return static_cast<int>(internal::parse_number<long>(str, pos, base, std::strtol));
 }
@@ -252,7 +252,7 @@ inline float stof(const StringRef &str, size_t *pos = nullptr) {
 inline double stod(const StringRef &str, size_t *pos = nullptr) {
   return internal::parse_number<double>(str, pos, std::strtod);
 }
-// NOLINTEND(readability-identifier-naming,google-runtime-int)
+// NOLINTEND(readability-identifier-naming,google-runtime-int,readability-non-const-parameter)
 
 #ifdef USE_JSON
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/esphome/core/string_ref.h
+++ b/esphome/core/string_ref.h
@@ -239,6 +239,8 @@ template<typename R, typename F> inline R parse_number(const StringRef &str, siz
 }
 // NOLINTEND(google-runtime-int)
 }  // namespace internal
+// readability-non-const-parameter: `pos` is written through by internal::parse_number, one call
+// frame away; the check only inspects these bodies, so it wrongly proposes `const size_t *`.
 // NOLINTBEGIN(readability-identifier-naming,google-runtime-int,readability-non-const-parameter)
 inline int stoi(const StringRef &str, size_t *pos = nullptr, int base = 10) {
   return static_cast<int>(internal::parse_number<long>(str, pos, base, std::strtol));


### PR DESCRIPTION
## Summary

`esphome/core/string_ref.h` has a latent clang-tidy `readability-non-const-parameter` false positive on the `pos` parameter of `stoi`/`stol`/`stof`/`stod`. It went unnoticed because `script/clang-tidy` only lints `--changed` files and sweeps in whatever headers they transitively include via `--header-filter` — no recent PR had happened to touch a file that both includes `string_ref.h` and is in scope for the ESP8266 clang-tidy job, until now.

**Why this is a false positive, not a real issue:** the check only analyzes each flagged function's own body. For example:

```cpp
inline int stoi(const StringRef &str, size_t *pos = nullptr, int base = 10) {
  return static_cast<int>(internal::parse_number<long>(str, pos, base, std::strtol));
}
```

`pos` is never dereferenced directly inside `stoi` — it's just forwarded to `internal::parse_number`. The checker doesn't look inside that call, so it concludes `pos` "could be const." But `parse_number` genuinely writes through it:

```cpp
if (pos)
  *pos = (end == str.c_str()) ? 0 : static_cast<size_t>(end - str.c_str());
```

**Why the obvious fix (add `const`) doesn't work:** const-qualifying `pos` in `stoi`/`stol`/`stof`/`stod` would make it a `const size_t *`, which cannot be passed to `parse_number`'s non-const `size_t *pos` parameter — the mutation is real, just one call frame away. That would fail to compile.

## Fix

Extend the existing `NOLINTBEGIN`/`NOLINTEND(readability-identifier-naming,google-runtime-int)` pragma pair that already wraps this exact block to also suppress `readability-non-const-parameter`, with no changes to any function signatures.

## Test plan

- [x] No functional/behavioral change — comment/pragma-only edit
- [ ] CI: ESP8266 clang-tidy job passes on this diff