### PR TITLE
[ci] Remove the remaining max-parallel caps

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -182,8 +182,6 @@ jobs:
       contents: read  # actions/checkout to load the test configs
     strategy:
       fail-fast: false
-      # Modest cap so this smoke test leaves room on the shared runner pool.
-      max-parallel: 8
       matrix:
         # One entry per distinct toolchain. ESP32 variants (c3/c6/s2/s3/p4)
         # share a toolchain bundle, so esp32 is exercised on the base variant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,7 +946,6 @@ jobs:
       ESPHOME_SDK_NRF_PREFIX: ~/.esphome-sdk-nrf
     strategy:
       fail-fast: false
-      max-parallel: ${{ needs.determine-jobs.outputs.release-pr == 'true' && 32 || 16 }}
       matrix:
         batch: ${{ fromJson(needs.determine-jobs.outputs.component-test-batches) }}
     steps:


### PR DESCRIPTION
# What does this implement/fix?

Removes the two `max-parallel` caps that #18125 kept "starting conservative", now that there is data showing neither is doing useful work:

- **test-build-components-split** (`16`, `32` on beta/release): recent full runs produce ~20-21 batches (2026.8.0b1: 20, 2026.8.0: 21), so the 32 cap never binds and the 16 cap only throttles exactly the PRs where wall-clock matters most (beta cuts, full-touch refactors). The batch count is the natural ceiling, backstopped by GitHub's 256-jobs-per-matrix limit and the per-PR `concurrency` group.
- **docker compile-test smoke** (`8`): the matrix is 11 fixed entries, so the cap just adds an extra wave to every ci-docker run. The matrix size is the natural limit, same rationale #18125 applied to the clang-tidy jobs.

The enterprise pool allows 500 concurrent jobs, so neither cap is protecting anything at this scale.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
