### PR TITLE
[core] Prefetch PlatformIO packages in parallel

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from ctypes.util import find_library
-from functools import partial
 import json
 import logging
 import os
@@ -20,15 +19,16 @@ from esphome.framework_helpers import (
     create_venv,
     download_and_extract,
     download_from_mirrors,
-    download_with_resume,
     failure_reason,
     get_python_env_executable_path,
     get_system_python_path,
+    resume_fetch_job,
     rmdir,
     run_batch_downloads,
     run_command,
     run_command_ok,
     str_to_lst_of_str,
+    warn_prefetch_failures,
 )
 from esphome.helpers import get_bool_env, get_str_env, write_file_if_changed
 
@@ -693,18 +693,6 @@ def _patch_tools_json_demote_unused_tools(framework_path: Path) -> None:
     )
 
 
-def _download_tool(
-    dist_path: Path, entry: dict, tracker: Callable[[int], None]
-) -> None:
-    download_with_resume(
-        entry["url"],
-        dist_path / entry["dest"],
-        sha256=entry["sha256"],
-        size=entry["size"],
-        progress=tracker,
-    )
-
-
 def _prefetch_idf_tool_archives(
     framework_path: Path,
     targets_str: str,
@@ -782,15 +770,17 @@ def _prefetch_idf_tool_archives(
                 (
                     entry["name"],
                     entry["size"],
-                    partial(_download_tool, dist_path, entry),
+                    resume_fetch_job(
+                        entry["url"],
+                        dist_path / entry["dest"],
+                        sha256=entry["sha256"],
+                        size=entry["size"],
+                    ),
                 )
                 for entry in entries
             ],
         )
