### PR TITLE
[ci] Save the venv caches only from non-PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: venv
           # yamllint disable-line rule:line-length
@@ -67,6 +67,15 @@ jobs:
           python --version
           uv pip install -r requirements.txt -r requirements_dev.txt -r requirements_test.txt
           uv pip install -e .
+      - name: Save Python virtual environment
+        # Pull request saves land in per-PR scopes nothing else can
+        # reuse; dev pushes seed the shared copy instead.
+        if: github.event_name != 'pull_request' && steps.cache-venv.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: venv
+          # yamllint disable-line rule:line-length
+          key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ steps.cache-key.outputs.key }}
 
   seed-apt-cache:
     name: Seed apt package cache
@@ -375,7 +384,7 @@ jobs:
           python-version: "3.13"
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: venv
           key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
@@ -400,6 +409,15 @@ jobs:
           python --version
           uv pip install -r requirements.txt -r requirements_test.txt
           uv pip install -e .
+      - name: Save Python virtual environment
+        # Pull request saves land in per-PR scopes nothing else can
+        # reuse; dev pushes seed the shared copy instead.
+        if: github.event_name != 'pull_request' && steps.cache-venv.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: venv
+          # yamllint disable-line rule:line-length
+          key: ${{ runner.os }}-${{ steps.python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
       - name: Register matcher
         run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
       - name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,10 @@ jobs:
           uv pip install -r requirements.txt -r requirements_dev.txt -r requirements_test.txt
           uv pip install -e .
       - name: Save Python virtual environment
-        # Pull request saves land in per-PR scopes nothing else can
-        # reuse; dev pushes seed the shared copy instead.
-        if: github.event_name != 'pull_request' && steps.cache-venv.outputs.cache-hit != 'true'
+        # Saves from PR and merge-queue runs land in temporary ref
+        # scopes nothing else can reuse, and dev (the default branch)
+        # is readable from every ref - so only dev seeds the copy.
+        if: github.ref == 'refs/heads/dev' && steps.cache-venv.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: venv
@@ -410,9 +411,10 @@ jobs:
           uv pip install -r requirements.txt -r requirements_test.txt
           uv pip install -e .
       - name: Save Python virtual environment
-        # Pull request saves land in per-PR scopes nothing else can
-        # reuse; dev pushes seed the shared copy instead.
-        if: github.event_name != 'pull_request' && steps.cache-venv.outputs.cache-hit != 'true'
+        # Saves from PR and merge-queue runs land in temporary ref
+        # scopes nothing else can reuse, and dev (the default branch)
+        # is readable from every ref - so only dev seeds the copy.
+        if: github.ref == 'refs/heads/dev' && steps.cache-venv.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: venv


### PR DESCRIPTION
# What does this implement/fix?

The `common` and `integration-tests` jobs cache their venv with the combined `actions/cache` action, whose post-job save also runs on pull requests. A PR run can only write into its own merge-ref scope, which no other run can ever read - so whenever the dev-scoped copy of the venv key is missing (evicted under quota pressure, or not yet seeded after a requirements bump), every open PR rebuilds the venv and saves its own identical ~97MB copy. There are currently 21 such duplicates (~1.8GB) in the repo's 10GB Actions cache quota.

Worse, it is self-sustaining: cache restore prefers the own-ref copy over the base-branch copy, so once a PR has its private copy it stops keeping the dev copy warm, the dev copy gets LRU-evicted, and every new PR then misses and duplicates it again. The duplicates crowd the quota and evict the high-value toolchain caches (ESP-IDF, sdk-nrf, clang-tidy PlatformIO objects).

This splits both cache steps into `actions/cache/restore` plus a save gated to `github.ref == 'refs/heads/dev'` - the same pattern the pytest venv and components-graph caches in the same file already use. Dev pushes seed the shared copies (readable from every ref, since dev is the default branch); PR, merge-queue, and beta/release runs become pure readers.

Cost: in the window between a requirements bump merging and the next dev push completing, PR runs rebuild the venv inline. A single rebuild measured ~15s with uv (run 32790921237), but the cost is per venv-building job, not per run: the old PR-scope save also seeded the merge-ref copy for the ~16 downstream `restore-python` call sites within the same run, so a cold window now costs ~15-30s in each of those job instances (roughly 5-8 runner-minutes per PR run) until dev re-seeds. The window is bounded by dev's merge frequency, and reduced eviction pressure makes cold windows rarer in the first place.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).