### PR TITLE
[runtime_image] Add FILTER_SOURCE_FILES

### DIFF
--- a/esphome/components/runtime_image/__init__.py
+++ b/esphome/components/runtime_image/__init__.py
@@ -10,6 +10,7 @@ from esphome.components.image import (
     validate_transparency,
     validate_type,
 )
+from esphome.config_helpers import filter_source_files_from_defines
 import esphome.config_validation as cv
 from esphome.const import CONF_FORMAT, CONF_ID, CONF_RESIZE, CONF_TYPE
 from esphome.core import CORE
@@ -123,6 +124,15 @@ IMAGE_FORMATS = {
     "JPG": _JPEG_FORMAT,  # Alias for JPEG
     "PNG": PNGFormat(),
 }
+
+FILTER_SOURCE_FILES = filter_source_files_from_defines(
+    {
+        "bmp_decoder.cpp": "USE_RUNTIME_IMAGE_BMP",
+        "jpeg_decoder.cpp": "USE_RUNTIME_IMAGE_JPEG",
+        "png_decoder.cpp": "USE_RUNTIME_IMAGE_PNG",
+        "qoi_decoder.cpp": "USE_RUNTIME_IMAGE_QOI",
+    }
+)
 
 AUTO_FORMAT = AUTOFormat()
 


### PR DESCRIPTION
Add the FILTER_SOURCE_FILES directive to the init.py file to ensure that only the configured decoders are compiled.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- mentioned as needed in #16945 

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/R

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/R

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