-        for name, e in failures:
-            # failure_reason: a message-less exception must not log blank
-            _LOGGER.warning("Could not prefetch %s: %s", name, failure_reason(e))
-            _LOGGER.debug("Prefetch failure detail", exc_info=e)
+        warn_prefetch_failures(failures)
         if len(failures) == len(entries):
             # A systematic fault, not one flaky mirror: the resume
             # workaround (#17703) is off for this whole install

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -898,6 +898,33 @@ def _cancellable_sleep(
         time.sleep(min(0.5, remaining))
 
 
+def resume_fetch_job(
+    url: str, dest: PathType, **kwargs
+) -> Callable[[Callable[[int], None]], None]:
+    """A ``run_batch_downloads`` job callable wrapping ``download_with_resume``.
+
+    The batch runner passes its progress tracker positionally; forward it as
+    the ``progress`` keyword along with any extra download arguments
+    (``sha256``, ``size``, ...).
+    """
+
+    def fetch(tracker: Callable[[int], None]) -> None:
+        download_with_resume(url, dest, progress=tracker, **kwargs)
+
+    return fetch
+
+
+def warn_prefetch_failures(
+    failures: list[tuple[str, BaseException]],
+    message: str = "Could not prefetch %s: %s",
+) -> None:
+    """Warn per failed batch-prefetch job; the caller's installer retries them."""
+    for name, err in failures:
+        # failure_reason: a message-less exception must not log blank
+        _LOGGER.warning(message, name, failure_reason(err))
+        _LOGGER.debug("Prefetch failure detail", exc_info=err)
+
+
 def download_with_resume(
     url: str,
     dest: PathType,

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -909,6 +909,14 @@ def _part_path(dest: Path) -> Path:
     return dest.with_name(dest.name + ".part")
 
 
+def discard_partial_download(dest: Path) -> None:
+    """Remove ``dest`` and the resume sidecars of an abandoned download."""
+    part = _part_path(dest)
+    for stale in (dest, part, part.with_name(part.name + ".meta")):
+        with suppress(OSError):
+            stale.unlink()
+
+
 def _cancellable_sleep(
     delay: float, progress: Callable[[int], None] | None, done: int
 ) -> None:

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -913,8 +913,13 @@ def discard_partial_download(dest: Path) -> None:
     """Remove ``dest`` and the resume sidecars of an abandoned download."""
     part = _part_path(dest)
     for stale in (dest, part, part.with_name(part.name + ".meta")):
-        with suppress(OSError):
+        try:
             stale.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as err:
+            # The caller's cache is never pruned; leave a trace
+            _LOGGER.debug("Could not remove %s: %s", stale, err)
 
 
 def _cancellable_sleep(

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -903,9 +903,7 @@ def resume_fetch_job(
 ) -> Callable[[Callable[[int], None]], None]:
     """A ``run_batch_downloads`` job callable wrapping ``download_with_resume``.
 
-    The batch runner passes its progress tracker positionally; forward it as
-    the ``progress`` keyword along with any extra download arguments
-    (``sha256``, ``size``, ...).
+    Forwards the runner's positional tracker as the ``progress`` keyword.
     """
 
     def fetch(tracker: Callable[[int], None]) -> None:

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -677,7 +677,7 @@ def _write_download_meta(
         _LOGGER.debug("Could not update download metadata %s: %s", meta, e)
 
 
-def _content_length(resp: "requests.Response") -> int:
+def content_length(resp: "requests.Response") -> int:
     """Return the response's Content-Length, or 0 when absent or malformed.
 
     0 means "unknown", which downstream disables the progress bar and the
@@ -720,7 +720,7 @@ def _stream_response_to_file(
     """
     f.seek(offset)
     f.truncate(offset)
-    total_size = size or offset + _content_length(resp)
+    total_size = size or offset + content_length(resp)
     downloaded = offset
     own_bar: ProgressBar | None = None
     if progress is None:
@@ -1025,7 +1025,7 @@ def download_with_resume(
                         streamed = True
                         if offset == 0:
                             validator = _response_validator(resp)
-                            expected_total = _content_length(resp)
+                            expected_total = content_length(resp)
                             # Recorded so a later run can prove an If-Range
                             # resume of this part file safe.
                             _write_download_meta(meta, url, validator, expected_total)

--- a/esphome/platformio/library.py
+++ b/esphome/platformio/library.py
@@ -35,6 +35,7 @@ from esphome.framework_helpers import (
     failure_reason,
     rmdir,
     run_batch_downloads,
+    warn_prefetch_failures,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -977,14 +978,10 @@ def _prefetch_wave(
                 for c in components
             ],
         )
-        for name, err in failures:
-            # The sequential call below retries and raises the real error
-            _LOGGER.warning(
-                "Prefetch of %s failed (retrying sequentially): %s",
-                name,
-                failure_reason(err),
-            )
-            _LOGGER.debug("Prefetch failure detail", exc_info=err)
+        # The sequential call below retries and raises the real error
+        warn_prefetch_failures(
+            failures, "Prefetch of %s failed (retrying sequentially): %s"
+        )
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Same policy as the ESP-IDF twin: the prefetch must never become a
         # new way for the build to fail

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -68,11 +68,14 @@ def _sweep_stale_sidecars(download_dir: Path) -> None:
 
     A version bump changes the cache key, stranding an aborted archive's
     sidecars forever; anything past pio's own expiry is dead weight.
+    Lock files are excluded: O_TRUNC does not refresh mtime, so a held
+    lock can look ancient, and unlinking it would reopen the
+    interleaved-writer hole it guards (they are a few bytes anyway).
     """
     cutoff = time.time() - _SIDECAR_EXPIRE_SECONDS
     try:
         for f in download_dir.iterdir():
-            if f.suffix not in (".part", ".meta", ".prefetch", ".lock"):
+            if f.suffix not in (".part", ".meta", ".prefetch"):
                 continue
             try:
                 if f.stat().st_mtime < cutoff:
@@ -215,9 +218,11 @@ def _registry_jobs(
                 return None  # let PlatformIO report it
             package, version = mgr.find_best_registry_version(packages, spec)
             if not package or not version:
+                _LOGGER.debug("%s has no matching registry version", spec)
                 return None
             pkgfile = mgr.pick_compatible_pkg_file(version["files"])
             if not pkgfile:
+                _LOGGER.debug("%s has no file for this systype", spec)
                 return None
             url, checksum = next(RegistryFileMirrorIterator(pkgfile["download_url"]))
             checksum = checksum or pkgfile["checksum"]["sha256"]
@@ -331,6 +336,9 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
             failed += 1
         elif size:
             jobs.append((name, size, _uri_fetch_job(manager, url, dl_path, size)))
+        else:
+            # Missing or unusable Content-Length; visible under -v
+            _LOGGER.debug("%s reports no usable length; PlatformIO fetches it", url)
     if failed:
         _LOGGER.warning(
             "Could not size %d of %d PlatformIO package URL(s) (%s); "

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -12,7 +12,10 @@ resolving a platform executes its code, and platform setup may rewrite the
 running interpreter's state (pioarduino's penv setup replaces ``sys.path``
 with its own virtualenv's, breaking every later import in the process).
 All other PlatformIO execution is already subprocess-isolated the same way
-(see ``run_platformio_cli``).
+(see ``run_platformio_cli``). When the child finds nothing to do it records
+a sentinel in the build dir, and the parent skips the spawn entirely while
+the sentinel stays valid, so warm incremental builds pay a file read
+instead of a subprocess.
 
 Strictly best-effort: any failure logs and returns, leaving PlatformIO to
 download whatever is missing exactly as before.
@@ -21,15 +24,19 @@ download whatever is missing exactly as before.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
+import json
 import logging
 import os
 from pathlib import Path
 import subprocess
 import sys
+import threading
 from typing import Any
 
 from esphome.framework_helpers import (
-    _content_length,
+    content_length,
+    failure_reason,
     resume_fetch_job,
     run_batch_downloads,
     warn_prefetch_failures,
@@ -37,23 +44,70 @@ from esphome.framework_helpers import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Concurrent registry resolutions / HEAD probes (each is network-bound)
+_RESOLVE_WORKERS = 8
+
+# Written by the child when a run found nothing to prefetch; read by the
+# parent to skip the next spawn. Any mismatch or missing dir re-spawns.
+_SENTINEL_NAME = ".esphome_prefetch.json"
+_SENTINEL_SCHEMA = 1
+
+
+def _ini_sha256(build_dir: Path) -> str:
+    return hashlib.sha256((build_dir / "platformio.ini").read_bytes()).hexdigest()
+
+
+def _sentinel_state(build_dir: Path) -> dict[str, Any]:
+    """The environment fingerprint a sentinel must match to stay valid."""
+    return {
+        "schema": _SENTINEL_SCHEMA,
+        "ini_sha256": _ini_sha256(build_dir),
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "core_dir_env": os.environ.get("PLATFORMIO_CORE_DIR", ""),
+    }
+
+
+def _prefetch_is_warm(build_dir: Path) -> bool:
+    """Whether the last prefetch found nothing to do and nothing changed since."""
+    try:
+        data = json.loads((build_dir / _SENTINEL_NAME).read_text(encoding="utf-8"))
+        dirs = data.pop("dirs")
+        return (
+            data == _sentinel_state(build_dir)
+            and bool(dirs)
+            and all(Path(d).is_dir() for d in dirs)
+        )
+    except (OSError, ValueError, KeyError, AttributeError, TypeError):
+        return False
+
 
 def prefetch_platformio_packages() -> None:
     """Warm PlatformIO's download cache for the current project, in parallel."""
     from esphome.core import CORE
+    from esphome.platformio.toolchain import (
+        default_libdeps_dir,
+        heal_platformio_python_env,
+    )
 
+    # Heal first: a Python-version wipe after the prefetch would discard the
+    # caches it just warmed (run_platformio_cli's own heal call is then a
+    # no-op), and its wipe invalidates the sentinel's dirs below.
+    heal_platformio_python_env()
+    build_dir = Path(CORE.build_path)
+    if _prefetch_is_warm(build_dir):
+        return
     env = dict(os.environ)
+    # Same hygiene as run_command: do not leak PYTHONPATH
+    env.pop("PYTHONPATH", None)
     # pio run later resolves installed libraries against this same dir
     # (run_platformio_cli sets it); the prefetch must agree or it re-resolves
     # every library on every warm build
-    env.setdefault(
-        "PLATFORMIO_LIBDEPS_DIR", str(CORE.relative_piolibdeps_path().absolute())
-    )
+    env.setdefault("PLATFORMIO_LIBDEPS_DIR", default_libdeps_dir())
     cmd = [
         sys.executable,
         "-m",
         "esphome.platformio.prefetch",
-        str(CORE.build_path),
+        str(build_dir),
         CORE.name,
     ]
     try:
@@ -61,7 +115,7 @@ def prefetch_platformio_packages() -> None:
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # PlatformIO installs anything missing itself; the prefetch must
         # never become a new way for the build to fail
-        _LOGGER.warning("PlatformIO package prefetch skipped: %s", err)
+        _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
         return
     if proc.returncode != 0:
@@ -93,11 +147,16 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
     """
     from platformio.registry.mirror import RegistryFileMirrorIterator
 
+    local = threading.local()
+
     def _resolve(spec) -> tuple[str, int, str, Path, str] | None:
-        # Fresh manager per task: the registry client's HTTP session is not
-        # shared across threads (installed-state was already checked on the
-        # shared manager, whose package dir a bare constructor may not match)
-        mgr = manager.__class__()
+        # One manager per worker thread: the registry client's HTTP session
+        # is not shared across threads, and a manager per spec would open a
+        # TLS connection per package. Installed-state was already checked on
+        # the shared manager, whose package dir a bare constructor may not
+        # match.
+        if (mgr := getattr(local, "mgr", None)) is None:
+            mgr = local.mgr = manager.__class__()
         packages = mgr.search_registry_packages(spec)
         if not packages:
             return None  # unknown to the registry; let PlatformIO report it
@@ -118,13 +177,18 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
         return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
 
     # Installed packages need no network at all; check them serially on the
-    # shared manager (a disk lookup) so a fully warm build resolves nothing
-    pending = [s for s in specs if not s.uri and not manager.get_package(s)]
+    # shared manager (a disk lookup) so a fully warm build resolves nothing.
+    # Duplicate specs resolve once.
+    unique: dict[tuple[str, str], Any] = {}
+    for s in specs:
+        if not s.uri and not manager.get_package(s):
+            unique.setdefault((s.name, str(getattr(s, "requirements", None))), s)
+    pending = list(unique.values())
     if not pending:
         return []
     # Each resolution is a registry GET plus a mirror HEAD; serially they
     # dominate the whole prefetch
-    with ThreadPoolExecutor(max_workers=min(8, len(pending))) as ex:
+    with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(pending))) as ex:
         results = list(ex.map(_resolve, pending))
     jobs: list[tuple[str, int, Any]] = []
     for res in results:
@@ -146,7 +210,7 @@ def _uri_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
     No registry metadata exists, so a HEAD supplies the size for the
     combined bar; entries without a usable length are left to PlatformIO.
     """
-    from esphome.net_retry import http_request
+    from esphome.net_retry import fetch_with_retry, http_request
 
     candidates: list[tuple[str, str, Path]] = []
     for spec in specs:
@@ -158,26 +222,27 @@ def _uri_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
         # PlatformIO downloads URL specs with no checksum
         dl_path = Path(manager.compute_download_path(url, ""))
         if dl_path.is_file() or str(dl_path) in seen:
-            continue
+            continue  # cached, or another spec already claimed this .part
+        seen.add(str(dl_path))
         candidates.append((spec.name or url.rsplit("/", 1)[-1], url, dl_path))
 
     def _head_size(url: str) -> int:
         try:
-            return _content_length(http_request("HEAD", url, timeout=30))
+            return content_length(
+                fetch_with_retry(url, lambda: http_request("HEAD", url, timeout=30))
+            )
         except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             return 0
 
     if not candidates:
         return []
-    with ThreadPoolExecutor(max_workers=min(8, len(candidates))) as ex:
+    with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(candidates))) as ex:
         sizes = list(ex.map(_head_size, [url for _, url, _ in candidates]))
-    jobs: list[tuple[str, int, Any]] = []
-    for (name, url, dl_path), size in zip(candidates, sizes, strict=True):
-        if not size:
-            continue
-        seen.add(str(dl_path))
-        jobs.append((name, size, resume_fetch_job(url, dl_path, size=size)))
-    return jobs
+    return [
+        (name, size, resume_fetch_job(url, dl_path, size=size))
+        for (name, url, dl_path), size in zip(candidates, sizes, strict=True)
+        if size
+    ]
 
 
 def _prefetch(build_dir: Path, env: str) -> None:
@@ -228,14 +293,25 @@ def _prefetch(build_dir: Path, env: str) -> None:
     lib_deps = config.get(f"env:{env}", "lib_deps", [])
     # Match pio run's storage dir for this env so already-installed
     # libraries are skipped by a disk lookup instead of re-resolved
-    lm = LibraryPackageManager(str(Path(config.get("platformio", "libdeps_dir")) / env))
+    libdeps_dir = Path(config.get("platformio", "libdeps_dir")) / env
+    lm = LibraryPackageManager(str(libdeps_dir))
     lib_specs = [
         PackageSpec(dep) for dep in lib_deps if dep and not dep.startswith("$")
     ]
     jobs += _registry_jobs(lm, lib_specs, seen) + _uri_jobs(lm, lib_specs, seen)
 
+    sentinel = build_dir / _SENTINEL_NAME
     if not jobs:
+        # Nothing to do; record it so the parent skips the next spawn while
+        # the ini, interpreter, and these dirs stay unchanged
+        dirs = [config.get("platformio", "packages_dir")]
+        if lib_specs:
+            dirs.append(str(libdeps_dir))
+        sentinel.write_text(
+            json.dumps({**_sentinel_state(build_dir), "dirs": dirs}), encoding="utf-8"
+        )
         return
+    sentinel.unlink(missing_ok=True)
     _LOGGER.info(
         "Prefetching %d PlatformIO package(s): %s",
         len(jobs),
@@ -254,7 +330,7 @@ def main(argv: list[str]) -> int:
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Best-effort even here: exit 0 so the parent never treats a failed
         # prefetch as a failed build
-        _LOGGER.warning("PlatformIO package prefetch skipped: %s", err)
+        _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
     return 0
 

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -44,7 +44,7 @@ _RESOLVE_WORKERS = 8
 _PREFETCH_TIMEOUT = 20 * 60
 
 # Waiting on another process's URL download; past this, leave it to pio
-_URI_LOCK_TIMEOUT = 60
+_DOWNLOAD_LOCK_TIMEOUT = 60
 
 # Child exit for a handled, already-warned failure; 1 would collide with
 # the interpreter's own import-failure exit
@@ -355,7 +355,7 @@ def _serialized_fetch_job(
         # fallback_to_soft would leave a stale marker on lock-less
         # filesystems that blocks every later build (see git.py)
         lock = FileLock(lock_path, fallback_to_soft=False)
-        deadline = time.monotonic() + _URI_LOCK_TIMEOUT
+        deadline = time.monotonic() + _DOWNLOAD_LOCK_TIMEOUT
         while True:
             try:
                 lock.acquire(timeout=_URI_LOCK_POLL)
@@ -363,9 +363,11 @@ def _serialized_fetch_job(
             except Timeout:
                 tracker(0)  # raises when the batch is cancelled
                 if time.monotonic() >= deadline:
-                    raise TimeoutError(
-                        "timed out waiting for another download of the same file"
-                    ) from None
+                    # Another process is fetching this same file; its copy
+                    # is what the build needs (a large framework archive
+                    # can hold the lock far longer than this deadline)
+                    _LOGGER.debug("Leaving %s to its current downloader", dl_path.name)
+                    return
             except OSError as err:
                 if not unlocked_ok:
                     # A body with no checksum to catch interleaved corruption
@@ -576,6 +578,10 @@ def main(argv: list[str]) -> int:
     build_dir, env = argv
     try:
         _prefetch(Path(build_dir), env)
+    except KeyboardInterrupt:
+        # Shared process group: exit quietly, no traceback on the terminal
+        _LOGGER.debug("Prefetch interrupted", exc_info=True)
+        return 130
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # The parent treats any exit as warn-and-continue, never a failure
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -590,13 +590,17 @@ def main(argv: list[str]) -> int:
         # A wiring break would otherwise silently drop -v propagation
         _LOGGER.warning("Ignoring malformed prefetch log level %r", raw_level)
     # pio's managers attach their own handler and still propagate; without
-    # this every manager line also prints through the root handler
+    # this every manager line also prints through the root handler. Their
+    # construction re-pins the logger to INFO, so a logger-level filter
+    # (which survives pio's handler reset) enforces a quiet level instead.
     for cls_name in (
         "ToolPackageManager",
         "LibraryPackageManager",
         "PlatformPackageManager",
     ):
-        logging.getLogger(cls_name.replace("Package", " ")).propagate = False
+        manager_logger = logging.getLogger(cls_name.replace("Package", " "))
+        manager_logger.propagate = False
+        manager_logger.addFilter(lambda record: record.levelno >= level)
     if len(argv) != 2:
         # A wiring bug, not a network failure; make it distinguishable
         _LOGGER.warning("prefetch usage: <build_dir> <env_name>")

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -1,24 +1,11 @@
 """Parallel prefetch of the packages a PlatformIO run would install.
 
-PlatformIO resolves and downloads platform packages, toolchains, frameworks,
-and libraries one at a time; on a cold cache (every CI run) the downloads
-dominate the install. This prefetch resolves the same registry metadata
-PlatformIO would, downloads the archives concurrently into PlatformIO's own
-download cache (``compute_download_path`` keyed identically), and lets the
-subsequent ``pio run`` find every file already cached.
-
-The prefetch runs in a subprocess (``python -m esphome.platformio.prefetch``):
-resolving a platform executes its code, and platform setup may rewrite the
-running interpreter's state (pioarduino's penv setup replaces ``sys.path``
-with its own virtualenv's, breaking every later import in the process).
-All other PlatformIO execution is already subprocess-isolated the same way
-(see ``run_platformio_cli``). When the child finds nothing to do it records
-a sentinel in the build dir, and the parent skips the spawn entirely while
-the sentinel stays valid, so warm incremental builds pay a file read
-instead of a subprocess.
-
-Strictly best-effort: any failure logs and returns, leaving PlatformIO to
-download whatever is missing exactly as before.
+Downloads the archives concurrently into PlatformIO's own download cache
+(identical ``compute_download_path`` keys) so the serial installer finds
+them already cached. Runs in a subprocess like all PlatformIO execution:
+loading a platform executes its code (pioarduino's penv setup rewrites
+``sys.path``). A sentinel in the build dir lets warm builds skip the
+spawn. Best-effort: any failure logs and PlatformIO downloads as before.
 """
 
 from __future__ import annotations
@@ -47,8 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 # Concurrent registry resolutions / HEAD probes (each is network-bound)
 _RESOLVE_WORKERS = 8
 
-# Written by the child when a run found nothing to prefetch; read by the
-# parent to skip the next spawn. Any mismatch or missing dir re-spawns.
+# Child records a no-work run; the parent skips the next spawn while valid
 _SENTINEL_NAME = ".esphome_prefetch.json"
 _SENTINEL_SCHEMA = 1
 
@@ -89,9 +75,8 @@ def prefetch_platformio_packages() -> None:
         heal_platformio_python_env,
     )
 
-    # Heal first: a Python-version wipe after the prefetch would discard the
-    # caches it just warmed (run_platformio_cli's own heal call is then a
-    # no-op), and its wipe invalidates the sentinel's dirs below.
+    # Heal first: its Python-version wipe would discard freshly warmed
+    # caches and the sentinel's dirs (the later heal call is a no-op)
     heal_platformio_python_env()
     build_dir = Path(CORE.build_path)
     if _prefetch_is_warm(build_dir):
@@ -99,9 +84,8 @@ def prefetch_platformio_packages() -> None:
     env = dict(os.environ)
     # Same hygiene as run_command: do not leak PYTHONPATH
     env.pop("PYTHONPATH", None)
-    # pio run later resolves installed libraries against this same dir
-    # (run_platformio_cli sets it); the prefetch must agree or it re-resolves
-    # every library on every warm build
+    # Must match run_platformio_cli's default or warm builds re-resolve
+    # every library
     env.setdefault("PLATFORMIO_LIBDEPS_DIR", default_libdeps_dir())
     cmd = [
         sys.executable,
@@ -113,8 +97,7 @@ def prefetch_platformio_packages() -> None:
     try:
         proc = subprocess.run(cmd, env=env, check=False)
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # PlatformIO installs anything missing itself; the prefetch must
-        # never become a new way for the build to fail
+        # The prefetch must never become a new way for the build to fail
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
         return
@@ -129,9 +112,8 @@ def _project_platform_and_config(ini: Path, env: str) -> tuple[str | None, Any]:
     from platformio import app
     from platformio.project.config import ProjectConfig
 
-    # Make this ini the default ProjectConfig: PlatformBase.config (which
-    # the package configuration reads) must see the same env options the
-    # later pio run will
+    # PlatformBase.config reads the default ProjectConfig; it must see
+    # this ini's env options
     app.set_session_var("custom_project_conf", str(ini))
     config = ProjectConfig.get_instance(str(ini))
     return config.get(f"env:{env}", "platform", None), config
@@ -140,21 +122,16 @@ def _project_platform_and_config(ini: Path, env: str) -> tuple[str | None, Any]:
 def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
     """Resolve registry specs to ``(name, size, fetch)`` batch jobs.
 
-    Resolution mirrors PlatformIO's install path exactly: best registry
-    version, systype-compatible file, first mirror (whose HEAD result
-    PlatformIO's own run then reuses from its content cache), and the same
-    sha1(url + checksum) download-cache key.
+    Mirrors PlatformIO's install path: best version, systype file, first
+    mirror, and the same sha1(url + checksum) download-cache key.
     """
     from platformio.registry.mirror import RegistryFileMirrorIterator
 
     local = threading.local()
 
     def _resolve(spec) -> tuple[str, int, str, Path, str] | None:
-        # One manager per worker thread: the registry client's HTTP session
-        # is not shared across threads, and a manager per spec would open a
-        # TLS connection per package. Installed-state was already checked on
-        # the shared manager, whose package dir a bare constructor may not
-        # match.
+        # One manager (and registry HTTP session) per worker thread;
+        # installed-state was already checked on the shared manager
         if (mgr := getattr(local, "mgr", None)) is None:
             mgr = local.mgr = manager.__class__()
         packages = mgr.search_registry_packages(spec)
@@ -176,9 +153,8 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
             return None  # no size, no bar share; PlatformIO fetches it
         return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
 
-    # Installed packages need no network at all; check them serially on the
-    # shared manager (a disk lookup) so a fully warm build resolves nothing.
-    # Duplicate specs resolve once.
+    # Serial disk lookups on the shared manager: a fully warm build
+    # resolves nothing, and duplicate specs resolve once
     unique: dict[tuple[str, str], Any] = {}
     for s in specs:
         if not s.uri and not manager.get_package(s):
@@ -186,8 +162,7 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
     pending = list(unique.values())
     if not pending:
         return []
-    # Each resolution is a registry GET plus a mirror HEAD; serially they
-    # dominate the whole prefetch
+    # Serial resolutions (registry GET + mirror HEAD each) dominate
     with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(pending))) as ex:
         results = list(ex.map(_resolve, pending))
     jobs: list[tuple[str, int, Any]] = []
@@ -205,11 +180,7 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
 
 
 def _uri_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
-    """Jobs for direct-URL package specs (e.g. pinned GitHub archives).
-
-    No registry metadata exists, so a HEAD supplies the size for the
-    combined bar; entries without a usable length are left to PlatformIO.
-    """
+    """Jobs for direct-URL specs; a HEAD sizes each for the combined bar."""
     from esphome.net_retry import fetch_with_retry, http_request
 
     candidates: list[tuple[str, str, Path]] = []
@@ -258,11 +229,9 @@ def _prefetch(build_dir: Path, env: str) -> None:
     if not platform_spec:
         return
 
-    # The platform package itself resolves the rest, so it installs first
-    # (small: manifest plus build scripts). project_env configures which
-    # optional packages (frameworks, toolchains) this env requires. Platform
-    # setup code may rewrite sys.path (pioarduino's penv setup does); put it
-    # back so this process's own later imports still resolve.
+    # The platform (manifest plus build scripts) installs first and
+    # resolves the rest. Its setup may rewrite sys.path (pioarduino's penv
+    # setup does); restore it so later imports here still resolve.
     saved_sys_path = list(sys.path)
     pm = PlatformPackageManager()
     pkg = pm.install(platform_spec, skip_dependencies=True)
@@ -275,10 +244,8 @@ def _prefetch(build_dir: Path, env: str) -> None:
         for name, opts in p.packages.items()
         if not opts.get("optional")
     ]
-    # PIO core's own build engine installs outside the platform's package
-    # list, on first run; the other core dependencies (piohome, check
-    # tools) are for commands a compile never touches. Some platforms list
-    # tool-scons themselves; do not fetch it twice.
+    # PIO's build engine installs outside the platform package list;
+    # skipped when the platform lists it itself
     if not any(s.name == "tool-scons" for s in specs):
         specs.append(
             PackageSpec(
@@ -291,8 +258,8 @@ def _prefetch(build_dir: Path, env: str) -> None:
     jobs = _registry_jobs(p.pm, specs, seen) + _uri_jobs(p.pm, specs, seen)
 
     lib_deps = config.get(f"env:{env}", "lib_deps", [])
-    # Match pio run's storage dir for this env so already-installed
-    # libraries are skipped by a disk lookup instead of re-resolved
+    # pio run's storage dir for this env: installed libraries skip by
+    # disk lookup
     libdeps_dir = Path(config.get("platformio", "libdeps_dir")) / env
     lm = LibraryPackageManager(str(libdeps_dir))
     lib_specs = [
@@ -302,8 +269,7 @@ def _prefetch(build_dir: Path, env: str) -> None:
 
     sentinel = build_dir / _SENTINEL_NAME
     if not jobs:
-        # Nothing to do; record it so the parent skips the next spawn while
-        # the ini, interpreter, and these dirs stay unchanged
+        # Record the no-work run so the parent skips the next spawn
         dirs = [config.get("platformio", "packages_dir")]
         if lib_specs:
             dirs.append(str(libdeps_dir))
@@ -328,8 +294,7 @@ def main(argv: list[str]) -> int:
         build_dir, env = argv
         _prefetch(Path(build_dir), env)
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # Best-effort even here: exit 0 so the parent never treats a failed
-        # prefetch as a failed build
+        # Exit 0: the parent must not treat a failed prefetch as a failed build
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
     return 0

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -14,7 +14,6 @@ they are serialized by a file lock and promoted with an atomic rename.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
 import hashlib
 import json
 import logging
@@ -28,11 +27,13 @@ from typing import Any
 
 from esphome.framework_helpers import (
     content_length,
+    discard_partial_download,
     failure_reason,
     resume_fetch_job,
     run_batch_downloads,
     warn_prefetch_failures,
 )
+from esphome.helpers import get_bool_env
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -208,12 +209,8 @@ def _registry_jobs(
     with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(pending))) as ex:
         results = list(ex.map(_resolve, pending))
     jobs: list[tuple[str, int, Any]] = []
-    failed = 0
     for res in results:
-        if res is None:
-            continue
-        if res is _RESOLVE_FAILED:
-            failed += 1
+        if res is None or res is _RESOLVE_FAILED:
             continue
         name, size, url, dl_path, checksum = res
         if str(dl_path) in seen:
@@ -222,7 +219,7 @@ def _registry_jobs(
         jobs.append(
             (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
         )
-    if failed:
+    if failed := len(errors):
         # Visible once per build, naming a cause so an API break does not
         # read as an outage; per-spec detail stays at debug
         _LOGGER.warning(
@@ -230,7 +227,7 @@ def _registry_jobs(
             "PlatformIO will download them serially",
             failed,
             len(pending),
-            errors[0] if errors else "unknown error",
+            errors[0],
         )
     return jobs, failed
 
@@ -337,7 +334,7 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
             if dl_path.is_file():
                 # Another process finished it while we waited; the staging
                 # files are dead weight PlatformIO's cache never prunes
-                _discard_staging(tmp)
+                discard_partial_download(tmp)
                 return
             fetch(tracker)
             tmp.replace(dl_path)
@@ -345,13 +342,6 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
             lock.release()
 
     return run
-
-
-def _discard_staging(tmp: Path) -> None:
-    part = tmp.with_name(tmp.name + ".part")
-    for stale in (tmp, part, part.with_name(part.name + ".meta")):
-        with suppress(OSError):
-            stale.unlink()
 
 
 def _prefetch(build_dir: Path, env: str) -> None:
@@ -451,8 +441,16 @@ def main(argv: list[str]) -> int:
         level = logging.INFO
     # Mirror the parent's log setup: warnings keep their level prefix and
     # color, and the download bar still draws under the dashboard
-    CORE.dashboard = bool(os.environ.get("ESPHOME_PREFETCH_DASHBOARD"))
+    CORE.dashboard = get_bool_env("ESPHOME_PREFETCH_DASHBOARD")
     setup_log(level)
+    # pio's managers attach their own handler and still propagate; without
+    # this every manager line also prints through the root handler
+    for cls_name in (
+        "ToolPackageManager",
+        "LibraryPackageManager",
+        "PlatformPackageManager",
+    ):
+        logging.getLogger(cls_name.replace("Package", " ")).propagate = False
     if len(argv) != 2:
         # A wiring bug, not a network failure; make it distinguishable
         _LOGGER.warning("prefetch usage: <build_dir> <env_name>")

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -71,9 +71,12 @@ def _sweep_stale_sidecars(download_dir: Path) -> None:
         for f in download_dir.iterdir():
             if f.suffix not in (".part", ".meta", ".prefetch", ".lock"):
                 continue
-            with suppress(OSError):
+            try:
                 if f.stat().st_mtime < cutoff:
                     f.unlink()
+            except OSError as err:
+                # An unprunable sidecar grows the cache forever otherwise
+                _LOGGER.debug("Could not remove %s: %s", f, err)
     except OSError:
         _LOGGER.debug("Could not sweep %s", download_dir, exc_info=True)
 
@@ -246,7 +249,9 @@ def _registry_jobs(
         if str(dl_path) in seen:
             continue  # duplicate spec; two workers must not share a .part
         seen.add(str(dl_path))
-        jobs.append((name, size, _registry_fetch_job(url, dl_path, checksum, size)))
+        jobs.append(
+            (name, size, _registry_fetch_job(manager, url, dl_path, checksum, size))
+        )
     if failed := len(errors):
         # Visible once per build, naming a cause so an API break does not
         # read as an outage; per-spec detail stays at debug
@@ -284,16 +289,20 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
         seen.add(str(dl_path))
         candidates.append((spec.name or url.rsplit("/", 1)[-1], url, dl_path))
 
+    errors: list[str] = []
+
     def _head_size(url: str) -> int:
         try:
             resp = fetch_with_retry(url, lambda: http_request("HEAD", url, timeout=30))
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             _LOGGER.debug("HEAD %s failed", url, exc_info=True)
+            errors.append(failure_reason(err))
             return -1
         if not resp.ok:
             # An error page's Content-Length is not a download size
             _LOGGER.debug("HEAD %s returned %s", url, resp.status_code)
             if resp.status_code in (408, 429) or resp.status_code >= 500:
+                errors.append(f"HTTP {resp.status_code}")
                 return -1  # transient; must not be cached as warm
             if resp.status_code in (405, 501):
                 # HEAD unsupported but GET may work: a clean skip, or the
@@ -315,26 +324,32 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
         if size < 0:
             failed += 1
         elif size:
-            jobs.append((name, size, _uri_fetch_job(url, dl_path, size)))
+            jobs.append((name, size, _uri_fetch_job(manager, url, dl_path, size)))
     if failed:
         _LOGGER.warning(
-            "Could not size %d of %d PlatformIO package URL(s); "
+            "Could not size %d of %d PlatformIO package URL(s) (%s); "
             "PlatformIO will download them serially",
             failed,
             len(candidates),
+            errors[0] if errors else "no length",
         )
     return jobs, failed
 
 
-def _serialized_fetch_job(dl_path: Path, lock_path: str, body: Any) -> Any:
+def _serialized_fetch_job(
+    dl_path: Path, lock_path: str, body: Any, unlocked_ok: bool = True
+) -> Any:
     """Wrap ``body`` so the shared destination is single-writer.
 
     Any download landing in PlatformIO's shared core dir can race a
     sibling esphome process writing the same ``.part``; interleaved
     writers truncate each other's bytes (see registry.py). A bounded
-    poll keeps a parked worker observing Ctrl-C via the tracker, a
-    blown deadline is a counted failure, and a lock-less filesystem
-    (git.py's ENOSYS/EPERM case) proceeds unlocked with one warning.
+    poll keeps a parked worker observing Ctrl-C via the tracker and a
+    blown deadline is a counted failure. On a lock-less filesystem
+    (git.py's ENOSYS/EPERM case) a sha256-verified body proceeds
+    unlocked with one warning; a checksum-less one becomes a counted
+    failure, since interleaved right-length corruption would go
+    undetected.
     """
 
     def run(tracker: Any) -> None:
@@ -358,9 +373,13 @@ def _serialized_fetch_job(dl_path: Path, lock_path: str, body: Any) -> Any:
                         "timed out waiting for another download of the same file"
                     ) from None
             except OSError as err:
-                if err.errno not in (errno.ENOSYS, errno.EPERM, errno.EROFS):
-                    # EACCES/ENOSPC/EMFILE are real faults; an unlocked
-                    # write of a shared destination is not a safe fallback
+                if not unlocked_ok or err.errno not in (
+                    errno.ENOSYS,
+                    errno.EPERM,
+                    errno.EROFS,
+                ):
+                    # Real faults (EACCES/ENOSPC/EMFILE), or a body with no
+                    # checksum to catch interleaved corruption
                     raise
                 lock = None
                 _LOGGER.warning(
@@ -380,18 +399,33 @@ def _serialized_fetch_job(dl_path: Path, lock_path: str, body: Any) -> Any:
     return run
 
 
-def _registry_fetch_job(url: str, dl_path: Path, checksum: str, size: int) -> Any:
+def _register_download(manager: Any, dl_path: Path) -> None:
+    """Hand the archive to pio's usage.db pruner; without an entry an
+    archive nothing ever consumes would be stranded at any age."""
+    with suppress(Exception):
+        manager.set_download_utime(str(dl_path))
+
+
+def _registry_fetch_job(
+    manager: Any, url: str, dl_path: Path, checksum: str, size: int
+) -> Any:
     """A locked fetch straight to the cache path; sha256 verifies it."""
     # .esphome.lock: pio's own LockFile(dl_path) owns <dl_path>.lock and
     # deletes it on release, which would unlink a held filelock
-    return _serialized_fetch_job(
+    fetch = _serialized_fetch_job(
         dl_path,
         f"{dl_path}.esphome.lock",
         resume_fetch_job(url, dl_path, sha256=checksum, size=size),
     )
 
+    def run(tracker: Any) -> None:
+        fetch(tracker)
+        _register_download(manager, dl_path)
 
-def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
+    return run
+
+
+def _uri_fetch_job(manager: Any, url: str, dl_path: Path, size: int) -> Any:
     """Fetch to a locked staging path, then rename into the cache.
 
     URL specs carry no checksum, so a same-length corrupt file could be
@@ -411,11 +445,14 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
         tmp.replace(dl_path)
 
     def run(tracker: Any) -> None:
-        _serialized_fetch_job(dl_path, f"{tmp}.lock", promote)(tracker)
+        _serialized_fetch_job(dl_path, f"{tmp}.lock", promote, unlocked_ok=False)(
+            tracker
+        )
         if dl_path.is_file():
             # Won or lost, the race is over; staging files left behind
             # are dead weight PlatformIO's cache never prunes
             discard_partial_download(tmp)
+            _register_download(manager, dl_path)
 
     return run
 

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -5,9 +5,10 @@ Downloads the archives concurrently into PlatformIO's own download cache
 them already cached. Runs in a subprocess like all PlatformIO execution:
 loading a platform executes its code (pioarduino's penv setup rewrites
 ``sys.path``). A sentinel in the build dir lets warm builds skip the
-spawn. Best-effort: any failure logs and PlatformIO downloads as before;
-concurrent esphome processes sharing a core dir may race a ``.part`` file,
-which the sha256 check catches at the cost of one wasted download.
+spawn. Best-effort: any failure logs and PlatformIO downloads as before.
+Across processes sharing a core dir, registry downloads share the cache
+key and rely on sha256 verification; URL downloads carry no checksum, so
+they are serialized by a file lock and promoted with an atomic rename.
 """
 
 from __future__ import annotations
@@ -38,6 +39,9 @@ _RESOLVE_WORKERS = 8
 
 # A hung child must not block the build; downloads resume on the next run
 _PREFETCH_TIMEOUT = 20 * 60
+
+# Waiting on another process's URL download; past this, leave it to pio
+_URI_LOCK_TIMEOUT = 60
 
 # Resolution errored (vs a clean skip); suppresses the warm sentinel
 _RESOLVE_FAILED = object()
@@ -101,6 +105,9 @@ def prefetch_platformio_packages() -> None:
     # Must match run_platformio_cli's default or warm builds re-resolve
     # every library
     env.setdefault("PLATFORMIO_LIBDEPS_DIR", default_libdeps_dir())
+    # -v/-vv must reach the child's debug logging or the swallowed
+    # failure detail is undiagnosable in the field
+    env["ESPHOME_PREFETCH_LOG_LEVEL"] = str(logging.getLogger().getEffectiveLevel())
     cmd = [
         sys.executable,
         "-m",
@@ -205,12 +212,13 @@ def _registry_jobs(
         jobs.append(
             (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
         )
-    if failed == len(pending):
-        # A systematic fault (outage, proxy), not one flaky package
+    if failed:
+        # Visible once per build; per-spec detail stays at debug
         _LOGGER.warning(
-            "Could not resolve any of %d PlatformIO package(s); "
+            "Could not resolve %d of %d PlatformIO package(s); "
             "PlatformIO will download them serially",
             failed,
+            len(pending),
         )
     return jobs, failed
 
@@ -246,10 +254,13 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
             _LOGGER.debug("HEAD %s failed", url, exc_info=True)
             return -1
         if not resp.ok:
-            # An error page's Content-Length is not a download size, and a
-            # failing URL must not feed the warm sentinel
+            # An error page's Content-Length is not a download size
             _LOGGER.debug("HEAD %s returned %s", url, resp.status_code)
-            return -1
+            if resp.status_code in (408, 429) or resp.status_code >= 500:
+                return -1  # transient; must not be cached as warm
+            # Permanent (e.g. a host that 405s HEAD but serves GET): a clean
+            # skip, or the sentinel would never be written again
+            return 0
         return content_length(resp)
 
     if not candidates:
@@ -263,6 +274,13 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
             failed += 1
         elif size:
             jobs.append((name, size, _uri_fetch_job(url, dl_path, size)))
+    if failed:
+        _LOGGER.warning(
+            "Could not size %d of %d PlatformIO package URL(s); "
+            "PlatformIO will download them serially",
+            failed,
+            len(candidates),
+        )
     return jobs, failed
 
 
@@ -279,13 +297,24 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
     fetch = resume_fetch_job(url, tmp, size=size)
 
     def run(tracker: Any) -> None:
-        from filelock import FileLock
+        from filelock import FileLock, Timeout
 
-        with FileLock(f"{tmp}.lock"):
+        # fallback_to_soft would leave a stale marker on lock-less
+        # filesystems that blocks every later build (see git.py); a bounded
+        # wait plus a skip keeps the job best-effort either way
+        lock = FileLock(f"{tmp}.lock", fallback_to_soft=False)
+        try:
+            lock.acquire(timeout=_URI_LOCK_TIMEOUT)
+        except (Timeout, OSError):
+            _LOGGER.debug("Could not lock %s; leaving it to PlatformIO", dl_path)
+            return
+        try:
             if dl_path.is_file():
                 return  # another process finished it while we waited
             fetch(tracker)
             tmp.replace(dl_path)
+        finally:
+            lock.release()
 
     return run
 
@@ -372,7 +401,11 @@ def _prefetch(build_dir: Path, env: str) -> None:
 
 def main(argv: list[str]) -> int:
     """Subprocess entry point: ``prefetch <build_dir> <env_name>``."""
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        level = int(os.environ.get("ESPHOME_PREFETCH_LOG_LEVEL", logging.INFO))
+    except ValueError:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
     if len(argv) != 2:
         # A wiring bug, not a network failure; make it distinguishable
         _LOGGER.warning("prefetch usage: <build_dir> <env_name>")

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -303,7 +303,8 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
         if not resp.ok:
             # An error page's Content-Length is not a download size
             _LOGGER.debug("HEAD %s returned %s", url, resp.status_code)
-            if resp.status_code in (408, 429) or resp.status_code >= 500:
+            if resp.status_code in (401, 403, 408, 429) or resp.status_code >= 500:
+                # 401/403 included: registries rate-limit with them
                 errors.append(f"HTTP {resp.status_code}")
                 return -1  # transient; must not be cached as warm
             # Permanent (405/501 HEAD-unsupported, 401/403/404): a clean
@@ -344,9 +345,10 @@ def _serialized_fetch_job(
 
     Interleaved writers truncate each other's ``.part`` bytes (see
     registry.py). The bounded poll observes Ctrl-C via the tracker; a
-    blown deadline is a counted failure. On a lock-less filesystem a
-    sha256-verified body runs unlocked with one warning; a checksum-less
-    one (``unlocked_ok=False``) is a counted failure instead.
+    blown deadline is a clean skip (the holder's copy is what the build
+    needs). On a lock-less filesystem a sha256-verified body runs
+    unlocked with one warning; a checksum-less one
+    (``unlocked_ok=False``) is a counted failure instead.
     """
 
     def run(tracker: Any) -> None:
@@ -419,7 +421,9 @@ def _registry_fetch_job(
 
     def run(tracker: Any) -> None:
         fetch(tracker)
-        _register_download(manager, dl_path)
+        if dl_path.is_file():
+            # The deadline skip can end with no archive landed
+            _register_download(manager, dl_path)
 
     return run
 
@@ -431,7 +435,9 @@ def _uri_fetch_job(manager: Any, url: str, dl_path: Path, size: int) -> Any:
     runs; the rename makes the promotion atomic.
     """
     tmp = dl_path.with_name(f"{dl_path.name}.prefetch")
-    fetch = resume_fetch_job(url, tmp, size=size)
+    # attempts=2: the size is only a HEAD probe's word, and a HEAD/GET
+    # disagreement would otherwise re-download the archive five times
+    fetch = resume_fetch_job(url, tmp, size=size, attempts=2)
 
     def promote(tracker: Any) -> None:
         fetch(tracker)

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -15,7 +15,6 @@ under a stable name and promote with an atomic rename.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
 import errno
 import hashlib
 import json
@@ -48,6 +47,10 @@ _PREFETCH_TIMEOUT = 20 * 60
 
 # Waiting on another process's URL download; past this, leave it to pio
 _URI_LOCK_TIMEOUT = 60
+
+# Child exit for a handled, already-warned failure; 1 would collide with
+# the interpreter's own import-failure exit
+_EXIT_HANDLED = 3
 
 # Short lock-acquire slices so a waiting worker still observes Ctrl-C
 _URI_LOCK_POLL = 1
@@ -163,11 +166,12 @@ def prefetch_platformio_packages() -> None:
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
         return
-    if proc.returncode == 1:
+    if proc.returncode == _EXIT_HANDLED:
         # The child already warned with the reason; a second line is noise
         _LOGGER.debug("Prefetch child reported a handled failure")
     elif proc.returncode != 0:
-        # Codes the child cannot emit itself (signal deaths, bad wiring)
+        # Exit 1 stays here: the interpreter exits 1 for import/module
+        # failures before main() ever runs, a wiring break worth a warning
         _LOGGER.warning(
             "PlatformIO package prefetch skipped (exit %d)", proc.returncode
         )
@@ -399,11 +403,20 @@ def _serialized_fetch_job(
     return run
 
 
+# usage.db is a whole-file read-modify-write behind pio's self-unlinking
+# LockFile; concurrent writers could reset every recorded entry
+_REGISTER_LOCK = threading.Lock()
+
+
 def _register_download(manager: Any, dl_path: Path) -> None:
     """Hand the archive to pio's usage.db pruner; without an entry an
     archive nothing ever consumes would be stranded at any age."""
-    with suppress(Exception):
-        manager.set_download_utime(str(dl_path))
+    try:
+        with _REGISTER_LOCK:
+            manager.set_download_utime(str(dl_path))
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # Unregistered archives are never pruned; leave a trace
+        _LOGGER.debug("Could not register %s with pio's cache: %s", dl_path, err)
 
 
 def _registry_fetch_job(
@@ -582,7 +595,7 @@ def main(argv: list[str]) -> int:
         # any prefetch exit as warn-and-continue, never a failed build
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
-        return 1
+        return _EXIT_HANDLED
     return 0
 
 

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -362,8 +362,14 @@ def _prefetch(build_dir: Path, env: str) -> None:
     # disk lookup
     libdeps_dir = Path(config.get("platformio", "libdeps_dir")) / env
     lm = LibraryPackageManager(str(libdeps_dir))
+    # pio run skips owner-less non-external lib_deps entirely (a bare
+    # name like WiFi is a framework built-in or private library);
+    # resolving one from the registry would shadow the bundled copy
     lib_specs = [
-        PackageSpec(dep) for dep in lib_deps if dep and not dep.startswith("$")
+        spec
+        for dep in lib_deps
+        if dep and not dep.startswith("$")
+        if (spec := PackageSpec(dep)).external or spec.owner
     ]
 
     seen: set[str] = set()

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -53,10 +53,13 @@ def _ini_sha256(build_dir: Path) -> str:
 
 def _sentinel_state(build_dir: Path) -> dict[str, Any]:
     """The environment fingerprint a sentinel must match to stay valid."""
+    # Same fingerprint as the heal stamp: the sentinel's dirs die with its wipe
+    from esphome.platformio.toolchain import current_python_minor
+
     return {
         "schema": _SENTINEL_SCHEMA,
         "ini_sha256": _ini_sha256(build_dir),
-        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "python": current_python_minor(),
         "core_dir_env": os.environ.get("PLATFORMIO_CORE_DIR", ""),
     }
 
@@ -180,14 +183,7 @@ def _registry_jobs(
     unique: dict[tuple[str | None, str, str], Any] = {}
     for s in specs:
         if not s.uri and not manager.get_package(s):
-            unique.setdefault(
-                (
-                    getattr(s, "owner", None),
-                    s.name,
-                    str(getattr(s, "requirements", None)),
-                ),
-                s,
-            )
+            unique.setdefault((s.owner, s.name, str(s.requirements)), s)
     pending = list(unique.values())
     if not pending:
         return [], 0
@@ -271,18 +267,25 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
 
 
 def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
-    """Fetch to a process-unique path, then rename into the cache.
+    """Fetch to a locked staging path, then rename into the cache.
 
     URL specs carry no checksum, so a shared destination could let two
-    processes interleave a same-length corrupt file into the cache; the
-    atomic rename makes the promotion single-writer.
+    processes interleave a same-length corrupt file into the cache. The
+    lock makes the staging file single-writer (a stable name keeps the
+    resume machinery working across interrupted runs) and the rename
+    makes the promotion atomic.
     """
-    tmp = dl_path.with_name(f"{dl_path.name}.{os.getpid()}.tmp")
+    tmp = dl_path.with_name(f"{dl_path.name}.prefetch")
     fetch = resume_fetch_job(url, tmp, size=size)
 
     def run(tracker: Any) -> None:
-        fetch(tracker)
-        tmp.replace(dl_path)
+        from filelock import FileLock
+
+        with FileLock(f"{tmp}.lock"):
+            if dl_path.is_file():
+                return  # another process finished it while we waited
+            fetch(tracker)
+            tmp.replace(dl_path)
 
     return run
 

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -14,7 +14,6 @@ stage under a stable name and promote with an atomic rename.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-import errno
 import hashlib
 import json
 import logging
@@ -57,19 +56,15 @@ _URI_LOCK_POLL = 1
 # Resolution errored (vs a clean skip); suppresses the warm sentinel
 _RESOLVE_FAILED = object()
 
-# Sidecars older than pio's own 30-day download expiry cannot be resumed
-# by anything and are invisible to its usage.db-driven pruner
-_SIDECAR_EXPIRE_SECONDS = 30 * 24 * 3600
 
-
-def _sweep_stale_sidecars(download_dir: Path) -> None:
+def _sweep_stale_sidecars(download_dir: Path, expire_seconds: int) -> None:
     """Prune resume sidecars pio's usage.db pruner cannot see.
 
     A version bump strands an aborted archive's sidecars forever. Lock
     files stay: a held lock can carry an ancient mtime (O_TRUNC keeps
     it), and unlinking one reopens the single-writer hole it guards.
     """
-    cutoff = time.time() - _SIDECAR_EXPIRE_SECONDS
+    cutoff = time.time() - expire_seconds
     try:
         for f in download_dir.iterdir():
             if f.suffix not in (".part", ".meta", ".prefetch"):
@@ -294,7 +289,7 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
         if dl_path.is_file() or str(dl_path) in seen:
             continue  # cached, or another spec already claimed this .part
         seen.add(str(dl_path))
-        candidates.append((spec.name or url.rsplit("/", 1)[-1], url, dl_path))
+        candidates.append((spec.name, url, dl_path))
 
     errors: list[str] = []
 
@@ -311,13 +306,9 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
             if resp.status_code in (408, 429) or resp.status_code >= 500:
                 errors.append(f"HTTP {resp.status_code}")
                 return -1  # transient; must not be cached as warm
-            if resp.status_code in (405, 501):
-                # HEAD unsupported but GET may work: a clean skip, or the
-                # sentinel would never be written again
-                return 0
-            # A real URL problem (401/403/404): name it, but still a clean
-            # skip so the warm sentinel is not disabled forever
-            _LOGGER.warning("HEAD %s returned %s", url, resp.status_code)
+            # Permanent (405/501 HEAD-unsupported, 401/403/404): a clean
+            # skip so the warm sentinel is not disabled forever; pio run
+            # surfaces a genuinely broken URL when it downloads
             return 0
         return content_length(resp)
 
@@ -341,7 +332,7 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
             "PlatformIO will download them serially",
             failed,
             len(candidates),
-            errors[0] if errors else "no length",
+            errors[0],
         )
     return jobs, failed
 
@@ -376,13 +367,8 @@ def _serialized_fetch_job(
                         "timed out waiting for another download of the same file"
                     ) from None
             except OSError as err:
-                if not unlocked_ok or err.errno not in (
-                    errno.ENOSYS,
-                    errno.EPERM,
-                    errno.EROFS,
-                ):
-                    # Real faults (EACCES/ENOSPC/EMFILE), or a body with no
-                    # checksum to catch interleaved corruption
+                if not unlocked_ok:
+                    # A body with no checksum to catch interleaved corruption
                     raise
                 lock = None
                 _LOGGER.warning(
@@ -406,27 +392,15 @@ def _serialized_fetch_job(
 # concurrent writers could reset every recorded entry
 _REGISTER_LOCK = threading.Lock()
 
-# Per-run (the child is a fresh process); systematic failures warn once
-_REGISTER_FAILURES: list[str] = []
-
-
-def _warn_register_failures() -> None:
-    if _REGISTER_FAILURES:
-        _LOGGER.warning(
-            "%d archive(s) could not be registered with PlatformIO's cache pruner",
-            len(_REGISTER_FAILURES),
-        )
-
 
 def _register_download(manager: Any, dl_path: Path) -> None:
     """Hand the archive to pio's usage.db pruner; an unregistered one is
-    never expired."""
+    never expired (disk garbage, never a bad build)."""
     try:
         with _REGISTER_LOCK:
             manager.set_download_utime(str(dl_path))
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         _LOGGER.debug("Could not register %s with pio's cache: %s", dl_path, err)
-        _REGISTER_FAILURES.append(dl_path.name)
 
 
 def _registry_fetch_job(
@@ -500,7 +474,7 @@ def _prefetch(build_dir: Path, env: str) -> None:
     # setup does); restore it so later imports here still resolve.
     saved_sys_path = list(sys.path)
     pm = PlatformPackageManager()
-    _sweep_stale_sidecars(Path(pm.get_download_dir()))
+    _sweep_stale_sidecars(Path(pm.get_download_dir()), pm.DOWNLOAD_CACHE_EXPIRE)
     pkg = pm.install(platform_spec, skip_dependencies=True)
     p = PlatformFactory.new(pkg)
     p.configure_project_packages(env, ["run"])
@@ -567,7 +541,6 @@ def _prefetch(build_dir: Path, env: str) -> None:
     )
     # PlatformIO retries failed packages itself, without resume
     warn_prefetch_failures(run_batch_downloads("Downloading PlatformIO packages", jobs))
-    _warn_register_failures()
 
 
 def main(argv: list[str]) -> int:
@@ -576,19 +549,14 @@ def main(argv: list[str]) -> int:
     from esphome.log import setup_log
 
     raw_level = os.environ.get("ESPHOME_PREFETCH_LOG_LEVEL")
-    malformed = False
     try:
         level = int(raw_level) if raw_level is not None else logging.INFO
     except ValueError:
-        malformed = True
         level = logging.INFO
     # Mirror the parent's log setup: warnings keep their level prefix and
     # color, and the download bar still draws under the dashboard
     CORE.dashboard = get_bool_env("ESPHOME_PREFETCH_DASHBOARD")
     setup_log(level)
-    if malformed:
-        # A wiring break would otherwise silently drop -v propagation
-        _LOGGER.warning("Ignoring malformed prefetch log level %r", raw_level)
     # pio's managers attach their own handler and still propagate; without
     # this every manager line also prints through the root handler. Their
     # construction re-pins the logger to INFO, so a logger-level filter

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -160,7 +160,11 @@ def prefetch_platformio_packages() -> None:
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
         return
-    if proc.returncode != 0:
+    if proc.returncode == 1:
+        # The child already warned with the reason; a second line is noise
+        _LOGGER.debug("Prefetch child reported a handled failure")
+    elif proc.returncode != 0:
+        # Codes the child cannot emit itself (signal deaths, bad wiring)
         _LOGGER.warning(
             "PlatformIO package prefetch skipped (exit %d)", proc.returncode
         )

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -5,7 +5,9 @@ Downloads the archives concurrently into PlatformIO's own download cache
 them already cached. Runs in a subprocess like all PlatformIO execution:
 loading a platform executes its code (pioarduino's penv setup rewrites
 ``sys.path``). A sentinel in the build dir lets warm builds skip the
-spawn. Best-effort: any failure logs and PlatformIO downloads as before.
+spawn. Best-effort: any failure logs and PlatformIO downloads as before;
+concurrent esphome processes sharing a core dir may race a ``.part`` file,
+which the sha256 check catches at the cost of one wasted download.
 """
 
 from __future__ import annotations
@@ -33,6 +35,12 @@ _LOGGER = logging.getLogger(__name__)
 
 # Concurrent registry resolutions / HEAD probes (each is network-bound)
 _RESOLVE_WORKERS = 8
+
+# A hung child must not block the build; downloads resume on the next run
+_PREFETCH_TIMEOUT = 20 * 60
+
+# Resolution errored (vs a clean skip); suppresses the warm sentinel
+_RESOLVE_FAILED = object()
 
 # Child records a no-work run; the parent skips the next spawn while valid
 _SENTINEL_NAME = ".esphome_prefetch.json"
@@ -63,7 +71,10 @@ def _prefetch_is_warm(build_dir: Path) -> bool:
             and bool(dirs)
             and all(Path(d).is_dir() for d in dirs)
         )
+    except FileNotFoundError:
+        return False
     except (OSError, ValueError, KeyError, AttributeError, TypeError):
+        _LOGGER.debug("Ignoring invalid prefetch sentinel", exc_info=True)
         return False
 
 
@@ -81,9 +92,9 @@ def prefetch_platformio_packages() -> None:
     build_dir = Path(CORE.build_path)
     if _prefetch_is_warm(build_dir):
         return
+    # The child is esphome itself: PYTHONPATH stays so it imports this
+    # tree's esphome (tests/integration pins the source tree through it)
     env = dict(os.environ)
-    # Same hygiene as run_command: do not leak PYTHONPATH
-    env.pop("PYTHONPATH", None)
     # Must match run_platformio_cli's default or warm builds re-resolve
     # every library
     env.setdefault("PLATFORMIO_LIBDEPS_DIR", default_libdeps_dir())
@@ -95,7 +106,10 @@ def prefetch_platformio_packages() -> None:
         CORE.name,
     ]
     try:
-        proc = subprocess.run(cmd, env=env, check=False)
+        proc = subprocess.run(cmd, env=env, check=False, timeout=_PREFETCH_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        _LOGGER.warning("PlatformIO package prefetch timed out; continuing without it")
+        return
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # The prefetch must never become a new way for the build to fail
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
@@ -119,39 +133,47 @@ def _project_platform_and_config(ini: Path, env: str) -> tuple[str | None, Any]:
     return config.get(f"env:{env}", "platform", None), config
 
 
-def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
+def _registry_jobs(
+    manager, specs, seen: set[str]
+) -> tuple[list[tuple[str, int, Any]], int]:
     """Resolve registry specs to ``(name, size, fetch)`` batch jobs.
 
     Mirrors PlatformIO's install path: best version, systype file, first
-    mirror, and the same sha1(url + checksum) download-cache key.
+    mirror, and the same sha1(url + checksum) download-cache key. Also
+    returns how many resolutions errored (a clean skip is not an error).
     """
     from platformio.registry.mirror import RegistryFileMirrorIterator
 
     local = threading.local()
 
-    def _resolve(spec) -> tuple[str, int, str, Path, str] | None:
+    def _resolve(spec) -> tuple[str, int, str, Path, str] | object | None:
         # One manager (and registry HTTP session) per worker thread;
         # installed-state was already checked on the shared manager
         if (mgr := getattr(local, "mgr", None)) is None:
             mgr = local.mgr = manager.__class__()
-        packages = mgr.search_registry_packages(spec)
-        if not packages:
-            return None  # unknown to the registry; let PlatformIO report it
-        package, version = mgr.find_best_registry_version(packages, spec)
-        if not package or not version:
-            return None
-        pkgfile = mgr.pick_compatible_pkg_file(version["files"])
-        if not pkgfile:
-            return None
-        url, checksum = next(RegistryFileMirrorIterator(pkgfile["download_url"]))
-        checksum = checksum or pkgfile["checksum"]["sha256"]
-        dl_path = Path(mgr.compute_download_path(url, checksum))
-        if dl_path.is_file():
-            return None  # cached from an earlier run
-        size = pkgfile.get("size")
-        if not size:
-            return None  # no size, no bar share; PlatformIO fetches it
-        return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
+        try:
+            packages = mgr.search_registry_packages(spec)
+            if not packages:
+                return None  # unknown to the registry; let PlatformIO report it
+            package, version = mgr.find_best_registry_version(packages, spec)
+            if not package or not version:
+                return None
+            pkgfile = mgr.pick_compatible_pkg_file(version["files"])
+            if not pkgfile:
+                return None
+            url, checksum = next(RegistryFileMirrorIterator(pkgfile["download_url"]))
+            checksum = checksum or pkgfile["checksum"]["sha256"]
+            dl_path = Path(mgr.compute_download_path(url, checksum))
+            if dl_path.is_file():
+                return None  # cached from an earlier run
+            size = pkgfile.get("size")
+            if not size:
+                return None  # no size, no bar share; PlatformIO fetches it
+            return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            # One flaky spec must not discard the rest of the batch
+            _LOGGER.debug("Could not resolve %s", spec, exc_info=True)
+            return _RESOLVE_FAILED
 
     # Serial disk lookups on the shared manager: a fully warm build
     # resolves nothing, and duplicate specs resolve once
@@ -161,13 +183,17 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
             unique.setdefault((s.name, str(getattr(s, "requirements", None))), s)
     pending = list(unique.values())
     if not pending:
-        return []
+        return [], 0
     # Serial resolutions (registry GET + mirror HEAD each) dominate
     with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(pending))) as ex:
         results = list(ex.map(_resolve, pending))
     jobs: list[tuple[str, int, Any]] = []
+    failed = 0
     for res in results:
         if res is None:
+            continue
+        if res is _RESOLVE_FAILED:
+            failed += 1
             continue
         name, size, url, dl_path, checksum = res
         if str(dl_path) in seen:
@@ -176,18 +202,24 @@ def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]
         jobs.append(
             (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
         )
-    return jobs
+    return jobs, failed
 
 
-def _uri_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
-    """Jobs for direct-URL specs; a HEAD sizes each for the combined bar."""
+def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]], int]:
+    """Jobs for direct-URL specs; a HEAD sizes each for the combined bar.
+
+    Also returns how many HEAD probes errored (an absent length is not an
+    error).
+    """
     from esphome.net_retry import fetch_with_retry, http_request
 
     candidates: list[tuple[str, str, Path]] = []
     for spec in specs:
         url = spec.uri
         if not url or not url.startswith(("http://", "https://")):
-            continue  # git/file specs are cloned/copied, not downloaded
+            continue  # git+/file specs are cloned/copied, not downloaded
+        if url.split("#", 1)[0].endswith(".git"):
+            continue  # bare-URL VCS spec; PlatformIO clones it
         if manager.get_package(spec):
             continue
         # PlatformIO downloads URL specs with no checksum
@@ -199,21 +231,25 @@ def _uri_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
 
     def _head_size(url: str) -> int:
         try:
-            return content_length(
-                fetch_with_retry(url, lambda: http_request("HEAD", url, timeout=30))
-            )
+            resp = fetch_with_retry(url, lambda: http_request("HEAD", url, timeout=30))
         except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-            return 0
+            _LOGGER.debug("HEAD %s failed", url, exc_info=True)
+            return -1
+        # An error page's Content-Length is not a download size
+        return content_length(resp) if resp.ok else 0
 
     if not candidates:
-        return []
+        return [], 0
     with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(candidates))) as ex:
         sizes = list(ex.map(_head_size, [url for _, url, _ in candidates]))
-    return [
-        (name, size, resume_fetch_job(url, dl_path, size=size))
-        for (name, url, dl_path), size in zip(candidates, sizes, strict=True)
-        if size
-    ]
+    jobs: list[tuple[str, int, Any]] = []
+    failed = 0
+    for (name, url, dl_path), size in zip(candidates, sizes, strict=True):
+        if size < 0:
+            failed += 1
+        elif size:
+            jobs.append((name, size, resume_fetch_job(url, dl_path, size=size)))
+    return jobs, failed
 
 
 def _prefetch(build_dir: Path, env: str) -> None:
@@ -254,9 +290,6 @@ def _prefetch(build_dir: Path, env: str) -> None:
                 requirements=get_core_dependencies()["tool-scons"],
             )
         )
-    seen: set[str] = set()
-    jobs = _registry_jobs(p.pm, specs, seen) + _uri_jobs(p.pm, specs, seen)
-
     lib_deps = config.get(f"env:{env}", "lib_deps", [])
     # pio run's storage dir for this env: installed libraries skip by
     # disk lookup
@@ -265,17 +298,29 @@ def _prefetch(build_dir: Path, env: str) -> None:
     lib_specs = [
         PackageSpec(dep) for dep in lib_deps if dep and not dep.startswith("$")
     ]
-    jobs += _registry_jobs(lm, lib_specs, seen) + _uri_jobs(lm, lib_specs, seen)
+
+    seen: set[str] = set()
+    jobs: list[tuple[str, int, Any]] = []
+    unresolved = 0
+    for mgr, batch in ((p.pm, specs), (lm, lib_specs)):
+        for build_jobs in (_registry_jobs, _uri_jobs):
+            batch_jobs, failed = build_jobs(mgr, batch, seen)
+            jobs += batch_jobs
+            unresolved += failed
 
     sentinel = build_dir / _SENTINEL_NAME
     if not jobs:
-        # Record the no-work run so the parent skips the next spawn
-        dirs = [config.get("platformio", "packages_dir")]
-        if lib_specs:
-            dirs.append(str(libdeps_dir))
-        sentinel.write_text(
-            json.dumps({**_sentinel_state(build_dir), "dirs": dirs}), encoding="utf-8"
-        )
+        if not unresolved:
+            # Record the no-work run so the parent skips the next spawn.
+            # A failed resolution is not "no work": a registry outage must
+            # not be cached as warm.
+            dirs = [config.get("platformio", "packages_dir")]
+            if lib_specs:
+                dirs.append(str(libdeps_dir))
+            sentinel.write_text(
+                json.dumps({**_sentinel_state(build_dir), "dirs": dirs}),
+                encoding="utf-8",
+            )
         return
     sentinel.unlink(missing_ok=True)
     _LOGGER.info(
@@ -290,8 +335,12 @@ def _prefetch(build_dir: Path, env: str) -> None:
 def main(argv: list[str]) -> int:
     """Subprocess entry point: ``prefetch <build_dir> <env_name>``."""
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    if len(argv) != 2:
+        # A wiring bug, not a network failure; make it distinguishable
+        _LOGGER.warning("prefetch usage: <build_dir> <env_name>")
+        return 2
+    build_dir, env = argv
     try:
-        build_dir, env = argv
         _prefetch(Path(build_dir), env)
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Exit 0: the parent must not treat a failed prefetch as a failed build

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -177,10 +177,17 @@ def _registry_jobs(
 
     # Serial disk lookups on the shared manager: a fully warm build
     # resolves nothing, and duplicate specs resolve once
-    unique: dict[tuple[str, str], Any] = {}
+    unique: dict[tuple[str | None, str, str], Any] = {}
     for s in specs:
         if not s.uri and not manager.get_package(s):
-            unique.setdefault((s.name, str(getattr(s, "requirements", None))), s)
+            unique.setdefault(
+                (
+                    getattr(s, "owner", None),
+                    s.name,
+                    str(getattr(s, "requirements", None)),
+                ),
+                s,
+            )
     pending = list(unique.values())
     if not pending:
         return [], 0
@@ -201,6 +208,13 @@ def _registry_jobs(
         seen.add(str(dl_path))
         jobs.append(
             (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
+        )
+    if failed == len(pending):
+        # A systematic fault (outage, proxy), not one flaky package
+        _LOGGER.warning(
+            "Could not resolve any of %d PlatformIO package(s); "
+            "PlatformIO will download them serially",
+            failed,
         )
     return jobs, failed
 
@@ -235,8 +249,12 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
         except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             _LOGGER.debug("HEAD %s failed", url, exc_info=True)
             return -1
-        # An error page's Content-Length is not a download size
-        return content_length(resp) if resp.ok else 0
+        if not resp.ok:
+            # An error page's Content-Length is not a download size, and a
+            # failing URL must not feed the warm sentinel
+            _LOGGER.debug("HEAD %s returned %s", url, resp.status_code)
+            return -1
+        return content_length(resp)
 
     if not candidates:
         return [], 0
@@ -248,8 +266,25 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
         if size < 0:
             failed += 1
         elif size:
-            jobs.append((name, size, resume_fetch_job(url, dl_path, size=size)))
+            jobs.append((name, size, _uri_fetch_job(url, dl_path, size)))
     return jobs, failed
+
+
+def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
+    """Fetch to a process-unique path, then rename into the cache.
+
+    URL specs carry no checksum, so a shared destination could let two
+    processes interleave a same-length corrupt file into the cache; the
+    atomic rename makes the promotion single-writer.
+    """
+    tmp = dl_path.with_name(f"{dl_path.name}.{os.getpid()}.tmp")
+    fetch = resume_fetch_job(url, tmp, size=size)
+
+    def run(tracker: Any) -> None:
+        fetch(tracker)
+        tmp.replace(dl_path)
+
+    return run
 
 
 def _prefetch(build_dir: Path, env: str) -> None:

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -14,6 +14,7 @@ they are serialized by a file lock and promoted with an atomic rename.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 import hashlib
 import json
 import logging
@@ -22,6 +23,7 @@ from pathlib import Path
 import subprocess
 import sys
 import threading
+import time
 from typing import Any
 
 from esphome.framework_helpers import (
@@ -42,6 +44,9 @@ _PREFETCH_TIMEOUT = 20 * 60
 
 # Waiting on another process's URL download; past this, leave it to pio
 _URI_LOCK_TIMEOUT = 60
+
+# Short lock-acquire slices so a waiting worker still observes Ctrl-C
+_URI_LOCK_POLL = 1
 
 # Resolution errored (vs a clean skip); suppresses the warm sentinel
 _RESOLVE_FAILED = object()
@@ -108,6 +113,9 @@ def prefetch_platformio_packages() -> None:
     # -v/-vv must reach the child's debug logging or the swallowed
     # failure detail is undiagnosable in the field
     env["ESPHOME_PREFETCH_LOG_LEVEL"] = str(logging.getLogger().getEffectiveLevel())
+    if CORE.dashboard:
+        # The child's progress bar and log escaping key off CORE.dashboard
+        env["ESPHOME_PREFETCH_DASHBOARD"] = "1"
     cmd = [
         sys.executable,
         "-m",
@@ -155,6 +163,7 @@ def _registry_jobs(
     from platformio.registry.mirror import RegistryFileMirrorIterator
 
     local = threading.local()
+    errors: list[str] = []
 
     def _resolve(spec) -> tuple[str, int, str, Path, str] | object | None:
         # One manager (and registry HTTP session) per worker thread;
@@ -180,9 +189,10 @@ def _registry_jobs(
             if not size:
                 return None  # no size, no bar share; PlatformIO fetches it
             return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             # One flaky spec must not discard the rest of the batch
             _LOGGER.debug("Could not resolve %s", spec, exc_info=True)
+            errors.append(failure_reason(err))
             return _RESOLVE_FAILED
 
     # Serial disk lookups on the shared manager: a fully warm build
@@ -213,12 +223,14 @@ def _registry_jobs(
             (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
         )
     if failed:
-        # Visible once per build; per-spec detail stays at debug
+        # Visible once per build, naming a cause so an API break does not
+        # read as an outage; per-spec detail stays at debug
         _LOGGER.warning(
-            "Could not resolve %d of %d PlatformIO package(s); "
+            "Could not resolve %d of %d PlatformIO package(s) (%s); "
             "PlatformIO will download them serially",
             failed,
             len(pending),
+            errors[0] if errors else "unknown error",
         )
     return jobs, failed
 
@@ -258,8 +270,13 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
             _LOGGER.debug("HEAD %s returned %s", url, resp.status_code)
             if resp.status_code in (408, 429) or resp.status_code >= 500:
                 return -1  # transient; must not be cached as warm
-            # Permanent (e.g. a host that 405s HEAD but serves GET): a clean
-            # skip, or the sentinel would never be written again
+            if resp.status_code in (405, 501):
+                # HEAD unsupported but GET may work: a clean skip, or the
+                # sentinel would never be written again
+                return 0
+            # A real URL problem (401/403/404): name it, but still a clean
+            # skip so the warm sentinel is not disabled forever
+            _LOGGER.warning("HEAD %s returned %s", url, resp.status_code)
             return 0
         return content_length(resp)
 
@@ -300,23 +317,41 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
         from filelock import FileLock, Timeout
 
         # fallback_to_soft would leave a stale marker on lock-less
-        # filesystems that blocks every later build (see git.py); a bounded
-        # wait plus a skip keeps the job best-effort either way
+        # filesystems that blocks every later build (see git.py)
         lock = FileLock(f"{tmp}.lock", fallback_to_soft=False)
-        try:
-            lock.acquire(timeout=_URI_LOCK_TIMEOUT)
-        except (Timeout, OSError):
-            _LOGGER.debug("Could not lock %s; leaving it to PlatformIO", dl_path)
-            return
+        deadline = time.monotonic() + _URI_LOCK_TIMEOUT
+        while True:
+            try:
+                lock.acquire(timeout=_URI_LOCK_POLL)
+                break
+            except Timeout:
+                # The tracker raises when the batch is cancelled, so a
+                # parked worker still observes Ctrl-C; a raise past the
+                # deadline makes the skip a counted, warned failure
+                tracker(0)
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        "timed out waiting for another download of the same file"
+                    ) from None
         try:
             if dl_path.is_file():
-                return  # another process finished it while we waited
+                # Another process finished it while we waited; the staging
+                # files are dead weight PlatformIO's cache never prunes
+                _discard_staging(tmp)
+                return
             fetch(tracker)
             tmp.replace(dl_path)
         finally:
             lock.release()
 
     return run
+
+
+def _discard_staging(tmp: Path) -> None:
+    part = tmp.with_name(tmp.name + ".part")
+    for stale in (tmp, part, part.with_name(part.name + ".meta")):
+        with suppress(OSError):
+            stale.unlink()
 
 
 def _prefetch(build_dir: Path, env: str) -> None:
@@ -407,11 +442,17 @@ def _prefetch(build_dir: Path, env: str) -> None:
 
 def main(argv: list[str]) -> int:
     """Subprocess entry point: ``prefetch <build_dir> <env_name>``."""
+    from esphome.core import CORE
+    from esphome.log import setup_log
+
     try:
         level = int(os.environ.get("ESPHOME_PREFETCH_LOG_LEVEL", logging.INFO))
     except ValueError:
         level = logging.INFO
-    logging.basicConfig(level=level, format="%(message)s")
+    # Mirror the parent's log setup: warnings keep their level prefix and
+    # color, and the download bar still draws under the dashboard
+    CORE.dashboard = bool(os.environ.get("ESPHOME_PREFETCH_DASHBOARD"))
+    setup_log(level)
     if len(argv) != 2:
         # A wiring bug, not a network failure; make it distinguishable
         _LOGGER.warning("prefetch usage: <build_dir> <env_name>")

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -6,9 +6,10 @@ them already cached. Runs in a subprocess like all PlatformIO execution:
 loading a platform executes its code (pioarduino's penv setup rewrites
 ``sys.path``). A sentinel in the build dir lets warm builds skip the
 spawn. Best-effort: any failure logs and PlatformIO downloads as before.
-Across processes sharing a core dir, registry downloads share the cache
-key and rely on sha256 verification; URL downloads carry no checksum, so
-they are serialized by a file lock and promoted with an atomic rename.
+Across processes sharing a core dir every download destination is
+serialized by a file lock (interleaved writers truncate each other's
+bytes); URL downloads carry no checksum, so they additionally stage
+under a stable name and promote with an atomic rename.
 """
 
 from __future__ import annotations
@@ -216,9 +217,7 @@ def _registry_jobs(
         if str(dl_path) in seen:
             continue  # duplicate spec; two workers must not share a .part
         seen.add(str(dl_path))
-        jobs.append(
-            (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
-        )
+        jobs.append((name, size, _registry_fetch_job(url, dl_path, checksum, size)))
     if failed := len(errors):
         # Visible once per build, naming a cause so an API break does not
         # read as an outage; per-spec detail stays at debug
@@ -298,24 +297,23 @@ def _uri_jobs(manager, specs, seen: set[str]) -> tuple[list[tuple[str, int, Any]
     return jobs, failed
 
 
-def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
-    """Fetch to a locked staging path, then rename into the cache.
+def _serialized_fetch_job(dl_path: Path, lock_path: str, body: Any) -> Any:
+    """Wrap ``body`` so the shared destination is single-writer.
 
-    URL specs carry no checksum, so a shared destination could let two
-    processes interleave a same-length corrupt file into the cache. The
-    lock makes the staging file single-writer (a stable name keeps the
-    resume machinery working across interrupted runs) and the rename
-    makes the promotion atomic.
+    Any download landing in PlatformIO's shared core dir can race a
+    sibling esphome process writing the same ``.part``; interleaved
+    writers truncate each other's bytes (see registry.py). A bounded
+    poll keeps a parked worker observing Ctrl-C via the tracker, a
+    blown deadline is a counted failure, and a lock-less filesystem
+    (git.py's ENOSYS/EPERM case) proceeds unlocked with one warning.
     """
-    tmp = dl_path.with_name(f"{dl_path.name}.prefetch")
-    fetch = resume_fetch_job(url, tmp, size=size)
 
     def run(tracker: Any) -> None:
         from filelock import FileLock, Timeout
 
         # fallback_to_soft would leave a stale marker on lock-less
         # filesystems that blocks every later build (see git.py)
-        lock = FileLock(f"{tmp}.lock", fallback_to_soft=False)
+        lock = FileLock(lock_path, fallback_to_soft=False)
         deadline = time.monotonic() + _URI_LOCK_TIMEOUT
         while True:
             try:
@@ -330,16 +328,54 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
                     raise TimeoutError(
                         "timed out waiting for another download of the same file"
                     ) from None
+            except OSError as err:
+                lock = None
+                _LOGGER.warning(
+                    "Could not lock %s (%s); downloading unlocked",
+                    dl_path.name,
+                    err,
+                )
+                break
         try:
             if dl_path.is_file():
-                # Another process finished it while we waited; the staging
-                # files are dead weight PlatformIO's cache never prunes
-                discard_partial_download(tmp)
-                return
-            fetch(tracker)
-            tmp.replace(dl_path)
+                return  # another process finished it while we waited
+            body(tracker)
         finally:
-            lock.release()
+            if lock is not None:
+                lock.release()
+
+    return run
+
+
+def _registry_fetch_job(url: str, dl_path: Path, checksum: str, size: int) -> Any:
+    """A locked fetch straight to the cache path; sha256 verifies it."""
+    return _serialized_fetch_job(
+        dl_path,
+        f"{dl_path}.lock",
+        resume_fetch_job(url, dl_path, sha256=checksum, size=size),
+    )
+
+
+def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
+    """Fetch to a locked staging path, then rename into the cache.
+
+    URL specs carry no checksum, so a same-length corrupt file could be
+    interleaved undetected; the stable staging name keeps resume working
+    across interrupted runs and the rename makes the promotion atomic.
+    """
+    tmp = dl_path.with_name(f"{dl_path.name}.prefetch")
+    fetch = resume_fetch_job(url, tmp, size=size)
+
+    def promote(tracker: Any) -> None:
+        fetch(tracker)
+        tmp.replace(dl_path)
+
+    def run(tracker: Any) -> None:
+        _serialized_fetch_job(dl_path, f"{tmp}.lock", promote)(tracker)
+        if dl_path.is_file():
+            # Won or lost, the race is over; staging files left behind
+            # are dead weight PlatformIO's cache never prunes
+            discard_partial_download(tmp)
 
     return run
 
@@ -355,6 +391,11 @@ def _prefetch(build_dir: Path, env: str) -> None:
         build_dir / "platformio.ini", env
     )
     if not platform_spec:
+        # Visible under -v: an env-name mismatch or an unreadable ini
+        # would otherwise disable the feature with no trace
+        _LOGGER.debug(
+            "No platform for env %s in %s; nothing to prefetch", env, build_dir
+        )
         return
 
     # The platform (manifest plus build scripts) installs first and
@@ -387,9 +428,9 @@ def _prefetch(build_dir: Path, env: str) -> None:
     # disk lookup
     libdeps_dir = Path(config.get("platformio", "libdeps_dir")) / env
     lm = LibraryPackageManager(str(libdeps_dir))
-    # pio run skips owner-less non-external lib_deps entirely (a bare
-    # name like WiFi is a framework built-in or private library);
-    # resolving one from the registry would shadow the bundled copy
+    # A bare name is usually a framework built-in (WiFi, SPI); with no
+    # lib builders here to tell built-in from registry, skip it. The only
+    # cost is that an owner-less user library is not prefetched
     lib_specs = [
         spec
         for dep in lib_deps

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -7,9 +7,8 @@ loading a platform executes its code (pioarduino's penv setup rewrites
 ``sys.path``). A sentinel in the build dir lets warm builds skip the
 spawn. Best-effort: any failure logs and PlatformIO downloads as before.
 Across processes sharing a core dir every download destination is
-serialized by a file lock (interleaved writers truncate each other's
-bytes); URL downloads carry no checksum, so they additionally stage
-under a stable name and promote with an atomic rename.
+serialized by a file lock; checksum-less URL downloads additionally
+stage under a stable name and promote with an atomic rename.
 """
 
 from __future__ import annotations
@@ -64,13 +63,11 @@ _SIDECAR_EXPIRE_SECONDS = 30 * 24 * 3600
 
 
 def _sweep_stale_sidecars(download_dir: Path) -> None:
-    """Prune abandoned resume/lock files pio's cache pruner cannot see.
+    """Prune resume sidecars pio's usage.db pruner cannot see.
 
-    A version bump changes the cache key, stranding an aborted archive's
-    sidecars forever; anything past pio's own expiry is dead weight.
-    Lock files are excluded: O_TRUNC does not refresh mtime, so a held
-    lock can look ancient, and unlinking it would reopen the
-    interleaved-writer hole it guards (they are a few bytes anyway).
+    A version bump strands an aborted archive's sidecars forever. Lock
+    files stay: a held lock can carry an ancient mtime (O_TRUNC keeps
+    it), and unlinking one reopens the single-writer hole it guards.
     """
     cutoff = time.time() - _SIDECAR_EXPIRE_SECONDS
     try:
@@ -81,7 +78,6 @@ def _sweep_stale_sidecars(download_dir: Path) -> None:
                 if f.stat().st_mtime < cutoff:
                     f.unlink()
             except OSError as err:
-                # An unprunable sidecar grows the cache forever otherwise
                 _LOGGER.debug("Could not remove %s: %s", f, err)
     except OSError:
         _LOGGER.debug("Could not sweep %s", download_dir, exc_info=True)
@@ -355,15 +351,11 @@ def _serialized_fetch_job(
 ) -> Any:
     """Wrap ``body`` so the shared destination is single-writer.
 
-    Any download landing in PlatformIO's shared core dir can race a
-    sibling esphome process writing the same ``.part``; interleaved
-    writers truncate each other's bytes (see registry.py). A bounded
-    poll keeps a parked worker observing Ctrl-C via the tracker and a
-    blown deadline is a counted failure. On a lock-less filesystem
-    (git.py's ENOSYS/EPERM case) a sha256-verified body proceeds
-    unlocked with one warning; a checksum-less one becomes a counted
-    failure, since interleaved right-length corruption would go
-    undetected.
+    Interleaved writers truncate each other's ``.part`` bytes (see
+    registry.py). The bounded poll observes Ctrl-C via the tracker; a
+    blown deadline is a counted failure. On a lock-less filesystem a
+    sha256-verified body runs unlocked with one warning; a checksum-less
+    one (``unlocked_ok=False``) is a counted failure instead.
     """
 
     def run(tracker: Any) -> None:
@@ -378,10 +370,7 @@ def _serialized_fetch_job(
                 lock.acquire(timeout=_URI_LOCK_POLL)
                 break
             except Timeout:
-                # The tracker raises when the batch is cancelled, so a
-                # parked worker still observes Ctrl-C; a raise past the
-                # deadline makes the skip a counted, warned failure
-                tracker(0)
+                tracker(0)  # raises when the batch is cancelled
                 if time.monotonic() >= deadline:
                     raise TimeoutError(
                         "timed out waiting for another download of the same file"
@@ -413,19 +402,16 @@ def _serialized_fetch_job(
     return run
 
 
-# usage.db is a whole-file read-modify-write behind pio's self-unlinking
-# LockFile; concurrent writers could reset every recorded entry
+# usage.db is a whole-file rewrite behind pio's self-unlinking LockFile;
+# concurrent writers could reset every recorded entry
 _REGISTER_LOCK = threading.Lock()
 
-# Registration failures this run; systematic ones deserve one warning
-# (the child is a fresh process, so module state is per-run)
+# Per-run (the child is a fresh process); systematic failures warn once
 _REGISTER_FAILURES: list[str] = []
 
 
 def _warn_register_failures() -> None:
     if _REGISTER_FAILURES:
-        # Unregistered archives are never pruned; a systematic failure
-        # (usage.db corruption, a pio API change) must be visible once
         _LOGGER.warning(
             "%d archive(s) could not be registered with PlatformIO's cache pruner",
             len(_REGISTER_FAILURES),
@@ -433,13 +419,12 @@ def _warn_register_failures() -> None:
 
 
 def _register_download(manager: Any, dl_path: Path) -> None:
-    """Hand the archive to pio's usage.db pruner; without an entry an
-    archive nothing ever consumes would be stranded at any age."""
+    """Hand the archive to pio's usage.db pruner; an unregistered one is
+    never expired."""
     try:
         with _REGISTER_LOCK:
             manager.set_download_utime(str(dl_path))
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # Unregistered archives are never pruned; leave a trace
         _LOGGER.debug("Could not register %s with pio's cache: %s", dl_path, err)
         _REGISTER_FAILURES.append(dl_path.name)
 
@@ -466,9 +451,8 @@ def _registry_fetch_job(
 def _uri_fetch_job(manager: Any, url: str, dl_path: Path, size: int) -> Any:
     """Fetch to a locked staging path, then rename into the cache.
 
-    URL specs carry no checksum, so a same-length corrupt file could be
-    interleaved undetected; the stable staging name keeps resume working
-    across interrupted runs and the rename makes the promotion atomic.
+    The stable staging name keeps resume working across interrupted
+    runs; the rename makes the promotion atomic.
     """
     tmp = dl_path.with_name(f"{dl_path.name}.prefetch")
     fetch = resume_fetch_job(url, tmp, size=size)
@@ -476,8 +460,7 @@ def _uri_fetch_job(manager: Any, url: str, dl_path: Path, size: int) -> Any:
     def promote(tracker: Any) -> None:
         fetch(tracker)
         if (actual := tmp.stat().st_size) != size:
-            # No checksum on URL archives: a wrong-length body must not be
-            # published under a cache key pio never re-validates
+            # A wrong-length checksum-less body must never be published
             discard_partial_download(tmp)
             raise ValueError(f"expected {size} bytes, fetched {actual}")
         tmp.replace(dl_path)
@@ -506,8 +489,7 @@ def _prefetch(build_dir: Path, env: str) -> None:
         build_dir / "platformio.ini", env
     )
     if not platform_spec:
-        # Visible under -v: an env-name mismatch or an unreadable ini
-        # would otherwise disable the feature with no trace
+        # An env mismatch must not disable the feature with no trace
         _LOGGER.debug(
             "No platform for env %s in %s; nothing to prefetch", env, build_dir
         )
@@ -623,8 +605,7 @@ def main(argv: list[str]) -> int:
     try:
         _prefetch(Path(build_dir), env)
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # Nonzero so the parent's exit-code warning stays live; it treats
-        # any prefetch exit as warn-and-continue, never a failed build
+        # The parent treats any exit as warn-and-continue, never a failure
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
         return _EXIT_HANDLED

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -1,0 +1,263 @@
+"""Parallel prefetch of the packages a PlatformIO run would install.
+
+PlatformIO resolves and downloads platform packages, toolchains, frameworks,
+and libraries one at a time; on a cold cache (every CI run) the downloads
+dominate the install. This prefetch resolves the same registry metadata
+PlatformIO would, downloads the archives concurrently into PlatformIO's own
+download cache (``compute_download_path`` keyed identically), and lets the
+subsequent ``pio run`` find every file already cached.
+
+The prefetch runs in a subprocess (``python -m esphome.platformio.prefetch``):
+resolving a platform executes its code, and platform setup may rewrite the
+running interpreter's state (pioarduino's penv setup replaces ``sys.path``
+with its own virtualenv's, breaking every later import in the process).
+All other PlatformIO execution is already subprocess-isolated the same way
+(see ``run_platformio_cli``).
+
+Strictly best-effort: any failure logs and returns, leaving PlatformIO to
+download whatever is missing exactly as before.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+from esphome.framework_helpers import (
+    _content_length,
+    resume_fetch_job,
+    run_batch_downloads,
+    warn_prefetch_failures,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def prefetch_platformio_packages() -> None:
+    """Warm PlatformIO's download cache for the current project, in parallel."""
+    from esphome.core import CORE
+
+    env = dict(os.environ)
+    # pio run later resolves installed libraries against this same dir
+    # (run_platformio_cli sets it); the prefetch must agree or it re-resolves
+    # every library on every warm build
+    env.setdefault(
+        "PLATFORMIO_LIBDEPS_DIR", str(CORE.relative_piolibdeps_path().absolute())
+    )
+    cmd = [
+        sys.executable,
+        "-m",
+        "esphome.platformio.prefetch",
+        str(CORE.build_path),
+        CORE.name,
+    ]
+    try:
+        proc = subprocess.run(cmd, env=env, check=False)
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # PlatformIO installs anything missing itself; the prefetch must
+        # never become a new way for the build to fail
+        _LOGGER.warning("PlatformIO package prefetch skipped: %s", err)
+        _LOGGER.debug("Prefetch failure detail", exc_info=True)
+        return
+    if proc.returncode != 0:
+        _LOGGER.warning(
+            "PlatformIO package prefetch skipped (exit %d)", proc.returncode
+        )
+
+
+def _project_platform_and_config(ini: Path, env: str) -> tuple[str | None, Any]:
+    """The env's platform spec and the ProjectConfig for the given ini."""
+    from platformio import app
+    from platformio.project.config import ProjectConfig
+
+    # Make this ini the default ProjectConfig: PlatformBase.config (which
+    # the package configuration reads) must see the same env options the
+    # later pio run will
+    app.set_session_var("custom_project_conf", str(ini))
+    config = ProjectConfig.get_instance(str(ini))
+    return config.get(f"env:{env}", "platform", None), config
+
+
+def _registry_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
+    """Resolve registry specs to ``(name, size, fetch)`` batch jobs.
+
+    Resolution mirrors PlatformIO's install path exactly: best registry
+    version, systype-compatible file, first mirror (whose HEAD result
+    PlatformIO's own run then reuses from its content cache), and the same
+    sha1(url + checksum) download-cache key.
+    """
+    from platformio.registry.mirror import RegistryFileMirrorIterator
+
+    def _resolve(spec) -> tuple[str, int, str, Path, str] | None:
+        # Fresh manager per task: the registry client's HTTP session is not
+        # shared across threads (installed-state was already checked on the
+        # shared manager, whose package dir a bare constructor may not match)
+        mgr = manager.__class__()
+        packages = mgr.search_registry_packages(spec)
+        if not packages:
+            return None  # unknown to the registry; let PlatformIO report it
+        package, version = mgr.find_best_registry_version(packages, spec)
+        if not package or not version:
+            return None
+        pkgfile = mgr.pick_compatible_pkg_file(version["files"])
+        if not pkgfile:
+            return None
+        url, checksum = next(RegistryFileMirrorIterator(pkgfile["download_url"]))
+        checksum = checksum or pkgfile["checksum"]["sha256"]
+        dl_path = Path(mgr.compute_download_path(url, checksum))
+        if dl_path.is_file():
+            return None  # cached from an earlier run
+        size = pkgfile.get("size")
+        if not size:
+            return None  # no size, no bar share; PlatformIO fetches it
+        return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
+
+    # Installed packages need no network at all; check them serially on the
+    # shared manager (a disk lookup) so a fully warm build resolves nothing
+    pending = [s for s in specs if not s.uri and not manager.get_package(s)]
+    if not pending:
+        return []
+    # Each resolution is a registry GET plus a mirror HEAD; serially they
+    # dominate the whole prefetch
+    with ThreadPoolExecutor(max_workers=min(8, len(pending))) as ex:
+        results = list(ex.map(_resolve, pending))
+    jobs: list[tuple[str, int, Any]] = []
+    for res in results:
+        if res is None:
+            continue
+        name, size, url, dl_path, checksum = res
+        if str(dl_path) in seen:
+            continue  # duplicate spec; two workers must not share a .part
+        seen.add(str(dl_path))
+        jobs.append(
+            (name, size, resume_fetch_job(url, dl_path, sha256=checksum, size=size))
+        )
+    return jobs
+
+
+def _uri_jobs(manager, specs, seen: set[str]) -> list[tuple[str, int, Any]]:
+    """Jobs for direct-URL package specs (e.g. pinned GitHub archives).
+
+    No registry metadata exists, so a HEAD supplies the size for the
+    combined bar; entries without a usable length are left to PlatformIO.
+    """
+    from esphome.net_retry import http_request
+
+    candidates: list[tuple[str, str, Path]] = []
+    for spec in specs:
+        url = spec.uri
+        if not url or not url.startswith(("http://", "https://")):
+            continue  # git/file specs are cloned/copied, not downloaded
+        if manager.get_package(spec):
+            continue
+        # PlatformIO downloads URL specs with no checksum
+        dl_path = Path(manager.compute_download_path(url, ""))
+        if dl_path.is_file() or str(dl_path) in seen:
+            continue
+        candidates.append((spec.name or url.rsplit("/", 1)[-1], url, dl_path))
+
+    def _head_size(url: str) -> int:
+        try:
+            return _content_length(http_request("HEAD", url, timeout=30))
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            return 0
+
+    if not candidates:
+        return []
+    with ThreadPoolExecutor(max_workers=min(8, len(candidates))) as ex:
+        sizes = list(ex.map(_head_size, [url for _, url, _ in candidates]))
+    jobs: list[tuple[str, int, Any]] = []
+    for (name, url, dl_path), size in zip(candidates, sizes, strict=True):
+        if not size:
+            continue
+        seen.add(str(dl_path))
+        jobs.append((name, size, resume_fetch_job(url, dl_path, size=size)))
+    return jobs
+
+
+def _prefetch(build_dir: Path, env: str) -> None:
+    from platformio.dependencies import get_core_dependencies
+    from platformio.package.manager.library import LibraryPackageManager
+    from platformio.package.manager.platform import PlatformPackageManager
+    from platformio.package.meta import PackageSpec
+    from platformio.platform.factory import PlatformFactory
+
+    platform_spec, config = _project_platform_and_config(
+        build_dir / "platformio.ini", env
+    )
+    if not platform_spec:
+        return
+
+    # The platform package itself resolves the rest, so it installs first
+    # (small: manifest plus build scripts). project_env configures which
+    # optional packages (frameworks, toolchains) this env requires. Platform
+    # setup code may rewrite sys.path (pioarduino's penv setup does); put it
+    # back so this process's own later imports still resolve.
+    saved_sys_path = list(sys.path)
+    pm = PlatformPackageManager()
+    pkg = pm.install(platform_spec, skip_dependencies=True)
+    p = PlatformFactory.new(pkg)
+    p.configure_project_packages(env, ["run"])
+    sys.path[:] = saved_sys_path
+
+    specs = [
+        p.get_package_spec(name)
+        for name, opts in p.packages.items()
+        if not opts.get("optional")
+    ]
+    # PIO core's own build engine installs outside the platform's package
+    # list, on first run; the other core dependencies (piohome, check
+    # tools) are for commands a compile never touches. Some platforms list
+    # tool-scons themselves; do not fetch it twice.
+    if not any(s.name == "tool-scons" for s in specs):
+        specs.append(
+            PackageSpec(
+                owner="platformio",
+                name="tool-scons",
+                requirements=get_core_dependencies()["tool-scons"],
+            )
+        )
+    seen: set[str] = set()
+    jobs = _registry_jobs(p.pm, specs, seen) + _uri_jobs(p.pm, specs, seen)
+
+    lib_deps = config.get(f"env:{env}", "lib_deps", [])
+    # Match pio run's storage dir for this env so already-installed
+    # libraries are skipped by a disk lookup instead of re-resolved
+    lm = LibraryPackageManager(str(Path(config.get("platformio", "libdeps_dir")) / env))
+    lib_specs = [
+        PackageSpec(dep) for dep in lib_deps if dep and not dep.startswith("$")
+    ]
+    jobs += _registry_jobs(lm, lib_specs, seen) + _uri_jobs(lm, lib_specs, seen)
+
+    if not jobs:
+        return
+    _LOGGER.info(
+        "Prefetching %d PlatformIO package(s): %s",
+        len(jobs),
+        ", ".join(name for name, _, _ in jobs),
+    )
+    # PlatformIO retries failed packages itself, without resume
+    warn_prefetch_failures(run_batch_downloads("Downloading PlatformIO packages", jobs))
+
+
+def main(argv: list[str]) -> int:
+    """Subprocess entry point: ``prefetch <build_dir> <env_name>``."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        build_dir, env = argv
+        _prefetch(Path(build_dir), env)
+    except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # Best-effort even here: exit 0 so the parent never treats a failed
+        # prefetch as a failed build
+        _LOGGER.warning("PlatformIO package prefetch skipped: %s", err)
+        _LOGGER.debug("Prefetch failure detail", exc_info=True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -15,6 +15,8 @@ under a stable name and promote with an atomic rename.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
+import errno
 import hashlib
 import json
 import logging
@@ -52,6 +54,29 @@ _URI_LOCK_POLL = 1
 
 # Resolution errored (vs a clean skip); suppresses the warm sentinel
 _RESOLVE_FAILED = object()
+
+# Sidecars older than pio's own 30-day download expiry cannot be resumed
+# by anything and are invisible to its usage.db-driven pruner
+_SIDECAR_EXPIRE_SECONDS = 30 * 24 * 3600
+
+
+def _sweep_stale_sidecars(download_dir: Path) -> None:
+    """Prune abandoned resume/lock files pio's cache pruner cannot see.
+
+    A version bump changes the cache key, stranding an aborted archive's
+    sidecars forever; anything past pio's own expiry is dead weight.
+    """
+    cutoff = time.time() - _SIDECAR_EXPIRE_SECONDS
+    try:
+        for f in download_dir.iterdir():
+            if f.suffix not in (".part", ".meta", ".prefetch", ".lock"):
+                continue
+            with suppress(OSError):
+                if f.stat().st_mtime < cutoff:
+                    f.unlink()
+    except OSError:
+        _LOGGER.debug("Could not sweep %s", download_dir, exc_info=True)
+
 
 # Child records a no-work run; the parent skips the next spawn while valid
 _SENTINEL_NAME = ".esphome_prefetch.json"
@@ -329,6 +354,10 @@ def _serialized_fetch_job(dl_path: Path, lock_path: str, body: Any) -> Any:
                         "timed out waiting for another download of the same file"
                     ) from None
             except OSError as err:
+                if err.errno not in (errno.ENOSYS, errno.EPERM, errno.EROFS):
+                    # EACCES/ENOSPC/EMFILE are real faults; an unlocked
+                    # write of a shared destination is not a safe fallback
+                    raise
                 lock = None
                 _LOGGER.warning(
                     "Could not lock %s (%s); downloading unlocked",
@@ -349,9 +378,11 @@ def _serialized_fetch_job(dl_path: Path, lock_path: str, body: Any) -> Any:
 
 def _registry_fetch_job(url: str, dl_path: Path, checksum: str, size: int) -> Any:
     """A locked fetch straight to the cache path; sha256 verifies it."""
+    # .esphome.lock: pio's own LockFile(dl_path) owns <dl_path>.lock and
+    # deletes it on release, which would unlink a held filelock
     return _serialized_fetch_job(
         dl_path,
-        f"{dl_path}.lock",
+        f"{dl_path}.esphome.lock",
         resume_fetch_job(url, dl_path, sha256=checksum, size=size),
     )
 
@@ -368,6 +399,11 @@ def _uri_fetch_job(url: str, dl_path: Path, size: int) -> Any:
 
     def promote(tracker: Any) -> None:
         fetch(tracker)
+        if (actual := tmp.stat().st_size) != size:
+            # No checksum on URL archives: a wrong-length body must not be
+            # published under a cache key pio never re-validates
+            discard_partial_download(tmp)
+            raise ValueError(f"expected {size} bytes, fetched {actual}")
         tmp.replace(dl_path)
 
     def run(tracker: Any) -> None:
@@ -403,6 +439,7 @@ def _prefetch(build_dir: Path, env: str) -> None:
     # setup does); restore it so later imports here still resolve.
     saved_sys_path = list(sys.path)
     pm = PlatformPackageManager()
+    _sweep_stale_sidecars(Path(pm.get_download_dir()))
     pkg = pm.install(platform_spec, skip_dependencies=True)
     p = PlatformFactory.new(pkg)
     p.configure_project_packages(env, ["run"])
@@ -500,9 +537,11 @@ def main(argv: list[str]) -> int:
     try:
         _prefetch(Path(build_dir), env)
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # Exit 0: the parent must not treat a failed prefetch as a failed build
+        # Nonzero so the parent's exit-code warning stays live; it treats
+        # any prefetch exit as warn-and-continue, never a failed build
         _LOGGER.warning("PlatformIO package prefetch skipped: %s", failure_reason(err))
         _LOGGER.debug("Prefetch failure detail", exc_info=True)
+        return 1
     return 0
 
 

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -211,7 +211,8 @@ def _registry_jobs(
         try:
             packages = mgr.search_registry_packages(spec)
             if not packages:
-                return None  # unknown to the registry; let PlatformIO report it
+                _LOGGER.debug("%s is unknown to the registry", spec)
+                return None  # let PlatformIO report it
             package, version = mgr.find_best_registry_version(packages, spec)
             if not package or not version:
                 return None
@@ -225,7 +226,8 @@ def _registry_jobs(
                 return None  # cached from an earlier run
             size = pkgfile.get("size")
             if not size:
-                return None  # no size, no bar share; PlatformIO fetches it
+                _LOGGER.debug("%s has no size; PlatformIO fetches it", spec)
+                return None  # no size, no bar share
             return f"{package['name']}@{version['name']}", size, url, dl_path, checksum
         except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             # One flaky spec must not discard the rest of the batch
@@ -407,6 +409,20 @@ def _serialized_fetch_job(
 # LockFile; concurrent writers could reset every recorded entry
 _REGISTER_LOCK = threading.Lock()
 
+# Registration failures this run; systematic ones deserve one warning
+# (the child is a fresh process, so module state is per-run)
+_REGISTER_FAILURES: list[str] = []
+
+
+def _warn_register_failures() -> None:
+    if _REGISTER_FAILURES:
+        # Unregistered archives are never pruned; a systematic failure
+        # (usage.db corruption, a pio API change) must be visible once
+        _LOGGER.warning(
+            "%d archive(s) could not be registered with PlatformIO's cache pruner",
+            len(_REGISTER_FAILURES),
+        )
+
 
 def _register_download(manager: Any, dl_path: Path) -> None:
     """Hand the archive to pio's usage.db pruner; without an entry an
@@ -417,6 +433,7 @@ def _register_download(manager: Any, dl_path: Path) -> None:
     except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Unregistered archives are never pruned; leave a trace
         _LOGGER.debug("Could not register %s with pio's cache: %s", dl_path, err)
+        _REGISTER_FAILURES.append(dl_path.name)
 
 
 def _registry_fetch_job(
@@ -560,6 +577,7 @@ def _prefetch(build_dir: Path, env: str) -> None:
     )
     # PlatformIO retries failed packages itself, without resume
     warn_prefetch_failures(run_batch_downloads("Downloading PlatformIO packages", jobs))
+    _warn_register_failures()
 
 
 def main(argv: list[str]) -> int:
@@ -567,14 +585,20 @@ def main(argv: list[str]) -> int:
     from esphome.core import CORE
     from esphome.log import setup_log
 
+    raw_level = os.environ.get("ESPHOME_PREFETCH_LOG_LEVEL")
+    malformed = False
     try:
-        level = int(os.environ.get("ESPHOME_PREFETCH_LOG_LEVEL", logging.INFO))
+        level = int(raw_level) if raw_level is not None else logging.INFO
     except ValueError:
+        malformed = True
         level = logging.INFO
     # Mirror the parent's log setup: warnings keep their level prefix and
     # color, and the download bar still draws under the dashboard
     CORE.dashboard = get_bool_env("ESPHOME_PREFETCH_DASHBOARD")
     setup_log(level)
+    if malformed:
+        # A wiring break would otherwise silently drop -v propagation
+        _LOGGER.warning("Ignoring malformed prefetch log level %r", raw_level)
     # pio's managers attach their own handler and still propagate; without
     # this every manager line also prints through the root handler
     for cls_name in (

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -368,11 +368,8 @@ def copy_ccache_script() -> None:
 
 
 def default_libdeps_dir() -> str:
-    """The PLATFORMIO_LIBDEPS_DIR value a pio run defaults to.
-
-    The package prefetch resolves installed libraries against the same dir;
-    both call sites must agree or warm builds re-resolve every library.
-    """
+    """The PLATFORMIO_LIBDEPS_DIR value a pio run defaults to; the package
+    prefetch must resolve installed libraries against the same dir."""
     return str(CORE.relative_piolibdeps_path().absolute())
 
 

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -131,7 +131,7 @@ def _clean_platformio_python_env(config: "ProjectConfig", core_dir: Path) -> Non
         rmtree(penv)
 
 
-def _current_python_minor() -> str:
+def current_python_minor() -> str:
     """Return the running interpreter's ``major.minor`` (e.g. ``3.13``)."""
     return f"{sys.version_info.major}.{sys.version_info.minor}"
 
@@ -196,7 +196,7 @@ def heal_platformio_python_env() -> None:
 
 def _check_platformio_python_stamp(config: "ProjectConfig") -> None:
     """Compare the stamp to the running interpreter; wipe and restamp on mismatch."""
-    current = _current_python_minor()
+    current = current_python_minor()
     stamp_dir = _pio_stamp_dir(config)
     # Host the stamp/lock even before PlatformIO's first run creates the dir.
     stamp_dir.mkdir(parents=True, exist_ok=True)

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -367,6 +367,15 @@ def copy_ccache_script() -> None:
     )
 
 
+def default_libdeps_dir() -> str:
+    """The PLATFORMIO_LIBDEPS_DIR value a pio run defaults to.
+
+    The package prefetch resolves installed libraries against the same dir;
+    both call sites must agree or warm builds re-resolve every library.
+    """
+    return str(CORE.relative_piolibdeps_path().absolute())
+
+
 def run_platformio_cli(*args, **kwargs) -> str | int:
     # Re-provision the PlatformIO cache if the interpreter's major.minor changed
     # since it was last built; a stale platform otherwise rejects the new Python
@@ -374,9 +383,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     heal_platformio_python_env()
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
-    os.environ.setdefault(
-        "PLATFORMIO_LIBDEPS_DIR", str(CORE.relative_piolibdeps_path().absolute())
-    )
+    os.environ.setdefault("PLATFORMIO_LIBDEPS_DIR", default_libdeps_dir())
     # Suppress Python syntax warnings from third-party scripts during compilation
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)
@@ -426,9 +433,6 @@ def run_platformio_cli_run(config, verbose, *args, **kwargs) -> str | int:
 def run_compile(config, verbose):
     from esphome.platformio.prefetch import prefetch_platformio_packages
 
-    # Heal before prefetching: a Python-version wipe would otherwise discard
-    # the caches the prefetch just warmed (the later heal call is a no-op)
-    heal_platformio_python_env()
     prefetch_platformio_packages()
     args = []
     if CONF_COMPILE_PROCESS_LIMIT in config[CONF_ESPHOME]:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -424,6 +424,12 @@ def run_platformio_cli_run(config, verbose, *args, **kwargs) -> str | int:
 
 
 def run_compile(config, verbose):
+    from esphome.platformio.prefetch import prefetch_platformio_packages
+
+    # Heal before prefetching: a Python-version wipe would otherwise discard
+    # the caches the prefetch just warmed (the later heal call is a no-op)
+    heal_platformio_python_env()
+    prefetch_platformio_packages()
     args = []
     if CONF_COMPILE_PROCESS_LIMIT in config[CONF_ESPHOME]:
         args += [f"-j{config[CONF_ESPHOME][CONF_COMPILE_PROCESS_LIMIT]}"]

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -911,7 +911,7 @@ def test_prefetch_leaves_unverifiable_entries_to_the_installer(
             "esphome.espidf.framework.run_command",
             return_value=(True, json.dumps(entries), ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume") as download,
+        patch("esphome.framework_helpers.download_with_resume") as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
         patch("esphome.framework_helpers._BatchDownloadProgress") as progress_cls,
     ):
@@ -934,7 +934,7 @@ def test_prefetch_all_entries_unverifiable_is_a_noop(tmp_path: Path) -> None:
             "esphome.espidf.framework.run_command",
             return_value=(True, json.dumps(entries), ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume") as download,
+        patch("esphome.framework_helpers.download_with_resume") as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
     ):
         _prefetch_idf_tool_archives(tmp_path, "esp32", ["required"], None)
@@ -952,7 +952,7 @@ def test_prefetch_dedupes_entries_by_dest(tmp_path: Path) -> None:
             "esphome.espidf.framework.run_command",
             return_value=(True, json.dumps(entries), ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume") as download,
+        patch("esphome.framework_helpers.download_with_resume") as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
         patch("esphome.framework_helpers._BatchDownloadProgress"),
     ):
@@ -967,7 +967,7 @@ def test_prefetch_downloads_each_archive_with_resume(tmp_path: Path) -> None:
             "esphome.espidf.framework.run_command",
             return_value=(True, _PREFETCH_JSON, ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume") as download,
+        patch("esphome.framework_helpers.download_with_resume") as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
         patch("esphome.framework_helpers._BatchDownloadProgress") as progress_cls,
     ):
@@ -1011,7 +1011,7 @@ def test_prefetch_downloads_archives_concurrently(tmp_path: Path) -> None:
             "esphome.espidf.framework.run_command",
             return_value=(True, json.dumps(entries), ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume") as download,
+        patch("esphome.framework_helpers.download_with_resume") as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
         patch(
             "esphome.framework_helpers.ThreadPoolExecutor", wraps=ThreadPoolExecutor
@@ -1032,7 +1032,7 @@ def test_prefetch_skips_already_downloaded_archives(tmp_path: Path) -> None:
             "esphome.espidf.framework.run_command",
             return_value=(True, _PREFETCH_JSON, ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume") as download,
+        patch("esphome.framework_helpers.download_with_resume") as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
     ):
         _prefetch_idf_tool_archives(tmp_path, "esp32", ["required"], None)
@@ -1065,7 +1065,7 @@ def test_prefetch_failures_never_raise(
     with (
         patch("esphome.espidf.framework.run_command", return_value=run_result),
         patch(
-            "esphome.espidf.framework.download_with_resume",
+            "esphome.framework_helpers.download_with_resume",
             side_effect=download_error,
         ),
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
@@ -1087,7 +1087,7 @@ def test_prefetch_total_failure_logs_error(
             return_value=(True, _PREFETCH_JSON, ""),
         ),
         patch(
-            "esphome.espidf.framework.download_with_resume",
+            "esphome.framework_helpers.download_with_resume",
             side_effect=OSError("proxy refuses everything"),
         ),
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
@@ -1112,7 +1112,7 @@ def test_prefetch_one_failed_archive_does_not_stop_the_rest(
             return_value=(True, _PREFETCH_JSON, ""),
         ),
         patch(
-            "esphome.espidf.framework.download_with_resume",
+            "esphome.framework_helpers.download_with_resume",
             side_effect=_fail_cmake_download,
         ) as download,
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
@@ -1133,7 +1133,7 @@ def test_prefetch_finishes_progress_bar_and_cancels_queue(tmp_path: Path) -> Non
             "esphome.espidf.framework.run_command",
             return_value=(True, _PREFETCH_JSON, ""),
         ),
-        patch("esphome.espidf.framework.download_with_resume"),
+        patch("esphome.framework_helpers.download_with_resume"),
         patch("esphome.espidf.framework.get_system_python_path", return_value="python"),
         patch("esphome.framework_helpers._BatchDownloadProgress") as progress_cls,
         patch("esphome.framework_helpers.ThreadPoolExecutor") as pool_cls,

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -2278,3 +2278,29 @@ class TestGetProjectCxxCompileFlags:
     def test_empty_flags(self) -> None:
         with patch("esphome.core.CORE", _make_core_cxx(set())):
             assert get_project_cxx_compile_flags() == []
+
+
+def test_resume_fetch_job_threads_tracker(tmp_path: Path) -> None:
+    """The batch runner passes the tracker positionally; the shared adapter
+    must deliver it as download_with_resume's progress keyword."""
+    from esphome.framework_helpers import resume_fetch_job
+
+    with patch("esphome.framework_helpers.download_with_resume") as mock_download:
+        fetch = resume_fetch_job("https://x/a.zip", tmp_path / "a", sha256="ff", size=9)
+        tracker = lambda done: None  # noqa: E731
+        fetch(tracker)
+    mock_download.assert_called_once_with(
+        "https://x/a.zip", tmp_path / "a", progress=tracker, sha256="ff", size=9
+    )
+
+
+def test_warn_prefetch_failures_names_each_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared failure loop warns per job with the failure reason."""
+    from esphome.framework_helpers import warn_prefetch_failures
+
+    warn_prefetch_failures([("toolchain-x@1", OSError("down"))])
+    assert "Could not prefetch toolchain-x@1: down" in caplog.text
+    warn_prefetch_failures([("lib", OSError("gone"))], "Prefetch of %s failed: %s")
+    assert "Prefetch of lib failed: gone" in caplog.text

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -2338,3 +2338,18 @@ def test_strip_win_long_path_prefix(
     r"""``\\?\`` and ``\\?\UNC\`` prefixes are stripped only on win32."""
     with patch("esphome.framework_helpers.sys.platform", platform):
         assert framework_helpers.strip_win_long_path_prefix(input_path) == expected
+
+
+def test_discard_partial_download_logs_undeletable(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An unremovable staging file leaves a debug trace; the caller's
+    cache is never pruned, so silence would hide unbounded growth."""
+    dest = tmp_path / "archive"
+    dest.write_bytes(b"stale")
+    with (
+        patch.object(Path, "unlink", side_effect=OSError("busy")),
+        caplog.at_level(logging.DEBUG),
+    ):
+        framework_helpers.discard_partial_download(dest)
+    assert "Could not remove" in caplog.text

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -114,13 +114,18 @@ def test_registry_jobs_skips_cached_and_sizeless(tmp_path: Path) -> None:
 
 
 def test_registry_jobs_dedupes_download_paths(tmp_path: Path) -> None:
-    """Duplicate specs resolving to one archive yield a single job; two
-    batch workers must never share a .part file."""
+    """Duplicate specs resolve once, and distinct specs resolving to one
+    archive yield a single job; two batch workers must never share a .part
+    file. Nine specs against eight workers also make one worker resolve
+    twice, reusing its thread-local manager."""
     m = _fake_manager(tmp_path)
     specs = [_FakeSpec(uri=None, name="dup"), _FakeSpec(uri=None, name="dup")]
+    specs += [_FakeSpec(uri=None, name=f"n{i}") for i in range(8)]
     with _mirror_patch():
         jobs = pf._registry_jobs(m, specs, set())
+    # the fake resolves every spec to the same mirror URL and checksum
     assert len(jobs) == 1
+    assert m.search_registry_packages.call_count == 9  # dup resolved once
 
 
 def test_registry_jobs_uri_specs_excluded(tmp_path: Path) -> None:
@@ -159,6 +164,25 @@ def test_uri_jobs_head_failure_skips(tmp_path: Path) -> None:
         )
 
 
+def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:
+    """Two specs with one URL yield one HEAD and one job; two batch workers
+    must never share a .part file."""
+    m = _fake_manager(tmp_path)
+    resp = MagicMock()
+    resp.headers = {"content-length": "5"}
+    with patch("esphome.net_retry.http_request", return_value=resp) as mock_head:
+        jobs = pf._uri_jobs(
+            m,
+            [
+                _FakeSpec(uri="https://x/a.zip", name="a"),
+                _FakeSpec(uri="https://x/a.zip", name="a"),
+            ],
+            set(),
+        )
+    assert len(jobs) == 1
+    mock_head.assert_called_once()
+
+
 def test_uri_jobs_skips_installed_cached_and_seen(tmp_path: Path) -> None:
     m = _fake_manager(tmp_path)
     m.get_package.return_value = object()
@@ -175,38 +199,24 @@ def test_uri_jobs_skips_installed_cached_and_seen(tmp_path: Path) -> None:
     )
 
 
-def test_resume_fetch_job_threads_tracker(tmp_path: Path) -> None:
-    """The batch runner passes the tracker positionally; the shared adapter
-    must deliver it as download_with_resume's progress keyword."""
-    from esphome.framework_helpers import resume_fetch_job
-
-    with patch("esphome.framework_helpers.download_with_resume") as mock_download:
-        fetch = resume_fetch_job("https://x/a.zip", tmp_path / "a", sha256="ff", size=9)
-        tracker = lambda done: None  # noqa: E731
-        fetch(tracker)
-    mock_download.assert_called_once_with(
-        "https://x/a.zip", tmp_path / "a", progress=tracker, sha256="ff", size=9
-    )
-
-
-def test_warn_prefetch_failures_names_each_failure(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """The shared failure loop warns per job with the failure reason."""
-    from esphome.framework_helpers import warn_prefetch_failures
-
-    warn_prefetch_failures([("toolchain-x@1", OSError("down"))])
-    assert "Could not prefetch toolchain-x@1: down" in caplog.text
-    warn_prefetch_failures([("lib", OSError("gone"))], "Prefetch of %s failed: %s")
-    assert "Prefetch of lib failed: gone" in caplog.text
-
-
 def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
-    """The prefetch runs in a subprocess (platform setup code may rewrite
-    the interpreter's sys.path) with pio run's libdeps dir."""
+    """The prefetch heals the PlatformIO cache first (a later Python-version
+    wipe would discard what it warms), then runs in a subprocess (platform
+    setup code may rewrite the interpreter's sys.path) with pio run's
+    libdeps dir and no leaked PYTHONPATH."""
     proc = MagicMock(returncode=0)
-    with patch.object(pf.subprocess, "run", return_value=proc) as mock_run:
+    order = MagicMock()
+    order.run.return_value = proc
+    with (
+        patch(
+            "esphome.platformio.toolchain.heal_platformio_python_env",
+            order.heal,
+        ),
+        patch.object(pf.subprocess, "run", order.run) as mock_run,
+        patch.dict("os.environ", {"PYTHONPATH": "/leak"}),
+    ):
         pf.prefetch_platformio_packages()
+    assert [c[0] for c in order.mock_calls[:2]] == ["heal", "run"]
     (cmd,), kwargs = mock_run.call_args
     assert cmd == [
         sys.executable,
@@ -218,11 +228,15 @@ def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
     assert kwargs["env"]["PLATFORMIO_LIBDEPS_DIR"] == str(
         CORE.relative_piolibdeps_path().absolute()
     )
+    assert "PYTHONPATH" not in kwargs["env"]
 
 
 def test_prefetch_nonzero_exit_warns(caplog: pytest.LogCaptureFixture) -> None:
     proc = MagicMock(returncode=3)
-    with patch.object(pf.subprocess, "run", return_value=proc):
+    with (
+        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
+        patch.object(pf.subprocess, "run", return_value=proc),
+    ):
         pf.prefetch_platformio_packages()
     assert "prefetch skipped (exit 3)" in caplog.text
 
@@ -231,7 +245,10 @@ def test_prefetch_launch_failure_never_raises(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Any spawn failure is one warning, never a build failure."""
-    with patch.object(pf.subprocess, "run", side_effect=OSError("no exec")):
+    with (
+        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
+        patch.object(pf.subprocess, "run", side_effect=OSError("no exec")),
+    ):
         pf.prefetch_platformio_packages()
     assert "PlatformIO package prefetch skipped" in caplog.text
 
@@ -261,6 +278,11 @@ def test_prefetch_no_platform_returns(tmp_path: Path) -> None:
 
 
 def _pio_modules(tmp_path: Path, fake_platform, fake_pm, config, lib_captures=None):
+    def fake_lib_manager(storage_dir):
+        if lib_captures is not None:
+            lib_captures.append(storage_dir)
+        return _fake_manager(tmp_path)
+
     modules = {
         "platformio": MagicMock(),
         "platformio.app": MagicMock(),
@@ -275,10 +297,7 @@ def _pio_modules(tmp_path: Path, fake_platform, fake_pm, config, lib_captures=No
         "platformio.package": MagicMock(),
         "platformio.package.manager": MagicMock(),
         "platformio.package.manager.library": SimpleNamespace(
-            LibraryPackageManager=lambda storage_dir: (
-                lib_captures.append(storage_dir) if lib_captures is not None else None,
-                _fake_manager(tmp_path),
-            )[1]
+            LibraryPackageManager=fake_lib_manager
         ),
         "platformio.package.manager.platform": SimpleNamespace(
             PlatformPackageManager=lambda: fake_pm
@@ -301,19 +320,28 @@ def _pio_modules(tmp_path: Path, fake_platform, fake_pm, config, lib_captures=No
 
 def _fake_config(tmp_path: Path, env_options: dict):
     config = MagicMock()
-    options = {"libdeps_dir": str(tmp_path / "libdeps"), **env_options}
+    options = {
+        "libdeps_dir": str(tmp_path / "libdeps"),
+        "packages_dir": str(tmp_path / "packages"),
+        **env_options,
+    }
     config.get.side_effect = lambda section, key, default=None: options.get(
         key, default
     )
     return config
 
 
-def test_prefetch_all_cached_is_quiet(tmp_path: Path) -> None:
-    """With nothing to download the prefetch neither logs nor batches."""
+def test_prefetch_all_cached_is_quiet_and_writes_sentinel(tmp_path: Path) -> None:
+    """With nothing to download the prefetch neither logs nor batches, and
+    records a sentinel so the parent skips the next spawn."""
     _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    (tmp_path / "packages").mkdir()
+    (tmp_path / "libdeps" / "testenv").mkdir(parents=True)
     fake_platform = MagicMock()
     fake_platform.packages = {}
-    config = _fake_config(tmp_path, {"platform": "fake/p@1"})
+    config = _fake_config(
+        tmp_path, {"platform": "fake/p@1", "lib_deps": ["esphome/noise-c@1.0"]}
+    )
     modules = _pio_modules(tmp_path, fake_platform, MagicMock(), config)
     with (
         patch.dict("sys.modules", modules),
@@ -323,6 +351,49 @@ def test_prefetch_all_cached_is_quiet(tmp_path: Path) -> None:
     ):
         pf._prefetch(tmp_path, "testenv")
     mock_batch.assert_not_called()
+    assert pf._prefetch_is_warm(tmp_path)
+
+
+def test_sentinel_invalidation(tmp_path: Path) -> None:
+    """The sentinel stops matching when the ini changes or a recorded dir
+    disappears; garbage sentinels read as cold."""
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    pkg_dir = tmp_path / "packages"
+    pkg_dir.mkdir()
+    assert not pf._prefetch_is_warm(tmp_path)  # no sentinel yet
+    (tmp_path / pf._SENTINEL_NAME).write_text(
+        __import__("json").dumps(
+            {**pf._sentinel_state(tmp_path), "dirs": [str(pkg_dir)]}
+        ),
+        encoding="utf-8",
+    )
+    assert pf._prefetch_is_warm(tmp_path)
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@2\n")
+    assert not pf._prefetch_is_warm(tmp_path)  # ini changed
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    pkg_dir.rmdir()
+    assert not pf._prefetch_is_warm(tmp_path)  # recorded dir gone
+    (tmp_path / pf._SENTINEL_NAME).write_text("not json", encoding="utf-8")
+    assert not pf._prefetch_is_warm(tmp_path)
+
+
+def test_prefetch_warm_sentinel_skips_spawn(tmp_path: Path) -> None:
+    """A valid sentinel skips the subprocess entirely."""
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    pkg_dir = tmp_path / "packages"
+    pkg_dir.mkdir()
+    (tmp_path / pf._SENTINEL_NAME).write_text(
+        __import__("json").dumps(
+            {**pf._sentinel_state(tmp_path), "dirs": [str(pkg_dir)]}
+        ),
+        encoding="utf-8",
+    )
+    with (
+        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
+        patch.object(pf.subprocess, "run") as mock_run,
+    ):
+        pf.prefetch_platformio_packages()
+    mock_run.assert_not_called()
 
 
 def test_prefetch_end_to_end_wiring(
@@ -357,6 +428,7 @@ def test_prefetch_end_to_end_wiring(
     )
     lib_dirs: list[str] = []
     modules = _pio_modules(tmp_path, fake_platform, fake_pm, config, lib_dirs)
+    (tmp_path / pf._SENTINEL_NAME).write_text("{}", encoding="utf-8")
     captured: dict = {}
 
     def fake_registry_jobs(manager, specs, seen):
@@ -375,6 +447,7 @@ def test_prefetch_end_to_end_wiring(
     ):
         pf._prefetch(tmp_path, "testenv")
     fake_pm.install.assert_called_once_with("fake/platform@1.0", skip_dependencies=True)
+    assert not (tmp_path / pf._SENTINEL_NAME).exists()  # stale sentinel removed
     fake_platform.configure_project_packages.assert_called_once_with("testenv", ["run"])
     assert bogus not in sys.path
     # non-optional platform package + tool-scons (never piohome), then libs

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -164,11 +164,12 @@ def test_registry_jobs_all_failed_warns_once(
             set(),
         )
     assert (jobs, failed) == ([], 2)
-    assert "Could not resolve any of 2" in caplog.text
+    assert "Could not resolve 2 of 2" in caplog.text
 
 
 def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
-    """Checksum-less URL archives land via a process-unique rename."""
+    """Checksum-less URL archives land via a locked staging file and an
+    atomic rename (the stable name is what keeps .part resume working)."""
     dl_path = tmp_path / "archive"
 
     def fake_download(url, dest, progress=None, **kwargs):
@@ -183,6 +184,30 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     # (filelock removes it on release on some platforms)
     leftovers = {f.name for f in tmp_path.iterdir()}
     assert leftovers - {f"{dl_path.name}.prefetch.lock"} == {dl_path.name}
+
+
+def test_uri_fetch_job_lock_timeout_skips(tmp_path: Path) -> None:
+    """A held or unavailable lock skips the job; pio downloads it later."""
+    from filelock import Timeout
+
+    dl_path = tmp_path / "archive"
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
+    ):
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+    mock_download.assert_not_called()
+    assert not dl_path.exists()
+
+
+def test_main_bad_log_level_falls_back(tmp_path: Path) -> None:
+    with (
+        patch.dict("os.environ", {"ESPHOME_PREFETCH_LOG_LEVEL": "verbose"}),
+        patch.object(pf.logging, "basicConfig") as mock_config,
+        patch.object(pf, "_prefetch"),
+    ):
+        assert pf.main([str(tmp_path), "testenv"]) == 0
+    assert mock_config.call_args[1]["level"] == pf.logging.INFO
 
 
 def test_uri_fetch_job_skips_when_another_process_won(tmp_path: Path) -> None:
@@ -238,20 +263,21 @@ def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
 
 
 def test_uri_jobs_head_failure_counts_as_unresolved(tmp_path: Path) -> None:
-    """HEAD errors and error responses both count as unresolved."""
+    """Network errors and transient statuses count as unresolved (and warn);
+    a permanent error status is a clean skip so the sentinel can still be
+    written."""
     m = _fake_manager(tmp_path)
+    spec = [_FakeSpec(uri="https://x/a.zip", name="a")]
     with patch("esphome.net_retry.http_request", side_effect=OSError("no route")):
-        assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == (
-            [],
-            1,
-        )
-    resp = MagicMock(ok=False, status_code=404)
+        assert pf._uri_jobs(m, spec, set()) == ([], 1)
+    resp = MagicMock(ok=False, status_code=503)
     resp.headers = {"content-length": "999"}
     with patch("esphome.net_retry.http_request", return_value=resp):
-        assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == (
-            [],
-            1,
-        )
+        assert pf._uri_jobs(m, spec, set()) == ([], 1)
+    resp = MagicMock(ok=False, status_code=405)
+    resp.headers = {"content-length": "999"}
+    with patch("esphome.net_retry.http_request", return_value=resp):
+        assert pf._uri_jobs(m, spec, set()) == ([], 0)
 
 
 def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -228,7 +228,10 @@ def test_registry_fetch_job_downloads_under_lock(tmp_path: Path) -> None:
     with (
         patch(
             "esphome.framework_helpers.download_with_resume",
-            side_effect=lambda url, dest, progress=None, **kw: order.append("fetch"),
+            side_effect=lambda url, dest, progress=None, **kw: (
+                order.append("fetch"),
+                Path(dest).write_bytes(b"data"),  # registration needs a real file
+            ),
         ),
         patch(
             "filelock.FileLock.acquire",
@@ -424,6 +427,23 @@ def test_lock_deadline_leaves_download_to_the_holder(tmp_path: Path) -> None:
     assert not dl_path.exists()
 
 
+def test_registry_lock_deadline_skips_registration(tmp_path: Path) -> None:
+    """A registry job that lost the download race to another process
+    must not stamp a nonexistent archive into pio's usage.db."""
+    manager = MagicMock()
+    dl_path = tmp_path / "archive"
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
+        patch.object(pf, "_DOWNLOAD_LOCK_TIMEOUT", 0),
+    ):
+        pf._registry_fetch_job(manager, "https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            lambda done: None
+        )
+    mock_download.assert_not_called()
+    manager.set_download_utime.assert_not_called()
+
+
 def test_main_interrupt_exits_quietly(tmp_path: Path) -> None:
     """Ctrl-C reaches the child via the shared process group; it must exit
     without a traceback."""
@@ -559,6 +579,11 @@ def test_uri_jobs_head_failure_counts_as_unresolved(
     with patch("esphome.net_retry.http_request", side_effect=OSError("no route")):
         assert pf._uri_jobs(m, spec, set()) == ([], 1)
     resp = MagicMock(ok=False, status_code=503)
+    resp.headers = {"content-length": "999"}
+    with patch("esphome.net_retry.http_request", return_value=resp):
+        assert pf._uri_jobs(m, spec, set()) == ([], 1)
+    # 403 is how registries rate-limit; it must not be cached as warm
+    resp = MagicMock(ok=False, status_code=403)
     resp.headers = {"content-length": "999"}
     with patch("esphome.net_retry.http_request", return_value=resp):
         assert pf._uri_jobs(m, spec, set()) == ([], 1)

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -194,7 +194,7 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     with patch(
         "esphome.framework_helpers.download_with_resume", side_effect=fake_download
     ):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
     assert dl_path.read_bytes() == b"data"
     # no orphaned staging file; the lock file may or may not persist
     # (filelock removes it on release on some platforms)
@@ -207,9 +207,9 @@ def test_registry_fetch_job_skips_when_cached(tmp_path: Path) -> None:
     dl_path = tmp_path / "archive"
     dl_path.write_bytes(b"done")
     with patch("esphome.framework_helpers.download_with_resume") as mock_download:
-        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
-            lambda done: None
-        )
+        pf._registry_fetch_job(
+            MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
+        )(lambda done: None)
     mock_download.assert_not_called()
     assert dl_path.read_bytes() == b"done"
 
@@ -233,9 +233,9 @@ def test_registry_fetch_job_downloads_under_lock(tmp_path: Path) -> None:
             side_effect=lambda *a, **k: order.append("unlock"),
         ),
     ):
-        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
-            lambda done: None
-        )
+        pf._registry_fetch_job(
+            MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
+        )(lambda done: None)
     # FileLock.__del__ may add a trailing release; the contract is the order
     assert order[:2] == ["lock", "fetch"]
     assert "unlock" in order[2:]
@@ -255,9 +255,9 @@ def test_lockless_filesystem_downloads_unlocked(
         ),
         patch("filelock.FileLock.release"),
     ):
-        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
-            lambda done: None
-        )
+        pf._registry_fetch_job(
+            MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
+        )(lambda done: None)
     mock_download.assert_called_once()
     assert "downloading unlocked" in caplog.text
 
@@ -274,7 +274,7 @@ def test_uri_fetch_job_failed_download_keeps_staging(tmp_path: Path) -> None:
         ),
         pytest.raises(OSError, match="network gone"),
     ):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
     assert part.read_bytes() == b"partial"
     assert not dl_path.exists()
 
@@ -291,9 +291,9 @@ def test_lock_real_fault_is_a_counted_failure(tmp_path: Path) -> None:
         ),
         pytest.raises(OSError),
     ):
-        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
-            lambda done: None
-        )
+        pf._registry_fetch_job(
+            MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
+        )(lambda done: None)
     mock_download.assert_not_called()
 
 
@@ -311,7 +311,9 @@ def test_uri_fetch_job_rejects_wrong_length(tmp_path: Path) -> None:
         ),
         pytest.raises(ValueError, match="expected 9999 bytes"),
     ):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 9999)(lambda done: None)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 9999)(
+            lambda done: None
+        )
     assert not dl_path.exists()
     assert not (tmp_path / "archive.prefetch").exists()
 
@@ -335,6 +337,39 @@ def test_sweep_stale_sidecars(tmp_path: Path) -> None:
     pf._sweep_stale_sidecars(tmp_path / "missing")  # tolerated
 
 
+def test_sweep_logs_unprunable_files(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sidecar that cannot be removed leaves a trace; a sweep that never
+    prunes must not look like a clean sweep."""
+    old_time = pf.time.time() - pf._SIDECAR_EXPIRE_SECONDS - 10
+    stale = tmp_path / "a.tar.gz.part"
+    stale.write_bytes(b"x")
+    os.utime(stale, (old_time, old_time))
+    with (
+        patch.object(Path, "unlink", side_effect=OSError("busy")),
+        caplog.at_level(pf.logging.DEBUG),
+    ):
+        pf._sweep_stale_sidecars(tmp_path)
+    assert "Could not remove" in caplog.text
+
+
+def test_uri_lock_failure_is_a_counted_failure(tmp_path: Path) -> None:
+    """The checksum-less URL path never degrades to an unlocked shared
+    write; interleaved right-length corruption would go undetected."""
+    dl_path = tmp_path / "archive"
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch(
+            "filelock.FileLock.acquire",
+            side_effect=OSError(errno.ENOSYS, "no locks"),
+        ),
+        pytest.raises(OSError),
+    ):
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
+    mock_download.assert_not_called()
+
+
 def test_uri_fetch_job_no_discard_without_a_file(tmp_path: Path) -> None:
     """When no archive landed (degraded serialized run), the staging bytes
     stay for the next resume instead of being discarded."""
@@ -342,7 +377,7 @@ def test_uri_fetch_job_no_discard_without_a_file(tmp_path: Path) -> None:
     part = tmp_path / "archive.prefetch.part"
     part.write_bytes(b"partial")
     with patch.object(pf, "_serialized_fetch_job", return_value=lambda tracker: None):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
     assert part.read_bytes() == b"partial"
 
 
@@ -362,7 +397,7 @@ def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
         patch("filelock.FileLock.acquire", side_effect=[Timeout("held"), None]),
         patch("filelock.FileLock.release"),
     ):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
     assert dl_path.read_bytes() == b"data"
 
 
@@ -379,7 +414,7 @@ def test_uri_fetch_job_lock_timeout_raises(tmp_path: Path) -> None:
         patch.object(pf, "_URI_LOCK_TIMEOUT", 0),
         pytest.raises(TimeoutError, match="another download"),
     ):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(ticks.append)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
     mock_download.assert_not_called()
     assert ticks == [0]
     assert not dl_path.exists()
@@ -432,7 +467,7 @@ def test_uri_fetch_job_skips_when_another_process_won(tmp_path: Path) -> None:
     for f in stale:
         f.write_bytes(b"stale")
     with patch("esphome.framework_helpers.download_with_resume") as mock_download:
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
     mock_download.assert_not_called()
     assert dl_path.read_bytes() == b"done"
     assert not any(f.exists() for f in stale)

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -18,7 +18,6 @@ import esphome.platformio.prefetch as pf
 @pytest.fixture(autouse=True)
 def _core(tmp_path: Path):
     CORE.reset()
-    pf._REGISTER_FAILURES.clear()
     CORE.build_path = str(tmp_path)
     CORE.name = "testenv"
     pio_loggers = ("Tool Manager", "Library Manager", "Platform Manager")
@@ -288,24 +287,6 @@ def test_uri_fetch_job_failed_download_keeps_staging(tmp_path: Path) -> None:
     assert not dl_path.exists()
 
 
-def test_lock_real_fault_is_a_counted_failure(tmp_path: Path) -> None:
-    """EACCES on the lock is a real fault, not a lock-less filesystem; an
-    unlocked shared write is not a safe fallback."""
-    dl_path = tmp_path / "archive"
-    with (
-        patch("esphome.framework_helpers.download_with_resume") as mock_download,
-        patch(
-            "filelock.FileLock.acquire",
-            side_effect=OSError(errno.EACCES, "denied"),
-        ),
-        pytest.raises(OSError),
-    ):
-        pf._registry_fetch_job(
-            MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
-        )(lambda done: None)
-    mock_download.assert_not_called()
-
-
 def test_uri_fetch_job_rejects_wrong_length(tmp_path: Path) -> None:
     """A checksum-less body of the wrong length is never published under a
     cache key pio would trust forever."""
@@ -330,7 +311,7 @@ def test_uri_fetch_job_rejects_wrong_length(tmp_path: Path) -> None:
 def test_sweep_stale_sidecars(tmp_path: Path) -> None:
     """Sidecars past pio's own expiry are pruned; fresh and foreign files
     stay."""
-    old_time = pf.time.time() - pf._SIDECAR_EXPIRE_SECONDS - 10
+    old_time = pf.time.time() - 110
     stale = tmp_path / "a.tar.gz.part"
     stale.write_bytes(b"x")
     os.utime(stale, (old_time, old_time))
@@ -344,12 +325,12 @@ def test_sweep_stale_sidecars(tmp_path: Path) -> None:
     held_lock = tmp_path / "d.tar.gz.esphome.lock"
     held_lock.write_bytes(b"")
     os.utime(held_lock, (old_time, old_time))
-    pf._sweep_stale_sidecars(tmp_path)
+    pf._sweep_stale_sidecars(tmp_path, 100)
     assert not stale.exists()
     assert fresh.exists()
     assert keep.exists()
     assert held_lock.exists()
-    pf._sweep_stale_sidecars(tmp_path / "missing")  # tolerated
+    pf._sweep_stale_sidecars(tmp_path / "missing", 100)  # tolerated
 
 
 def test_register_download_failure_leaves_a_trace(
@@ -364,34 +345,12 @@ def test_register_download_failure_leaves_a_trace(
     assert "Could not register" in caplog.text
 
 
-def test_register_failures_warn_once(caplog: pytest.LogCaptureFixture) -> None:
-    """Systematic registration failures surface once per run."""
-    pf._warn_register_failures()
-    assert "could not be registered" not in caplog.text
-    pf._REGISTER_FAILURES.extend(["a.tar.gz", "b.tar.gz"])
-    pf._warn_register_failures()
-    assert "2 archive(s) could not be registered" in caplog.text
-
-
-def test_main_malformed_log_level_warns(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A wiring break must not silently drop -v propagation."""
-    with (
-        patch.dict("os.environ", {"ESPHOME_PREFETCH_LOG_LEVEL": "verbose"}),
-        patch("esphome.log.setup_log"),
-        patch.object(pf, "_prefetch"),
-    ):
-        assert pf.main([str(tmp_path), "testenv"]) == 0
-    assert "malformed prefetch log level" in caplog.text
-
-
 def test_sweep_logs_unprunable_files(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A sidecar that cannot be removed leaves a trace; a sweep that never
     prunes must not look like a clean sweep."""
-    old_time = pf.time.time() - pf._SIDECAR_EXPIRE_SECONDS - 10
+    old_time = pf.time.time() - 110
     stale = tmp_path / "a.tar.gz.part"
     stale.write_bytes(b"x")
     os.utime(stale, (old_time, old_time))
@@ -399,7 +358,7 @@ def test_sweep_logs_unprunable_files(
         patch.object(Path, "unlink", side_effect=OSError("busy")),
         caplog.at_level(pf.logging.DEBUG),
     ):
-        pf._sweep_stale_sidecars(tmp_path)
+        pf._sweep_stale_sidecars(tmp_path, 100)
     assert "Could not remove" in caplog.text
 
 
@@ -583,8 +542,8 @@ def test_uri_jobs_head_failure_counts_as_unresolved(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Network errors and transient statuses count as unresolved (and warn);
-    a permanent error status is a clean skip so the sentinel can still be
-    written."""
+    any permanent error status is a clean skip so the sentinel can still
+    be written (pio run names a broken URL when it downloads)."""
     m = _fake_manager(tmp_path)
     spec = [_FakeSpec(uri="https://x/a.zip", name="a")]
     with patch("esphome.net_retry.http_request", side_effect=OSError("no route")):
@@ -598,13 +557,11 @@ def test_uri_jobs_head_failure_counts_as_unresolved(
     with patch("esphome.net_retry.http_request", return_value=resp):
         assert pf._uri_jobs(m, spec, set()) == ([], 0)
     assert "HEAD https://x/a.zip" not in caplog.text
-    # A real URL problem is named, but stays a clean skip so the warm
-    # sentinel is not disabled forever
     resp = MagicMock(ok=False, status_code=404)
     resp.headers = {"content-length": "999"}
     with patch("esphome.net_retry.http_request", return_value=resp):
         assert pf._uri_jobs(m, spec, set()) == ([], 0)
-    assert "HEAD https://x/a.zip returned 404" in caplog.text
+    assert "returned 404" not in caplog.text
 
 
 def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -135,6 +135,49 @@ def test_registry_jobs_uri_specs_excluded(tmp_path: Path) -> None:
     m.search_registry_packages.assert_not_called()
 
 
+def test_registry_jobs_dedup_keeps_distinct_owners(tmp_path: Path) -> None:
+    """platformio/x and pioarduino/x are different packages."""
+    m = _fake_manager(tmp_path)
+    specs = [
+        _FakeSpec(uri=None, name="framework-x", owner="platformio"),
+        _FakeSpec(uri=None, name="framework-x", owner="pioarduino"),
+    ]
+    with _mirror_patch():
+        pf._registry_jobs(m, specs, set())
+    assert m.search_registry_packages.call_count == 2
+
+
+def test_registry_jobs_all_failed_warns_once(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A whole-batch failure is a systemic fault and must be visible."""
+    m = _fake_manager(tmp_path)
+    m.search_registry_packages.side_effect = RuntimeError("registry down")
+    with _mirror_patch():
+        jobs, failed = pf._registry_jobs(
+            m,
+            [_FakeSpec(uri=None, name="a"), _FakeSpec(uri=None, name="b")],
+            set(),
+        )
+    assert (jobs, failed) == ([], 2)
+    assert "Could not resolve any of 2" in caplog.text
+
+
+def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
+    """Checksum-less URL archives land via a process-unique rename."""
+    dl_path = tmp_path / "archive"
+
+    def fake_download(url, dest, progress=None, **kwargs):
+        Path(dest).write_bytes(b"data")
+
+    with patch(
+        "esphome.framework_helpers.download_with_resume", side_effect=fake_download
+    ):
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+    assert dl_path.read_bytes() == b"data"
+    assert list(tmp_path.iterdir()) == [dl_path]
+
+
 def test_registry_jobs_one_bad_spec_keeps_the_rest(tmp_path: Path) -> None:
     """A flaky resolution counts as failed without discarding the batch."""
     m = _fake_manager(tmp_path)
@@ -170,22 +213,28 @@ def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
         )
     assert failed == 0
     assert [(n, s) for n, s, _ in jobs] == [("big", 2222)]
+    # a successful HEAD with no Content-Length is a clean skip
+    resp.headers = {}
+    with patch("esphome.net_retry.http_request", return_value=resp):
+        assert pf._uri_jobs(
+            m, [_FakeSpec(uri="https://x/nolen.zip", name="nolen")], set()
+        ) == ([], 0)
 
 
 def test_uri_jobs_head_failure_counts_as_unresolved(tmp_path: Path) -> None:
-    """A HEAD error is not a clean skip; an error response's length is."""
+    """HEAD errors and error responses both count as unresolved."""
     m = _fake_manager(tmp_path)
     with patch("esphome.net_retry.http_request", side_effect=OSError("no route")):
         assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == (
             [],
             1,
         )
-    resp = MagicMock(ok=False)
+    resp = MagicMock(ok=False, status_code=404)
     resp.headers = {"content-length": "999"}
     with patch("esphome.net_retry.http_request", return_value=resp):
         assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == (
             [],
-            0,
+            1,
         )
 
 
@@ -225,7 +274,7 @@ def test_uri_jobs_skips_installed_cached_and_seen(tmp_path: Path) -> None:
 
 def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
     """Heal runs first, then the subprocess spawns with pio run's libdeps
-    dir and no leaked PYTHONPATH."""
+    dir and the parent's PYTHONPATH preserved (the child is esphome)."""
     proc = MagicMock(returncode=0)
     order = MagicMock()
     order.run.return_value = proc

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -354,6 +354,32 @@ def test_register_download_failure_leaves_a_trace(
     assert "Could not register" in caplog.text
 
 
+def test_register_failures_warn_once(caplog: pytest.LogCaptureFixture) -> None:
+    """Systematic registration failures surface once per run."""
+    pf._REGISTER_FAILURES.clear()
+    pf._warn_register_failures()
+    assert "could not be registered" not in caplog.text
+    pf._REGISTER_FAILURES.extend(["a.tar.gz", "b.tar.gz"])
+    try:
+        pf._warn_register_failures()
+    finally:
+        pf._REGISTER_FAILURES.clear()
+    assert "2 archive(s) could not be registered" in caplog.text
+
+
+def test_main_malformed_log_level_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A wiring break must not silently drop -v propagation."""
+    with (
+        patch.dict("os.environ", {"ESPHOME_PREFETCH_LOG_LEVEL": "verbose"}),
+        patch("esphome.log.setup_log"),
+        patch.object(pf, "_prefetch"),
+    ):
+        assert pf.main([str(tmp_path), "testenv"]) == 0
+    assert "malformed prefetch log level" in caplog.text
+
+
 def test_sweep_logs_unprunable_files(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -650,6 +676,8 @@ def test_prefetch_passes_dashboard_flag(tmp_path: Path) -> None:
             "prefetch timed out",
         ),
         ({"return_value": MagicMock(returncode=4)}, "prefetch skipped (exit 4)"),
+        # Exit 1 is the interpreter's own import-failure code, never quiet
+        ({"return_value": MagicMock(returncode=1)}, "prefetch skipped (exit 1)"),
         ({"side_effect": OSError("no exec")}, "PlatformIO package prefetch skipped"),
     ],
 )
@@ -668,8 +696,8 @@ def test_prefetch_spawn_failures_warn_and_continue(
 def test_prefetch_child_handled_failure_is_quiet(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Exit 1 means the child already warned with the reason; the parent
-    adds no second warning."""
+    """Exit _EXIT_HANDLED (3) means the child already warned with the
+    reason; the parent adds no second warning."""
     with (
         patch("esphome.platformio.toolchain.heal_platformio_python_env"),
         patch.object(

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -8,6 +8,7 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from filelock import Timeout
 import pytest
 
 from esphome.core import CORE
@@ -429,8 +430,6 @@ def test_uri_fetch_job_no_discard_without_a_file(tmp_path: Path) -> None:
 
 def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
     """A lock freed within the deadline lets the job proceed normally."""
-    from filelock import Timeout
-
     dl_path = tmp_path / "archive"
 
     def fake_download(url, dest, progress=None, **kwargs):
@@ -450,8 +449,6 @@ def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
 def test_uri_fetch_job_lock_timeout_raises(tmp_path: Path) -> None:
     """A held lock is a counted, warned failure, and the tracker is polled
     between acquire slices so a parked worker observes cancellation."""
-    from filelock import Timeout
-
     dl_path = tmp_path / "archive"
     ticks: list[int] = []
     with (

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -168,7 +168,10 @@ def test_registry_jobs_all_failed_warns_once(
             set(),
         )
     assert (jobs, failed) == ([], 2)
+    # The aggregate warning names a cause so an API break does not read
+    # as a registry outage
     assert "Could not resolve 2 of 2" in caplog.text
+    assert "registry down" in caplog.text
 
 
 def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
@@ -190,37 +193,87 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     assert leftovers - {f"{dl_path.name}.prefetch.lock"} == {dl_path.name}
 
 
-def test_uri_fetch_job_lock_timeout_skips(tmp_path: Path) -> None:
-    """A held or unavailable lock skips the job; pio downloads it later."""
+def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
+    """A lock freed within the deadline lets the job proceed normally."""
     from filelock import Timeout
 
     dl_path = tmp_path / "archive"
+
+    def fake_download(url, dest, progress=None, **kwargs):
+        Path(dest).write_bytes(b"data")
+
+    with (
+        patch(
+            "esphome.framework_helpers.download_with_resume", side_effect=fake_download
+        ),
+        patch("filelock.FileLock.acquire", side_effect=[Timeout("held"), None]),
+        patch("filelock.FileLock.release"),
+    ):
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+    assert dl_path.read_bytes() == b"data"
+
+
+def test_uri_fetch_job_lock_timeout_raises(tmp_path: Path) -> None:
+    """A held lock is a counted, warned failure, and the tracker is polled
+    between acquire slices so a parked worker observes cancellation."""
+    from filelock import Timeout
+
+    dl_path = tmp_path / "archive"
+    ticks: list[int] = []
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
         patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
+        patch.object(pf, "_URI_LOCK_TIMEOUT", 0),
+        pytest.raises(TimeoutError, match="another download"),
     ):
-        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(ticks.append)
     mock_download.assert_not_called()
+    assert ticks == [0]
     assert not dl_path.exists()
 
 
 def test_main_bad_log_level_falls_back(tmp_path: Path) -> None:
     with (
         patch.dict("os.environ", {"ESPHOME_PREFETCH_LOG_LEVEL": "verbose"}),
-        patch.object(pf.logging, "basicConfig") as mock_config,
+        patch("esphome.log.setup_log") as mock_setup,
         patch.object(pf, "_prefetch"),
     ):
         assert pf.main([str(tmp_path), "testenv"]) == 0
-    assert mock_config.call_args[1]["level"] == pf.logging.INFO
+    assert mock_setup.call_args[0][0] == pf.logging.INFO
+
+
+def test_main_mirrors_parent_log_setup(tmp_path: Path) -> None:
+    """The child adopts the parent's dashboard flag and log formatter so
+    its warnings and progress bar match the parent's."""
+    with (
+        patch.dict(
+            "os.environ",
+            {"ESPHOME_PREFETCH_LOG_LEVEL": "30", "ESPHOME_PREFETCH_DASHBOARD": "1"},
+        ),
+        patch("esphome.log.setup_log") as mock_setup,
+        patch.object(pf, "_prefetch"),
+    ):
+        assert pf.main([str(tmp_path), "testenv"]) == 0
+    mock_setup.assert_called_once_with(30)
+    assert CORE.dashboard is True
 
 
 def test_uri_fetch_job_skips_when_another_process_won(tmp_path: Path) -> None:
+    """A lost race discards the staging files; the cache never prunes them."""
     dl_path = tmp_path / "archive"
     dl_path.write_bytes(b"done")
+    stale = [
+        tmp_path / "archive.prefetch",
+        tmp_path / "archive.prefetch.part",
+        tmp_path / "archive.prefetch.part.meta",
+    ]
+    for f in stale:
+        f.write_bytes(b"stale")
     with patch("esphome.framework_helpers.download_with_resume") as mock_download:
         pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
     mock_download.assert_not_called()
     assert dl_path.read_bytes() == b"done"
+    assert not any(f.exists() for f in stale)
 
 
 def test_registry_jobs_one_bad_spec_keeps_the_rest(tmp_path: Path) -> None:
@@ -266,7 +319,9 @@ def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
         ) == ([], 0)
 
 
-def test_uri_jobs_head_failure_counts_as_unresolved(tmp_path: Path) -> None:
+def test_uri_jobs_head_failure_counts_as_unresolved(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Network errors and transient statuses count as unresolved (and warn);
     a permanent error status is a clean skip so the sentinel can still be
     written."""
@@ -282,6 +337,14 @@ def test_uri_jobs_head_failure_counts_as_unresolved(tmp_path: Path) -> None:
     resp.headers = {"content-length": "999"}
     with patch("esphome.net_retry.http_request", return_value=resp):
         assert pf._uri_jobs(m, spec, set()) == ([], 0)
+    assert "HEAD https://x/a.zip" not in caplog.text
+    # A real URL problem is named, but stays a clean skip so the warm
+    # sentinel is not disabled forever
+    resp = MagicMock(ok=False, status_code=404)
+    resp.headers = {"content-length": "999"}
+    with patch("esphome.net_retry.http_request", return_value=resp):
+        assert pf._uri_jobs(m, spec, set()) == ([], 0)
+    assert "HEAD https://x/a.zip returned 404" in caplog.text
 
 
 def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:
@@ -348,7 +411,21 @@ def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
     # The child is esphome itself; PYTHONPATH must survive so it imports
     # the same tree (tests/integration pins the source tree through it)
     assert kwargs["env"]["PYTHONPATH"] == "/leak"
+    assert "ESPHOME_PREFETCH_DASHBOARD" not in kwargs["env"]
     assert kwargs["timeout"] == pf._PREFETCH_TIMEOUT
+
+
+def test_prefetch_passes_dashboard_flag(tmp_path: Path) -> None:
+    """The dashboard flag reaches the child so its bar still draws."""
+    CORE.dashboard = True
+    with (
+        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
+        patch.object(
+            pf.subprocess, "run", return_value=MagicMock(returncode=0)
+        ) as mock_run,
+    ):
+        pf.prefetch_platformio_packages()
+    assert mock_run.call_args[1]["env"]["ESPHOME_PREFETCH_DASHBOARD"] == "1"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -407,21 +407,31 @@ def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
     assert dl_path.read_bytes() == b"data"
 
 
-def test_uri_fetch_job_lock_timeout_raises(tmp_path: Path) -> None:
-    """A held lock is a counted, warned failure, and the tracker is polled
-    between acquire slices so a parked worker observes cancellation."""
+def test_lock_deadline_leaves_download_to_the_holder(tmp_path: Path) -> None:
+    """A lock held past the deadline means another process is fetching the
+    same file; skipping cleanly beats a misleading failure warning. The
+    tracker is still polled so a parked worker observes cancellation."""
     dl_path = tmp_path / "archive"
     ticks: list[int] = []
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
         patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
-        patch.object(pf, "_URI_LOCK_TIMEOUT", 0),
-        pytest.raises(TimeoutError, match="another download"),
+        patch.object(pf, "_DOWNLOAD_LOCK_TIMEOUT", 0),
     ):
         pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
     mock_download.assert_not_called()
     assert ticks == [0]
     assert not dl_path.exists()
+
+
+def test_main_interrupt_exits_quietly(tmp_path: Path) -> None:
+    """Ctrl-C reaches the child via the shared process group; it must exit
+    without a traceback."""
+    with (
+        patch("esphome.log.setup_log"),
+        patch.object(pf, "_prefetch", side_effect=KeyboardInterrupt),
+    ):
+        assert pf.main([str(tmp_path), "testenv"]) == 130
 
 
 def test_main_bad_log_level_falls_back(tmp_path: Path) -> None:
@@ -727,6 +737,11 @@ def test_prefetch_no_platform_returns(tmp_path: Path) -> None:
 
 
 def _pio_modules(tmp_path: Path, fake_platform, fake_pm, config, lib_captures=None):
+    # A bare MagicMock's get_download_dir would fspath to '' and point the
+    # sidecar sweep at the process cwd
+    fake_pm.get_download_dir.return_value = str(tmp_path / "downloads")
+    fake_pm.DOWNLOAD_CACHE_EXPIRE = 86400 * 30
+
     def fake_lib_manager(storage_dir):
         if lib_captures is not None:
             lib_captures.append(storage_dir)

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -23,12 +23,14 @@ def _core(tmp_path: Path):
     CORE.name = "testenv"
     pio_loggers = ("Tool Manager", "Library Manager", "Platform Manager")
     saved_propagate = {n: pf.logging.getLogger(n).propagate for n in pio_loggers}
+    saved_filters = {n: list(pf.logging.getLogger(n).filters) for n in pio_loggers}
     # The real setup_log would swap pytest's root-handler formatter
     with patch("esphome.log.setup_log"):
         yield
     # main() flips these process-wide; keep the suite hermetic
     for n, flag in saved_propagate.items():
         pf.logging.getLogger(n).propagate = flag
+        pf.logging.getLogger(n).filters[:] = saved_filters[n]
     CORE.reset()
 
 
@@ -480,6 +482,24 @@ def test_main_silences_pio_manager_propagation(tmp_path: Path) -> None:
         assert pf.main([str(tmp_path), "testenv"]) == 0
     for name in ("Tool Manager", "Library Manager", "Platform Manager"):
         assert pf.logging.getLogger(name).propagate is False
+
+
+def test_main_quiet_level_reaches_pio_manager_loggers(tmp_path: Path) -> None:
+    """Manager construction re-pins its logger to INFO, so a quiet run
+    needs the logger-level filter to keep per-package lines out."""
+    with (
+        patch.dict("os.environ", {"ESPHOME_PREFETCH_LOG_LEVEL": "30"}),
+        patch("esphome.log.setup_log"),
+        patch.object(pf, "_prefetch"),
+    ):
+        assert pf.main([str(tmp_path), "testenv"]) == 0
+    lib_logger = pf.logging.getLogger("Library Manager")
+    lib_logger.setLevel(pf.logging.INFO)  # what pio's _setup_logger does
+    info = pf.logging.LogRecord("Library Manager", 20, __file__, 1, "x", (), None)
+    warning = pf.logging.LogRecord("Library Manager", 30, __file__, 1, "x", (), None)
+    # Logger.filter returns falsy to drop, the record itself to pass
+    assert not lib_logger.filter(info)
+    assert lib_logger.filter(warning)
 
 
 def test_main_mirrors_parent_log_setup(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -191,11 +191,14 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     def fake_download(url, dest, progress=None, **kwargs):
         Path(dest).write_bytes(b"data")
 
+    manager = MagicMock()
     with patch(
         "esphome.framework_helpers.download_with_resume", side_effect=fake_download
     ):
-        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(lambda done: None)
+        pf._uri_fetch_job(manager, "https://x/a.zip", dl_path, 4)(lambda done: None)
     assert dl_path.read_bytes() == b"data"
+    # The archive is handed to pio's usage.db pruner
+    manager.set_download_utime.assert_called_once_with(str(dl_path))
     # no orphaned staging file; the lock file may or may not persist
     # (filelock removes it on release on some platforms)
     leftovers = {f.name for f in tmp_path.iterdir()}
@@ -233,12 +236,14 @@ def test_registry_fetch_job_downloads_under_lock(tmp_path: Path) -> None:
             side_effect=lambda *a, **k: order.append("unlock"),
         ),
     ):
-        pf._registry_fetch_job(
-            MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
-        )(lambda done: None)
+        manager = MagicMock()
+        pf._registry_fetch_job(manager, "https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            lambda done: None
+        )
     # FileLock.__del__ may add a trailing release; the contract is the order
     assert order[:2] == ["lock", "fetch"]
     assert "unlock" in order[2:]
+    manager.set_download_utime.assert_called_once_with(str(dl_path))
 
 
 def test_lockless_filesystem_downloads_unlocked(
@@ -335,6 +340,18 @@ def test_sweep_stale_sidecars(tmp_path: Path) -> None:
     assert fresh.exists()
     assert keep.exists()
     pf._sweep_stale_sidecars(tmp_path / "missing")  # tolerated
+
+
+def test_register_download_failure_leaves_a_trace(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed usage.db registration is traced; an unregistered archive
+    is never pruned, so silence would hide the leak coming back."""
+    manager = MagicMock()
+    manager.set_download_utime.side_effect = RuntimeError("db locked")
+    with caplog.at_level(pf.logging.DEBUG):
+        pf._register_download(manager, tmp_path / "a.tar.gz")
+    assert "Could not register" in caplog.text
 
 
 def test_sweep_logs_unprunable_files(
@@ -632,7 +649,7 @@ def test_prefetch_passes_dashboard_flag(tmp_path: Path) -> None:
             {"side_effect": pf.subprocess.TimeoutExpired("cmd", pf._PREFETCH_TIMEOUT)},
             "prefetch timed out",
         ),
-        ({"return_value": MagicMock(returncode=3)}, "prefetch skipped (exit 3)"),
+        ({"return_value": MagicMock(returncode=4)}, "prefetch skipped (exit 4)"),
         ({"side_effect": OSError("no exec")}, "PlatformIO package prefetch skipped"),
     ],
 )
@@ -655,7 +672,9 @@ def test_prefetch_child_handled_failure_is_quiet(
     adds no second warning."""
     with (
         patch("esphome.platformio.toolchain.heal_platformio_python_env"),
-        patch.object(pf.subprocess, "run", return_value=MagicMock(returncode=1)),
+        patch.object(
+            pf.subprocess, "run", return_value=MagicMock(returncode=pf._EXIT_HANDLED)
+        ),
     ):
         pf.prefetch_platformio_packages()
     assert "prefetch skipped" not in caplog.text
@@ -665,7 +684,7 @@ def test_main_guards_and_exits_nonzero(caplog: pytest.LogCaptureFixture) -> None
     """A swallowed failure still reaches the parent as a nonzero exit; the
     parent warns and continues, never failing the build."""
     with patch.object(pf, "_prefetch", side_effect=RuntimeError("boom")):
-        assert pf.main(["/b", "testenv"]) == 1
+        assert pf.main(["/b", "testenv"]) == pf._EXIT_HANDLED
     assert "PlatformIO package prefetch skipped" in caplog.text
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -19,7 +19,9 @@ def _core(tmp_path: Path):
     CORE.name = "testenv"
     pio_loggers = ("Tool Manager", "Library Manager", "Platform Manager")
     saved_propagate = {n: pf.logging.getLogger(n).propagate for n in pio_loggers}
-    yield
+    # The real setup_log would swap pytest's root-handler formatter
+    with patch("esphome.log.setup_log"):
+        yield
     # main() flips these process-wide; keep the suite hermetic
     for n, flag in saved_propagate.items():
         pf.logging.getLogger(n).propagate = flag
@@ -196,6 +198,91 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     # (filelock removes it on release on some platforms)
     leftovers = {f.name for f in tmp_path.iterdir()}
     assert leftovers - {f"{dl_path.name}.prefetch.lock"} == {dl_path.name}
+
+
+def test_registry_fetch_job_skips_when_cached(tmp_path: Path) -> None:
+    """A destination another process completed is not re-downloaded."""
+    dl_path = tmp_path / "archive"
+    dl_path.write_bytes(b"done")
+    with patch("esphome.framework_helpers.download_with_resume") as mock_download:
+        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            lambda done: None
+        )
+    mock_download.assert_not_called()
+    assert dl_path.read_bytes() == b"done"
+
+
+def test_registry_fetch_job_downloads_under_lock(tmp_path: Path) -> None:
+    """Registry downloads write the shared cache path under the same lock
+    the URL path uses; interleaved writers would corrupt the archive."""
+    dl_path = tmp_path / "archive"
+    order: list[str] = []
+    with (
+        patch(
+            "esphome.framework_helpers.download_with_resume",
+            side_effect=lambda url, dest, progress=None, **kw: order.append("fetch"),
+        ),
+        patch(
+            "filelock.FileLock.acquire",
+            side_effect=lambda *a, **k: order.append("lock"),
+        ),
+        patch(
+            "filelock.FileLock.release",
+            side_effect=lambda *a, **k: order.append("unlock"),
+        ),
+    ):
+        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            lambda done: None
+        )
+    # FileLock.__del__ may add a trailing release; the contract is the order
+    assert order[:2] == ["lock", "fetch"]
+    assert "unlock" in order[2:]
+
+
+def test_lockless_filesystem_downloads_unlocked(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A filesystem without lock support (ENOSYS/EPERM) degrades to an
+    unlocked download with one warning, never a per-package failure."""
+    dl_path = tmp_path / "archive"
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch("filelock.FileLock.acquire", side_effect=OSError("ENOSYS")),
+        patch("filelock.FileLock.release"),
+    ):
+        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            lambda done: None
+        )
+    mock_download.assert_called_once()
+    assert "downloading unlocked" in caplog.text
+
+
+def test_uri_fetch_job_failed_download_keeps_staging(tmp_path: Path) -> None:
+    """A failed fetch keeps the .part staging bytes for the next resume."""
+    dl_path = tmp_path / "archive"
+    part = tmp_path / "archive.prefetch.part"
+    part.write_bytes(b"partial")
+    with (
+        patch(
+            "esphome.framework_helpers.download_with_resume",
+            side_effect=OSError("network gone"),
+        ),
+        pytest.raises(OSError, match="network gone"),
+    ):
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+    assert part.read_bytes() == b"partial"
+    assert not dl_path.exists()
+
+
+def test_uri_fetch_job_no_discard_without_a_file(tmp_path: Path) -> None:
+    """When no archive landed (degraded serialized run), the staging bytes
+    stay for the next resume instead of being discarded."""
+    dl_path = tmp_path / "archive"
+    part = tmp_path / "archive.prefetch.part"
+    part.write_bytes(b"partial")
+    with patch.object(pf, "_serialized_fetch_job", return_value=lambda tracker: None):
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+    assert part.read_bytes() == b"partial"
 
 
 def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1,6 +1,8 @@
 """Tests for the parallel PlatformIO package prefetch."""
 
+import errno
 import json
+import os
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -247,7 +249,10 @@ def test_lockless_filesystem_downloads_unlocked(
     dl_path = tmp_path / "archive"
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
-        patch("filelock.FileLock.acquire", side_effect=OSError("ENOSYS")),
+        patch(
+            "filelock.FileLock.acquire",
+            side_effect=OSError(errno.ENOSYS, "no locks"),
+        ),
         patch("filelock.FileLock.release"),
     ):
         pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
@@ -272,6 +277,62 @@ def test_uri_fetch_job_failed_download_keeps_staging(tmp_path: Path) -> None:
         pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
     assert part.read_bytes() == b"partial"
     assert not dl_path.exists()
+
+
+def test_lock_real_fault_is_a_counted_failure(tmp_path: Path) -> None:
+    """EACCES on the lock is a real fault, not a lock-less filesystem; an
+    unlocked shared write is not a safe fallback."""
+    dl_path = tmp_path / "archive"
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch(
+            "filelock.FileLock.acquire",
+            side_effect=OSError(errno.EACCES, "denied"),
+        ),
+        pytest.raises(OSError),
+    ):
+        pf._registry_fetch_job("https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            lambda done: None
+        )
+    mock_download.assert_not_called()
+
+
+def test_uri_fetch_job_rejects_wrong_length(tmp_path: Path) -> None:
+    """A checksum-less body of the wrong length is never published under a
+    cache key pio would trust forever."""
+    dl_path = tmp_path / "archive"
+
+    def fake_download(url, dest, progress=None, **kwargs):
+        Path(dest).write_bytes(b"short")
+
+    with (
+        patch(
+            "esphome.framework_helpers.download_with_resume", side_effect=fake_download
+        ),
+        pytest.raises(ValueError, match="expected 9999 bytes"),
+    ):
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 9999)(lambda done: None)
+    assert not dl_path.exists()
+    assert not (tmp_path / "archive.prefetch").exists()
+
+
+def test_sweep_stale_sidecars(tmp_path: Path) -> None:
+    """Sidecars past pio's own expiry are pruned; fresh and foreign files
+    stay."""
+    old_time = pf.time.time() - pf._SIDECAR_EXPIRE_SECONDS - 10
+    stale = tmp_path / "a.tar.gz.part"
+    stale.write_bytes(b"x")
+    os.utime(stale, (old_time, old_time))
+    fresh = tmp_path / "b.tar.gz.part"
+    fresh.write_bytes(b"x")
+    keep = tmp_path / "c.tar.gz"
+    keep.write_bytes(b"x")
+    os.utime(keep, (old_time, old_time))
+    pf._sweep_stale_sidecars(tmp_path)
+    assert not stale.exists()
+    assert fresh.exists()
+    assert keep.exists()
+    pf._sweep_stale_sidecars(tmp_path / "missing")  # tolerated
 
 
 def test_uri_fetch_job_no_discard_without_a_file(tmp_path: Path) -> None:
@@ -552,10 +613,11 @@ def test_prefetch_spawn_failures_warn_and_continue(
     assert expected in caplog.text
 
 
-def test_main_guards_and_exits_zero(caplog: pytest.LogCaptureFixture) -> None:
-    """The subprocess entry never propagates a failure exit code."""
+def test_main_guards_and_exits_nonzero(caplog: pytest.LogCaptureFixture) -> None:
+    """A swallowed failure still reaches the parent as a nonzero exit; the
+    parent warns and continues, never failing the build."""
     with patch.object(pf, "_prefetch", side_effect=RuntimeError("boom")):
-        assert pf.main(["/b", "testenv"]) == 0
+        assert pf.main(["/b", "testenv"]) == 1
     assert "PlatformIO package prefetch skipped" in caplog.text
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -335,10 +335,16 @@ def test_sweep_stale_sidecars(tmp_path: Path) -> None:
     keep = tmp_path / "c.tar.gz"
     keep.write_bytes(b"x")
     os.utime(keep, (old_time, old_time))
+    # A held lock can carry an ancient mtime (O_TRUNC keeps it); locks
+    # must never be swept or the single-writer guarantee reopens
+    held_lock = tmp_path / "d.tar.gz.esphome.lock"
+    held_lock.write_bytes(b"")
+    os.utime(held_lock, (old_time, old_time))
     pf._sweep_stale_sidecars(tmp_path)
     assert not stale.exists()
     assert fresh.exists()
     assert keep.exists()
+    assert held_lock.exists()
     pf._sweep_stale_sidecars(tmp_path / "missing")  # tolerated
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -17,6 +17,7 @@ import esphome.platformio.prefetch as pf
 @pytest.fixture(autouse=True)
 def _core(tmp_path: Path):
     CORE.reset()
+    pf._REGISTER_FAILURES.clear()
     CORE.build_path = str(tmp_path)
     CORE.name = "testenv"
     pio_loggers = ("Tool Manager", "Library Manager", "Platform Manager")
@@ -362,14 +363,10 @@ def test_register_download_failure_leaves_a_trace(
 
 def test_register_failures_warn_once(caplog: pytest.LogCaptureFixture) -> None:
     """Systematic registration failures surface once per run."""
-    pf._REGISTER_FAILURES.clear()
     pf._warn_register_failures()
     assert "could not be registered" not in caplog.text
     pf._REGISTER_FAILURES.extend(["a.tar.gz", "b.tar.gz"])
-    try:
-        pf._warn_register_failures()
-    finally:
-        pf._REGISTER_FAILURES.clear()
+    pf._warn_register_failures()
     assert "2 archive(s) could not be registered" in caplog.text
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -17,7 +17,12 @@ def _core(tmp_path: Path):
     CORE.reset()
     CORE.build_path = str(tmp_path)
     CORE.name = "testenv"
+    pio_loggers = ("Tool Manager", "Library Manager", "Platform Manager")
+    saved_propagate = {n: pf.logging.getLogger(n).propagate for n in pio_loggers}
     yield
+    # main() flips these process-wide; keep the suite hermetic
+    for n, flag in saved_propagate.items():
+        pf.logging.getLogger(n).propagate = flag
     CORE.reset()
 
 
@@ -240,6 +245,15 @@ def test_main_bad_log_level_falls_back(tmp_path: Path) -> None:
     ):
         assert pf.main([str(tmp_path), "testenv"]) == 0
     assert mock_setup.call_args[0][0] == pf.logging.INFO
+
+
+def test_main_silences_pio_manager_propagation(tmp_path: Path) -> None:
+    """The pio manager loggers carry their own handler; propagation to
+    the root handler would print every install line twice."""
+    with patch("esphome.log.setup_log"), patch.object(pf, "_prefetch"):
+        assert pf.main([str(tmp_path), "testenv"]) == 0
+    for name in ("Tool Manager", "Library Manager", "Platform Manager"):
+        assert pf.logging.getLogger(name).propagate is False
 
 
 def test_main_mirrors_parent_log_setup(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -24,8 +24,12 @@ def _core(tmp_path: Path):
 class _FakeSpec(SimpleNamespace):
     """PackageSpec stand-in for the attributes the prefetch reads."""
 
-    def __init__(self, *, owner=None, requirements=None, **kwargs) -> None:
-        super().__init__(owner=owner, requirements=requirements, **kwargs)
+    def __init__(
+        self, *, owner=None, requirements=None, external=False, **kwargs
+    ) -> None:
+        super().__init__(
+            owner=owner, requirements=requirements, external=external, **kwargs
+        )
 
 
 def _fake_manager(tmp_path: Path) -> MagicMock:
@@ -437,7 +441,11 @@ def _pio_modules(tmp_path: Path, fake_platform, fake_pm, config, lib_captures=No
         ),
         "platformio.package.meta": SimpleNamespace(
             PackageSpec=lambda *a, **kw: _FakeSpec(
-                uri=None, name=kw.get("name") or (a[0] if a else None)
+                uri=None,
+                name=kw.get("name") or (a[0] if a else None),
+                owner=kw.get("owner")
+                or (str(a[0]).split("/")[0] if a and "/" in str(a[0]) else None),
+                external=bool(a and "://" in str(a[0])),
             )
         ),
         "platformio.platform": MagicMock(),
@@ -562,7 +570,9 @@ def test_prefetch_end_to_end_wiring(
         tmp_path,
         {
             "platform": "fake/platform@1.0",
-            "lib_deps": ["esphome/noise-c@1.0", "${common.lib_deps}"],
+            # the bare built-in name and the interpolation are skipped;
+            # only the owner-qualified library resolves
+            "lib_deps": ["esphome/noise-c@1.0", "WiFi", "${common.lib_deps}"],
         },
     )
     lib_dirs: list[str] = []

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1,5 +1,6 @@
 """Tests for the parallel PlatformIO package prefetch."""
 
+import json
 from pathlib import Path
 import sys
 from types import SimpleNamespace
@@ -21,7 +22,10 @@ def _core(tmp_path: Path):
 
 
 class _FakeSpec(SimpleNamespace):
-    """PackageSpec stand-in: .uri and .name are all the prefetch reads."""
+    """PackageSpec stand-in for the attributes the prefetch reads."""
+
+    def __init__(self, *, owner=None, requirements=None, **kwargs) -> None:
+        super().__init__(owner=owner, requirements=requirements, **kwargs)
 
 
 def _fake_manager(tmp_path: Path) -> MagicMock:
@@ -175,16 +179,27 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     ):
         pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
     assert dl_path.read_bytes() == b"data"
-    assert list(tmp_path.iterdir()) == [dl_path]
+    # only the archive and the lock file remain; no orphaned staging file
+    leftovers = {f.name for f in tmp_path.iterdir()}
+    assert leftovers == {dl_path.name, f"{dl_path.name}.prefetch.lock"}
+
+
+def test_uri_fetch_job_skips_when_another_process_won(tmp_path: Path) -> None:
+    dl_path = tmp_path / "archive"
+    dl_path.write_bytes(b"done")
+    with patch("esphome.framework_helpers.download_with_resume") as mock_download:
+        pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
+    mock_download.assert_not_called()
+    assert dl_path.read_bytes() == b"done"
 
 
 def test_registry_jobs_one_bad_spec_keeps_the_rest(tmp_path: Path) -> None:
     """A flaky resolution counts as failed without discarding the batch."""
     m = _fake_manager(tmp_path)
-    calls = iter([RuntimeError("registry 500"), [{"any": 1}]])
-    m.search_registry_packages.side_effect = lambda spec: (
-        (_ for _ in ()).throw(v) if isinstance(v := next(calls), Exception) else v
-    )
+    m.search_registry_packages.side_effect = [
+        RuntimeError("registry 500"),
+        [{"any": 1}],
+    ]
     with _mirror_patch():
         jobs, failed = pf._registry_jobs(
             m,
@@ -305,44 +320,27 @@ def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
     assert kwargs["timeout"] == pf._PREFETCH_TIMEOUT
 
 
-def test_prefetch_timeout_warns_and_continues(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A hung child is killed and the build continues."""
-    import subprocess
-
-    with (
-        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
-        patch.object(
-            pf.subprocess,
-            "run",
-            side_effect=subprocess.TimeoutExpired("cmd", pf._PREFETCH_TIMEOUT),
+@pytest.mark.parametrize(
+    ("run_effect", "expected"),
+    [
+        (
+            {"side_effect": pf.subprocess.TimeoutExpired("cmd", pf._PREFETCH_TIMEOUT)},
+            "prefetch timed out",
         ),
-    ):
-        pf.prefetch_platformio_packages()
-    assert "prefetch timed out" in caplog.text
-
-
-def test_prefetch_nonzero_exit_warns(caplog: pytest.LogCaptureFixture) -> None:
-    proc = MagicMock(returncode=3)
-    with (
-        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
-        patch.object(pf.subprocess, "run", return_value=proc),
-    ):
-        pf.prefetch_platformio_packages()
-    assert "prefetch skipped (exit 3)" in caplog.text
-
-
-def test_prefetch_launch_failure_never_raises(
-    caplog: pytest.LogCaptureFixture,
+        ({"return_value": MagicMock(returncode=3)}, "prefetch skipped (exit 3)"),
+        ({"side_effect": OSError("no exec")}, "PlatformIO package prefetch skipped"),
+    ],
+)
+def test_prefetch_spawn_failures_warn_and_continue(
+    caplog: pytest.LogCaptureFixture, run_effect, expected
 ) -> None:
-    """Any spawn failure is one warning, never a build failure."""
+    """Timeouts, nonzero exits, and spawn failures each warn, never raise."""
     with (
         patch("esphome.platformio.toolchain.heal_platformio_python_env"),
-        patch.object(pf.subprocess, "run", side_effect=OSError("no exec")),
+        patch.object(pf.subprocess, "run", **run_effect),
     ):
         pf.prefetch_platformio_packages()
-    assert "PlatformIO package prefetch skipped" in caplog.text
+    assert expected in caplog.text
 
 
 def test_main_guards_and_exits_zero(caplog: pytest.LogCaptureFixture) -> None:
@@ -370,6 +368,12 @@ def test_main_bad_argv_is_a_distinct_exit(
 
 def _write_ini(tmp_path: Path, body: str) -> None:
     (tmp_path / "platformio.ini").write_text(body)
+
+
+def _write_valid_sentinel(tmp_path: Path, dirs: list[str]) -> None:
+    (tmp_path / pf._SENTINEL_NAME).write_text(
+        json.dumps({**pf._sentinel_state(tmp_path), "dirs": dirs}), encoding="utf-8"
+    )
 
 
 def test_prefetch_no_platform_returns(tmp_path: Path) -> None:
@@ -480,12 +484,7 @@ def test_sentinel_invalidation(tmp_path: Path) -> None:
     pkg_dir = tmp_path / "packages"
     pkg_dir.mkdir()
     assert not pf._prefetch_is_warm(tmp_path)  # no sentinel yet
-    (tmp_path / pf._SENTINEL_NAME).write_text(
-        __import__("json").dumps(
-            {**pf._sentinel_state(tmp_path), "dirs": [str(pkg_dir)]}
-        ),
-        encoding="utf-8",
-    )
+    _write_valid_sentinel(tmp_path, [str(pkg_dir)])
     assert pf._prefetch_is_warm(tmp_path)
     _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@2\n")
     assert not pf._prefetch_is_warm(tmp_path)  # ini changed
@@ -501,12 +500,7 @@ def test_prefetch_warm_sentinel_skips_spawn(tmp_path: Path) -> None:
     _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
     pkg_dir = tmp_path / "packages"
     pkg_dir.mkdir()
-    (tmp_path / pf._SENTINEL_NAME).write_text(
-        __import__("json").dumps(
-            {**pf._sentinel_state(tmp_path), "dirs": [str(pkg_dir)]}
-        ),
-        encoding="utf-8",
-    )
+    _write_valid_sentinel(tmp_path, [str(pkg_dir)])
     with (
         patch("esphome.platformio.toolchain.heal_platformio_python_env"),
         patch.object(pf.subprocess, "run") as mock_run,

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -613,6 +613,19 @@ def test_prefetch_spawn_failures_warn_and_continue(
     assert expected in caplog.text
 
 
+def test_prefetch_child_handled_failure_is_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Exit 1 means the child already warned with the reason; the parent
+    adds no second warning."""
+    with (
+        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
+        patch.object(pf.subprocess, "run", return_value=MagicMock(returncode=1)),
+    ):
+        pf.prefetch_platformio_packages()
+    assert "prefetch skipped" not in caplog.text
+
+
 def test_main_guards_and_exits_nonzero(caplog: pytest.LogCaptureFixture) -> None:
     """A swallowed failure still reaches the parent as a nonzero exit; the
     parent warns and continues, never failing the build."""

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -63,8 +63,7 @@ def _mirror_patch():
 
 
 def test_registry_jobs_resolves_like_platformio(tmp_path: Path) -> None:
-    """A registry spec resolves to a job keyed by the mirror URL and
-    checksum, sized from the registry file entry."""
+    """A registry spec resolves to a job keyed by mirror URL and checksum."""
     m = _fake_manager(tmp_path)
     with _mirror_patch():
         jobs = pf._registry_jobs(
@@ -99,8 +98,7 @@ def test_registry_jobs_skips(tmp_path: Path, method, attr, value) -> None:
 
 
 def test_registry_jobs_skips_cached_and_sizeless(tmp_path: Path) -> None:
-    """A file already in PlatformIO's cache, or one the registry reports no
-    size for, is left to PlatformIO."""
+    """Cached or sizeless files are left to PlatformIO."""
     m = _fake_manager(tmp_path)
     dl = Path(m.compute_download_path("https://mirror.example/t.tar.gz", "beef"))
     dl.parent.mkdir(parents=True, exist_ok=True)
@@ -114,10 +112,9 @@ def test_registry_jobs_skips_cached_and_sizeless(tmp_path: Path) -> None:
 
 
 def test_registry_jobs_dedupes_download_paths(tmp_path: Path) -> None:
-    """Duplicate specs resolve once, and distinct specs resolving to one
-    archive yield a single job; two batch workers must never share a .part
-    file. Nine specs against eight workers also make one worker resolve
-    twice, reusing its thread-local manager."""
+    """Duplicate specs resolve once and one archive yields one job (two
+    workers must never share a .part); nine specs against eight workers
+    also exercise the thread-local manager reuse."""
     m = _fake_manager(tmp_path)
     specs = [_FakeSpec(uri=None, name="dup"), _FakeSpec(uri=None, name="dup")]
     specs += [_FakeSpec(uri=None, name=f"n{i}") for i in range(8)]
@@ -138,8 +135,7 @@ def test_registry_jobs_uri_specs_excluded(tmp_path: Path) -> None:
 
 
 def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
-    """A direct-URL spec gets its size from a HEAD; git specs and
-    unreachable URLs are left to PlatformIO."""
+    """HEAD sizes direct-URL specs; git and unreachable URLs are skipped."""
     m = _fake_manager(tmp_path)
     resp = MagicMock()
     resp.headers = {"content-length": "2222"}
@@ -165,8 +161,7 @@ def test_uri_jobs_head_failure_skips(tmp_path: Path) -> None:
 
 
 def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:
-    """Two specs with one URL yield one HEAD and one job; two batch workers
-    must never share a .part file."""
+    """Two specs with one URL yield one HEAD and one job."""
     m = _fake_manager(tmp_path)
     resp = MagicMock()
     resp.headers = {"content-length": "5"}
@@ -200,10 +195,8 @@ def test_uri_jobs_skips_installed_cached_and_seen(tmp_path: Path) -> None:
 
 
 def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
-    """The prefetch heals the PlatformIO cache first (a later Python-version
-    wipe would discard what it warms), then runs in a subprocess (platform
-    setup code may rewrite the interpreter's sys.path) with pio run's
-    libdeps dir and no leaked PYTHONPATH."""
+    """Heal runs first, then the subprocess spawns with pio run's libdeps
+    dir and no leaked PYTHONPATH."""
     proc = MagicMock(returncode=0)
     order = MagicMock()
     order.run.return_value = proc
@@ -332,8 +325,7 @@ def _fake_config(tmp_path: Path, env_options: dict):
 
 
 def test_prefetch_all_cached_is_quiet_and_writes_sentinel(tmp_path: Path) -> None:
-    """With nothing to download the prefetch neither logs nor batches, and
-    records a sentinel so the parent skips the next spawn."""
+    """A no-work run neither logs nor batches, and records the sentinel."""
     _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
     (tmp_path / "packages").mkdir()
     (tmp_path / "libdeps" / "testenv").mkdir(parents=True)
@@ -355,8 +347,7 @@ def test_prefetch_all_cached_is_quiet_and_writes_sentinel(tmp_path: Path) -> Non
 
 
 def test_sentinel_invalidation(tmp_path: Path) -> None:
-    """The sentinel stops matching when the ini changes or a recorded dir
-    disappears; garbage sentinels read as cold."""
+    """Ini changes, missing dirs, and garbage sentinels all read as cold."""
     _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
     pkg_dir = tmp_path / "packages"
     pkg_dir.mkdir()
@@ -399,10 +390,9 @@ def test_prefetch_warm_sentinel_skips_spawn(tmp_path: Path) -> None:
 def test_prefetch_end_to_end_wiring(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Platform installs dep-free, the env is configured, non-optional
-    packages plus tool-scons resolve, libraries resolve against the env's
-    libdeps dir, a platform sys.path rewrite is undone, and failures warn
-    by name."""
+    """Platform installs dep-free, non-optional packages plus tool-scons
+    resolve, libraries use the env libdeps dir, a platform sys.path rewrite
+    is undone, and failures warn by name."""
     _write_ini(tmp_path, "[env:testenv]\nplatform = fake/platform@1.0\n")
     fake_platform = MagicMock()
     fake_platform.packages = {

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1,0 +1,411 @@
+"""Tests for the parallel PlatformIO package prefetch."""
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from esphome.core import CORE
+import esphome.platformio.prefetch as pf
+
+
+@pytest.fixture(autouse=True)
+def _core(tmp_path: Path):
+    CORE.reset()
+    CORE.build_path = str(tmp_path)
+    CORE.name = "testenv"
+    yield
+    CORE.reset()
+
+
+class _FakeSpec(SimpleNamespace):
+    """PackageSpec stand-in: .uri and .name are all the prefetch reads."""
+
+
+def _fake_manager(tmp_path: Path) -> MagicMock:
+    m = MagicMock()
+    m.__class__ = lambda: m  # _resolve constructs a same-class instance
+    m.get_package.return_value = None
+    m.search_registry_packages.return_value = [{"any": 1}]
+    m.find_best_registry_version.return_value = (
+        {"name": "toolchain-xtensa"},
+        {
+            "name": "2.0.0",
+            "files": [
+                {
+                    "download_url": "https://dl.example/t.tar.gz",
+                    "checksum": {"sha256": "cafe"},
+                    "size": 1000,
+                }
+            ],
+        },
+    )
+    m.pick_compatible_pkg_file.side_effect = lambda files: files[0]
+    m.compute_download_path.side_effect = lambda url, checksum: str(
+        tmp_path / "dl" / f"{abs(hash((url, checksum)))}"
+    )
+    return m
+
+
+def _mirror_patch():
+    return patch.dict(
+        "sys.modules",
+        {
+            "platformio.registry.mirror": SimpleNamespace(
+                RegistryFileMirrorIterator=lambda url: iter(
+                    [("https://mirror.example/t.tar.gz", "beef")]
+                )
+            )
+        },
+    )
+
+
+def test_registry_jobs_resolves_like_platformio(tmp_path: Path) -> None:
+    """A registry spec resolves to a job keyed by the mirror URL and
+    checksum, sized from the registry file entry."""
+    m = _fake_manager(tmp_path)
+    with _mirror_patch():
+        jobs = pf._registry_jobs(
+            m, [_FakeSpec(uri=None, name="toolchain-xtensa")], set()
+        )
+    assert len(jobs) == 1
+    name, size, fetch = jobs[0]
+    assert name == "toolchain-xtensa@2.0.0"
+    assert size == 1000
+    m.compute_download_path.assert_called_once_with(
+        "https://mirror.example/t.tar.gz", "beef"
+    )
+    assert callable(fetch)
+
+
+@pytest.mark.parametrize(
+    ("method", "attr", "value"),
+    [
+        ("get_package", "return_value", object()),  # already installed
+        ("search_registry_packages", "return_value", []),  # unknown package
+        ("find_best_registry_version", "return_value", (None, None)),  # no match
+        ("pick_compatible_pkg_file", "side_effect", lambda files: None),  # no file
+    ],
+)
+def test_registry_jobs_skips(tmp_path: Path, method, attr, value) -> None:
+    """Entries PlatformIO would not download produce no job."""
+    m = _fake_manager(tmp_path)
+    setattr(getattr(m, method), attr, value)
+    with _mirror_patch():
+        jobs = pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set())
+    assert jobs == []
+
+
+def test_registry_jobs_skips_cached_and_sizeless(tmp_path: Path) -> None:
+    """A file already in PlatformIO's cache, or one the registry reports no
+    size for, is left to PlatformIO."""
+    m = _fake_manager(tmp_path)
+    dl = Path(m.compute_download_path("https://mirror.example/t.tar.gz", "beef"))
+    dl.parent.mkdir(parents=True, exist_ok=True)
+    dl.touch()
+    with _mirror_patch():
+        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == []
+    dl.unlink()
+    m.find_best_registry_version.return_value[1]["files"][0]["size"] = 0
+    with _mirror_patch():
+        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == []
+
+
+def test_registry_jobs_dedupes_download_paths(tmp_path: Path) -> None:
+    """Duplicate specs resolving to one archive yield a single job; two
+    batch workers must never share a .part file."""
+    m = _fake_manager(tmp_path)
+    specs = [_FakeSpec(uri=None, name="dup"), _FakeSpec(uri=None, name="dup")]
+    with _mirror_patch():
+        jobs = pf._registry_jobs(m, specs, set())
+    assert len(jobs) == 1
+
+
+def test_registry_jobs_uri_specs_excluded(tmp_path: Path) -> None:
+    """URL specs never reach the registry resolution."""
+    m = _fake_manager(tmp_path)
+    assert (
+        pf._registry_jobs(m, [_FakeSpec(uri="https://x/y.zip", name="y")], set()) == []
+    )
+    m.search_registry_packages.assert_not_called()
+
+
+def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
+    """A direct-URL spec gets its size from a HEAD; git specs and
+    unreachable URLs are left to PlatformIO."""
+    m = _fake_manager(tmp_path)
+    resp = MagicMock()
+    resp.headers = {"content-length": "2222"}
+    with patch("esphome.net_retry.http_request", return_value=resp):
+        jobs = pf._uri_jobs(
+            m,
+            [
+                _FakeSpec(uri="https://x/big.zip", name="big"),
+                _FakeSpec(uri="git+https://x/repo.git", name="repo"),
+                _FakeSpec(uri=None, name="registry"),
+            ],
+            set(),
+        )
+    assert [(n, s) for n, s, _ in jobs] == [("big", 2222)]
+
+
+def test_uri_jobs_head_failure_skips(tmp_path: Path) -> None:
+    m = _fake_manager(tmp_path)
+    with patch("esphome.net_retry.http_request", side_effect=OSError("no route")):
+        assert (
+            pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == []
+        )
+
+
+def test_uri_jobs_skips_installed_cached_and_seen(tmp_path: Path) -> None:
+    m = _fake_manager(tmp_path)
+    m.get_package.return_value = object()
+    assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == []
+    m.get_package.return_value = None
+    dl = Path(m.compute_download_path("https://x/a.zip", ""))
+    dl.parent.mkdir(parents=True, exist_ok=True)
+    dl.touch()
+    assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == []
+    dl.unlink()
+    # a registry job already claimed this download path
+    assert (
+        pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], {str(dl)}) == []
+    )
+
+
+def test_resume_fetch_job_threads_tracker(tmp_path: Path) -> None:
+    """The batch runner passes the tracker positionally; the shared adapter
+    must deliver it as download_with_resume's progress keyword."""
+    from esphome.framework_helpers import resume_fetch_job
+
+    with patch("esphome.framework_helpers.download_with_resume") as mock_download:
+        fetch = resume_fetch_job("https://x/a.zip", tmp_path / "a", sha256="ff", size=9)
+        tracker = lambda done: None  # noqa: E731
+        fetch(tracker)
+    mock_download.assert_called_once_with(
+        "https://x/a.zip", tmp_path / "a", progress=tracker, sha256="ff", size=9
+    )
+
+
+def test_warn_prefetch_failures_names_each_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared failure loop warns per job with the failure reason."""
+    from esphome.framework_helpers import warn_prefetch_failures
+
+    warn_prefetch_failures([("toolchain-x@1", OSError("down"))])
+    assert "Could not prefetch toolchain-x@1: down" in caplog.text
+    warn_prefetch_failures([("lib", OSError("gone"))], "Prefetch of %s failed: %s")
+    assert "Prefetch of lib failed: gone" in caplog.text
+
+
+def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
+    """The prefetch runs in a subprocess (platform setup code may rewrite
+    the interpreter's sys.path) with pio run's libdeps dir."""
+    proc = MagicMock(returncode=0)
+    with patch.object(pf.subprocess, "run", return_value=proc) as mock_run:
+        pf.prefetch_platformio_packages()
+    (cmd,), kwargs = mock_run.call_args
+    assert cmd == [
+        sys.executable,
+        "-m",
+        "esphome.platformio.prefetch",
+        str(CORE.build_path),
+        "testenv",
+    ]
+    assert kwargs["env"]["PLATFORMIO_LIBDEPS_DIR"] == str(
+        CORE.relative_piolibdeps_path().absolute()
+    )
+
+
+def test_prefetch_nonzero_exit_warns(caplog: pytest.LogCaptureFixture) -> None:
+    proc = MagicMock(returncode=3)
+    with patch.object(pf.subprocess, "run", return_value=proc):
+        pf.prefetch_platformio_packages()
+    assert "prefetch skipped (exit 3)" in caplog.text
+
+
+def test_prefetch_launch_failure_never_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Any spawn failure is one warning, never a build failure."""
+    with patch.object(pf.subprocess, "run", side_effect=OSError("no exec")):
+        pf.prefetch_platformio_packages()
+    assert "PlatformIO package prefetch skipped" in caplog.text
+
+
+def test_main_guards_and_exits_zero(caplog: pytest.LogCaptureFixture) -> None:
+    """The subprocess entry never propagates a failure exit code."""
+    with patch.object(pf, "_prefetch", side_effect=RuntimeError("boom")):
+        assert pf.main(["/b", "testenv"]) == 0
+    assert "PlatformIO package prefetch skipped" in caplog.text
+
+
+def test_main_runs_prefetch(tmp_path: Path) -> None:
+    with patch.object(pf, "_prefetch") as mock_prefetch:
+        assert pf.main([str(tmp_path), "testenv"]) == 0
+    mock_prefetch.assert_called_once_with(tmp_path, "testenv")
+
+
+def _write_ini(tmp_path: Path, body: str) -> None:
+    (tmp_path / "platformio.ini").write_text(body)
+
+
+def test_prefetch_no_platform_returns(tmp_path: Path) -> None:
+    _write_ini(tmp_path, "[env:testenv]\n")
+    with patch.object(pf, "_registry_jobs") as mock_jobs:
+        pf._prefetch(tmp_path, "testenv")
+    mock_jobs.assert_not_called()
+
+
+def _pio_modules(tmp_path: Path, fake_platform, fake_pm, config, lib_captures=None):
+    modules = {
+        "platformio": MagicMock(),
+        "platformio.app": MagicMock(),
+        "platformio.project": MagicMock(),
+        "platformio.project.config": MagicMock(),
+        "platformio.dependencies": SimpleNamespace(
+            get_core_dependencies=lambda: {
+                "tool-scons": "~4.0",
+                "contrib-piohome": "~3",
+            }
+        ),
+        "platformio.package": MagicMock(),
+        "platformio.package.manager": MagicMock(),
+        "platformio.package.manager.library": SimpleNamespace(
+            LibraryPackageManager=lambda storage_dir: (
+                lib_captures.append(storage_dir) if lib_captures is not None else None,
+                _fake_manager(tmp_path),
+            )[1]
+        ),
+        "platformio.package.manager.platform": SimpleNamespace(
+            PlatformPackageManager=lambda: fake_pm
+        ),
+        "platformio.package.meta": SimpleNamespace(
+            PackageSpec=lambda *a, **kw: _FakeSpec(
+                uri=None, name=kw.get("name") or (a[0] if a else None)
+            )
+        ),
+        "platformio.platform": MagicMock(),
+        "platformio.platform.factory": SimpleNamespace(
+            PlatformFactory=SimpleNamespace(new=lambda pkg: fake_platform)
+        ),
+    }
+    modules[
+        "platformio.project.config"
+    ].ProjectConfig.get_instance.return_value = config
+    return modules
+
+
+def _fake_config(tmp_path: Path, env_options: dict):
+    config = MagicMock()
+    options = {"libdeps_dir": str(tmp_path / "libdeps"), **env_options}
+    config.get.side_effect = lambda section, key, default=None: options.get(
+        key, default
+    )
+    return config
+
+
+def test_prefetch_all_cached_is_quiet(tmp_path: Path) -> None:
+    """With nothing to download the prefetch neither logs nor batches."""
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    fake_platform = MagicMock()
+    fake_platform.packages = {}
+    config = _fake_config(tmp_path, {"platform": "fake/p@1"})
+    modules = _pio_modules(tmp_path, fake_platform, MagicMock(), config)
+    with (
+        patch.dict("sys.modules", modules),
+        patch.object(pf, "_registry_jobs", return_value=[]),
+        patch.object(pf, "_uri_jobs", return_value=[]),
+        patch.object(pf, "run_batch_downloads") as mock_batch,
+    ):
+        pf._prefetch(tmp_path, "testenv")
+    mock_batch.assert_not_called()
+
+
+def test_prefetch_end_to_end_wiring(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Platform installs dep-free, the env is configured, non-optional
+    packages plus tool-scons resolve, libraries resolve against the env's
+    libdeps dir, a platform sys.path rewrite is undone, and failures warn
+    by name."""
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/platform@1.0\n")
+    fake_platform = MagicMock()
+    fake_platform.packages = {
+        "toolchain-x": {"optional": False},
+        "framework-y": {"optional": True},
+    }
+    fake_platform.get_package_spec.side_effect = lambda name: _FakeSpec(
+        uri=None, name=name
+    )
+    # Platform setup code rewrites sys.path (pioarduino penv); _prefetch
+    # must restore it
+    bogus = str(tmp_path / "penv-site-packages")
+    fake_platform.configure_project_packages.side_effect = lambda env, targets: (
+        sys.path.insert(0, bogus)
+    )
+    fake_pm = MagicMock()
+    config = _fake_config(
+        tmp_path,
+        {
+            "platform": "fake/platform@1.0",
+            "lib_deps": ["esphome/noise-c@1.0", "${common.lib_deps}"],
+        },
+    )
+    lib_dirs: list[str] = []
+    modules = _pio_modules(tmp_path, fake_platform, fake_pm, config, lib_dirs)
+    captured: dict = {}
+
+    def fake_registry_jobs(manager, specs, seen):
+        captured.setdefault("spec_batches", []).append([s.name for s in specs])
+        return [("toolchain-x@1", 10, lambda t: None)]
+
+    with (
+        patch.dict("sys.modules", modules),
+        patch.object(pf, "_registry_jobs", side_effect=fake_registry_jobs),
+        patch.object(pf, "_uri_jobs", return_value=[]),
+        patch.object(
+            pf,
+            "run_batch_downloads",
+            return_value=[("toolchain-x@1", OSError("down"))],
+        ) as mock_batch,
+    ):
+        pf._prefetch(tmp_path, "testenv")
+    fake_pm.install.assert_called_once_with("fake/platform@1.0", skip_dependencies=True)
+    fake_platform.configure_project_packages.assert_called_once_with("testenv", ["run"])
+    assert bogus not in sys.path
+    # non-optional platform package + tool-scons (never piohome), then libs
+    assert captured["spec_batches"][0] == ["toolchain-x", "tool-scons"]
+    assert captured["spec_batches"][1] == ["esphome/noise-c@1.0"]
+    assert lib_dirs == [str(Path(tmp_path / "libdeps") / "testenv")]
+    mock_batch.assert_called_once()
+    assert "Could not prefetch toolchain-x@1" in caplog.text
+
+
+def test_prefetch_skips_duplicate_tool_scons(tmp_path: Path) -> None:
+    """A platform that lists tool-scons itself does not get it appended."""
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    fake_platform = MagicMock()
+    fake_platform.packages = {"tool-scons": {"optional": False}}
+    fake_platform.get_package_spec.side_effect = lambda name: _FakeSpec(
+        uri=None, name=name
+    )
+    config = _fake_config(tmp_path, {"platform": "fake/p@1"})
+    modules = _pio_modules(tmp_path, fake_platform, MagicMock(), config)
+    batches: list[list[str]] = []
+    with (
+        patch.dict("sys.modules", modules),
+        patch.object(
+            pf,
+            "_registry_jobs",
+            side_effect=lambda mgr, specs, seen: (
+                batches.append([s.name for s in specs]) or []
+            ),
+        ),
+        patch.object(pf, "_uri_jobs", return_value=[]),
+    ):
+        pf._prefetch(tmp_path, "testenv")
+    assert batches[0] == ["tool-scons"]

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -179,9 +179,10 @@ def test_uri_fetch_job_promotes_atomically(tmp_path: Path) -> None:
     ):
         pf._uri_fetch_job("https://x/a.zip", dl_path, 4)(lambda done: None)
     assert dl_path.read_bytes() == b"data"
-    # only the archive and the lock file remain; no orphaned staging file
+    # no orphaned staging file; the lock file may or may not persist
+    # (filelock removes it on release on some platforms)
     leftovers = {f.name for f in tmp_path.iterdir()}
-    assert leftovers == {dl_path.name, f"{dl_path.name}.prefetch.lock"}
+    assert leftovers - {f"{dl_path.name}.prefetch.lock"} == {dl_path.name}
 
 
 def test_uri_fetch_job_skips_when_another_process_won(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -66,9 +66,10 @@ def test_registry_jobs_resolves_like_platformio(tmp_path: Path) -> None:
     """A registry spec resolves to a job keyed by mirror URL and checksum."""
     m = _fake_manager(tmp_path)
     with _mirror_patch():
-        jobs = pf._registry_jobs(
+        jobs, failed = pf._registry_jobs(
             m, [_FakeSpec(uri=None, name="toolchain-xtensa")], set()
         )
+    assert failed == 0
     assert len(jobs) == 1
     name, size, fetch = jobs[0]
     assert name == "toolchain-xtensa@2.0.0"
@@ -93,8 +94,7 @@ def test_registry_jobs_skips(tmp_path: Path, method, attr, value) -> None:
     m = _fake_manager(tmp_path)
     setattr(getattr(m, method), attr, value)
     with _mirror_patch():
-        jobs = pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set())
-    assert jobs == []
+        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == ([], 0)
 
 
 def test_registry_jobs_skips_cached_and_sizeless(tmp_path: Path) -> None:
@@ -104,11 +104,11 @@ def test_registry_jobs_skips_cached_and_sizeless(tmp_path: Path) -> None:
     dl.parent.mkdir(parents=True, exist_ok=True)
     dl.touch()
     with _mirror_patch():
-        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == []
+        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == ([], 0)
     dl.unlink()
     m.find_best_registry_version.return_value[1]["files"][0]["size"] = 0
     with _mirror_patch():
-        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == []
+        assert pf._registry_jobs(m, [_FakeSpec(uri=None, name="x")], set()) == ([], 0)
 
 
 def test_registry_jobs_dedupes_download_paths(tmp_path: Path) -> None:
@@ -119,8 +119,9 @@ def test_registry_jobs_dedupes_download_paths(tmp_path: Path) -> None:
     specs = [_FakeSpec(uri=None, name="dup"), _FakeSpec(uri=None, name="dup")]
     specs += [_FakeSpec(uri=None, name=f"n{i}") for i in range(8)]
     with _mirror_patch():
-        jobs = pf._registry_jobs(m, specs, set())
+        jobs, failed = pf._registry_jobs(m, specs, set())
     # the fake resolves every spec to the same mirror URL and checksum
+    assert failed == 0
     assert len(jobs) == 1
     assert m.search_registry_packages.call_count == 9  # dup resolved once
 
@@ -128,10 +129,27 @@ def test_registry_jobs_dedupes_download_paths(tmp_path: Path) -> None:
 def test_registry_jobs_uri_specs_excluded(tmp_path: Path) -> None:
     """URL specs never reach the registry resolution."""
     m = _fake_manager(tmp_path)
-    assert (
-        pf._registry_jobs(m, [_FakeSpec(uri="https://x/y.zip", name="y")], set()) == []
-    )
+    assert pf._registry_jobs(
+        m, [_FakeSpec(uri="https://x/y.zip", name="y")], set()
+    ) == ([], 0)
     m.search_registry_packages.assert_not_called()
+
+
+def test_registry_jobs_one_bad_spec_keeps_the_rest(tmp_path: Path) -> None:
+    """A flaky resolution counts as failed without discarding the batch."""
+    m = _fake_manager(tmp_path)
+    calls = iter([RuntimeError("registry 500"), [{"any": 1}]])
+    m.search_registry_packages.side_effect = lambda spec: (
+        (_ for _ in ()).throw(v) if isinstance(v := next(calls), Exception) else v
+    )
+    with _mirror_patch():
+        jobs, failed = pf._registry_jobs(
+            m,
+            [_FakeSpec(uri=None, name="flaky"), _FakeSpec(uri=None, name="good")],
+            set(),
+        )
+    assert failed == 1
+    assert len(jobs) == 1
 
 
 def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
@@ -140,23 +158,34 @@ def test_uri_jobs_head_sizes_the_bar(tmp_path: Path) -> None:
     resp = MagicMock()
     resp.headers = {"content-length": "2222"}
     with patch("esphome.net_retry.http_request", return_value=resp):
-        jobs = pf._uri_jobs(
+        jobs, failed = pf._uri_jobs(
             m,
             [
                 _FakeSpec(uri="https://x/big.zip", name="big"),
                 _FakeSpec(uri="git+https://x/repo.git", name="repo"),
+                _FakeSpec(uri="https://x/repo.git#v1", name="barevcs"),
                 _FakeSpec(uri=None, name="registry"),
             ],
             set(),
         )
+    assert failed == 0
     assert [(n, s) for n, s, _ in jobs] == [("big", 2222)]
 
 
-def test_uri_jobs_head_failure_skips(tmp_path: Path) -> None:
+def test_uri_jobs_head_failure_counts_as_unresolved(tmp_path: Path) -> None:
+    """A HEAD error is not a clean skip; an error response's length is."""
     m = _fake_manager(tmp_path)
     with patch("esphome.net_retry.http_request", side_effect=OSError("no route")):
-        assert (
-            pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == []
+        assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == (
+            [],
+            1,
+        )
+    resp = MagicMock(ok=False)
+    resp.headers = {"content-length": "999"}
+    with patch("esphome.net_retry.http_request", return_value=resp):
+        assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == (
+            [],
+            0,
         )
 
 
@@ -166,7 +195,7 @@ def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:
     resp = MagicMock()
     resp.headers = {"content-length": "5"}
     with patch("esphome.net_retry.http_request", return_value=resp) as mock_head:
-        jobs = pf._uri_jobs(
+        jobs, failed = pf._uri_jobs(
             m,
             [
                 _FakeSpec(uri="https://x/a.zip", name="a"),
@@ -174,6 +203,7 @@ def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:
             ],
             set(),
         )
+    assert failed == 0
     assert len(jobs) == 1
     mock_head.assert_called_once()
 
@@ -181,17 +211,16 @@ def test_uri_jobs_dedupes_duplicate_urls(tmp_path: Path) -> None:
 def test_uri_jobs_skips_installed_cached_and_seen(tmp_path: Path) -> None:
     m = _fake_manager(tmp_path)
     m.get_package.return_value = object()
-    assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == []
+    spec = [_FakeSpec(uri="https://x/a.zip", name="a")]
+    assert pf._uri_jobs(m, spec, set()) == ([], 0)
     m.get_package.return_value = None
     dl = Path(m.compute_download_path("https://x/a.zip", ""))
     dl.parent.mkdir(parents=True, exist_ok=True)
     dl.touch()
-    assert pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], set()) == []
+    assert pf._uri_jobs(m, spec, set()) == ([], 0)
     dl.unlink()
     # a registry job already claimed this download path
-    assert (
-        pf._uri_jobs(m, [_FakeSpec(uri="https://x/a.zip", name="a")], {str(dl)}) == []
-    )
+    assert pf._uri_jobs(m, spec, {str(dl)}) == ([], 0)
 
 
 def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
@@ -221,7 +250,28 @@ def test_prefetch_spawns_isolated_subprocess(tmp_path: Path) -> None:
     assert kwargs["env"]["PLATFORMIO_LIBDEPS_DIR"] == str(
         CORE.relative_piolibdeps_path().absolute()
     )
-    assert "PYTHONPATH" not in kwargs["env"]
+    # The child is esphome itself; PYTHONPATH must survive so it imports
+    # the same tree (tests/integration pins the source tree through it)
+    assert kwargs["env"]["PYTHONPATH"] == "/leak"
+    assert kwargs["timeout"] == pf._PREFETCH_TIMEOUT
+
+
+def test_prefetch_timeout_warns_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hung child is killed and the build continues."""
+    import subprocess
+
+    with (
+        patch("esphome.platformio.toolchain.heal_platformio_python_env"),
+        patch.object(
+            pf.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("cmd", pf._PREFETCH_TIMEOUT),
+        ),
+    ):
+        pf.prefetch_platformio_packages()
+    assert "prefetch timed out" in caplog.text
 
 
 def test_prefetch_nonzero_exit_warns(caplog: pytest.LogCaptureFixture) -> None:
@@ -257,6 +307,16 @@ def test_main_runs_prefetch(tmp_path: Path) -> None:
     with patch.object(pf, "_prefetch") as mock_prefetch:
         assert pf.main([str(tmp_path), "testenv"]) == 0
     mock_prefetch.assert_called_once_with(tmp_path, "testenv")
+
+
+def test_main_bad_argv_is_a_distinct_exit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parent/child wiring bug must not look like a network failure."""
+    with patch.object(pf, "_prefetch") as mock_prefetch:
+        assert pf.main(["only-one"]) == 2
+    mock_prefetch.assert_not_called()
+    assert "prefetch usage" in caplog.text
 
 
 def _write_ini(tmp_path: Path, body: str) -> None:
@@ -337,13 +397,32 @@ def test_prefetch_all_cached_is_quiet_and_writes_sentinel(tmp_path: Path) -> Non
     modules = _pio_modules(tmp_path, fake_platform, MagicMock(), config)
     with (
         patch.dict("sys.modules", modules),
-        patch.object(pf, "_registry_jobs", return_value=[]),
-        patch.object(pf, "_uri_jobs", return_value=[]),
+        patch.object(pf, "_registry_jobs", return_value=([], 0)),
+        patch.object(pf, "_uri_jobs", return_value=([], 0)),
         patch.object(pf, "run_batch_downloads") as mock_batch,
     ):
         pf._prefetch(tmp_path, "testenv")
     mock_batch.assert_not_called()
     assert pf._prefetch_is_warm(tmp_path)
+
+
+def test_prefetch_failed_resolution_is_not_cached_as_warm(tmp_path: Path) -> None:
+    """A registry outage must not write the sentinel."""
+    _write_ini(tmp_path, "[env:testenv]\nplatform = fake/p@1\n")
+    (tmp_path / "packages").mkdir()
+    fake_platform = MagicMock()
+    fake_platform.packages = {}
+    config = _fake_config(tmp_path, {"platform": "fake/p@1"})
+    modules = _pio_modules(tmp_path, fake_platform, MagicMock(), config)
+    with (
+        patch.dict("sys.modules", modules),
+        patch.object(pf, "_registry_jobs", return_value=([], 1)),
+        patch.object(pf, "_uri_jobs", return_value=([], 0)),
+        patch.object(pf, "run_batch_downloads") as mock_batch,
+    ):
+        pf._prefetch(tmp_path, "testenv")
+    mock_batch.assert_not_called()
+    assert not (tmp_path / pf._SENTINEL_NAME).exists()
 
 
 def test_sentinel_invalidation(tmp_path: Path) -> None:
@@ -423,12 +502,12 @@ def test_prefetch_end_to_end_wiring(
 
     def fake_registry_jobs(manager, specs, seen):
         captured.setdefault("spec_batches", []).append([s.name for s in specs])
-        return [("toolchain-x@1", 10, lambda t: None)]
+        return [("toolchain-x@1", 10, lambda t: None)], 0
 
     with (
         patch.dict("sys.modules", modules),
         patch.object(pf, "_registry_jobs", side_effect=fake_registry_jobs),
-        patch.object(pf, "_uri_jobs", return_value=[]),
+        patch.object(pf, "_uri_jobs", return_value=([], 0)),
         patch.object(
             pf,
             "run_batch_downloads",
@@ -465,10 +544,10 @@ def test_prefetch_skips_duplicate_tool_scons(tmp_path: Path) -> None:
             pf,
             "_registry_jobs",
             side_effect=lambda mgr, specs, seen: (
-                batches.append([s.name for s in specs]) or []
+                batches.append([s.name for s in specs]) or ([], 0)
             ),
         ),
-        patch.object(pf, "_uri_jobs", return_value=[]),
+        patch.object(pf, "_uri_jobs", return_value=([], 0)),
     ):
         pf._prefetch(tmp_path, "testenv")
     assert batches[0] == ["tool-scons"]

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -1719,8 +1719,8 @@ def pio_core_dir(tmp_path: Path) -> Path:
 
 
 def test_current_python_minor_matches_running_interpreter() -> None:
-    """_current_python_minor returns major.minor of the running interpreter."""
-    assert toolchain._current_python_minor() == _CURRENT_MINOR
+    """current_python_minor returns major.minor of the running interpreter."""
+    assert toolchain.current_python_minor() == _CURRENT_MINOR
 
 
 def test_pio_stamp_round_trip(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -968,9 +968,13 @@ def test_run_compile(setup_core: Path, mock_run_platformio_cli_run: Mock) -> Non
     config = {CONF_ESPHOME: {CONF_COMPILE_PROCESS_LIMIT: 4}}
     mock_run_platformio_cli_run.return_value = 0
 
-    with patch("esphome.platformio.prefetch.prefetch_platformio_packages"):
+    with patch(
+        "esphome.platformio.prefetch.prefetch_platformio_packages"
+    ) as mock_prefetch:
         toolchain.run_compile(config, verbose=True)
 
+    # The only wiring of the prefetch into a build lives here
+    mock_prefetch.assert_called_once_with()
     mock_run_platformio_cli_run.assert_called_once_with(config, True, "-j4")
 
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -968,7 +968,11 @@ def test_run_compile(setup_core: Path, mock_run_platformio_cli_run: Mock) -> Non
     config = {CONF_ESPHOME: {CONF_COMPILE_PROCESS_LIMIT: 4}}
     mock_run_platformio_cli_run.return_value = 0
 
-    toolchain.run_compile(config, verbose=True)
+    with (
+        patch.object(toolchain, "heal_platformio_python_env"),
+        patch("esphome.platformio.prefetch.prefetch_platformio_packages"),
+    ):
+        toolchain.run_compile(config, verbose=True)
 
     mock_run_platformio_cli_run.assert_called_once_with(config, True, "-j4")
 
@@ -983,9 +987,36 @@ def test_run_compile_without_process_limit(
     config = {CONF_ESPHOME: {}}
     mock_run_platformio_cli_run.return_value = 0
 
-    toolchain.run_compile(config, verbose=False)
+    with (
+        patch.object(toolchain, "heal_platformio_python_env"),
+        patch("esphome.platformio.prefetch.prefetch_platformio_packages"),
+    ):
+        toolchain.run_compile(config, verbose=False)
 
     mock_run_platformio_cli_run.assert_called_once_with(config, False)
+
+
+def test_run_compile_heals_before_prefetching(
+    setup_core: Path, mock_run_platformio_cli_run: Mock
+) -> None:
+    """The Python-version heal must run before the prefetch, or its wipe
+    would discard the caches the prefetch just warmed."""
+    from esphome.const import CONF_ESPHOME
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    mock_run_platformio_cli_run.return_value = 0
+    order = Mock()
+
+    with (
+        patch.object(toolchain, "heal_platformio_python_env", order.heal),
+        patch(
+            "esphome.platformio.prefetch.prefetch_platformio_packages",
+            order.prefetch,
+        ),
+    ):
+        toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
+
+    assert order.mock_calls == [call.heal(), call.prefetch()]
 
 
 def test_get_idedata_caches_result(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -968,10 +968,7 @@ def test_run_compile(setup_core: Path, mock_run_platformio_cli_run: Mock) -> Non
     config = {CONF_ESPHOME: {CONF_COMPILE_PROCESS_LIMIT: 4}}
     mock_run_platformio_cli_run.return_value = 0
 
-    with (
-        patch.object(toolchain, "heal_platformio_python_env"),
-        patch("esphome.platformio.prefetch.prefetch_platformio_packages"),
-    ):
+    with patch("esphome.platformio.prefetch.prefetch_platformio_packages"):
         toolchain.run_compile(config, verbose=True)
 
     mock_run_platformio_cli_run.assert_called_once_with(config, True, "-j4")
@@ -987,36 +984,10 @@ def test_run_compile_without_process_limit(
     config = {CONF_ESPHOME: {}}
     mock_run_platformio_cli_run.return_value = 0
 
-    with (
-        patch.object(toolchain, "heal_platformio_python_env"),
-        patch("esphome.platformio.prefetch.prefetch_platformio_packages"),
-    ):
+    with patch("esphome.platformio.prefetch.prefetch_platformio_packages"):
         toolchain.run_compile(config, verbose=False)
 
     mock_run_platformio_cli_run.assert_called_once_with(config, False)
-
-
-def test_run_compile_heals_before_prefetching(
-    setup_core: Path, mock_run_platformio_cli_run: Mock
-) -> None:
-    """The Python-version heal must run before the prefetch, or its wipe
-    would discard the caches the prefetch just warmed."""
-    from esphome.const import CONF_ESPHOME
-
-    CORE.build_path = str(setup_core / "build" / "test")
-    mock_run_platformio_cli_run.return_value = 0
-    order = Mock()
-
-    with (
-        patch.object(toolchain, "heal_platformio_python_env", order.heal),
-        patch(
-            "esphome.platformio.prefetch.prefetch_platformio_packages",
-            order.prefetch,
-        ),
-    ):
-        toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
-
-    assert order.mock_calls == [call.heal(), call.prefetch()]
 
 
 def test_get_idedata_caches_result(


### PR DESCRIPTION
# What does this implement/fix?

ESPHome now prefetches the packages a `pio run` would install: it resolves the same registry metadata PlatformIO would, downloads the archives in parallel into PlatformIO's own download cache under the identical sha1(url + checksum) key, and the run installs without touching the network. Any prefetch failure logs one warning and PlatformIO downloads exactly as before; a warm-build sentinel skips even the subprocess spawn.

Same-day CI A/B on the docker smoke's esp8266-arduino leg (identical runner pool; the baseline image carries dev esphome; single-sample timings):

| | total build | package phase | % of build | download output |
|---|---|---|---|---|
| dev | 48s | 17.1s | 36% | 296 serial progress frames |
| this PR | 39s | 13.3s | 34% | one combined bar |
| + #18775 (parallel install) | 41s | 10.3s | 25% | one combined bar |

Compile time itself varies a couple of seconds run to run, which is the 39s/41s inversion. The absolute win should be much larger on slow SBCs (the Home Assistant add-on on Raspberry Pi class hardware), where limited bandwidth and slow flash turn the serial download and unpack phase into minutes rather than seconds.

The prefetch runs in a subprocess like all PlatformIO execution (loading a platform executes its code; pioarduino's penv setup rewrites `sys.path`). Registry libraries resolve against the env's libdeps dir, URL specs are sized with a HEAD, git specs stay with pio's cloner, shared download destinations are serialized by a file lock, and downloads register with pio's usage.db pruner. Also verified locally on a cold `PLATFORMIO_CORE_DIR` (all 5 esp8266 packages prefetched at the versions pio itself resolves, zero serial downloads) and in this PR's CI (esp32 pioarduino drops from 190 progress frames to 5).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the native toolchain build speed work

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (internal build behavior)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes; any PlatformIO build benefits automatically
esp8266:
  board: esp01_1m
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).



