### PR TITLE
[docker] Parallelize the image's PlatformIO library preinstall

### DIFF
--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -105,7 +105,7 @@ def parallel_install(manager_cls, specs: list) -> None:
     # (_MEMORY_CACHE, _INSTALL_HISTORY, the registry client). Built
     # serially, because every construction rewires the shared manager
     # logger and concurrent handler swaps drop log lines.
-    managers: queue.Queue = queue.Queue()
+    managers: queue.SimpleQueue = queue.SimpleQueue()
     for _ in range(workers):
         managers.put(manager_cls(None))
     local = threading.local()

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,9 +5,12 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
-import os
 import subprocess
-import threading
+
+from platformio.package.manager.library import LibraryPackageManager
+from platformio.package.manager.platform import PlatformPackageManager
+from platformio.package.manager.tool import ToolPackageManager
+from platformio.package.meta import PackageSpec
 
 config = configparser.ConfigParser(inline_comment_prefixes=(";",))
 
@@ -59,73 +62,69 @@ for section in config.sections():
 def spec_key(spec: str) -> str:
     """The destination identity of a spec: PlatformIO installs by package
     name, so two specs sharing a name share a directory."""
-    base = spec.split("@", 1)[0].strip()
-    if base.startswith(("http://", "https://", "file://")):
-        return spec.strip()
-    return base.split("/")[-1].lower()
+    name = PackageSpec(spec).name
+    return name.lower() if name else spec.strip()
 
 
 def parallel_install(manager_cls, specs: list[str]) -> None:
-    """Best-effort parallel top-level install, one extraction worker per core.
+    """Best-effort parallel top-level install.
 
     PlatformIO's own installer downloads and unpacks one package at a time
-    on one core. Each worker downloads (network bound, GIL released) and
-    unpacks (CPU bound), so the pool oversubscribes the cores to keep the
-    network busy while unpacks share them. Dependencies are skipped (two
-    packages sharing one must not extract into the same directory from two
-    threads) and any failure is left alone: the stock ``pkg install`` pass
-    below installs whatever is missing and is the authority on the final
-    state.
+    on one core. Each worker alternates a network bound download with a CPU
+    bound unpack, so the pool oversubscribes the cores to keep the network
+    busy while unpacks share them. Dependencies are skipped (two packages
+    sharing one must not extract into the same directory from two threads)
+    and failures are only reported: the stock ``pkg install`` pass below
+    installs whatever is missing and is the authority on the final state.
     """
+    if not specs:
+        return
     manager = manager_cls(None)
     # One spec per destination: platformio.ini repeats specs across env
     # sections, and two threads must not extract into the same directory.
-    # A second spec for the same name is left to the pkg install pass.
-    unique: dict[str, str] = {}
-    for spec in specs:
-        unique.setdefault(spec_key(spec), spec)
+    # Another spec for the same name is left to the pkg install pass.
+    unique = {spec_key(spec): spec for spec in specs}
     pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
         return
-    local = threading.local()
 
-    def install_one(spec: str) -> None:
+    def install_one(spec: str) -> bool:
         try:
-            if (mgr := getattr(local, "mgr", None)) is None:
-                mgr = local.mgr = manager_cls(None)
-            mgr._install(spec, skip_dependencies=True)  # noqa: SLF001
-        except Exception:  # noqa: BLE001
-            pass
+            manager_cls(None)._install(spec, skip_dependencies=True)  # noqa: SLF001
+            return True
+        except Exception as err:  # noqa: BLE001
+            print(f"Pre-install of {spec} failed ({err!r})", flush=True)
+            return False
 
-    cpus = getattr(os, "process_cpu_count", os.cpu_count)() or 4
-    workers = min(len(pending), max(8, 4 * cpus), 16)
-    print(f"Preinstalling {len(pending)} package(s) with {workers} workers")
+    workers = min(len(pending), 16)
+    print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
     manager.lock()
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
-            list(ex.map(install_one, pending))
+            results = list(ex.map(install_one, pending))
     finally:
         manager.unlock()
+    if not any(results):
+        # A systematic fault (e.g. a PlatformIO API change), not archive noise
+        print(
+            "Pre-install failed for every package; pkg install runs serially",
+            flush=True,
+        )
 
 
-if libs or platforms or tools:
-    from platformio.package.manager.library import LibraryPackageManager
-    from platformio.package.manager.platform import PlatformPackageManager
-    from platformio.package.manager.tool import ToolPackageManager
+for manager_cls, specs in (
+    (PlatformPackageManager, platforms),
+    (ToolPackageManager, tools),
+    (LibraryPackageManager, libs),
+):
+    parallel_install(manager_cls, specs)
 
-    for manager_cls, specs in (
-        (PlatformPackageManager, platforms),
-        (ToolPackageManager, tools),
-        (LibraryPackageManager, libs),
-    ):
-        if specs:
-            parallel_install(manager_cls, specs)
-
-cli_args = []
-for flag, specs in (("-l", libs), ("-p", platforms), ("-t", tools)):
-    for spec in specs:
-        cli_args.append(flag)
-        cli_args.append(spec)
+cli_args = [
+    arg
+    for flag, specs in (("-l", libs), ("-p", platforms), ("-t", tools))
+    for spec in specs
+    for arg in (flag, spec)
+]
 
 subprocess.check_call(
     ["platformio", "pkg", "install", "-g", *cli_args], close_fds=False

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -93,8 +93,12 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
 
 
 def predicted_dest(mgr, spec) -> Path | None:
-    """The spec's own install dir; a fallback (case/safe-dirname quirks),
-    not the primary lookup."""
+    """The spec's likely install dir; a best-effort fallback only.
+
+    pio installs into safe_dirname(manifest name), which can differ from
+    the registry spec name; a miss here degrades to a printed line and
+    the serial pass, never a wrong deletion.
+    """
     name = BasePackageManager.ensure_spec(spec).name
     return Path(mgr.package_dir, name) if name else None
 
@@ -126,7 +130,8 @@ def clean_torn(mgr, spec) -> None:
         except Exception as err:  # noqa: BLE001
             # Likely another worker's in-flight copy; back off and retry
             scan_err = err
-            time.sleep(0.2 * (2**attempt))
+            if attempt < 4:
+                time.sleep(0.2 * (2**attempt))
     if pkg is not None:
         remove_dir(spec, Path(pkg.path))
         return

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -71,14 +71,31 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     )
 
 
-def spec_key(spec: str) -> str:
+def spec_key(spec) -> str:
     """The destination identity of a spec: PlatformIO installs by package
     name, so two specs sharing a name share a directory."""
-    name = PackageSpec(spec).name
-    return name.lower() if name else spec.strip()
+    name = spec.name if isinstance(spec, PackageSpec) else PackageSpec(spec).name
+    return name.lower() if name else str(spec).strip()
 
 
-def parallel_install(manager_cls, specs: list) -> None:
+def dependency_specs(manager, specs) -> list:
+    """The registry dependency specs of the given installed packages.
+
+    Local manifest reads only. Name-only dependencies (platform-bundled
+    libs like SPI) are left to the ``pkg install`` pass."""
+    deps = []
+    for spec in specs:
+        if (pkg := manager.get_package(spec)) is None:
+            continue
+        deps.extend(
+            manager.dependency_to_spec(dep)
+            for dep in manager.get_pkg_dependencies(pkg) or []
+            if dep.get("owner") or dep.get("version")
+        )
+    return deps
+
+
+def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -> None:
     """Best-effort parallel top-level install.
 
     PlatformIO's own installer downloads and unpacks one package at a time
@@ -92,11 +109,15 @@ def parallel_install(manager_cls, specs: list) -> None:
     manager = manager_cls(None)
     # One spec per destination: platformio.ini repeats specs across env
     # sections, and two threads must not extract into the same directory.
-    # Another spec for the same name is left to the pkg install pass.
+    # Another spec for the same name, and URL specs (which install into a
+    # manifest-named dir the spec cannot predict), are left to the pkg
+    # install pass.
+    seen_names: set = prior_names if prior_names is not None else set()
     unique = {
-        spec_key(spec): spec for spec in specs if "://" not in spec
-    }  # URL specs install into a manifest-named dir the spec cannot predict;
-    # only the serial pass may handle them
+        spec_key(spec): spec
+        for spec in specs
+        if isinstance(spec, PackageSpec) or "://" not in spec
+    }
     pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
         return
@@ -148,6 +169,20 @@ def parallel_install(manager_cls, specs: list) -> None:
             "pkg install retries them serially",
             flush=True,
         )
+
+    # The wave skipped dependencies (a shared one must not extract from two
+    # threads); collect them from the installed manifests, dedupe by name,
+    # and run them as the next wave until nothing new appears
+    seen_names.update(unique)
+    # The pre-wave get_package calls memoized an empty storage snapshot
+    manager.memcache_reset()
+    next_specs = [
+        dep
+        for dep in dependency_specs(manager, pending)
+        if spec_key(dep) not in seen_names
+    ]
+    if next_specs and len(seen_names) < 200:  # cycle backstop
+        parallel_install(manager_cls, next_specs, seen_names)
 
 
 def build_cli_args(libs: list, platforms: list, tools: list) -> list:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,6 +5,7 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
+import json
 import os
 from pathlib import Path
 import queue
@@ -24,10 +25,11 @@ try:
     from platformio.package.meta import PackageCompatibility
 
     PARALLEL_AVAILABLE = True
-except ImportError:  # pragma: no cover
+except ImportError as err:  # pragma: no cover
     # A moved pio module must degrade to the serial pass, not kill the
     # image build; the tripwire test makes the drift loud in CI
     PARALLEL_AVAILABLE = False
+    IMPORT_ERROR = repr(err)
 
 # Network-bound downloads release the GIL, so the pool oversubscribes
 # the cores. This bypasses pio's 500ms registry throttle and races its
@@ -92,6 +94,33 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     )
 
 
+def piopm_matches(package_dir: str, spec) -> list[Path]:
+    """Dirs whose .piopm metadata names this spec; a positive match beats
+    guessing the manifest-derived dirname from the registry name."""
+    parsed = BasePackageManager.ensure_spec(spec)
+    want = (parsed.name or "").lower()
+    matches: list[Path] = []
+    try:
+        entries = list(Path(package_dir).iterdir())
+    except OSError:
+        return matches
+    for d in entries:
+        try:
+            meta = json.loads((d / ".piopm").read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue  # no metadata means pio does not trust it either
+        mspec = meta.get("spec") or {}
+        name = (mspec.get("name") or meta.get("name") or "").lower()
+        owner = (mspec.get("owner") or "").lower()
+        if (
+            want
+            and name == want
+            and (not parsed.owner or owner == parsed.owner.lower())
+        ):
+            matches.append(d)
+    return matches
+
+
 def predicted_dest(mgr, spec) -> Path | None:
     """The spec's likely install dir; a best-effort fallback only.
 
@@ -136,11 +165,16 @@ def clean_torn(mgr, spec) -> None:
         remove_dir(spec, Path(pkg.path))
         return
     # The scan verdict depends on the whole storage tree (or the manifest
-    # is unparsable); judge by this spec's own destination so an innocent
-    # worker's in-flight copy cannot fail the build naming the wrong spec
-    dest = predicted_dest(mgr, spec)
-    if dest is not None and dest.exists():
-        remove_dir(spec, dest)
+    # is unparsable); judge by this spec's own footprint so an innocent
+    # worker's in-flight copy cannot fail the build naming the wrong spec.
+    # A .piopm naming this spec is the exact shape the serial pass trusts.
+    dests = piopm_matches(mgr.package_dir, spec)
+    guess = predicted_dest(mgr, spec)
+    if guess is not None and guess.exists() and guess not in dests:
+        dests.append(guess)
+    if dests:
+        for dest in dests:
+            remove_dir(spec, dest)
     elif scan_err is not None:
         print(
             f"Could not inspect failed pre-install of {spec} "
@@ -295,17 +329,18 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         except Exception as err:  # noqa: BLE001
             unlock_error = err
             print(f"Could not release the manager lock ({err!r})", flush=True)
-            if isinstance(body_error, Exception) and not isinstance(
-                body_error, CleanupError
+            if body_error is not None and not isinstance(
+                body_error, (CleanupError, KeyboardInterrupt)
             ):
-                # A plain wave error would fall back to a serial pass that
-                # blocks on the held flock; the held lock is worse
+                # Any body error main() would swallow (SystemExit included)
+                # falls back to a serial pass that blocks on the held
+                # flock for its full timeout; the held lock is worse
                 raise LockReleaseError(
                     f"could not release the manager lock ({err!r}) after "
                     f"a wave failure ({body_error!r})"
                 ) from err
             if body_error is not None:
-                # Fatal classes stay in flight; record the second fault
+                # Build-fatal classes stay in flight; record the second fault
                 body_error.add_note(
                     f"also: could not release the manager lock ({err!r})"
                 )
@@ -315,6 +350,13 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             os.chdir(cwd)
         except OSError as chdir_err:
             print(f"Could not restore the working dir ({chdir_err!r})", flush=True)
+            if body_error is None:
+                # Further waves cannot run from an unknown cwd; the serial
+                # pass is safe either way (its cwd is pinned)
+                raise
+            body_error.add_note(
+                f"also: could not restore the working dir ({chdir_err!r})"
+            )
     if unlock_error is not None:
         # A held flock would hang the serial pass in another process;
         # failing loudly beats an unexplained stuck docker build
@@ -387,7 +429,10 @@ def main() -> None:
         wave_groups = [(ToolPackageManager, tools), (LibraryPackageManager, libs)]
     else:  # pragma: no cover
         wave_groups = []
-        print("PlatformIO layout changed; serial install only", flush=True)
+        print(
+            f"PlatformIO layout changed ({IMPORT_ERROR}); serial install only",
+            flush=True,
+        )
     for manager_cls, specs in wave_groups:
         try:
             parallel_install(manager_cls, specs)

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -60,10 +60,13 @@ def parallel_install(manager_cls, specs: list[str]) -> None:
     """Best-effort parallel top-level install, one extraction worker per core.
 
     PlatformIO's own installer downloads and unpacks one package at a time
-    on one core. Dependencies are skipped (two packages sharing one must
-    not extract into the same directory from two threads) and any failure
-    is left alone: the stock ``pkg install`` pass below installs whatever
-    is missing and is the authority on the final state.
+    on one core. Each worker downloads (network bound, GIL released) and
+    unpacks (CPU bound), so the pool oversubscribes the cores to keep the
+    network busy while unpacks share them. Dependencies are skipped (two
+    packages sharing one must not extract into the same directory from two
+    threads) and any failure is left alone: the stock ``pkg install`` pass
+    below installs whatever is missing and is the authority on the final
+    state.
     """
     manager = manager_cls(None)
     pending = [spec for spec in specs if not manager.get_package(spec)]
@@ -80,9 +83,11 @@ def parallel_install(manager_cls, specs: list[str]) -> None:
             pass
 
     cpus = getattr(os, "process_cpu_count", os.cpu_count)() or 4
+    workers = min(len(pending), max(8, 4 * cpus), 16)
+    print(f"Preinstalling {len(pending)} package(s) with {workers} workers")
     manager.lock()
     try:
-        with ThreadPoolExecutor(max_workers=min(cpus, len(pending))) as ex:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
             list(ex.map(install_one, pending))
     finally:
         manager.unlock()

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -3,8 +3,11 @@
 # all platformio libraries in the global storage
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 import configparser
+import os
 import subprocess
+import threading
 
 config = configparser.ConfigParser(inline_comment_prefixes=(";",))
 
@@ -36,10 +39,8 @@ for section in config.sections():
             if "@" not in lib_dep:
                 # No version pinned, this is an internal lib
                 continue
-            libs.append("-l")
             libs.append(lib_dep)
     if "platform" in conf and args.platforms:
-        platforms.append("-p")
         platforms.append(conf["platform"])
     if "platform_packages" in conf and args.tools:
         for tool in conf["platform_packages"].splitlines():
@@ -52,9 +53,60 @@ for section in config.sections():
             if tool.find("https://github.com") != -1:
                 split = tool.find("@")
                 tool = tool[split + 1 :]
-            tools.append("-t")
             tools.append(tool)
 
+
+def parallel_install(manager_cls, specs: list[str]) -> None:
+    """Best-effort parallel top-level install, one extraction worker per core.
+
+    PlatformIO's own installer downloads and unpacks one package at a time
+    on one core. Dependencies are skipped (two packages sharing one must
+    not extract into the same directory from two threads) and any failure
+    is left alone: the stock ``pkg install`` pass below installs whatever
+    is missing and is the authority on the final state.
+    """
+    manager = manager_cls(None)
+    pending = [spec for spec in specs if not manager.get_package(spec)]
+    if not pending:
+        return
+    local = threading.local()
+
+    def install_one(spec: str) -> None:
+        try:
+            if (mgr := getattr(local, "mgr", None)) is None:
+                mgr = local.mgr = manager_cls(None)
+            mgr._install(spec, skip_dependencies=True)  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            pass
+
+    cpus = getattr(os, "process_cpu_count", os.cpu_count)() or 4
+    manager.lock()
+    try:
+        with ThreadPoolExecutor(max_workers=min(cpus, len(pending))) as ex:
+            list(ex.map(install_one, pending))
+    finally:
+        manager.unlock()
+
+
+if libs or platforms or tools:
+    from platformio.package.manager.library import LibraryPackageManager
+    from platformio.package.manager.platform import PlatformPackageManager
+    from platformio.package.manager.tool import ToolPackageManager
+
+    for manager_cls, specs in (
+        (PlatformPackageManager, platforms),
+        (ToolPackageManager, tools),
+        (LibraryPackageManager, libs),
+    ):
+        if specs:
+            parallel_install(manager_cls, specs)
+
+cli_args = []
+for flag, specs in (("-l", libs), ("-p", platforms), ("-t", tools)):
+    for spec in specs:
+        cli_args.append(flag)
+        cli_args.append(spec)
+
 subprocess.check_call(
-    ["platformio", "pkg", "install", "-g", *libs, *platforms, *tools], close_fds=False
+    ["platformio", "pkg", "install", "-g", *cli_args], close_fds=False
 )

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -189,7 +189,11 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         except Exception as scan_err:  # noqa: BLE001
             # A transient read of another worker's in-flight copy must not
             # hard-fail the build blaming this spec
-            print(f"Could not inspect failed pre-install of {spec} ({scan_err!r})")
+            print(
+                f"Could not inspect failed pre-install of {spec} ({scan_err!r}); "
+                "a torn destination may remain",
+                flush=True,
+            )
             return
         if pkg is None:
             # Visible: an unresolvable torn directory is indistinguishable
@@ -215,10 +219,11 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
                 spec, skip_dependencies=True, compatibility=compat
             )
             return True
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError) as err:
             # A PlatformIO API break, not a flaky package; clean the torn
             # destination, then surface it so total degradation reads
             # differently from a network blip
+            print(f"Pre-install of {spec} hit an API break ({err!r})", flush=True)
             clean_torn(mgr, spec)
             raise
         except Exception as err:  # noqa: BLE001
@@ -241,6 +246,10 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         # All futures are done (the with-block joins); drain every one so
         # a concurrent CleanupError is never dropped by iteration order
         errors = [err for f in futures if (err := f.exception()) is not None]
+        for err in errors[1:] if errors else []:
+            # Every sibling failure is part of the record, not just the
+            # one that wins the raise
+            print(f"Additional wave failure: {err!r}", flush=True)
         for err in errors:
             if isinstance(err, CleanupError):
                 raise err
@@ -250,8 +259,12 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     finally:
         manager.unlock()
         # Worker postinstall scripts chdir process-wide (pio's fs.cd);
-        # restore between waves, not only for the final subprocess
-        os.chdir(cwd)
+        # restore between waves, not only for the final subprocess. A
+        # restore failure must not replace an in-flight CleanupError.
+        try:
+            os.chdir(cwd)
+        except OSError as chdir_err:
+            print(f"Could not restore the working dir ({chdir_err!r})", flush=True)
     if failures := len(results) - sum(results):
         # Visible once per wave. The stock pass retries CLI specs and,
         # for already-installed packages, re-walks their dependencies

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import queue
+import stat
 import subprocess
 import threading
 import time
@@ -139,7 +140,17 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
             f"could not scan {package_dir} while cleaning up {spec}: {err!r}"
         ) from err
     for d in entries:
-        if not d.is_dir():
+        try:
+            entry_stat = os.lstat(d)
+        except FileNotFoundError:
+            continue  # vanished mid-scan; nothing left to clean
+        except OSError as err:
+            # Path.is_dir would read this as skippable; unverifiable
+            # entries must fail the build like everywhere else
+            raise CleanupError(
+                f"could not stat {d} while cleaning up {spec}: {err!r}"
+            ) from err
+        if not stat.S_ISDIR(entry_stat.st_mode):
             continue  # pio's get_installed skips files and *.pio-link too
         meta = None
         last_err = None
@@ -239,9 +250,11 @@ def clean_torn(mgr, spec) -> None:
     if pkg is not None:
         dest = Path(pkg.path)
         store = Path(os.path.realpath(mgr.package_dir))
-        if not Path(os.path.realpath(dest)).is_relative_to(store):
+        resolved = Path(os.path.realpath(dest))
+        if resolved == store or not resolved.is_relative_to(store):
             # A symlinked (.pio-link) package resolves to its external
-            # source dir; this script only ever removes inside the store
+            # source dir; this script only removes strictly inside the
+            # store, never the store itself
             print(f"Refusing to remove {dest} outside {store}", flush=True)
             return
         remove_dir(spec, dest)

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -54,7 +54,14 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
                     split = tool.find("@")
                     tool = tool[split + 1 :]
                 tools.append(tool)
-    return libs, platforms, tools
+    # Exact-string duplicates only: each costs the pkg install pass a
+    # lock and rescan cycle. Name-level dedupe would change which version
+    # conflicts the pass reconciles, so it stays out of scope here.
+    return (
+        list(dict.fromkeys(libs)),
+        list(dict.fromkeys(platforms)),
+        list(dict.fromkeys(tools)),
+    )
 
 
 def spec_key(spec: str) -> str:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,58 +5,56 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
+import shutil
 import subprocess
+import threading
 
 from platformio.package.manager.library import LibraryPackageManager
-from platformio.package.manager.platform import PlatformPackageManager
 from platformio.package.manager.tool import ToolPackageManager
 from platformio.package.meta import PackageSpec
 
-config = configparser.ConfigParser(inline_comment_prefixes=(";",))
-
-parser = argparse.ArgumentParser(description="")
-parser.add_argument("file", help="Path to platformio.ini", nargs=1)
-parser.add_argument("-l", "--libraries", help="Install libraries", action="store_true")
-parser.add_argument("-p", "--platforms", help="Install platforms", action="store_true")
-parser.add_argument("-t", "--tools", help="Install tools", action="store_true")
-
-args = parser.parse_args()
-
-config.read(args.file)
+# Downloads are network bound and release the GIL, unpacks are CPU bound;
+# a fixed pool well past the core count keeps the network busy while
+# unpacks share the cores.
+MAX_WORKERS = 16
 
 
-libs = []
-tools = []
-platforms = []
-# Extract from every lib_deps key in all sections
-for section in config.sections():
-    conf = config[section]
-    if "lib_deps" in conf and args.libraries:
-        for lib_dep in conf["lib_deps"].splitlines():
-            if not lib_dep:
-                # Empty line or comment
-                continue
-            if lib_dep.startswith("${"):
-                # Extending from another section
-                continue
-            if "@" not in lib_dep:
-                # No version pinned, this is an internal lib
-                continue
-            libs.append(lib_dep)
-    if "platform" in conf and args.platforms:
-        platforms.append(conf["platform"])
-    if "platform_packages" in conf and args.tools:
-        for tool in conf["platform_packages"].splitlines():
-            if not tool:
-                # Empty line or comment
-                continue
-            if tool.startswith("${"):
-                # Extending from another section
-                continue
-            if tool.find("https://github.com") != -1:
-                split = tool.find("@")
-                tool = tool[split + 1 :]
-            tools.append(tool)
+def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
+    """Extract lib/platform/tool specs from every section of a platformio.ini."""
+    config = configparser.ConfigParser(inline_comment_prefixes=(";",))
+    config.read(path)
+    libs = []
+    tools = []
+    platforms = []
+    for section in config.sections():
+        conf = config[section]
+        if "lib_deps" in conf and args.libraries:
+            for lib_dep in conf["lib_deps"].splitlines():
+                if not lib_dep:
+                    # Empty line or comment
+                    continue
+                if lib_dep.startswith("${"):
+                    # Extending from another section
+                    continue
+                if "@" not in lib_dep:
+                    # No version pinned, this is an internal lib
+                    continue
+                libs.append(lib_dep)
+        if "platform" in conf and args.platforms:
+            platforms.append(conf["platform"])
+        if "platform_packages" in conf and args.tools:
+            for tool in conf["platform_packages"].splitlines():
+                if not tool:
+                    # Empty line or comment
+                    continue
+                if tool.startswith("${"):
+                    # Extending from another section
+                    continue
+                if tool.find("https://github.com") != -1:
+                    split = tool.find("@")
+                    tool = tool[split + 1 :]
+                tools.append(tool)
+    return libs, platforms, tools
 
 
 def spec_key(spec: str) -> str:
@@ -66,16 +64,14 @@ def spec_key(spec: str) -> str:
     return name.lower() if name else spec.strip()
 
 
-def parallel_install(manager_cls, specs: list[str]) -> None:
+def parallel_install(manager_cls, specs: list) -> None:
     """Best-effort parallel top-level install.
 
     PlatformIO's own installer downloads and unpacks one package at a time
-    on one core. Each worker alternates a network bound download with a CPU
-    bound unpack, so the pool oversubscribes the cores to keep the network
-    busy while unpacks share them. Dependencies are skipped (two packages
-    sharing one must not extract into the same directory from two threads)
-    and failures are only reported: the stock ``pkg install`` pass below
-    installs whatever is missing and is the authority on the final state.
+    on one core. Dependencies are skipped (two packages sharing one must
+    not extract into the same directory from two threads) and failures are
+    only reported: the stock ``pkg install`` pass afterwards installs
+    whatever is missing and is the authority on the final state.
     """
     if not specs:
         return
@@ -87,16 +83,28 @@ def parallel_install(manager_cls, specs: list[str]) -> None:
     pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
         return
+    # One manager per worker thread: each construction rewires the
+    # process-global manager logger, which drops lines under concurrency
+    local = threading.local()
 
     def install_one(spec: str) -> bool:
+        if (mgr := getattr(local, "mgr", None)) is None:
+            mgr = local.mgr = manager_cls(None)
         try:
-            manager_cls(None)._install(spec, skip_dependencies=True)  # noqa: SLF001
+            mgr._install(spec, skip_dependencies=True)  # noqa: SLF001
             return True
         except Exception as err:  # noqa: BLE001
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
+            # A torn copy into the destination can carry valid metadata the
+            # pkg install pass would trust; remove it so that pass redoes it
+            try:
+                if (pkg := mgr.get_package(spec)) is not None:
+                    shutil.rmtree(pkg.path, ignore_errors=True)
+            except Exception:  # noqa: BLE001
+                pass
             return False
 
-    workers = min(len(pending), 16)
+    workers = min(len(pending), MAX_WORKERS)
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
     manager.lock()
     try:
@@ -112,20 +120,45 @@ def parallel_install(manager_cls, specs: list[str]) -> None:
         )
 
 
-for manager_cls, specs in (
-    (PlatformPackageManager, platforms),
-    (ToolPackageManager, tools),
-    (LibraryPackageManager, libs),
-):
-    parallel_install(manager_cls, specs)
+def build_cli_args(libs: list, platforms: list, tools: list) -> list:
+    return [
+        arg
+        for flag, specs in (("-l", libs), ("-p", platforms), ("-t", tools))
+        for spec in specs
+        for arg in (flag, spec)
+    ]
 
-cli_args = [
-    arg
-    for flag, specs in (("-l", libs), ("-p", platforms), ("-t", tools))
-    for spec in specs
-    for arg in (flag, spec)
-]
 
-subprocess.check_call(
-    ["platformio", "pkg", "install", "-g", *cli_args], close_fds=False
-)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("file", help="Path to platformio.ini", nargs=1)
+    parser.add_argument(
+        "-l", "--libraries", help="Install libraries", action="store_true"
+    )
+    parser.add_argument(
+        "-p", "--platforms", help="Install platforms", action="store_true"
+    )
+    parser.add_argument("-t", "--tools", help="Install tools", action="store_true")
+    args = parser.parse_args()
+    libs, platforms, tools = parse_specs(args.file, args)
+
+    # Platforms stay serial: PlatformPackageManager.install runs an
+    # on_installed hook the private _install path would skip
+    for manager_cls, specs in (
+        (ToolPackageManager, tools),
+        (LibraryPackageManager, libs),
+    ):
+        try:
+            parallel_install(manager_cls, specs)
+        except Exception as err:  # noqa: BLE001
+            # The wave is an optimization; it must never stop the real pass
+            print(f"Parallel preinstall skipped ({err!r})", flush=True)
+
+    subprocess.check_call(
+        ["platformio", "pkg", "install", "-g", *build_cli_args(libs, platforms, tools)],
+        close_fds=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -106,6 +106,22 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     )
 
 
+def manifest_present(d: Path) -> bool:
+    """Whether the dir carries one of pio's manifest files. Path.is_file
+    reads any OSError as "absent"; a stat error is unverifiable instead."""
+    for m in _MANIFEST_NAMES:
+        try:
+            os.lstat(d / m)
+        except FileNotFoundError:
+            continue
+        except OSError as err:
+            raise CleanupError(
+                f"could not check for a manifest in {d}: {err!r}"
+            ) from err
+        return True
+    return False
+
+
 def piopm_matches(package_dir: str, spec) -> list[Path]:
     """Dirs whose .piopm metadata names this spec; a positive match beats
     guessing the manifest-derived dirname from the registry name."""
@@ -141,9 +157,11 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
                 if attempt < 2:
                     time.sleep(0.1 * (2**attempt))
         if meta is None:
-            if last_err is not None:
+            if last_err is not None and d.name.lower() == want:
                 # A corrupt .piopm crashes pio's own storage scan, so the
-                # serial pass could not even run over it; remove it
+                # serial pass could not even run over it; remove it, but
+                # only under this spec's own name (an innocent worker may
+                # be mid-copy of another package's metadata)
                 print(
                     f"Removing unreadable-metadata dir {d} ({last_err!r})", flush=True
                 )
@@ -164,7 +182,7 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
                 )
             except ValueError:
                 other_version = False  # unparsable version stays a candidate
-            if other_version and any((d / m).is_file() for m in _MANIFEST_NAMES):
+            if other_version and manifest_present(d):
                 # An intact other version this run never tried to write
                 continue
             # An other-version dir without a manifest is a half-deleted
@@ -219,7 +237,14 @@ def clean_torn(mgr, spec) -> None:
             if attempt < 4:
                 time.sleep(0.2 * (2**attempt))
     if pkg is not None:
-        remove_dir(spec, Path(pkg.path))
+        dest = Path(pkg.path)
+        store = Path(os.path.realpath(mgr.package_dir))
+        if not Path(os.path.realpath(dest)).is_relative_to(store):
+            # A symlinked (.pio-link) package resolves to its external
+            # source dir; this script only ever removes inside the store
+            print(f"Refusing to remove {dest} outside {store}", flush=True)
+            return
+        remove_dir(spec, dest)
         return
     # The scan verdict depends on the whole storage tree (or the manifest
     # is unparsable); judge by this spec's own footprint so an innocent
@@ -248,35 +273,42 @@ def spec_key(spec) -> str | None:
     return name.lower() if name else None
 
 
-def dependency_specs(manager, specs: list, installed_ok: set) -> list:
+def dependency_specs(manager, specs: list, failed: set) -> list:
     """``(spec, compatibility)`` registry dependencies of installed packages.
 
     Local manifest reads only. Name-only dependencies (platform-bundled
-    libs like SPI) are left to the ``pkg install`` pass; a *versioned*
-    built-in name cannot be recognized here (no platforms are installed
-    at wave time), so it may be installed from the registry. The
-    compatibility qualifiers mirror pio's install_dependency, so a
-    qualified dep resolves to the same package the serial pass picks."""
+    libs like SPI) are left to the ``pkg install`` pass, and a versioned
+    owner-less name is skipped when the manager recognizes it as built-in,
+    exactly like pio's install_dependency (built-ins only resolve once
+    platforms are in the store, e.g. on a warm run). The compatibility
+    qualifiers mirror install_dependency, so a qualified dep resolves to
+    the same package the serial pass picks."""
     deps = []
+    is_builtin = getattr(manager, "is_builtin_lib", None)
     for spec in specs:
         if (pkg := manager.get_package(spec)) is None:
-            if spec_key(spec) in installed_ok:
-                # A reported-success install that resolves to nothing is an
-                # anomaly; its subtree quietly falls to the serial pass
+            if spec_key(spec) not in failed:
+                # Everything but a failed install resolved moments ago;
+                # losing it now is an anomaly, and its subtree quietly
+                # falls to the serial pass
                 print(
                     f"Installed {spec} is not resolvable afterwards; its "
                     "dependencies are left to pkg install",
                     flush=True,
                 )
             continue
-        deps.extend(
-            (
-                manager.dependency_to_spec(dep),
-                PackageCompatibility.from_dependency(dep),
-            )
-            for dep in manager.get_pkg_dependencies(pkg) or []
-            if dep.get("owner") or dep.get("version")
-        )
+        for dep in manager.get_pkg_dependencies(pkg) or []:
+            if not dep.get("owner") and not dep.get("version"):
+                continue  # bare platform-bundled names stay with pkg install
+            dspec = manager.dependency_to_spec(dep)
+            if (
+                is_builtin is not None
+                and not dspec.external
+                and not dspec.owner
+                and is_builtin(dspec.name)
+            ):
+                continue  # pio's install_dependency skips known built-ins
+            deps.append((dspec, PackageCompatibility.from_dependency(dep)))
     return deps
 
 
@@ -455,13 +487,13 @@ def _next_wave(
     seen_names.update(unique)
     # The pre-wave get_package calls memoized an empty storage snapshot
     manager.memcache_reset()
-    installed_ok = {
-        spec_key(spec) for (spec, _), ok in zip(pending, results, strict=True) if ok
+    failed = {
+        spec_key(spec) for (spec, _), ok in zip(pending, results, strict=True) if not ok
     }
     next_specs = [
         item
         for item in dependency_specs(
-            manager, [spec for spec, _ in unique.values()], installed_ok
+            manager, [spec for spec, _ in unique.values()], failed
         )
         if spec_key(item[0]) not in seen_names
     ]

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,6 +5,7 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
+import os
 from pathlib import Path
 import queue
 import subprocess
@@ -29,7 +30,9 @@ except ImportError:  # pragma: no cover
 
 # Downloads are network bound and release the GIL, unpacks are CPU bound;
 # a fixed pool well past the core count keeps the network busy while
-# unpacks share the cores.
+# unpacks share the cores. This bypasses pio's 500ms registry throttle
+# and races its self-unlinking usage.db/http-cache LockFiles; both are
+# cache-only bookkeeping and self-healing.
 MAX_WORKERS = 16
 
 
@@ -149,9 +152,11 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     pairs = [item if isinstance(item, tuple) else (item, None) for item in specs]
     unique = {}
     for spec, compat in pairs:
-        if spec.uri if isinstance(spec, PackageSpec) else "://" in spec:
+        # Normalize once: a dependency's URL version surfaces as spec.uri
+        parsed = spec if isinstance(spec, PackageSpec) else PackageSpec(spec)
+        if parsed.uri:
             continue
-        if (key := spec_key(spec)) is None:
+        if (key := spec_key(parsed)) is None:
             # No name, no destination identity; leave it to the serial pass
             print(f"Skipping unresolvable spec {spec!r} in the wave", flush=True)
             continue
@@ -228,6 +233,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     for lazy_dir in (manager.get_download_dir(), manager.get_tmp_dir()):
         Path(lazy_dir).mkdir(parents=True, exist_ok=True)
     ContentCache("http")
+    cwd = Path.cwd()
     manager.lock()
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
@@ -243,6 +249,9 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         results = [f.result() for f in futures]
     finally:
         manager.unlock()
+        # Worker postinstall scripts chdir process-wide (pio's fs.cd);
+        # restore between waves, not only for the final subprocess
+        os.chdir(cwd)
     if failures := len(results) - sum(results):
         # Visible once per wave. The stock pass retries CLI specs and,
         # for already-installed packages, re-walks their dependencies

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,9 +5,11 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
+from pathlib import Path
 import queue
 import subprocess
 import threading
+import traceback
 
 # esphome is not installed at this docker layer, so its rmtree helper is
 # out of reach; pio's fs.rmtree is the same chmod-on-readonly shape and
@@ -15,7 +17,7 @@ import threading
 from platformio import fs
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.tool import ToolPackageManager
-from platformio.package.meta import PackageSpec
+from platformio.package.meta import PackageCompatibility, PackageSpec
 
 # Downloads are network bound and release the GIL, unpacks are CPU bound;
 # a fixed pool well past the core count keeps the network busy while
@@ -78,17 +80,30 @@ def spec_key(spec) -> str:
     return name.lower() if name else str(spec).strip()
 
 
-def dependency_specs(manager, specs) -> list:
-    """The registry dependency specs of the given installed packages.
+def dependency_specs(manager, specs: list, installed_ok: set) -> list:
+    """``(spec, compatibility)`` registry dependencies of installed packages.
 
     Local manifest reads only. Name-only dependencies (platform-bundled
-    libs like SPI) are left to the ``pkg install`` pass."""
+    libs like SPI) are left to the ``pkg install`` pass. The compatibility
+    qualifiers mirror pio's install_dependency, so a qualified dep resolves
+    to the same package the serial pass would have picked."""
     deps = []
     for spec in specs:
         if (pkg := manager.get_package(spec)) is None:
+            if spec_key(spec) in installed_ok:
+                # A reported-success install that resolves to nothing is an
+                # anomaly; its subtree quietly falls to the serial pass
+                print(
+                    f"Installed {spec} is not resolvable afterwards; its "
+                    "dependencies are left to pkg install",
+                    flush=True,
+                )
             continue
         deps.extend(
-            manager.dependency_to_spec(dep)
+            (
+                manager.dependency_to_spec(dep),
+                PackageCompatibility.from_dependency(dep),
+            )
             for dep in manager.get_pkg_dependencies(pkg) or []
             if dep.get("owner") or dep.get("version")
         )
@@ -113,12 +128,18 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     # manifest-named dir the spec cannot predict), are left to the pkg
     # install pass; a dependency's URL version surfaces as spec.uri.
     seen_names: set = prior_names if prior_names is not None else set()
+    # Wave-1 items are strings; dependency waves carry (spec, compatibility)
+    pairs = [item if isinstance(item, tuple) else (item, None) for item in specs]
     unique = {
-        spec_key(spec): spec
-        for spec in specs
+        spec_key(spec): (spec, compat)
+        for spec, compat in pairs
         if not (spec.uri if isinstance(spec, PackageSpec) else "://" in spec)
     }
-    pending = [spec for spec in unique.values() if not manager.get_package(spec)]
+    pending = [
+        (spec, compat)
+        for spec, compat in unique.values()
+        if not manager.get_package(spec)
+    ]
     if not pending:
         return
     workers = min(len(pending), MAX_WORKERS)
@@ -131,11 +152,14 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         managers.put(manager_cls(None))
     local = threading.local()
 
-    def install_one(spec: str) -> bool:
+    def install_one(item) -> bool:
+        spec, compat = item
         if (mgr := getattr(local, "mgr", None)) is None:
             mgr = local.mgr = managers.get_nowait()
         try:
-            mgr._install(spec, skip_dependencies=True)  # noqa: SLF001
+            mgr._install(  # noqa: SLF001
+                spec, skip_dependencies=True, compatibility=compat
+            )
             return True
         except Exception as err:  # noqa: BLE001
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
@@ -178,13 +202,27 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     seen_names.update(unique)
     # The pre-wave get_package calls memoized an empty storage snapshot
     manager.memcache_reset()
+    installed_ok = {
+        spec_key(spec) for (spec, _), ok in zip(pending, results, strict=True) if ok
+    }
     next_specs = [
-        dep
-        for dep in dependency_specs(manager, pending)
-        if spec_key(dep) not in seen_names
+        item
+        for item in dependency_specs(
+            manager, [spec for spec, _ in pending], installed_ok
+        )
+        if spec_key(item[0]) not in seen_names
     ]
-    if next_specs and len(seen_names) < 200:  # cycle backstop
+    if not next_specs:
+        return
+    if len(seen_names) < 200:  # cycle backstop
         parallel_install(manager_cls, next_specs, seen_names)
+    else:
+        # Truncation must be visible, not an unexplained slow serial pass
+        print(
+            f"Dependency wave limit reached; {len(next_specs)} spec(s) "
+            "left to pkg install",
+            flush=True,
+        )
 
 
 def build_cli_args(libs: list, platforms: list, tools: list) -> list:
@@ -207,6 +245,7 @@ def main() -> None:
     )
     parser.add_argument("-t", "--tools", help="Install tools", action="store_true")
     args = parser.parse_args()
+    start_cwd = Path.cwd()
     libs, platforms, tools = parse_specs(args.file[0], args)
 
     # Platforms stay serial: PlatformPackageManager.install runs an
@@ -217,13 +256,18 @@ def main() -> None:
     ):
         try:
             parallel_install(manager_cls, specs)
-        except Exception as err:  # noqa: BLE001
-            # The wave is an optimization; it must never stop the real pass
-            print(f"Parallel preinstall skipped ({err!r})", flush=True)
+        except Exception:  # noqa: BLE001
+            # The wave is an optimization; it must never stop the real
+            # pass, but a persistent break must read as a failure in logs
+            print("Parallel preinstall failed, falling back to serial", flush=True)
+            traceback.print_exc()
 
+    # Postinstall scripts chdir process-wide (pio's fs.cd captures its
+    # restore path at construction); pin the authoritative pass's cwd
     subprocess.check_call(
         ["platformio", "pkg", "install", "-g", *build_cli_args(libs, platforms, tools)],
         close_fds=False,
+        cwd=start_cwd,
     )
 
 

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -123,6 +123,8 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
             f"could not scan {package_dir} while cleaning up {spec}: {err!r}"
         ) from err
     for d in entries:
+        if not d.is_dir():
+            continue  # pio's get_installed skips files and *.pio-link too
         meta = None
         last_err = None
         for attempt in range(3):
@@ -364,7 +366,10 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         submit_error = None
         with ThreadPoolExecutor(max_workers=workers) as ex:
             try:
-                futures.extend(ex.submit(install_one, item) for item in pending)
+                for item in pending:
+                    # An explicit append: every submitted future must be
+                    # drained even when a later submit raises
+                    futures.append(ex.submit(install_one, item))  # noqa: PERF401
             except BaseException as err:  # noqa: BLE001
                 # Already-submitted workers run to completion in __exit__;
                 # their CleanupErrors must still be drained below

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -39,6 +39,11 @@ class CleanupError(RuntimeError):
     trust it, so the build must fail rather than bake a corrupt image."""
 
 
+class LockReleaseError(RuntimeError):
+    """The manager lock could not be released; the serial pass would
+    block on it, so the build must fail with the cause named."""
+
+
 def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     """Extract lib/platform/tool specs from every section of a platformio.ini."""
     config = configparser.ConfigParser(inline_comment_prefixes=(";",))
@@ -171,12 +176,29 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         managers.put(manager_cls(None))
     local = threading.local()
 
+    def predicted_dest(mgr, spec) -> Path | None:
+        # pio installs by package name; case and safe-dirname quirks make
+        # this a fallback, not the primary lookup
+        name = spec.name if isinstance(spec, PackageSpec) else PackageSpec(spec).name
+        return Path(mgr.package_dir, name) if name else None
+
+    def remove_dir(spec, dest: Path) -> None:
+        # fs.rmtree never raises (errors go to a printing onexc handler);
+        # only the destination's absence proves the cleanup worked
+        fs.rmtree(str(dest))
+        if dest.exists():
+            # Failing the build beats baking a corrupt image
+            raise CleanupError(
+                f"could not remove the failed pre-install of {spec} at {dest}"
+            )
+        print(f"Removed torn destination {dest}", flush=True)
+
     def clean_torn(mgr, spec) -> None:
         # A torn copy into the destination can carry valid metadata the
         # pkg install pass would trust; remove it so that pass redoes it
         scan_err = None
         pkg = None
-        for _attempt in range(3):
+        for attempt in range(5):
             try:
                 # get_package memoizes a pre-install snapshot; without a
                 # reset it cannot see the torn directory
@@ -185,26 +207,33 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
                 scan_err = None
                 break
             except Exception as err:  # noqa: BLE001
-                # Likely another worker's in-flight copy; retry first
+                # Likely another worker's in-flight copy; back off and retry
                 scan_err = err
-                time.sleep(0.2)
+                time.sleep(0.2 * (2**attempt))
         if scan_err is not None:
-            # Unverifiable: a trusted torn destination may remain
-            raise CleanupError(
-                f"could not verify the failed pre-install of {spec}: {scan_err!r}"
-            ) from scan_err
-        if pkg is None:
-            # An unresolvable torn dir must not look like nothing-to-clean
-            print(f"No resolvable destination to clean for {spec}", flush=True)
+            # The scan verdict depends on the whole storage tree; judge by
+            # this spec's own destination so an innocent worker's in-flight
+            # copy cannot fail the build naming the wrong spec
+            dest = predicted_dest(mgr, spec)
+            if dest is not None and dest.exists():
+                remove_dir(spec, dest)
+            else:
+                print(
+                    f"Could not inspect failed pre-install of {spec} "
+                    f"({scan_err!r}); no destination to clean",
+                    flush=True,
+                )
             return
-        # fs.rmtree never raises (errors go to a printing onexc handler);
-        # only the destination's absence proves the cleanup worked
-        fs.rmtree(pkg.path)
-        if Path(pkg.path).exists():
-            # Failing the build beats baking a corrupt image
-            raise CleanupError(
-                f"could not remove the failed pre-install of {spec} at {pkg.path}"
-            )
+        if pkg is None:
+            # A torn dir with an unparsable manifest is invisible to
+            # get_package; fall back to the predicted destination
+            dest = predicted_dest(mgr, spec)
+            if dest is not None and dest.exists():
+                remove_dir(spec, dest)
+            else:
+                print(f"No resolvable destination to clean for {spec}", flush=True)
+            return
+        remove_dir(spec, Path(pkg.path))
 
     def install_one(item) -> bool:
         spec, compat = item
@@ -232,6 +261,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         Path(lazy_dir).mkdir(parents=True, exist_ok=True)
     ContentCache("http")
     cwd = Path.cwd()
+    unlock_error = None
     manager.lock()
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
@@ -252,14 +282,21 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         # Neither cleanup may replace an in-flight CleanupError
         try:
             manager.unlock()
-        except Exception as unlock_err:  # noqa: BLE001
-            print(f"Could not release the manager lock ({unlock_err!r})", flush=True)
+        except Exception as err:  # noqa: BLE001
+            unlock_error = err
+            print(f"Could not release the manager lock ({err!r})", flush=True)
         # Worker postinstall scripts chdir process-wide (pio's fs.cd);
         # restore between waves, not only for the final subprocess
         try:
             os.chdir(cwd)
         except OSError as chdir_err:
             print(f"Could not restore the working dir ({chdir_err!r})", flush=True)
+    if unlock_error is not None:
+        # A held flock would hang the serial pass in another process;
+        # failing loudly beats an unexplained stuck docker build
+        raise LockReleaseError(
+            f"could not release the manager lock: {unlock_error!r}"
+        ) from unlock_error
     if failures := len(results) - sum(results):
         # The stock pass retries CLI specs and re-walks installed
         # packages' dependencies, so failed deps retry too
@@ -332,12 +369,12 @@ def main() -> None:
     for manager_cls, specs in wave_groups:
         try:
             parallel_install(manager_cls, specs)
-        except CleanupError:
-            # A torn package the serial pass would trust is still on disk
+        except (CleanupError, LockReleaseError, KeyboardInterrupt):
+            # A torn package or a held lock must fail the build
             raise
-        except Exception:  # noqa: BLE001
-            # The wave is an optimization; it must never stop the real
-            # pass, but a persistent break must read as a failure in logs
+        except BaseException:  # noqa: BLE001
+            # BaseException: a worker postinstall's SystemExit must not
+            # skip the authoritative serial pass (partial deps, exit 0)
             print("Parallel preinstall failed, falling back to serial", flush=True)
             traceback.print_exc()
 

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,6 +5,7 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
+import queue
 import subprocess
 import threading
 
@@ -99,13 +100,19 @@ def parallel_install(manager_cls, specs: list) -> None:
     pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
         return
-    # One manager per worker thread: each construction rewires the
-    # process-global manager logger, which drops lines under concurrency
+    workers = min(len(pending), MAX_WORKERS)
+    # One manager per worker thread: _install mutates per-instance state
+    # (_MEMORY_CACHE, _INSTALL_HISTORY, the registry client). Built
+    # serially, because every construction rewires the shared manager
+    # logger and concurrent handler swaps drop log lines.
+    managers: queue.Queue = queue.Queue()
+    for _ in range(workers):
+        managers.put(manager_cls(None))
     local = threading.local()
 
     def install_one(spec: str) -> bool:
         if (mgr := getattr(local, "mgr", None)) is None:
-            mgr = local.mgr = manager_cls(None)
+            mgr = local.mgr = managers.get_nowait()
         try:
             mgr._install(spec, skip_dependencies=True)  # noqa: SLF001
             return True
@@ -127,7 +134,6 @@ def parallel_install(manager_cls, specs: list) -> None:
                 )
             return False
 
-    workers = min(len(pending), MAX_WORKERS)
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
     manager.lock()
     try:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -111,12 +111,12 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     # sections, and two threads must not extract into the same directory.
     # Another spec for the same name, and URL specs (which install into a
     # manifest-named dir the spec cannot predict), are left to the pkg
-    # install pass.
+    # install pass; a dependency's URL version surfaces as spec.uri.
     seen_names: set = prior_names if prior_names is not None else set()
     unique = {
         spec_key(spec): spec
         for spec in specs
-        if isinstance(spec, PackageSpec) or "://" not in spec
+        if not (spec.uri if isinstance(spec, PackageSpec) else "://" in spec)
     }
     pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
@@ -163,7 +163,9 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     finally:
         manager.unlock()
     if failures := len(results) - sum(results):
-        # Visible once per wave; pkg install retries every failed spec
+        # Visible once per wave. The stock pass retries CLI specs and,
+        # for already-installed packages, re-walks their dependencies
+        # (_install without skip_dependencies), so failed deps retry too
         print(
             f"Pre-install failed for {failures} of {len(results)} package(s); "
             "pkg install retries them serially",

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -14,11 +14,18 @@ import traceback
 # esphome is not installed at this docker layer, so its rmtree helper is
 # out of reach; pio's fs.rmtree is the same chmod-on-readonly shape and
 # is what pio's own installer uses on these directories
-from platformio import fs
-from platformio.cache import ContentCache
-from platformio.package.manager.library import LibraryPackageManager
-from platformio.package.manager.tool import ToolPackageManager
-from platformio.package.meta import PackageCompatibility, PackageSpec
+try:
+    from platformio import fs
+    from platformio.cache import ContentCache
+    from platformio.package.manager.library import LibraryPackageManager
+    from platformio.package.manager.tool import ToolPackageManager
+    from platformio.package.meta import PackageCompatibility, PackageSpec
+
+    PARALLEL_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    # A moved pio module must degrade to the serial pass, not kill the
+    # image build; the tripwire test makes the drift loud in CI
+    PARALLEL_AVAILABLE = False
 
 # Downloads are network bound and release the GIL, unpacks are CPU bound;
 # a fixed pool well past the core count keeps the network busy while
@@ -148,7 +155,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             # No name, no destination identity; leave it to the serial pass
             print(f"Skipping unresolvable spec {spec!r} in the wave", flush=True)
             continue
-        unique[key] = (spec, compat)
+        unique.setdefault(key, (spec, compat))  # first-wins, like pio's walk
     pending = [
         (spec, compat)
         for spec, compat in unique.values()
@@ -166,6 +173,34 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         managers.put(manager_cls(None))
     local = threading.local()
 
+    def clean_torn(mgr, spec) -> None:
+        # A torn copy into the destination can carry valid metadata the
+        # pkg install pass would trust; remove it so that pass redoes it
+        try:
+            # get_package memoizes a pre-install snapshot; without a
+            # reset it cannot see the torn directory
+            mgr.memcache_reset()
+            pkg = mgr.get_package(spec)
+        except Exception as scan_err:  # noqa: BLE001
+            # A transient read of another worker's in-flight copy must not
+            # hard-fail the build blaming this spec
+            print(f"Could not inspect failed pre-install of {spec} ({scan_err!r})")
+            return
+        if pkg is None:
+            # Visible: an unresolvable torn directory is indistinguishable
+            # from nothing-to-clean without this line
+            print(f"No resolvable destination to clean for {spec}", flush=True)
+            return
+        # fs.rmtree never raises (errors go to a printing onexc handler);
+        # only the destination's absence proves the cleanup worked
+        fs.rmtree(pkg.path)
+        if Path(pkg.path).exists():
+            # The serial pass would trust this directory; failing the
+            # build beats baking a corrupt image
+            raise CleanupError(
+                f"could not remove the failed pre-install of {spec} at {pkg.path}"
+            )
+
     def install_one(item) -> bool:
         spec, compat = item
         if (mgr := getattr(local, "mgr", None)) is None:
@@ -176,38 +211,36 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             )
             return True
         except (AttributeError, TypeError):
-            # A PlatformIO API break, not a flaky package; surface it so
-            # total degradation reads differently from a network blip
+            # A PlatformIO API break, not a flaky package; clean the torn
+            # destination, then surface it so total degradation reads
+            # differently from a network blip
+            clean_torn(mgr, spec)
             raise
         except Exception as err:  # noqa: BLE001
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
-            # A torn copy into the destination can carry valid metadata the
-            # pkg install pass would trust; remove it so that pass redoes it
-            try:
-                # get_package memoizes a pre-install snapshot; without a
-                # reset it cannot see the torn directory
-                mgr.memcache_reset()
-                if (pkg := mgr.get_package(spec)) is not None:
-                    fs.rmtree(pkg.path)
-            except Exception as cleanup_err:
-                # A torn destination the serial pass would trust cannot be
-                # removed; failing the build beats baking a corrupt image
-                raise CleanupError(
-                    f"could not remove the failed pre-install of {spec}: "
-                    f"{cleanup_err!r}"
-                ) from cleanup_err
+            clean_torn(mgr, spec)
             return False
 
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
     # PlatformIO creates these lazily with a bare isdir/makedirs; touch
-    # them once serially so cold-cache workers never race the creation
-    manager.get_download_dir()
-    manager.get_tmp_dir()
+    # them once serially so cold-cache workers never race the creation,
+    # and re-create with exist_ok in case pio moves the side effect
+    for lazy_dir in (manager.get_download_dir(), manager.get_tmp_dir()):
+        Path(lazy_dir).mkdir(parents=True, exist_ok=True)
     ContentCache("http")
     manager.lock()
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
-            results = list(ex.map(install_one, pending))
+            futures = [ex.submit(install_one, item) for item in pending]
+        # All futures are done (the with-block joins); drain every one so
+        # a concurrent CleanupError is never dropped by iteration order
+        errors = [err for f in futures if (err := f.exception()) is not None]
+        for err in errors:
+            if isinstance(err, CleanupError):
+                raise err
+        if errors:
+            raise errors[0]
+        results = [f.result() for f in futures]
     finally:
         manager.unlock()
     if failures := len(results) - sum(results):
@@ -274,10 +307,14 @@ def main() -> None:
 
     # Platforms stay serial: PlatformPackageManager.install runs an
     # on_installed hook the private _install path would skip
-    for manager_cls, specs in (
-        (ToolPackageManager, tools),
-        (LibraryPackageManager, libs),
-    ):
+    wave_groups = (
+        [(ToolPackageManager, tools), (LibraryPackageManager, libs)]
+        if PARALLEL_AVAILABLE
+        else []
+    )
+    if not PARALLEL_AVAILABLE:  # pragma: no cover
+        print("PlatformIO layout changed; serial install only", flush=True)
+    for manager_cls, specs in wave_groups:
         try:
             parallel_install(manager_cls, specs)
         except CleanupError:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -38,6 +38,17 @@ except ImportError as err:  # pragma: no cover
 MAX_WORKERS = 16
 
 
+# A spared other-version dir must carry one of pio's manifest files to
+# count as intact rather than half-deleted
+_MANIFEST_NAMES = (
+    "package.json",
+    "library.json",
+    "library.properties",
+    "platform.json",
+    "module.json",
+)
+
+
 class CleanupError(RuntimeError):
     """A torn destination could not be removed; the serial pass would
     trust it, so the build must fail rather than bake a corrupt image."""
@@ -112,14 +123,29 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
             f"could not scan {package_dir} while cleaning up {spec}: {err!r}"
         ) from err
     for d in entries:
-        try:
-            meta = json.loads((d / ".piopm").read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            continue  # no metadata means pio does not trust it either
-        except (OSError, ValueError) as err:
-            # Half-written metadata: pio re-synthesizes and overwrites such
-            # a dir, but the refused judgment must be named in the log
-            print(f"Skipping unreadable metadata in {d} ({err!r})", flush=True)
+        meta = None
+        last_err = None
+        for attempt in range(3):
+            try:
+                meta = json.loads((d / ".piopm").read_text(encoding="utf-8"))
+                last_err = None
+                break
+            except FileNotFoundError:
+                last_err = None
+                break  # no metadata means pio does not trust it either
+            except (OSError, ValueError) as err:
+                # Possibly another worker mid-copy of the tiny file
+                last_err = err
+                if attempt < 2:
+                    time.sleep(0.1 * (2**attempt))
+        if meta is None:
+            if last_err is not None:
+                # A corrupt .piopm crashes pio's own storage scan, so the
+                # serial pass could not even run over it; remove it
+                print(
+                    f"Removing unreadable-metadata dir {d} ({last_err!r})", flush=True
+                )
+                matches.append(d)
             continue
         mspec = meta.get("spec") or {}
         name = (mspec.get("name") or meta.get("name") or "").lower()
@@ -131,11 +157,16 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
         version = str(meta.get("version") or "")
         if parsed.requirements and version:
             try:
-                if semantic_version.Version.coerce(version) not in parsed.requirements:
-                    # A healthy other version this run never tried to write
-                    continue
+                other_version = (
+                    semantic_version.Version.coerce(version) not in parsed.requirements
+                )
             except ValueError:
-                pass  # unparsable version stays a candidate
+                other_version = False  # unparsable version stays a candidate
+            if other_version and any((d / m).is_file() for m in _MANIFEST_NAMES):
+                # An intact other version this run never tried to write
+                continue
+            # An other-version dir without a manifest is a half-deleted
+            # tree (an interrupted detach); it stays a candidate
         matches.append(d)
     return matches
 
@@ -282,6 +313,9 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         if not manager.get_package(spec)
     ]
     if not pending:
+        # Nothing to install, but a warm store's dependencies must still
+        # feed the next wave (a transitive dep may be missing)
+        _next_wave(manager_cls, manager, unique, [], [], seen_names)
         return
     workers = min(len(pending), MAX_WORKERS)
     # One manager per worker (_install mutates instance state); built
@@ -326,8 +360,15 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     body_error: BaseException | None = None
     manager.lock()
     try:
+        futures = []
+        submit_error = None
         with ThreadPoolExecutor(max_workers=workers) as ex:
-            futures = [ex.submit(install_one, item) for item in pending]
+            try:
+                futures.extend(ex.submit(install_one, item) for item in pending)
+            except BaseException as err:  # noqa: BLE001
+                # Already-submitted workers run to completion in __exit__;
+                # their CleanupErrors must still be drained below
+                submit_error = err
         # The with-block joined every future; drain them all so a
         # concurrent CleanupError is never dropped
         errors = [err for f in futures if (err := f.exception()) is not None]
@@ -337,6 +378,8 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         for err in errors:
             if isinstance(err, CleanupError):
                 raise err
+        if submit_error is not None:
+            raise submit_error
         if errors:
             raise errors[0]
         results = [f.result() for f in futures]
@@ -396,6 +439,14 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
 
     # Waves skip dependencies (a shared one must not extract from two
     # threads); the installed manifests feed the next wave
+    _next_wave(manager_cls, manager, unique, pending, results, seen_names)
+
+
+def _next_wave(
+    manager_cls, manager, unique: dict, pending: list, results: list, seen_names: set
+) -> None:
+    """Queue the dependency wave for every requested spec, installed or
+    freshly waved; a warm store can still be missing a transitive dep."""
     seen_names.update(unique)
     # The pre-wave get_package calls memoized an empty storage snapshot
     manager.memcache_reset()
@@ -405,7 +456,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     next_specs = [
         item
         for item in dependency_specs(
-            manager, [spec for spec, _ in pending], installed_ok
+            manager, [spec for spec, _ in unique.values()], installed_ok
         )
         if spec_key(item[0]) not in seen_names
     ]

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -23,6 +23,7 @@ try:
     from platformio.package.manager.library import LibraryPackageManager
     from platformio.package.manager.tool import ToolPackageManager
     from platformio.package.meta import PackageCompatibility
+    import semantic_version
 
     PARALLEL_AVAILABLE = True
 except ImportError as err:  # pragma: no cover
@@ -112,12 +113,19 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
         mspec = meta.get("spec") or {}
         name = (mspec.get("name") or meta.get("name") or "").lower()
         owner = (mspec.get("owner") or "").lower()
-        if (
-            want
-            and name == want
-            and (not parsed.owner or owner == parsed.owner.lower())
-        ):
-            matches.append(d)
+        if not want or name != want:
+            continue
+        if parsed.owner and owner != parsed.owner.lower():
+            continue
+        version = str(meta.get("version") or "")
+        if parsed.requirements and version:
+            try:
+                if semantic_version.Version.coerce(version) not in parsed.requirements:
+                    # A healthy other version this run never tried to write
+                    continue
+            except ValueError:
+                pass  # unparsable version stays a candidate
+        matches.append(d)
     return matches
 
 
@@ -350,11 +358,12 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             os.chdir(cwd)
         except OSError as chdir_err:
             print(f"Could not restore the working dir ({chdir_err!r})", flush=True)
-            if body_error is None:
+            if body_error is None and unlock_error is None:
                 # Further waves cannot run from an unknown cwd; the serial
                 # pass is safe either way (its cwd is pinned)
                 raise
-            body_error.add_note(
+            # A pending LockReleaseError must still win the raise
+            (body_error or unlock_error).add_note(
                 f"also: could not restore the working dir ({chdir_err!r})"
             )
     if unlock_error is not None:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -18,9 +18,10 @@ import traceback
 try:
     from platformio import fs
     from platformio.cache import ContentCache
+    from platformio.package.manager.base import BasePackageManager
     from platformio.package.manager.library import LibraryPackageManager
     from platformio.package.manager.tool import ToolPackageManager
-    from platformio.package.meta import PackageCompatibility, PackageSpec
+    from platformio.package.meta import PackageCompatibility
 
     PARALLEL_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -91,12 +92,66 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     )
 
 
+def predicted_dest(mgr, spec) -> Path | None:
+    """The spec's own install dir; a fallback (case/safe-dirname quirks),
+    not the primary lookup."""
+    name = BasePackageManager.ensure_spec(spec).name
+    return Path(mgr.package_dir, name) if name else None
+
+
+def remove_dir(spec, dest: Path) -> None:
+    # fs.rmtree never raises (errors go to a printing onexc handler);
+    # only the destination's absence proves the cleanup worked
+    fs.rmtree(str(dest))
+    if dest.exists():
+        # Failing the build beats baking a corrupt image
+        raise CleanupError(
+            f"could not remove the failed pre-install of {spec} at {dest}"
+        )
+    print(f"Removed torn destination {dest}", flush=True)
+
+
+def clean_torn(mgr, spec) -> None:
+    """Remove a torn destination so the serial pass cannot trust it."""
+    scan_err = None
+    pkg = None
+    for attempt in range(5):
+        try:
+            # get_package memoizes a pre-install snapshot; without a
+            # reset it cannot see the torn directory
+            mgr.memcache_reset()
+            pkg = mgr.get_package(spec)
+            scan_err = None
+            break
+        except Exception as err:  # noqa: BLE001
+            # Likely another worker's in-flight copy; back off and retry
+            scan_err = err
+            time.sleep(0.2 * (2**attempt))
+    if pkg is not None:
+        remove_dir(spec, Path(pkg.path))
+        return
+    # The scan verdict depends on the whole storage tree (or the manifest
+    # is unparsable); judge by this spec's own destination so an innocent
+    # worker's in-flight copy cannot fail the build naming the wrong spec
+    dest = predicted_dest(mgr, spec)
+    if dest is not None and dest.exists():
+        remove_dir(spec, dest)
+    elif scan_err is not None:
+        print(
+            f"Could not inspect failed pre-install of {spec} "
+            f"({scan_err!r}); no destination to clean",
+            flush=True,
+        )
+    else:
+        print(f"No resolvable destination to clean for {spec}", flush=True)
+
+
 def spec_key(spec) -> str | None:
     """The destination identity of a spec: PlatformIO installs by package
     name, so two specs sharing a name share a directory. ``None`` means
     the name could not be derived; such a spec must stay out of the wave
     (a raw-string key would break the one-per-destination guarantee)."""
-    name = spec.name if isinstance(spec, PackageSpec) else PackageSpec(spec).name
+    name = BasePackageManager.ensure_spec(spec).name
     return name.lower() if name else None
 
 
@@ -153,7 +208,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     unique = {}
     for spec, compat in pairs:
         # Normalize once: a dependency's URL version surfaces as spec.uri
-        parsed = spec if isinstance(spec, PackageSpec) else PackageSpec(spec)
+        parsed = BasePackageManager.ensure_spec(spec)
         if parsed.uri:
             continue
         if (key := spec_key(parsed)) is None:
@@ -175,65 +230,6 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     for _ in range(workers):
         managers.put(manager_cls(None))
     local = threading.local()
-
-    def predicted_dest(mgr, spec) -> Path | None:
-        # pio installs by package name; case and safe-dirname quirks make
-        # this a fallback, not the primary lookup
-        name = spec.name if isinstance(spec, PackageSpec) else PackageSpec(spec).name
-        return Path(mgr.package_dir, name) if name else None
-
-    def remove_dir(spec, dest: Path) -> None:
-        # fs.rmtree never raises (errors go to a printing onexc handler);
-        # only the destination's absence proves the cleanup worked
-        fs.rmtree(str(dest))
-        if dest.exists():
-            # Failing the build beats baking a corrupt image
-            raise CleanupError(
-                f"could not remove the failed pre-install of {spec} at {dest}"
-            )
-        print(f"Removed torn destination {dest}", flush=True)
-
-    def clean_torn(mgr, spec) -> None:
-        # A torn copy into the destination can carry valid metadata the
-        # pkg install pass would trust; remove it so that pass redoes it
-        scan_err = None
-        pkg = None
-        for attempt in range(5):
-            try:
-                # get_package memoizes a pre-install snapshot; without a
-                # reset it cannot see the torn directory
-                mgr.memcache_reset()
-                pkg = mgr.get_package(spec)
-                scan_err = None
-                break
-            except Exception as err:  # noqa: BLE001
-                # Likely another worker's in-flight copy; back off and retry
-                scan_err = err
-                time.sleep(0.2 * (2**attempt))
-        if scan_err is not None:
-            # The scan verdict depends on the whole storage tree; judge by
-            # this spec's own destination so an innocent worker's in-flight
-            # copy cannot fail the build naming the wrong spec
-            dest = predicted_dest(mgr, spec)
-            if dest is not None and dest.exists():
-                remove_dir(spec, dest)
-            else:
-                print(
-                    f"Could not inspect failed pre-install of {spec} "
-                    f"({scan_err!r}); no destination to clean",
-                    flush=True,
-                )
-            return
-        if pkg is None:
-            # A torn dir with an unparsable manifest is invisible to
-            # get_package; fall back to the predicted destination
-            dest = predicted_dest(mgr, spec)
-            if dest is not None and dest.exists():
-                remove_dir(spec, dest)
-            else:
-                print(f"No resolvable destination to clean for {spec}", flush=True)
-            return
-        remove_dir(spec, Path(pkg.path))
 
     def install_one(item) -> bool:
         spec, compat = item
@@ -359,12 +355,10 @@ def main() -> None:
 
     # Platforms stay serial: PlatformPackageManager.install runs an
     # on_installed hook the private _install path would skip
-    wave_groups = (
-        [(ToolPackageManager, tools), (LibraryPackageManager, libs)]
-        if PARALLEL_AVAILABLE
-        else []
-    )
-    if not PARALLEL_AVAILABLE:  # pragma: no cover
+    if PARALLEL_AVAILABLE:
+        wave_groups = [(ToolPackageManager, tools), (LibraryPackageManager, libs)]
+    else:  # pragma: no cover
+        wave_groups = []
         print("PlatformIO layout changed; serial install only", flush=True)
     for manager_cls, specs in wave_groups:
         try:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -129,17 +129,6 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
     return matches
 
 
-def predicted_dest(mgr, spec) -> Path | None:
-    """The spec's likely install dir; a best-effort fallback only.
-
-    pio installs into safe_dirname(manifest name), which can differ from
-    the registry spec name; a miss here degrades to a printed line and
-    the serial pass, never a wrong deletion.
-    """
-    name = BasePackageManager.ensure_spec(spec).name
-    return Path(mgr.package_dir, name) if name else None
-
-
 def remove_dir(spec, dest: Path) -> None:
     # fs.rmtree never raises (errors go to a printing onexc handler);
     # only the destination's absence proves the cleanup worked
@@ -175,12 +164,9 @@ def clean_torn(mgr, spec) -> None:
     # The scan verdict depends on the whole storage tree (or the manifest
     # is unparsable); judge by this spec's own footprint so an innocent
     # worker's in-flight copy cannot fail the build naming the wrong spec.
-    # A .piopm naming this spec is the exact shape the serial pass trusts.
-    dests = piopm_matches(mgr.package_dir, spec)
-    guess = predicted_dest(mgr, spec)
-    if guess is not None and guess.exists() and guess not in dests:
-        dests.append(guess)
-    if dests:
+    # A .piopm naming this spec is the exact shape the serial pass trusts;
+    # a dir without one is overwritten by pio's own install either way.
+    if dests := piopm_matches(mgr.package_dir, spec):
         for dest in dests:
             remove_dir(spec, dest)
     elif scan_err is not None:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,14 +5,12 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
-import json
+from contextlib import suppress
 import os
 from pathlib import Path
 import queue
-import stat
 import subprocess
 import threading
-import time
 import traceback
 
 # esphome is not installed at this docker layer; pio's fs.rmtree is the
@@ -24,7 +22,6 @@ try:
     from platformio.package.manager.library import LibraryPackageManager
     from platformio.package.manager.tool import ToolPackageManager
     from platformio.package.meta import PackageCompatibility
-    import semantic_version
 
     PARALLEL_AVAILABLE = True
 except ImportError as err:  # pragma: no cover
@@ -37,17 +34,6 @@ except ImportError as err:  # pragma: no cover
 # the cores. This bypasses pio's 500ms registry throttle and races its
 # self-unlinking cache LockFiles; both are cache-only and self-healing.
 MAX_WORKERS = 16
-
-
-# A spared other-version dir must carry one of pio's manifest files to
-# count as intact rather than half-deleted
-_MANIFEST_NAMES = (
-    "package.json",
-    "library.json",
-    "library.properties",
-    "platform.json",
-    "module.json",
-)
 
 
 class CleanupError(RuntimeError):
@@ -107,117 +93,46 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     )
 
 
-def manifest_present(d: Path) -> bool:
-    """Whether the dir carries one of pio's manifest files. Path.is_file
-    reads any OSError as "absent"; a stat error is unverifiable instead."""
-    for m in _MANIFEST_NAMES:
-        try:
-            os.lstat(d / m)
-        except FileNotFoundError:
-            continue
-        except OSError as err:
-            raise CleanupError(
-                f"could not check for a manifest in {d}: {err!r}"
-            ) from err
-        return True
-    return False
-
-
 def piopm_matches(package_dir: str, spec) -> list[Path]:
     """Dirs whose .piopm metadata names this spec; a positive match beats
     guessing the manifest-derived dirname from the registry name."""
-    parsed = BasePackageManager.ensure_spec(spec)
-    want = (parsed.name or "").lower()
+    want = (BasePackageManager.ensure_spec(spec).name or "").lower()
     matches: list[Path] = []
+    if not want:
+        return matches
     try:
         entries = list(Path(package_dir).iterdir())
     except FileNotFoundError:
         return matches
-    except OSError as err:
-        # Cannot look means cannot verify; the serial pass could trust
-        # whatever is in here
-        raise CleanupError(
-            f"could not scan {package_dir} while cleaning up {spec}: {err!r}"
-        ) from err
     for d in entries:
-        try:
-            entry_stat = os.lstat(d)
-        except FileNotFoundError:
-            continue  # vanished mid-scan; nothing left to clean
-        except OSError as err:
-            # Path.is_dir would read this as skippable; unverifiable
-            # entries must fail the build like everywhere else
-            raise CleanupError(
-                f"could not stat {d} while cleaning up {spec}: {err!r}"
-            ) from err
-        if not stat.S_ISDIR(entry_stat.st_mode):
+        if not d.is_dir():
             continue  # pio's get_installed skips files and *.pio-link too
-        meta = None
-        last_err = None
-        for attempt in range(3):
-            try:
-                meta = json.loads((d / ".piopm").read_text(encoding="utf-8"))
-                last_err = None
-                break
-            except FileNotFoundError:
-                last_err = None
-                break  # no metadata means pio does not trust it either
-            except (OSError, ValueError) as err:
-                # Possibly another worker mid-copy of the tiny file
-                last_err = err
-                if attempt < 2:
-                    time.sleep(0.1 * (2**attempt))
-        if meta is None:
-            if last_err is not None and d.name.lower() == want:
-                # A corrupt .piopm crashes pio's own storage scan, so the
-                # serial pass could not even run over it; remove it, but
-                # only under this spec's own name (an innocent worker may
-                # be mid-copy of another package's metadata)
-                print(
-                    f"Removing unreadable-metadata dir {d} ({last_err!r})", flush=True
-                )
+        try:
+            meta = fs.load_json(str(d / ".piopm"))
+        except FileNotFoundError:
+            continue  # no metadata means pio does not trust it either
+        except (OSError, ValueError):
+            if d.name.lower() == want:
+                # A corrupt .piopm under this spec's own name would crash
+                # pio's whole storage scan; remove it
                 matches.append(d)
             continue
         mspec = meta.get("spec") or {}
-        name = (mspec.get("name") or meta.get("name") or "").lower()
-        owner = (mspec.get("owner") or "").lower()
-        if not want or name != want:
-            continue
-        if parsed.owner and owner != parsed.owner.lower():
-            continue
-        version = str(meta.get("version") or "")
-        if parsed.requirements and version:
-            try:
-                other_version = (
-                    semantic_version.Version.coerce(version) not in parsed.requirements
-                )
-            except ValueError:
-                other_version = False  # unparsable version stays a candidate
-            if other_version and manifest_present(d):
-                # An intact other version this run never tried to write
-                continue
-            # An other-version dir without a manifest is a half-deleted
-            # tree (an interrupted detach); it stays a candidate
-        matches.append(d)
+        if (mspec.get("name") or meta.get("name") or "").lower() == want:
+            matches.append(d)
     return matches
 
 
 def remove_dir(spec, dest: Path) -> None:
-    # fs.rmtree never raises (errors go to a printing onexc handler), and
-    # Path.exists suppresses stat errors; only a confirmed ENOENT proves
-    # the cleanup worked
+    # fs.rmtree never raises (errors go to a printing onexc handler);
+    # only the destination's absence proves the cleanup worked
     fs.rmtree(str(dest))
-    try:
-        os.lstat(dest)
-    except FileNotFoundError:
-        print(f"Removed torn destination {dest}", flush=True)
-        return
-    except OSError as err:
+    if dest.exists():
+        # Failing the build beats baking a corrupt image
         raise CleanupError(
-            f"could not verify removal of {spec} at {dest} ({err!r})"
-        ) from err
-    # Failing the build beats baking a corrupt image
-    raise CleanupError(f"could not remove the failed pre-install of {spec} at {dest}")
+            f"could not remove the failed pre-install of {spec} at {dest}"
+        )
+    print(f"Removed torn destination {dest}", flush=True)
 
 
 def cleanup_or_die(mgr, spec) -> None:
@@ -232,47 +147,20 @@ def cleanup_or_die(mgr, spec) -> None:
 
 def clean_torn(mgr, spec) -> None:
     """Remove a torn destination so the serial pass cannot trust it."""
-    scan_err = None
     pkg = None
-    for attempt in range(5):
-        try:
-            # get_package memoizes a pre-install snapshot; without a
-            # reset it cannot see the torn directory
-            mgr.memcache_reset()
-            pkg = mgr.get_package(spec)
-            scan_err = None
-            break
-        except Exception as err:  # noqa: BLE001
-            # Likely another worker's in-flight copy; back off and retry
-            scan_err = err
-            if attempt < 4:
-                time.sleep(0.2 * (2**attempt))
+    with suppress(Exception):
+        # get_package memoizes a pre-install snapshot; reset to see the
+        # torn dir. It also recognizes manifest-only legacy dirs pio's
+        # storage scan would trust, which the .piopm fallback cannot see.
+        mgr.memcache_reset()
+        pkg = mgr.get_package(spec)
     if pkg is not None:
-        dest = Path(pkg.path)
-        store = Path(os.path.realpath(mgr.package_dir))
-        resolved = Path(os.path.realpath(dest))
-        if resolved == store or not resolved.is_relative_to(store):
-            # A symlinked (.pio-link) package resolves to its external
-            # source dir; this script only removes strictly inside the
-            # store, never the store itself
-            print(f"Refusing to remove {dest} outside {store}", flush=True)
-            return
-        remove_dir(spec, dest)
-        return
-    # The scan verdict depends on the whole storage tree (or the manifest
-    # is unparsable); judge by this spec's own footprint so an innocent
-    # worker's in-flight copy cannot fail the build naming the wrong spec.
-    # A .piopm naming this spec is the exact shape the serial pass trusts;
-    # a dir without one is overwritten by pio's own install either way.
-    if dests := piopm_matches(mgr.package_dir, spec):
+        remove_dir(spec, Path(pkg.path))
+    elif dests := piopm_matches(mgr.package_dir, spec):
+        # A .piopm naming this spec is the exact shape the serial pass
+        # trusts; a dir without one is overwritten by pio's own install
         for dest in dests:
             remove_dir(spec, dest)
-    elif scan_err is not None:
-        print(
-            f"Could not inspect failed pre-install of {spec} "
-            f"({scan_err!r}); no destination to clean",
-            flush=True,
-        )
     else:
         print(f"No resolvable destination to clean for {spec}", flush=True)
 
@@ -286,43 +174,19 @@ def spec_key(spec) -> str | None:
     return name.lower() if name else None
 
 
-def dependency_specs(manager, specs: list, failed: set) -> list:
-    """``(spec, compatibility)`` registry dependencies of installed packages.
-
-    Local manifest reads only. Name-only dependencies (platform-bundled
-    libs like SPI) are left to the ``pkg install`` pass, and a versioned
-    owner-less name is skipped when the manager recognizes it as built-in,
-    exactly like pio's install_dependency (built-ins only resolve once
-    platforms are in the store, e.g. on a warm run). The compatibility
-    qualifiers mirror install_dependency, so a qualified dep resolves to
-    the same package the serial pass picks."""
-    deps = []
-    is_builtin = getattr(manager, "is_builtin_lib", None)
-    for spec in specs:
-        if (pkg := manager.get_package(spec)) is None:
-            if spec_key(spec) not in failed:
-                # Everything but a failed install resolved moments ago;
-                # losing it now is an anomaly, and its subtree quietly
-                # falls to the serial pass
-                print(
-                    f"Installed {spec} is not resolvable afterwards; its "
-                    "dependencies are left to pkg install",
-                    flush=True,
-                )
-            continue
-        for dep in manager.get_pkg_dependencies(pkg) or []:
-            if not dep.get("owner") and not dep.get("version"):
-                continue  # bare platform-bundled names stay with pkg install
-            dspec = manager.dependency_to_spec(dep)
-            if (
-                is_builtin is not None
-                and not dspec.external
-                and not dspec.owner
-                and is_builtin(dspec.name)
-            ):
-                continue  # pio's install_dependency skips known built-ins
-            deps.append((dspec, PackageCompatibility.from_dependency(dep)))
-    return deps
+def dependency_specs(manager, specs: list) -> list:
+    """``(spec, compatibility)`` registry dependencies of installed
+    packages, from local manifest reads. Name-only dependencies
+    (platform-bundled libs like SPI) stay with the ``pkg install`` pass;
+    the compatibility qualifiers mirror pio's install_dependency, so a
+    qualified dep resolves to the same package the serial pass picks."""
+    return [
+        (manager.dependency_to_spec(dep), PackageCompatibility.from_dependency(dep))
+        for spec in specs
+        if (pkg := manager.get_package(spec)) is not None
+        for dep in manager.get_pkg_dependencies(pkg) or []
+        if dep.get("owner") or dep.get("version")
+    ]
 
 
 def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -> None:
@@ -362,7 +226,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     if not pending:
         # Nothing to install, but a warm store's dependencies must still
         # feed the next wave (a transitive dep may be missing)
-        _next_wave(manager_cls, manager, unique, [], [], seen_names)
+        _next_wave(manager_cls, manager, unique, seen_names)
         return
     workers = min(len(pending), MAX_WORKERS)
     # One manager per worker (_install mutates instance state); built
@@ -381,11 +245,6 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
                 spec, skip_dependencies=True, compatibility=compat
             )
             return True
-        except (AttributeError, TypeError) as err:
-            # A pio API break, not a flaky package; clean, then surface it
-            print(f"Pre-install of {spec} hit an API break ({err!r})", flush=True)
-            cleanup_or_die(mgr, spec)
-            raise
         except Exception as err:  # noqa: BLE001
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
             cleanup_or_die(mgr, spec)
@@ -397,87 +256,39 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             raise
 
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
-    # pio creates these lazily without exist_ok; touch them serially so
-    # cold-cache workers never race the creation
-    for lazy_dir in (manager.get_download_dir(), manager.get_tmp_dir()):
-        Path(lazy_dir).mkdir(parents=True, exist_ok=True)
+    # The serial getter calls create pio's lazy dirs (made without
+    # exist_ok) before cold-cache workers can race the creation
+    manager.get_download_dir()
+    manager.get_tmp_dir()
     ContentCache("http")
     cwd = Path.cwd()
-    unlock_error = None
-    body_error: BaseException | None = None
     manager.lock()
     try:
-        futures = []
-        submit_error = None
         with ThreadPoolExecutor(max_workers=workers) as ex:
-            try:
-                for item in pending:
-                    # An explicit append: every submitted future must be
-                    # drained even when a later submit raises
-                    futures.append(ex.submit(install_one, item))  # noqa: PERF401
-            except BaseException as err:  # noqa: BLE001
-                # Already-submitted workers run to completion in __exit__;
-                # their CleanupErrors must still be drained below
-                submit_error = err
+            futures = [ex.submit(install_one, item) for item in pending]
         # The with-block joined every future; drain them all so a
         # concurrent CleanupError is never dropped
         errors = [err for f in futures if (err := f.exception()) is not None]
         for err in errors:
             # Every failure is on the record; the raised one is a summary
             print(f"Wave failure: {err!r}", flush=True)
-        for err in errors:
-            if isinstance(err, CleanupError):
-                raise err
-        if submit_error is not None:
-            raise submit_error
         if errors:
-            raise errors[0]
+            raise next((e for e in errors if isinstance(e, CleanupError)), errors[0])
         results = [f.result() for f in futures]
-    except BaseException as err:
-        body_error = err
-        raise
     finally:
-        # Neither cleanup may replace an in-flight CleanupError
         try:
             manager.unlock()
-        except Exception as err:  # noqa: BLE001
-            unlock_error = err
-            print(f"Could not release the manager lock ({err!r})", flush=True)
-            if body_error is not None and not isinstance(
-                body_error, (CleanupError, KeyboardInterrupt)
-            ):
-                # Any body error main() would swallow (SystemExit included)
-                # falls back to a serial pass that blocks on the held
-                # flock for its full timeout; the held lock is worse
-                raise LockReleaseError(
-                    f"could not release the manager lock ({err!r}) after "
-                    f"a wave failure ({body_error!r})"
-                ) from err
-            if body_error is not None:
-                # Build-fatal classes stay in flight; record the second fault
-                body_error.add_note(
-                    f"also: could not release the manager lock ({err!r})"
-                )
+        except Exception as unlock_err:  # noqa: BLE001
+            # A held flock would hang the serial pass in another process;
+            # failing loudly beats an unexplained stuck docker build. Any
+            # in-flight error stays attached as the context.
+            raise LockReleaseError(
+                f"could not release the manager lock: {unlock_err!r}"
+            ) from unlock_err
         # Worker postinstall scripts chdir process-wide (pio's fs.cd);
-        # restore between waves, not only for the final subprocess
-        try:
+        # restore between waves. The serial pass pins its own cwd.
+        with suppress(OSError):
             os.chdir(cwd)
-        except OSError as chdir_err:
-            print(f"Could not restore the working dir ({chdir_err!r})", flush=True)
-            if body_error is None and unlock_error is None:
-                # Further waves cannot run from an unknown cwd; the serial
-                # pass is safe either way (its cwd is pinned)
-                raise
-            # A pending LockReleaseError must still win the raise
-            (body_error or unlock_error).add_note(
-                f"also: could not restore the working dir ({chdir_err!r})"
-            )
-    if unlock_error is not None:
-        # A held flock would hang the serial pass in another process;
-        # failing loudly beats an unexplained stuck docker build
-        raise LockReleaseError(
-            f"could not release the manager lock: {unlock_error!r}"
-        ) from unlock_error
     if failures := len(results) - sum(results):
         # The stock pass retries CLI specs and re-walks installed
         # packages' dependencies, so failed deps retry too
@@ -489,38 +300,23 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
 
     # Waves skip dependencies (a shared one must not extract from two
     # threads); the installed manifests feed the next wave
-    _next_wave(manager_cls, manager, unique, pending, results, seen_names)
+    _next_wave(manager_cls, manager, unique, seen_names)
 
 
-def _next_wave(
-    manager_cls, manager, unique: dict, pending: list, results: list, seen_names: set
-) -> None:
+def _next_wave(manager_cls, manager, unique: dict, seen_names: set) -> None:
     """Queue the dependency wave for every requested spec, installed or
-    freshly waved; a warm store can still be missing a transitive dep."""
+    freshly waved; a warm store can still be missing a transitive dep.
+    Terminates without a cap: each wave admits only never-seen names."""
     seen_names.update(unique)
     # The pre-wave get_package calls memoized an empty storage snapshot
     manager.memcache_reset()
-    failed = {
-        spec_key(spec) for (spec, _), ok in zip(pending, results, strict=True) if not ok
-    }
     next_specs = [
         item
-        for item in dependency_specs(
-            manager, [spec for spec, _ in unique.values()], failed
-        )
+        for item in dependency_specs(manager, [spec for spec, _ in unique.values()])
         if spec_key(item[0]) not in seen_names
     ]
-    if not next_specs:
-        return
-    if len(seen_names) < 200:  # cycle backstop
+    if next_specs:
         parallel_install(manager_cls, next_specs, seen_names)
-    else:
-        # Truncation must be visible, not an unexplained slow serial pass
-        print(
-            f"Dependency wave limit reached; {len(next_specs)} spec(s) "
-            "left to pkg install",
-            flush=True,
-        )
 
 
 def build_cli_args(libs: list, platforms: list, tools: list) -> list:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import queue
 import subprocess
 import threading
+import time
 import traceback
 
 # esphome is not installed at this docker layer, so its rmtree helper is
@@ -181,20 +182,27 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     def clean_torn(mgr, spec) -> None:
         # A torn copy into the destination can carry valid metadata the
         # pkg install pass would trust; remove it so that pass redoes it
-        try:
-            # get_package memoizes a pre-install snapshot; without a
-            # reset it cannot see the torn directory
-            mgr.memcache_reset()
-            pkg = mgr.get_package(spec)
-        except Exception as scan_err:  # noqa: BLE001
-            # A transient read of another worker's in-flight copy must not
-            # hard-fail the build blaming this spec
-            print(
-                f"Could not inspect failed pre-install of {spec} ({scan_err!r}); "
-                "a torn destination may remain",
-                flush=True,
-            )
-            return
+        scan_err = None
+        pkg = None
+        for _attempt in range(3):
+            try:
+                # get_package memoizes a pre-install snapshot; without a
+                # reset it cannot see the torn directory
+                mgr.memcache_reset()
+                pkg = mgr.get_package(spec)
+                scan_err = None
+                break
+            except Exception as err:  # noqa: BLE001
+                # Likely a transient read of another worker's in-flight
+                # copy; retry before deciding anything destructive
+                scan_err = err
+                time.sleep(0.2)
+        if scan_err is not None:
+            # Persistently unverifiable: a torn destination the serial
+            # pass would trust may remain, so the build must fail
+            raise CleanupError(
+                f"could not verify the failed pre-install of {spec}: {scan_err!r}"
+            ) from scan_err
         if pkg is None:
             # Visible: an unresolvable torn directory is indistinguishable
             # from nothing-to-clean without this line
@@ -246,10 +254,9 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         # All futures are done (the with-block joins); drain every one so
         # a concurrent CleanupError is never dropped by iteration order
         errors = [err for f in futures if (err := f.exception()) is not None]
-        for err in errors[1:] if errors else []:
-            # Every sibling failure is part of the record, not just the
-            # one that wins the raise
-            print(f"Additional wave failure: {err!r}", flush=True)
+        for err in errors:
+            # Every failure is on the record; the raised one is a summary
+            print(f"Wave failure: {err!r}", flush=True)
         for err in errors:
             if isinstance(err, CleanupError):
                 raise err
@@ -257,10 +264,13 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             raise errors[0]
         results = [f.result() for f in futures]
     finally:
-        manager.unlock()
+        # Neither cleanup may replace an in-flight CleanupError
+        try:
+            manager.unlock()
+        except Exception as unlock_err:  # noqa: BLE001
+            print(f"Could not release the manager lock ({unlock_err!r})", flush=True)
         # Worker postinstall scripts chdir process-wide (pio's fs.cd);
-        # restore between waves, not only for the final subprocess. A
-        # restore failure must not replace an in-flight CleanupError.
+        # restore between waves, not only for the final subprocess
         try:
             os.chdir(cwd)
         except OSError as chdir_err:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -5,10 +5,13 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 import configparser
-import shutil
 import subprocess
 import threading
 
+# esphome is not installed at this docker layer, so its rmtree helper is
+# out of reach; pio's fs.rmtree is the same chmod-on-readonly shape and
+# is what pio's own installer uses on these directories
+from platformio import fs
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.tool import ToolPackageManager
 from platformio.package.meta import PackageSpec
@@ -115,7 +118,7 @@ def parallel_install(manager_cls, specs: list) -> None:
                 # reset it cannot see the torn directory
                 mgr.memcache_reset()
                 if (pkg := mgr.get_package(spec)) is not None:
-                    shutil.rmtree(pkg.path)
+                    fs.rmtree(pkg.path)
             except Exception as cleanup_err:  # noqa: BLE001
                 print(
                     f"Cleanup after failed pre-install of {spec} "

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -15,6 +15,7 @@ import traceback
 # out of reach; pio's fs.rmtree is the same chmod-on-readonly shape and
 # is what pio's own installer uses on these directories
 from platformio import fs
+from platformio.cache import ContentCache
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.tool import ToolPackageManager
 from platformio.package.meta import PackageCompatibility, PackageSpec
@@ -23,6 +24,11 @@ from platformio.package.meta import PackageCompatibility, PackageSpec
 # a fixed pool well past the core count keeps the network busy while
 # unpacks share the cores.
 MAX_WORKERS = 16
+
+
+class CleanupError(RuntimeError):
+    """A torn destination could not be removed; the serial pass would
+    trust it, so the build must fail rather than bake a corrupt image."""
 
 
 def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
@@ -73,20 +79,24 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     )
 
 
-def spec_key(spec) -> str:
+def spec_key(spec) -> str | None:
     """The destination identity of a spec: PlatformIO installs by package
-    name, so two specs sharing a name share a directory."""
+    name, so two specs sharing a name share a directory. ``None`` means
+    the name could not be derived; such a spec must stay out of the wave
+    (a raw-string key would break the one-per-destination guarantee)."""
     name = spec.name if isinstance(spec, PackageSpec) else PackageSpec(spec).name
-    return name.lower() if name else str(spec).strip()
+    return name.lower() if name else None
 
 
 def dependency_specs(manager, specs: list, installed_ok: set) -> list:
     """``(spec, compatibility)`` registry dependencies of installed packages.
 
     Local manifest reads only. Name-only dependencies (platform-bundled
-    libs like SPI) are left to the ``pkg install`` pass. The compatibility
-    qualifiers mirror pio's install_dependency, so a qualified dep resolves
-    to the same package the serial pass would have picked."""
+    libs like SPI) are left to the ``pkg install`` pass; a *versioned*
+    built-in name cannot be recognized here (no platforms are installed
+    at wave time), so it may be installed from the registry. The
+    compatibility qualifiers mirror pio's install_dependency, so a
+    qualified dep resolves to the same package the serial pass picks."""
     deps = []
     for spec in specs:
         if (pkg := manager.get_package(spec)) is None:
@@ -130,11 +140,15 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     seen_names: set = prior_names if prior_names is not None else set()
     # Wave-1 items are strings; dependency waves carry (spec, compatibility)
     pairs = [item if isinstance(item, tuple) else (item, None) for item in specs]
-    unique = {
-        spec_key(spec): (spec, compat)
-        for spec, compat in pairs
-        if not (spec.uri if isinstance(spec, PackageSpec) else "://" in spec)
-    }
+    unique = {}
+    for spec, compat in pairs:
+        if spec.uri if isinstance(spec, PackageSpec) else "://" in spec:
+            continue
+        if (key := spec_key(spec)) is None:
+            # No name, no destination identity; leave it to the serial pass
+            print(f"Skipping unresolvable spec {spec!r} in the wave", flush=True)
+            continue
+        unique[key] = (spec, compat)
     pending = [
         (spec, compat)
         for spec, compat in unique.values()
@@ -161,6 +175,10 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
                 spec, skip_dependencies=True, compatibility=compat
             )
             return True
+        except (AttributeError, TypeError):
+            # A PlatformIO API break, not a flaky package; surface it so
+            # total degradation reads differently from a network blip
+            raise
         except Exception as err:  # noqa: BLE001
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
             # A torn copy into the destination can carry valid metadata the
@@ -171,15 +189,21 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
                 mgr.memcache_reset()
                 if (pkg := mgr.get_package(spec)) is not None:
                     fs.rmtree(pkg.path)
-            except Exception as cleanup_err:  # noqa: BLE001
-                print(
-                    f"Cleanup after failed pre-install of {spec} "
-                    f"failed ({cleanup_err!r})",
-                    flush=True,
-                )
+            except Exception as cleanup_err:
+                # A torn destination the serial pass would trust cannot be
+                # removed; failing the build beats baking a corrupt image
+                raise CleanupError(
+                    f"could not remove the failed pre-install of {spec}: "
+                    f"{cleanup_err!r}"
+                ) from cleanup_err
             return False
 
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
+    # PlatformIO creates these lazily with a bare isdir/makedirs; touch
+    # them once serially so cold-cache workers never race the creation
+    manager.get_download_dir()
+    manager.get_tmp_dir()
+    ContentCache("http")
     manager.lock()
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
@@ -256,6 +280,9 @@ def main() -> None:
     ):
         try:
             parallel_install(manager_cls, specs)
+        except CleanupError:
+            # A torn package the serial pass would trust is still on disk
+            raise
         except Exception:  # noqa: BLE001
             # The wave is an optimization; it must never stop the real
             # pass, but a persistent break must read as a failure in logs

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -13,9 +13,8 @@ import threading
 import time
 import traceback
 
-# esphome is not installed at this docker layer, so its rmtree helper is
-# out of reach; pio's fs.rmtree is the same chmod-on-readonly shape and
-# is what pio's own installer uses on these directories
+# esphome is not installed at this docker layer; pio's fs.rmtree is the
+# same chmod-on-readonly shape its own installer uses
 try:
     from platformio import fs
     from platformio.cache import ContentCache
@@ -29,11 +28,9 @@ except ImportError:  # pragma: no cover
     # image build; the tripwire test makes the drift loud in CI
     PARALLEL_AVAILABLE = False
 
-# Downloads are network bound and release the GIL, unpacks are CPU bound;
-# a fixed pool well past the core count keeps the network busy while
-# unpacks share the cores. This bypasses pio's 500ms registry throttle
-# and races its self-unlinking usage.db/http-cache LockFiles; both are
-# cache-only bookkeeping and self-healing.
+# Network-bound downloads release the GIL, so the pool oversubscribes
+# the cores. This bypasses pio's 500ms registry throttle and races its
+# self-unlinking cache LockFiles; both are cache-only and self-healing.
 MAX_WORKERS = 16
 
 
@@ -80,9 +77,8 @@ def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
                     split = tool.find("@")
                     tool = tool[split + 1 :]
                 tools.append(tool)
-    # Exact-string duplicates only: each costs the pkg install pass a
-    # lock and rescan cycle. Name-level dedupe would change which version
-    # conflicts the pass reconciles, so it stays out of scope here.
+    # Exact-string dedupe only: name-level dedupe would change which
+    # version conflicts the pkg install pass reconciles
     return (
         list(dict.fromkeys(libs)),
         list(dict.fromkeys(platforms)),
@@ -143,11 +139,9 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     if not specs:
         return
     manager = manager_cls(None)
-    # One spec per destination: platformio.ini repeats specs across env
-    # sections, and two threads must not extract into the same directory.
-    # Another spec for the same name, and URL specs (which install into a
-    # manifest-named dir the spec cannot predict), are left to the pkg
-    # install pass; a dependency's URL version surfaces as spec.uri.
+    # One spec per destination: two threads must not extract into the
+    # same directory. Second versions of a name and URL specs (their dir
+    # comes from the archive manifest) stay with the pkg install pass.
     seen_names: set = prior_names if prior_names is not None else set()
     # Wave-1 items are strings; dependency waves carry (spec, compatibility)
     pairs = [item if isinstance(item, tuple) else (item, None) for item in specs]
@@ -170,10 +164,8 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     if not pending:
         return
     workers = min(len(pending), MAX_WORKERS)
-    # One manager per worker thread: _install mutates per-instance state
-    # (_MEMORY_CACHE, _INSTALL_HISTORY, the registry client). Built
-    # serially, because every construction rewires the shared manager
-    # logger and concurrent handler swaps drop log lines.
+    # One manager per worker (_install mutates instance state); built
+    # serially because construction rewires the shared manager logger
     managers: queue.SimpleQueue = queue.SimpleQueue()
     for _ in range(workers):
         managers.put(manager_cls(None))
@@ -193,27 +185,23 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
                 scan_err = None
                 break
             except Exception as err:  # noqa: BLE001
-                # Likely a transient read of another worker's in-flight
-                # copy; retry before deciding anything destructive
+                # Likely another worker's in-flight copy; retry first
                 scan_err = err
                 time.sleep(0.2)
         if scan_err is not None:
-            # Persistently unverifiable: a torn destination the serial
-            # pass would trust may remain, so the build must fail
+            # Unverifiable: a trusted torn destination may remain
             raise CleanupError(
                 f"could not verify the failed pre-install of {spec}: {scan_err!r}"
             ) from scan_err
         if pkg is None:
-            # Visible: an unresolvable torn directory is indistinguishable
-            # from nothing-to-clean without this line
+            # An unresolvable torn dir must not look like nothing-to-clean
             print(f"No resolvable destination to clean for {spec}", flush=True)
             return
         # fs.rmtree never raises (errors go to a printing onexc handler);
         # only the destination's absence proves the cleanup worked
         fs.rmtree(pkg.path)
         if Path(pkg.path).exists():
-            # The serial pass would trust this directory; failing the
-            # build beats baking a corrupt image
+            # Failing the build beats baking a corrupt image
             raise CleanupError(
                 f"could not remove the failed pre-install of {spec} at {pkg.path}"
             )
@@ -228,9 +216,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             )
             return True
         except (AttributeError, TypeError) as err:
-            # A PlatformIO API break, not a flaky package; clean the torn
-            # destination, then surface it so total degradation reads
-            # differently from a network blip
+            # A pio API break, not a flaky package; clean, then surface it
             print(f"Pre-install of {spec} hit an API break ({err!r})", flush=True)
             clean_torn(mgr, spec)
             raise
@@ -240,9 +226,8 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             return False
 
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
-    # PlatformIO creates these lazily with a bare isdir/makedirs; touch
-    # them once serially so cold-cache workers never race the creation,
-    # and re-create with exist_ok in case pio moves the side effect
+    # pio creates these lazily without exist_ok; touch them serially so
+    # cold-cache workers never race the creation
     for lazy_dir in (manager.get_download_dir(), manager.get_tmp_dir()):
         Path(lazy_dir).mkdir(parents=True, exist_ok=True)
     ContentCache("http")
@@ -251,8 +236,8 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
             futures = [ex.submit(install_one, item) for item in pending]
-        # All futures are done (the with-block joins); drain every one so
-        # a concurrent CleanupError is never dropped by iteration order
+        # The with-block joined every future; drain them all so a
+        # concurrent CleanupError is never dropped
         errors = [err for f in futures if (err := f.exception()) is not None]
         for err in errors:
             # Every failure is on the record; the raised one is a summary
@@ -276,18 +261,16 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         except OSError as chdir_err:
             print(f"Could not restore the working dir ({chdir_err!r})", flush=True)
     if failures := len(results) - sum(results):
-        # Visible once per wave. The stock pass retries CLI specs and,
-        # for already-installed packages, re-walks their dependencies
-        # (_install without skip_dependencies), so failed deps retry too
+        # The stock pass retries CLI specs and re-walks installed
+        # packages' dependencies, so failed deps retry too
         print(
             f"Pre-install failed for {failures} of {len(results)} package(s); "
             "pkg install retries them serially",
             flush=True,
         )
 
-    # The wave skipped dependencies (a shared one must not extract from two
-    # threads); collect them from the installed manifests, dedupe by name,
-    # and run them as the next wave until nothing new appears
+    # Waves skip dependencies (a shared one must not extract from two
+    # threads); the installed manifests feed the next wave
     seen_names.update(unique)
     # The pre-wave get_package calls memoized an empty storage snapshot
     manager.memcache_reset()

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -22,7 +22,10 @@ MAX_WORKERS = 16
 def parse_specs(path: str, args: argparse.Namespace) -> tuple[list, list, list]:
     """Extract lib/platform/tool specs from every section of a platformio.ini."""
     config = configparser.ConfigParser(inline_comment_prefixes=(";",))
-    config.read(path)
+    if not config.read(path):
+        # ConfigParser silently ignores unreadable files; an empty spec
+        # list would build an image with no dependencies at all
+        raise SystemExit(f"Could not read {path}")
     libs = []
     tools = []
     platforms = []
@@ -86,7 +89,10 @@ def parallel_install(manager_cls, specs: list) -> None:
     # One spec per destination: platformio.ini repeats specs across env
     # sections, and two threads must not extract into the same directory.
     # Another spec for the same name is left to the pkg install pass.
-    unique = {spec_key(spec): spec for spec in specs}
+    unique = {
+        spec_key(spec): spec for spec in specs if "://" not in spec
+    }  # URL specs install into a manifest-named dir the spec cannot predict;
+    # only the serial pass may handle them
     pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
         return
@@ -105,10 +111,17 @@ def parallel_install(manager_cls, specs: list) -> None:
             # A torn copy into the destination can carry valid metadata the
             # pkg install pass would trust; remove it so that pass redoes it
             try:
+                # get_package memoizes a pre-install snapshot; without a
+                # reset it cannot see the torn directory
+                mgr.memcache_reset()
                 if (pkg := mgr.get_package(spec)) is not None:
-                    shutil.rmtree(pkg.path, ignore_errors=True)
-            except Exception:  # noqa: BLE001
-                pass
+                    shutil.rmtree(pkg.path)
+            except Exception as cleanup_err:  # noqa: BLE001
+                print(
+                    f"Cleanup after failed pre-install of {spec} "
+                    f"failed ({cleanup_err!r})",
+                    flush=True,
+                )
             return False
 
     workers = min(len(pending), MAX_WORKERS)
@@ -119,10 +132,11 @@ def parallel_install(manager_cls, specs: list) -> None:
             results = list(ex.map(install_one, pending))
     finally:
         manager.unlock()
-    if not any(results):
-        # A systematic fault (e.g. a PlatformIO API change), not archive noise
+    if failures := len(results) - sum(results):
+        # Visible once per wave; pkg install retries every failed spec
         print(
-            "Pre-install failed for every package; pkg install runs serially",
+            f"Pre-install failed for {failures} of {len(results)} package(s); "
+            "pkg install retries them serially",
             flush=True,
         )
 
@@ -147,7 +161,7 @@ def main() -> None:
     )
     parser.add_argument("-t", "--tools", help="Install tools", action="store_true")
     args = parser.parse_args()
-    libs, platforms, tools = parse_specs(args.file, args)
+    libs, platforms, tools = parse_specs(args.file[0], args)
 
     # Platforms stay serial: PlatformPackageManager.install runs an
     # on_installed hook the private _install path would skip

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -56,6 +56,15 @@ for section in config.sections():
             tools.append(tool)
 
 
+def spec_key(spec: str) -> str:
+    """The destination identity of a spec: PlatformIO installs by package
+    name, so two specs sharing a name share a directory."""
+    base = spec.split("@", 1)[0].strip()
+    if base.startswith(("http://", "https://", "file://")):
+        return spec.strip()
+    return base.split("/")[-1].lower()
+
+
 def parallel_install(manager_cls, specs: list[str]) -> None:
     """Best-effort parallel top-level install, one extraction worker per core.
 
@@ -69,7 +78,13 @@ def parallel_install(manager_cls, specs: list[str]) -> None:
     state.
     """
     manager = manager_cls(None)
-    pending = [spec for spec in specs if not manager.get_package(spec)]
+    # One spec per destination: platformio.ini repeats specs across env
+    # sections, and two threads must not extract into the same directory.
+    # A second spec for the same name is left to the pkg install pass.
+    unique: dict[str, str] = {}
+    for spec in specs:
+        unique.setdefault(spec_key(spec), spec)
+    pending = [spec for spec in unique.values() if not manager.get_package(spec)]
     if not pending:
         return
     local = threading.local()

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -254,6 +254,11 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
             clean_torn(mgr, spec)
             return False
+        except BaseException:
+            # A worker SystemExit (main() guards against it) must not skip
+            # the cleanup and leave a torn dir the serial pass trusts
+            clean_torn(mgr, spec)
+            raise
 
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)
     # pio creates these lazily without exist_ok; touch them serially so
@@ -263,6 +268,7 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
     ContentCache("http")
     cwd = Path.cwd()
     unlock_error = None
+    body_error: BaseException | None = None
     manager.lock()
     try:
         with ThreadPoolExecutor(max_workers=workers) as ex:
@@ -279,6 +285,9 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         if errors:
             raise errors[0]
         results = [f.result() for f in futures]
+    except BaseException as err:
+        body_error = err
+        raise
     finally:
         # Neither cleanup may replace an in-flight CleanupError
         try:
@@ -286,6 +295,20 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         except Exception as err:  # noqa: BLE001
             unlock_error = err
             print(f"Could not release the manager lock ({err!r})", flush=True)
+            if isinstance(body_error, Exception) and not isinstance(
+                body_error, CleanupError
+            ):
+                # A plain wave error would fall back to a serial pass that
+                # blocks on the held flock; the held lock is worse
+                raise LockReleaseError(
+                    f"could not release the manager lock ({err!r}) after "
+                    f"a wave failure ({body_error!r})"
+                ) from err
+            if body_error is not None:
+                # Fatal classes stay in flight; record the second fault
+                body_error.add_note(
+                    f"also: could not release the manager lock ({err!r})"
+                )
         # Worker postinstall scripts chdir process-wide (pio's fs.cd);
         # restore between waves, not only for the final subprocess
         try:

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -103,13 +103,24 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
     matches: list[Path] = []
     try:
         entries = list(Path(package_dir).iterdir())
-    except OSError:
+    except FileNotFoundError:
         return matches
+    except OSError as err:
+        # Cannot look means cannot verify; the serial pass could trust
+        # whatever is in here
+        raise CleanupError(
+            f"could not scan {package_dir} while cleaning up {spec}: {err!r}"
+        ) from err
     for d in entries:
         try:
             meta = json.loads((d / ".piopm").read_text(encoding="utf-8"))
-        except (OSError, ValueError):
+        except FileNotFoundError:
             continue  # no metadata means pio does not trust it either
+        except (OSError, ValueError) as err:
+            # Half-written metadata: pio re-synthesizes and overwrites such
+            # a dir, but the refused judgment must be named in the log
+            print(f"Skipping unreadable metadata in {d} ({err!r})", flush=True)
+            continue
         mspec = meta.get("spec") or {}
         name = (mspec.get("name") or meta.get("name") or "").lower()
         owner = (mspec.get("owner") or "").lower()
@@ -130,15 +141,31 @@ def piopm_matches(package_dir: str, spec) -> list[Path]:
 
 
 def remove_dir(spec, dest: Path) -> None:
-    # fs.rmtree never raises (errors go to a printing onexc handler);
-    # only the destination's absence proves the cleanup worked
+    # fs.rmtree never raises (errors go to a printing onexc handler), and
+    # Path.exists suppresses stat errors; only a confirmed ENOENT proves
+    # the cleanup worked
     fs.rmtree(str(dest))
-    if dest.exists():
-        # Failing the build beats baking a corrupt image
+    try:
+        os.lstat(dest)
+    except FileNotFoundError:
+        print(f"Removed torn destination {dest}", flush=True)
+        return
+    except OSError as err:
         raise CleanupError(
-            f"could not remove the failed pre-install of {spec} at {dest}"
-        )
-    print(f"Removed torn destination {dest}", flush=True)
+            f"could not verify removal of {spec} at {dest} ({err!r})"
+        ) from err
+    # Failing the build beats baking a corrupt image
+    raise CleanupError(f"could not remove the failed pre-install of {spec} at {dest}")
+
+
+def cleanup_or_die(mgr, spec) -> None:
+    """Cleanup that did not demonstrably succeed must fail the build."""
+    try:
+        clean_torn(mgr, spec)
+    except CleanupError:
+        raise
+    except Exception as err:  # noqa: BLE001
+        raise CleanupError(f"cleanup failed for {spec}: {err!r}") from err
 
 
 def clean_torn(mgr, spec) -> None:
@@ -276,16 +303,16 @@ def parallel_install(manager_cls, specs: list, prior_names: set | None = None) -
         except (AttributeError, TypeError) as err:
             # A pio API break, not a flaky package; clean, then surface it
             print(f"Pre-install of {spec} hit an API break ({err!r})", flush=True)
-            clean_torn(mgr, spec)
+            cleanup_or_die(mgr, spec)
             raise
         except Exception as err:  # noqa: BLE001
             print(f"Pre-install of {spec} failed ({err!r})", flush=True)
-            clean_torn(mgr, spec)
+            cleanup_or_die(mgr, spec)
             return False
         except BaseException:
             # A worker SystemExit (main() guards against it) must not skip
             # the cleanup and leave a torn dir the serial pass trusts
-            clean_torn(mgr, spec)
+            cleanup_or_die(mgr, spec)
             raise
 
     print(f"Preinstalling {len(pending)} package(s) with {workers} workers", flush=True)

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from platformio import fs
 from platformio.cache import ContentCache
+from platformio.exception import InvalidJSONFile
 from platformio.package.manager._install import PackageManagerInstallMixin
 from platformio.package.manager.base import BasePackageManager
 from platformio.package.manager.library import LibraryPackageManager
@@ -641,5 +642,8 @@ def test_platformio_surface_for_install_deps_script() -> None:
     # The failure-cleanup path degrades to a single line if these vanish
     assert callable(fs.rmtree)
     assert callable(fs.load_json)
+    # piopm_matches only tolerates a corrupt .piopm through this base;
+    # losing it would flip a wave failure from degrade to build failure
+    assert issubclass(InvalidJSONFile, ValueError)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -6,7 +6,7 @@ import inspect
 from pathlib import Path
 import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -385,6 +385,59 @@ def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert not dest.exists()
     assert "Removed torn destination" in capsys.readouterr().out
+
+
+def test_worker_system_exit_still_cleans(tmp_path: Path, capsys) -> None:
+    """A worker SystemExit runs the torn cleanup before propagating; the
+    serial pass must never trust its leftovers."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+    torn = tmp_path / "torn-pkg"
+    torn.mkdir()
+
+    def exiting_install(self, spec, skip_dependencies, compatibility=None):
+        raise SystemExit(0)
+
+    def get_package(self, spec):
+        if getattr(cls, "resets", 0):
+            return SimpleNamespace(path=str(torn), spec=spec)
+        return None
+
+    cls._install = exiting_install
+    cls.get_package = get_package
+
+    def real_rmtree(path):
+        Path(path).rmdir()
+
+    with (
+        patch.object(mod.fs, "rmtree", real_rmtree),
+        pytest.raises(SystemExit),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert not torn.exists()
+
+
+def test_unlock_failure_after_wave_error_is_fatal(tmp_path: Path) -> None:
+    """A plain wave error plus a failed unlock must not fall back to a
+    serial pass that would block on the held flock."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+
+    def bad_unlock(self):
+        type(self).lock_events.append("unlock")
+        raise OSError("flock broke")
+
+    cls.unlock = bad_unlock
+    # make the wave error non-Cleanup: plain install failure raises nothing,
+    # so force an error out of the drain via a broken executor
+    boom = MagicMock()
+    boom.__enter__.return_value = boom
+    boom.submit.side_effect = RuntimeError("no threads")
+    with (
+        patch.object(mod, "ThreadPoolExecutor", return_value=boom),
+        pytest.raises(mod.LockReleaseError, match="after a wave failure"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
 
 def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -622,6 +622,18 @@ def test_unscannable_package_dir_fails_the_build(tmp_path: Path) -> None:
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
 
+def test_stray_file_in_package_dir_is_ignored(tmp_path: Path) -> None:
+    """A plain file (or a pio-link) beside the packages is skipped by
+    pio's own scan and must never hard-fail the build."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    (tmp_path / "packages").mkdir(parents=True)
+    (tmp_path / "packages" / "stray.pio-link").write_text("x")
+    with patch.object(mod.time, "sleep", lambda s: None):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert (tmp_path / "packages" / "stray.pio-link").exists()
+
+
 def test_unreadable_piopm_dir_is_removed(tmp_path: Path, capsys) -> None:
     """A persistently corrupt .piopm would crash pio's own storage scan;
     the dir is removed rather than left to break the serial pass."""
@@ -767,3 +779,8 @@ def test_platformio_surface_for_install_deps_script() -> None:
     assert callable(fs.rmtree)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)
+    from platformio.package.meta import PackageType
+
+    mod = _load_script()
+    # The intact-dir heuristic hand-copies pio's manifest map
+    assert set(mod._MANIFEST_NAMES) == set(PackageType.get_manifest_map().values())

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -783,4 +783,6 @@ def test_platformio_surface_for_install_deps_script() -> None:
 
     mod = _load_script()
     # The intact-dir heuristic hand-copies pio's manifest map
-    assert set(mod._MANIFEST_NAMES) == set(PackageType.get_manifest_map().values())
+    assert set(mod._MANIFEST_NAMES) == {
+        name for names in PackageType.get_manifest_map().values() for name in names
+    }

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -394,6 +394,61 @@ def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
     assert "Removed torn destination" in capsys.readouterr().out
 
 
+def test_parse_specs_tools_branch(tmp_path: Path) -> None:
+    """platform_packages parsing keeps owner'd tools and rewrites github
+    URL pins to bare URLs the wave then skips via parsed.uri."""
+    mod = _load_script()
+    ini = tmp_path / "platformio.ini"
+    ini.write_text(
+        "[env:t]\n"
+        "platform_packages =\n"
+        "    platformio/tool-scons@~4.40801.0\n"
+        "    framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip\n"
+    )
+    args = Namespace(libraries=False, platforms=False, tools=True)
+    libs, platforms, tools = mod.parse_specs(str(ini), args)
+    assert libs == [] and platforms == []
+    assert tools == [
+        "platformio/tool-scons@~4.40801.0",
+        "https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip",
+    ]
+    assert mod.build_cli_args([], [], tools)[:2] == ["-t", tools[0]]
+
+
+def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
+    """Already-installed top-level packages still feed the dependency
+    wave; a warm store can be missing a transitive dep."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.21"})
+    cls.deps = {
+        "esphome/noise-c @ 0.1.21": [
+            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
+        ],
+    }
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
+    assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
+
+
+def test_partial_submission_still_drains_cleanup_errors(tmp_path: Path) -> None:
+    """A submit failure partway must not drop an already-running worker's
+    CleanupError; the serial pass would trust its torn directory."""
+    from concurrent.futures import Future
+
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+    done: Future = Future()
+    done.set_exception(mod.CleanupError("torn dir stuck"))
+    boom = MagicMock()
+    boom.__enter__.return_value = boom
+    boom.__exit__.return_value = False
+    boom.submit.side_effect = [done, RuntimeError("no threads")]
+    with (
+        patch.object(mod, "ThreadPoolExecutor", return_value=boom),
+        pytest.raises(mod.CleanupError, match="torn dir stuck"),
+    ):
+        mod.parallel_install(cls, ["esphome/a @ 1.0", "esphome/b @ 1.0"])
+
+
 def test_worker_system_exit_still_cleans(tmp_path: Path, capsys) -> None:
     """A worker SystemExit runs the torn cleanup before propagating; the
     serial pass must never trust its leftovers."""
@@ -517,6 +572,7 @@ def test_piopm_match_spares_other_versions(tmp_path: Path) -> None:
     (healthy / ".piopm").write_text(
         '{"version": "1.0.0", "spec": {"owner": "esphome", "name": "bad"}}'
     )
+    (healthy / "library.json").write_text("{}")  # intact, not half-deleted
     removed: list[str] = []
     with patch.object(mod.fs, "rmtree", removed.append):
         mod.parallel_install(cls, ["esphome/bad @ ^2.0"])
@@ -566,16 +622,18 @@ def test_unscannable_package_dir_fails_the_build(tmp_path: Path) -> None:
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
 
-def test_unreadable_piopm_is_named(tmp_path: Path, capsys) -> None:
-    """A half-written .piopm the cleanup refuses to judge is named."""
+def test_unreadable_piopm_dir_is_removed(tmp_path: Path, capsys) -> None:
+    """A persistently corrupt .piopm would crash pio's own storage scan;
+    the dir is removed rather than left to break the serial pass."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     weird = tmp_path / "packages" / "weird"
     weird.mkdir(parents=True)
     (weird / ".piopm").write_text("{not json")
-    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert "Skipping unreadable metadata" in capsys.readouterr().out
-    assert weird.exists()
+    with patch.object(mod.time, "sleep", lambda s: None):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert "Removing unreadable-metadata dir" in capsys.readouterr().out
+    assert not weird.exists()
 
 
 def test_unverifiable_removal_fails_the_build(tmp_path: Path) -> None:

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -1,10 +1,8 @@
 """Tests for script/platformio_install_deps.py."""
 
 from argparse import Namespace
-from concurrent.futures import Future
 import importlib.util
 import inspect
-import os
 from pathlib import Path
 import shutil
 import sys
@@ -17,12 +15,7 @@ from platformio.package.manager._install import PackageManagerInstallMixin
 from platformio.package.manager.base import BasePackageManager
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.tool import ToolPackageManager
-from platformio.package.meta import (
-    PackageCompatibility,
-    PackageItem,
-    PackageSpec,
-    PackageType,
-)
+from platformio.package.meta import PackageCompatibility, PackageItem, PackageSpec
 import pytest
 from semantic_version import Version
 
@@ -153,6 +146,13 @@ def _reset_fake(base_dir: str = "", **kwargs) -> type:
     )
 
 
+def test_parallel_install_empty_specs_is_a_no_op(tmp_path: Path) -> None:
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+    mod.parallel_install(cls, [])
+    assert cls.calls == [] and cls.lock_events == []
+
+
 def test_parallel_install_behavior(tmp_path: Path) -> None:
     """Duplicates collapse to one install, installed specs are filtered,
     URL specs stay out of the wave, and the lock wraps the pool."""
@@ -196,8 +196,6 @@ def test_parallel_install_failure_cleans_torn_destination(
     out = capsys.readouterr().out
     assert "Pre-install of esphome/bad @ 1.0 failed" in out
     assert "Pre-install failed for 1 of 2 package(s)" in out
-    # A failed install is expected to be unresolvable; no anomaly print
-    assert "not resolvable afterwards" not in out
 
 
 def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
@@ -238,63 +236,6 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
-def test_success_without_package_prints_anomaly(tmp_path: Path, capsys) -> None:
-    """An install that reported success but resolves to nothing prints the
-    anomaly instead of silently pruning its dependency subtree."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path))
-    cls.get_package = lambda self, spec: None  # throwaway subclass
-    mod.parallel_install(cls, ["esphome/ghost @ 1.0"])
-    assert "not resolvable afterwards" in capsys.readouterr().out
-
-
-def test_warm_spec_lost_after_reset_prints_anomaly(tmp_path: Path, capsys) -> None:
-    """A warm-store spec that stops resolving after the memcache reset
-    prints the anomaly instead of silently dropping its subtree."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/warm @ 1.0"})
-
-    def get_package(self, spec):
-        if getattr(cls, "resets", 0):
-            return None
-        return _FakeManager.get_package(self, spec)
-
-    cls.get_package = get_package  # throwaway subclass; nothing to restore
-    mod.parallel_install(cls, ["esphome/warm @ 1.0"])
-    assert "not resolvable afterwards" in capsys.readouterr().out
-
-
-def test_dependency_wave_skips_known_builtins(tmp_path: Path) -> None:
-    """A versioned owner-less dep the manager recognizes as built-in is
-    skipped like pio's install_dependency skips it."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path))
-    cls.deps = {
-        "esphome/noise-c @ 0.1.21": [
-            {"name": "SPI", "version": "^1.0"},
-            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
-        ],
-    }
-    cls.is_builtin_lib = staticmethod(lambda name: name == "SPI")
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
-    assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "libsodium"}
-
-
-def test_wave_limit_prints_truncation(tmp_path: Path, capsys) -> None:
-    """Hitting the cycle backstop announces what is left to pkg install."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path))
-    cls.deps = {
-        "esphome/noise-c @ 0.1.21": [
-            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
-        ],
-    }
-    prior = {f"seen{i}" for i in range(200)}
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"], prior)
-    out = capsys.readouterr().out
-    assert "Dependency wave limit reached; 1 spec(s) left to pkg install" in out
-
-
 def test_failed_cleanup_fails_the_build(tmp_path: Path) -> None:
     """A torn destination still on disk after rmtree must fail the build:
     fs.rmtree never raises (its onexc handler prints), so only the
@@ -318,42 +259,9 @@ def test_failed_cleanup_fails_the_build(tmp_path: Path) -> None:
     assert cls.lock_events == ["lock", "unlock"]  # still released
 
 
-def test_api_break_cleans_before_surfacing(tmp_path: Path) -> None:
-    """An AttributeError from _install still removes the torn destination
-    before propagating to the logged serial fallback."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path))
-    torn = tmp_path / "packages" / "torn-pkg"
-    torn.mkdir(parents=True)
-
-    def bad_install(self, spec, skip_dependencies, compatibility=None):
-        raise AttributeError("_install went away")
-
-    def get_package(self, spec):
-        if getattr(cls, "resets", 0):
-            return SimpleNamespace(path=str(torn), spec=spec)
-        return None
-
-    cls._install = bad_install
-    cls.get_package = get_package
-    removed: list[str] = []
-
-    def fake_rmtree(path):
-        removed.append(path)
-        Path(path).rmdir()
-
-    with (
-        patch.object(mod.fs, "rmtree", fake_rmtree),
-        pytest.raises(AttributeError),
-    ):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert removed == [str(torn)]
-
-
 def test_unverifiable_torn_destination_fails_the_build(tmp_path: Path) -> None:
-    """When the scan keeps failing, the spec's own predicted destination
-    decides: an unremovable leftover fails the build; no leftover means
-    an innocent worker's in-flight copy cannot fail it."""
+    """When the scan fails, the spec's own .piopm decides: an unremovable
+    leftover fails the build."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     dest = Path(cls.base_dir) / "packages" / "bad"
@@ -365,7 +273,6 @@ def test_unverifiable_torn_destination_fails_the_build(tmp_path: Path) -> None:
 
     cls.memcache_reset = bad_reset
     with (
-        patch.object(mod.time, "sleep", lambda s: None),
         patch.object(mod.fs, "rmtree", lambda path: None),  # onexc swallowed
         pytest.raises(mod.CleanupError, match="could not remove"),
     ):
@@ -373,39 +280,20 @@ def test_unverifiable_torn_destination_fails_the_build(tmp_path: Path) -> None:
 
 
 def test_unverifiable_scan_without_leftover_degrades(tmp_path: Path, capsys) -> None:
-    """A persistently failing scan with no destination on disk is another
-    worker's problem, never a build failure blaming this spec."""
+    """A failing scan with no destination on disk is never a build
+    failure blaming this spec."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     resets = {"n": 0}
 
     def bad_reset(self):
-        # Exhaust clean_torn's retries; the coordinator's later reset works
+        # Fail clean_torn's reset; the coordinator's later reset works
         resets["n"] += 1
-        if resets["n"] <= 5:
+        if resets["n"] <= 1:
             raise OSError("scan broken")
 
     cls.memcache_reset = bad_reset
-    with patch.object(mod.time, "sleep", lambda s: None):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert "no destination to clean" in capsys.readouterr().out
-
-
-def test_transient_inspect_failure_retries(tmp_path: Path, capsys) -> None:
-    """A transient read of another worker's copy is retried, not fatal."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    attempts: list[int] = []
-
-    def flaky_reset(self):
-        attempts.append(1)
-        if len(attempts) < 2:
-            raise OSError("mid-copy read")
-
-    cls.memcache_reset = flaky_reset
-    with patch.object(mod.time, "sleep", lambda s: None):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert len(attempts) >= 2
+    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert "No resolvable destination to clean" in capsys.readouterr().out
 
 
@@ -427,10 +315,7 @@ def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
     dest.mkdir(parents=True)
     (dest / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
 
-    def real_rmtree(path):
-        shutil.rmtree(path)
-
-    with patch.object(mod.fs, "rmtree", real_rmtree):
+    with patch.object(mod.fs, "rmtree", shutil.rmtree):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert not dest.exists()
     assert "Removed torn destination" in capsys.readouterr().out
@@ -444,6 +329,7 @@ def test_parse_specs_tools_branch(tmp_path: Path) -> None:
     ini.write_text(
         "[env:t]\n"
         "platform_packages =\n"
+        "    ${common.platform_packages}\n"
         "    platformio/tool-scons@~4.40801.0\n"
         "    framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/6.0.0/rp2040-6.0.0.zip\n"
     )
@@ -469,24 +355,6 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     }
     mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
-
-
-def test_partial_submission_still_drains_cleanup_errors(tmp_path: Path) -> None:
-    """A submit failure partway must not drop an already-running worker's
-    CleanupError; the serial pass would trust its torn directory."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path))
-    done: Future = Future()
-    done.set_exception(mod.CleanupError("torn dir stuck"))
-    boom = MagicMock()
-    boom.__enter__.return_value = boom
-    boom.__exit__.return_value = False
-    boom.submit.side_effect = [done, RuntimeError("no threads")]
-    with (
-        patch.object(mod, "ThreadPoolExecutor", return_value=boom),
-        pytest.raises(mod.CleanupError, match="torn dir stuck"),
-    ):
-        mod.parallel_install(cls, ["esphome/a @ 1.0", "esphome/b @ 1.0"])
 
 
 def test_worker_system_exit_still_cleans(tmp_path: Path, capsys) -> None:
@@ -519,49 +387,23 @@ def test_worker_system_exit_still_cleans(tmp_path: Path, capsys) -> None:
     assert not torn.exists()
 
 
-def test_unlock_failure_after_wave_error_is_fatal(tmp_path: Path) -> None:
-    """A plain wave error plus a failed unlock must not fall back to a
-    serial pass that would block on the held flock."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-
-    def bad_unlock(self):
-        type(self).lock_events.append("unlock")
-        raise OSError("flock broke")
-
-    cls.unlock = bad_unlock
-    # make the wave error non-Cleanup: plain install failure raises nothing,
-    # so force an error out of the drain via a broken executor
-    boom = MagicMock()
-    boom.__enter__.return_value = boom
-    boom.submit.side_effect = RuntimeError("no threads")
-    with (
-        patch.object(mod, "ThreadPoolExecutor", return_value=boom),
-        pytest.raises(mod.LockReleaseError, match="after a wave failure"),
-    ):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-
-
-def test_unlock_failure_after_system_exit_is_fatal(tmp_path: Path) -> None:
-    """A worker SystemExit plus a failed unlock must not fall through to a
-    serial pass that would block on the held flock."""
+def test_unlock_failure_is_fatal(tmp_path: Path) -> None:
+    """A failed unlock must fail the build: the serial pass in another
+    process would block on the held flock."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
 
-    def exiting_install(self, spec, skip_dependencies, compatibility=None):
-        raise SystemExit(0)
-
     def bad_unlock(self):
         raise OSError("flock broke")
 
-    cls._install = exiting_install
     cls.unlock = bad_unlock
-    with pytest.raises(mod.LockReleaseError, match="after a wave failure"):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    with pytest.raises(mod.LockReleaseError, match="manager lock"):
+        mod.parallel_install(cls, ["esphome/good @ 1.0"])
 
 
-def test_unlock_failure_with_cleanup_error_stays_fatal(tmp_path: Path) -> None:
-    """A CleanupError body stays in flight; the unlock fault becomes a note."""
+def test_unlock_failure_keeps_inflight_error_as_context(tmp_path: Path) -> None:
+    """An in-flight CleanupError stays attached when the unlock fault
+    takes over the raise."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     torn = tmp_path / "packages" / "bad"
@@ -579,10 +421,20 @@ def test_unlock_failure_with_cleanup_error_stays_fatal(tmp_path: Path) -> None:
     cls.unlock = bad_unlock
     with (
         patch.object(mod.fs, "rmtree", lambda path: None),  # leaves torn
-        pytest.raises(mod.CleanupError) as err,
+        pytest.raises(mod.LockReleaseError) as err,
     ):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert any("manager lock" in n for n in err.value.__notes__)
+    assert isinstance(err.value.__cause__.__context__, mod.CleanupError)
+
+
+def test_chdir_failure_does_not_fail_the_wave(tmp_path: Path, monkeypatch) -> None:
+    """A lost cwd is suppressed: further waves may misbehave and fall to
+    the serial pass, whose cwd is pinned."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+    monkeypatch.setattr(mod.os, "chdir", MagicMock(side_effect=OSError("gone")))
+    mod.parallel_install(cls, ["esphome/good @ 1.0"])
+    assert cls.calls == ["esphome/good @ 1.0"]
 
 
 def test_piopm_match_removes_manifest_named_torn_dir(tmp_path: Path, capsys) -> None:
@@ -593,55 +445,14 @@ def test_piopm_match_removes_manifest_named_torn_dir(tmp_path: Path, capsys) -> 
     torn = tmp_path / "packages" / "ManifestName"
     torn.mkdir(parents=True)
     (torn / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
-
-    def real_rmtree(path):
-        shutil.rmtree(path)
-
-    with patch.object(mod.fs, "rmtree", real_rmtree):
+    innocent = tmp_path / "packages" / "innocent"
+    innocent.mkdir()
+    (innocent / ".piopm").write_text('{"spec": {"owner": "o", "name": "other"}}')
+    with patch.object(mod.fs, "rmtree", shutil.rmtree):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert not torn.exists()
+    assert innocent.exists()  # another package's valid metadata survives
     assert "Removed torn destination" in capsys.readouterr().out
-
-
-def test_piopm_match_spares_other_versions(tmp_path: Path) -> None:
-    """A healthy install of another version is never a cleanup casualty."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ ^2.0"})
-    healthy = tmp_path / "packages" / "bad"
-    healthy.mkdir(parents=True)
-    (healthy / ".piopm").write_text(
-        '{"version": "1.0.0", "spec": {"owner": "esphome", "name": "bad"}}'
-    )
-    (healthy / "library.json").write_text("{}")  # intact, not half-deleted
-    removed: list[str] = []
-    with patch.object(mod.fs, "rmtree", removed.append):
-        mod.parallel_install(cls, ["esphome/bad @ ^2.0"])
-    assert removed == []
-    assert healthy.exists()
-
-
-def test_chdir_failure_defers_to_pending_lock_fault(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """An unlock fault plus a failed cwd restore must still raise the
-    LockReleaseError; the OSError must not displace it."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path))
-
-    def bad_unlock(self):
-        raise OSError("flock broke")
-
-    cls.unlock = bad_unlock
-    real_chdir = mod.os.chdir
-    monkeypatch.setattr(
-        mod.os, "chdir", lambda path: (_ for _ in ()).throw(OSError("cwd gone"))
-    )
-    try:
-        with pytest.raises(mod.LockReleaseError) as err:
-            mod.parallel_install(cls, ["esphome/a @ 1.0"])
-    finally:
-        monkeypatch.setattr(mod.os, "chdir", real_chdir)
-    assert any("working dir" in n for n in err.value.__cause__.__notes__)
 
 
 def test_unscannable_package_dir_fails_the_build(tmp_path: Path) -> None:
@@ -657,7 +468,7 @@ def test_unscannable_package_dir_fails_the_build(tmp_path: Path) -> None:
 
     with (
         patch.object(Path, "iterdir", broken_iterdir),
-        pytest.raises(mod.CleanupError, match="could not scan"),
+        pytest.raises(mod.CleanupError, match="cleanup failed"),
     ):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
@@ -669,12 +480,13 @@ def test_stray_file_in_package_dir_is_ignored(tmp_path: Path) -> None:
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     (tmp_path / "packages").mkdir(parents=True)
     (tmp_path / "packages" / "stray.pio-link").write_text("x")
-    with patch.object(mod.time, "sleep", lambda s: None):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    (tmp_path / "packages" / "no-metadata").mkdir()  # pio overwrites these
+    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert (tmp_path / "packages" / "stray.pio-link").exists()
+    assert (tmp_path / "packages" / "no-metadata").exists()
 
 
-def test_unreadable_piopm_dir_is_removed(tmp_path: Path, capsys) -> None:
+def test_unreadable_piopm_dir_is_removed(tmp_path: Path) -> None:
     """A persistently corrupt .piopm under this spec's own name would
     crash pio's storage scan; the dir is removed rather than left to
     break the serial pass."""
@@ -683,13 +495,11 @@ def test_unreadable_piopm_dir_is_removed(tmp_path: Path, capsys) -> None:
     torn = tmp_path / "packages" / "bad"
     torn.mkdir(parents=True)
     (torn / ".piopm").write_text("{not json")
-    with patch.object(mod.time, "sleep", lambda s: None):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert "Removing unreadable-metadata dir" in capsys.readouterr().out
+    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert not torn.exists()
 
 
-def test_unreadable_piopm_under_other_name_survives(tmp_path: Path, capsys) -> None:
+def test_unreadable_piopm_under_other_name_survives(tmp_path: Path) -> None:
     """A corrupt .piopm in another package's dir may be a worker mid-copy;
     a failing spec must not remove a directory it does not own."""
     mod = _load_script()
@@ -697,122 +507,8 @@ def test_unreadable_piopm_under_other_name_survives(tmp_path: Path, capsys) -> N
     other = tmp_path / "packages" / "innocent"
     other.mkdir(parents=True)
     (other / ".piopm").write_text("{not json")
-    with patch.object(mod.time, "sleep", lambda s: None):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert "Removing unreadable-metadata dir" not in capsys.readouterr().out
+    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert other.exists()
-
-
-def test_manifest_stat_error_is_unverifiable(tmp_path: Path) -> None:
-    """A stat error on a spared dir's manifest is not proof of absence;
-    judging it half-deleted would remove an intact other version."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    other = tmp_path / "packages" / "bad"
-    other.mkdir(parents=True)
-    (other / ".piopm").write_text(
-        '{"spec": {"owner": "esphome", "name": "bad"}, "version": "2.0.0"}'
-    )
-    (other / "library.json").write_text("{}")
-    real_lstat = os.lstat
-
-    def manifest_lstat_denied(path, *args, **kwargs):
-        if Path(path).name in mod._MANIFEST_NAMES:
-            raise PermissionError("denied")
-        return real_lstat(path, *args, **kwargs)
-
-    with (
-        patch.object(mod.os, "lstat", manifest_lstat_denied),
-        pytest.raises(mod.CleanupError, match="could not check for a manifest"),
-    ):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert other.exists()
-
-
-def test_unstattable_entry_fails_the_build(tmp_path: Path) -> None:
-    """An entry the scan cannot stat may be the torn destination itself;
-    silently dropping it would hand the serial pass an unverified dir."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    shady = tmp_path / "packages" / "shady"
-    shady.mkdir(parents=True)
-    real_lstat = os.lstat
-
-    def entry_lstat_denied(path, *args, **kwargs):
-        if Path(path).name == "shady":
-            raise PermissionError("denied")
-        return real_lstat(path, *args, **kwargs)
-
-    with (
-        patch.object(mod.os, "lstat", entry_lstat_denied),
-        pytest.raises(mod.CleanupError, match="could not stat"),
-    ):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-
-
-def test_refuses_to_remove_the_store_itself(tmp_path: Path, capsys) -> None:
-    """is_relative_to is reflexive; a destination resolving to the store
-    itself must be refused, not handed to the script's only rmtree."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    store = tmp_path / "packages"
-    store.mkdir(parents=True)
-
-    def get_package(self, spec):
-        if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
-            return SimpleNamespace(path=str(store), spec=spec)
-        return _FakeManager.get_package(self, spec)
-
-    cls.get_package = get_package  # throwaway subclass; nothing to restore
-    removed = []
-    with patch.object(mod.fs, "rmtree", side_effect=removed.append):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert removed == []
-    assert store.exists()
-    assert "Refusing to remove" in capsys.readouterr().out
-
-
-def test_refuses_to_remove_outside_the_store(tmp_path: Path, capsys) -> None:
-    """A .pio-link package resolves to its external source dir; cleanup
-    must never rmtree beyond the store it owns."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    external = tmp_path / "elsewhere" / "bad-src"
-    external.mkdir(parents=True)
-
-    def get_package(self, spec):
-        if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
-            return SimpleNamespace(path=str(external), spec=spec)
-        return _FakeManager.get_package(self, spec)
-
-    cls.get_package = get_package  # throwaway subclass; nothing to restore
-    removed = []
-    with patch.object(mod.fs, "rmtree", side_effect=removed.append):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
-    assert removed == []
-    assert external.exists()
-    assert "Refusing to remove" in capsys.readouterr().out
-
-
-def test_unverifiable_removal_fails_the_build(tmp_path: Path) -> None:
-    """A stat error after rmtree is not proof of removal."""
-    mod = _load_script()
-    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    torn = tmp_path / "packages" / "bad"
-    torn.mkdir(parents=True)
-
-    def get_package(self, spec):
-        if getattr(cls, "resets", 0):
-            return SimpleNamespace(path=str(torn), spec=spec)
-        return None
-
-    cls.get_package = get_package  # throwaway subclass; nothing to restore
-    with (
-        patch.object(mod.fs, "rmtree", lambda path: None),
-        patch.object(mod.os, "lstat", MagicMock(side_effect=PermissionError("denied"))),
-        pytest.raises(mod.CleanupError, match="could not verify removal"),
-    ):
-        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
 
 def test_unexpected_cleanup_class_becomes_cleanup_error(tmp_path: Path) -> None:
@@ -872,6 +568,12 @@ def test_content_cache_creates_its_dir(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("PLATFORMIO_CACHE_DIR", str(tmp_path / "cache"))
     ContentCache("http")
     assert (tmp_path / "cache" / "http").is_dir()
+
+
+def test_piopm_matches_without_name_matches_nothing(tmp_path: Path) -> None:
+    """A spec with no derivable name can never match a directory."""
+    mod = _load_script()
+    assert mod.piopm_matches(str(tmp_path), "") == []
 
 
 def test_unresolvable_spec_stays_out_of_the_wave(tmp_path: Path, capsys) -> None:
@@ -938,15 +640,6 @@ def test_platformio_surface_for_install_deps_script() -> None:
     assert Version("1.5.0") in spec.requirements
     # The failure-cleanup path degrades to a single line if these vanish
     assert callable(fs.rmtree)
+    assert callable(fs.load_json)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)
-    # dependency_specs calls it with one positional argument
-    assert list(inspect.signature(LibraryPackageManager.is_builtin_lib).parameters) == [
-        "name"
-    ]
-
-    mod = _load_script()
-    # The intact-dir heuristic hand-copies pio's manifest map
-    assert set(mod._MANIFEST_NAMES) == {
-        name for names in PackageType.get_manifest_map().values() for name in names
-    }

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -117,15 +117,10 @@ class _FakeManager:
     def get_pkg_dependencies(self, pkg):
         return getattr(type(self), "deps", {}).get(pkg.spec)
 
-    @staticmethod
-    def dependency_to_spec(dependency):
-        from platformio.package.meta import PackageSpec
+    # The real conversion: the fake must not drift from what pio does
+    from platformio.package.manager.base import BasePackageManager
 
-        return PackageSpec(
-            owner=dependency.get("owner"),
-            name=dependency.get("name"),
-            requirements=dependency.get("version"),
-        )
+    dependency_to_spec = staticmethod(BasePackageManager.dependency_to_spec)
 
 
 def _reset_fake(base_dir: str = "", **kwargs) -> type:
@@ -231,10 +226,8 @@ def test_success_without_package_prints_anomaly(tmp_path: Path, capsys) -> None:
     anomaly instead of silently pruning its dependency subtree."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
-    real_get = cls.get_package
-    cls.get_package = lambda self, spec: None  # never resolvable
+    cls.get_package = lambda self, spec: None  # throwaway subclass
     mod.parallel_install(cls, ["esphome/ghost @ 1.0"])
-    cls.get_package = real_get
     assert "not resolvable afterwards" in capsys.readouterr().out
 
 

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -381,7 +381,9 @@ def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
     (dest / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
 
     def real_rmtree(path):
-        Path(path).rmdir()
+        import shutil
+
+        shutil.rmtree(path)
 
     with patch.object(mod.fs, "rmtree", real_rmtree):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -168,16 +168,18 @@ def test_parallel_install_failure_cleans_torn_destination(
 
     removed = []
 
+    torn = str(tmp_path / "torn-pkg")  # never created; only rmtree'd
+
     def get_package(self, spec):
         if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
-            return SimpleNamespace(path="/tmp/torn-pkg", spec=spec)
+            return SimpleNamespace(path=torn, spec=spec)
         return _FakeManager.get_package(self, spec)
 
     cls.get_package = get_package  # throwaway subclass; nothing to restore
     with patch.object(mod.fs, "rmtree", side_effect=removed.append):
         mod.parallel_install(cls, ["esphome/bad @ 1.0", "esphome/good @ 1.0"])
     assert "esphome/good @ 1.0" in cls.calls
-    assert removed == ["/tmp/torn-pkg"]
+    assert removed == [torn]
     out = capsys.readouterr().out
     assert "Pre-install of esphome/bad @ 1.0 failed" in out
     assert "Pre-install failed for 1 of 2 package(s)" in out

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -548,6 +548,66 @@ def test_chdir_failure_defers_to_pending_lock_fault(
     assert any("working dir" in n for n in err.value.__cause__.__notes__)
 
 
+def test_unscannable_package_dir_fails_the_build(tmp_path: Path) -> None:
+    """A storage dir the cleanup cannot scan is not proof of cleanliness."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    real_iterdir = Path.iterdir
+
+    def broken_iterdir(self):
+        if self.name == "packages":
+            raise PermissionError("denied")
+        return real_iterdir(self)
+
+    with (
+        patch.object(Path, "iterdir", broken_iterdir),
+        pytest.raises(mod.CleanupError, match="could not scan"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+
+
+def test_unreadable_piopm_is_named(tmp_path: Path, capsys) -> None:
+    """A half-written .piopm the cleanup refuses to judge is named."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    weird = tmp_path / "packages" / "weird"
+    weird.mkdir(parents=True)
+    (weird / ".piopm").write_text("{not json")
+    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert "Skipping unreadable metadata" in capsys.readouterr().out
+    assert weird.exists()
+
+
+def test_unverifiable_removal_fails_the_build(tmp_path: Path) -> None:
+    """A stat error after rmtree is not proof of removal."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    torn = tmp_path / "packages" / "bad"
+    torn.mkdir(parents=True)
+    (torn / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
+    with (
+        patch.object(mod.fs, "rmtree", lambda path: None),
+        patch.object(mod.os, "lstat", MagicMock(side_effect=PermissionError("denied"))),
+        pytest.raises(mod.CleanupError, match="could not verify removal"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+
+
+def test_unexpected_cleanup_class_becomes_cleanup_error(tmp_path: Path) -> None:
+    """Cleanup failures of any class fail the build; nothing may be
+    downgraded to the serial fallback over a torn directory."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+
+    with (
+        patch.object(
+            mod, "piopm_matches", MagicMock(side_effect=ValueError("bad spec"))
+        ),
+        pytest.raises(mod.CleanupError, match="cleanup failed"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+
+
 def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:
     """A CleanupError must escape main's serial fallback: the clause order
     decides whether a stuck torn package fails the image build."""

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -112,7 +112,7 @@ class _FakeManager:
             raise RuntimeError("boom")
         type(self).calls.append(spec)
         type(self).compat_calls.append((self._key(spec), compatibility))
-        type(self).installed = type(self).installed | {self._key(spec)}
+        type(self).installed.add(self._key(spec))  # atomic under the GIL
 
     def get_pkg_dependencies(self, pkg):
         return getattr(type(self), "deps", {}).get(pkg.spec)
@@ -501,6 +501,46 @@ def test_piopm_match_removes_manifest_named_torn_dir(tmp_path: Path, capsys) -> 
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert not torn.exists()
     assert "Removed torn destination" in capsys.readouterr().out
+
+
+def test_piopm_match_spares_other_versions(tmp_path: Path) -> None:
+    """A healthy install of another version is never a cleanup casualty."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ ^2.0"})
+    healthy = tmp_path / "packages" / "bad"
+    healthy.mkdir(parents=True)
+    (healthy / ".piopm").write_text(
+        '{"version": "1.0.0", "spec": {"owner": "esphome", "name": "bad"}}'
+    )
+    removed: list[str] = []
+    with patch.object(mod.fs, "rmtree", removed.append):
+        mod.parallel_install(cls, ["esphome/bad @ ^2.0"])
+    assert removed == []
+    assert healthy.exists()
+
+
+def test_chdir_failure_defers_to_pending_lock_fault(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An unlock fault plus a failed cwd restore must still raise the
+    LockReleaseError; the OSError must not displace it."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+
+    def bad_unlock(self):
+        raise OSError("flock broke")
+
+    cls.unlock = bad_unlock
+    real_chdir = mod.os.chdir
+    monkeypatch.setattr(
+        mod.os, "chdir", lambda path: (_ for _ in ()).throw(OSError("cwd gone"))
+    )
+    try:
+        with pytest.raises(mod.LockReleaseError) as err:
+            mod.parallel_install(cls, ["esphome/a @ 1.0"])
+    finally:
+        monkeypatch.setattr(mod.os, "chdir", real_chdir)
+    assert any("working dir" in n for n in err.value.__notes__)
 
 
 def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -1,6 +1,7 @@
 """Tests for script/platformio_install_deps.py."""
 
 from argparse import Namespace
+from concurrent.futures import Future
 import importlib.util
 import inspect
 from pathlib import Path
@@ -15,7 +16,12 @@ from platformio.package.manager._install import PackageManagerInstallMixin
 from platformio.package.manager.base import BasePackageManager
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.tool import ToolPackageManager
-from platformio.package.meta import PackageCompatibility, PackageItem, PackageSpec
+from platformio.package.meta import (
+    PackageCompatibility,
+    PackageItem,
+    PackageSpec,
+    PackageType,
+)
 import pytest
 
 _SCRIPT = Path(__file__).parents[2] / "script" / "platformio_install_deps.py"
@@ -173,7 +179,7 @@ def test_parallel_install_failure_cleans_torn_destination(
 
     removed = []
 
-    torn = str(tmp_path / "torn-pkg")  # never created; only rmtree'd
+    torn = str(tmp_path / "packages" / "torn-pkg")  # never created; only rmtree'd
 
     def get_package(self, spec):
         if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
@@ -188,6 +194,8 @@ def test_parallel_install_failure_cleans_torn_destination(
     out = capsys.readouterr().out
     assert "Pre-install of esphome/bad @ 1.0 failed" in out
     assert "Pre-install failed for 1 of 2 package(s)" in out
+    # A failed install is expected to be unresolvable; no anomaly print
+    assert "not resolvable afterwards" not in out
 
 
 def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
@@ -238,6 +246,38 @@ def test_success_without_package_prints_anomaly(tmp_path: Path, capsys) -> None:
     assert "not resolvable afterwards" in capsys.readouterr().out
 
 
+def test_warm_spec_lost_after_reset_prints_anomaly(tmp_path: Path, capsys) -> None:
+    """A warm-store spec that stops resolving after the memcache reset
+    prints the anomaly instead of silently dropping its subtree."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), installed={"esphome/warm @ 1.0"})
+
+    def get_package(self, spec):
+        if getattr(cls, "resets", 0):
+            return None
+        return _FakeManager.get_package(self, spec)
+
+    cls.get_package = get_package  # throwaway subclass; nothing to restore
+    mod.parallel_install(cls, ["esphome/warm @ 1.0"])
+    assert "not resolvable afterwards" in capsys.readouterr().out
+
+
+def test_dependency_wave_skips_known_builtins(tmp_path: Path) -> None:
+    """A versioned owner-less dep the manager recognizes as built-in is
+    skipped like pio's install_dependency skips it."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+    cls.deps = {
+        "esphome/noise-c @ 0.1.21": [
+            {"name": "SPI", "version": "^1.0"},
+            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
+        ],
+    }
+    cls.is_builtin_lib = staticmethod(lambda name: name == "SPI")
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
+    assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "libsodium"}
+
+
 def test_wave_limit_prints_truncation(tmp_path: Path, capsys) -> None:
     """Hitting the cycle backstop announces what is left to pkg install."""
     mod = _load_script()
@@ -259,8 +299,8 @@ def test_failed_cleanup_fails_the_build(tmp_path: Path) -> None:
     destination's absence proves the cleanup worked."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    torn = tmp_path / "torn-pkg"
-    torn.mkdir()
+    torn = tmp_path / "packages" / "torn-pkg"
+    torn.mkdir(parents=True)
 
     def get_package(self, spec):
         if getattr(cls, "resets", 0):
@@ -281,8 +321,8 @@ def test_api_break_cleans_before_surfacing(tmp_path: Path) -> None:
     before propagating to the logged serial fallback."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
-    torn = tmp_path / "torn-pkg"
-    torn.mkdir()
+    torn = tmp_path / "packages" / "torn-pkg"
+    torn.mkdir(parents=True)
 
     def bad_install(self, spec, skip_dependencies, compatibility=None):
         raise AttributeError("_install went away")
@@ -432,8 +472,6 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
 def test_partial_submission_still_drains_cleanup_errors(tmp_path: Path) -> None:
     """A submit failure partway must not drop an already-running worker's
     CleanupError; the serial pass would trust its torn directory."""
-    from concurrent.futures import Future
-
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     done: Future = Future()
@@ -454,8 +492,8 @@ def test_worker_system_exit_still_cleans(tmp_path: Path, capsys) -> None:
     serial pass must never trust its leftovers."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
-    torn = tmp_path / "torn-pkg"
-    torn.mkdir()
+    torn = tmp_path / "packages" / "torn-pkg"
+    torn.mkdir(parents=True)
 
     def exiting_install(self, spec, skip_dependencies, compatibility=None):
         raise SystemExit(0)
@@ -635,17 +673,73 @@ def test_stray_file_in_package_dir_is_ignored(tmp_path: Path) -> None:
 
 
 def test_unreadable_piopm_dir_is_removed(tmp_path: Path, capsys) -> None:
-    """A persistently corrupt .piopm would crash pio's own storage scan;
-    the dir is removed rather than left to break the serial pass."""
+    """A persistently corrupt .piopm under this spec's own name would
+    crash pio's storage scan; the dir is removed rather than left to
+    break the serial pass."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
-    weird = tmp_path / "packages" / "weird"
-    weird.mkdir(parents=True)
-    (weird / ".piopm").write_text("{not json")
+    torn = tmp_path / "packages" / "bad"
+    torn.mkdir(parents=True)
+    (torn / ".piopm").write_text("{not json")
     with patch.object(mod.time, "sleep", lambda s: None):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert "Removing unreadable-metadata dir" in capsys.readouterr().out
-    assert not weird.exists()
+    assert not torn.exists()
+
+
+def test_unreadable_piopm_under_other_name_survives(tmp_path: Path, capsys) -> None:
+    """A corrupt .piopm in another package's dir may be a worker mid-copy;
+    a failing spec must not remove a directory it does not own."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    other = tmp_path / "packages" / "innocent"
+    other.mkdir(parents=True)
+    (other / ".piopm").write_text("{not json")
+    with patch.object(mod.time, "sleep", lambda s: None):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert "Removing unreadable-metadata dir" not in capsys.readouterr().out
+    assert other.exists()
+
+
+def test_manifest_stat_error_is_unverifiable(tmp_path: Path) -> None:
+    """A stat error on a spared dir's manifest is not proof of absence;
+    judging it half-deleted would remove an intact other version."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    other = tmp_path / "packages" / "bad"
+    other.mkdir(parents=True)
+    (other / ".piopm").write_text(
+        '{"spec": {"owner": "esphome", "name": "bad"}, "version": "2.0.0"}'
+    )
+    (other / "library.json").write_text("{}")
+    with (
+        patch.object(mod.os, "lstat", MagicMock(side_effect=PermissionError("denied"))),
+        pytest.raises(mod.CleanupError, match="could not check for a manifest"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert other.exists()
+
+
+def test_refuses_to_remove_outside_the_store(tmp_path: Path, capsys) -> None:
+    """A .pio-link package resolves to its external source dir; cleanup
+    must never rmtree beyond the store it owns."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    external = tmp_path / "elsewhere" / "bad-src"
+    external.mkdir(parents=True)
+
+    def get_package(self, spec):
+        if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
+            return SimpleNamespace(path=str(external), spec=spec)
+        return _FakeManager.get_package(self, spec)
+
+    cls.get_package = get_package  # throwaway subclass; nothing to restore
+    removed = []
+    with patch.object(mod.fs, "rmtree", side_effect=removed.append):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert removed == []
+    assert external.exists()
+    assert "Refusing to remove" in capsys.readouterr().out
 
 
 def test_unverifiable_removal_fails_the_build(tmp_path: Path) -> None:
@@ -779,7 +873,7 @@ def test_platformio_surface_for_install_deps_script() -> None:
     assert callable(fs.rmtree)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)
-    from platformio.package.meta import PackageType
+    assert callable(LibraryPackageManager.is_builtin_lib)
 
     mod = _load_script()
     # The intact-dir heuristic hand-copies pio's manifest map

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from concurrent.futures import Future
 import importlib.util
 import inspect
+import os
 from pathlib import Path
 import shutil
 import sys
@@ -23,6 +24,7 @@ from platformio.package.meta import (
     PackageType,
 )
 import pytest
+from semantic_version import Version
 
 _SCRIPT = Path(__file__).parents[2] / "script" / "platformio_install_deps.py"
 
@@ -712,12 +714,62 @@ def test_manifest_stat_error_is_unverifiable(tmp_path: Path) -> None:
         '{"spec": {"owner": "esphome", "name": "bad"}, "version": "2.0.0"}'
     )
     (other / "library.json").write_text("{}")
+    real_lstat = os.lstat
+
+    def manifest_lstat_denied(path, *args, **kwargs):
+        if Path(path).name in mod._MANIFEST_NAMES:
+            raise PermissionError("denied")
+        return real_lstat(path, *args, **kwargs)
+
     with (
-        patch.object(mod.os, "lstat", MagicMock(side_effect=PermissionError("denied"))),
+        patch.object(mod.os, "lstat", manifest_lstat_denied),
         pytest.raises(mod.CleanupError, match="could not check for a manifest"),
     ):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert other.exists()
+
+
+def test_unstattable_entry_fails_the_build(tmp_path: Path) -> None:
+    """An entry the scan cannot stat may be the torn destination itself;
+    silently dropping it would hand the serial pass an unverified dir."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    shady = tmp_path / "packages" / "shady"
+    shady.mkdir(parents=True)
+    real_lstat = os.lstat
+
+    def entry_lstat_denied(path, *args, **kwargs):
+        if Path(path).name == "shady":
+            raise PermissionError("denied")
+        return real_lstat(path, *args, **kwargs)
+
+    with (
+        patch.object(mod.os, "lstat", entry_lstat_denied),
+        pytest.raises(mod.CleanupError, match="could not stat"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+
+
+def test_refuses_to_remove_the_store_itself(tmp_path: Path, capsys) -> None:
+    """is_relative_to is reflexive; a destination resolving to the store
+    itself must be refused, not handed to the script's only rmtree."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    store = tmp_path / "packages"
+    store.mkdir(parents=True)
+
+    def get_package(self, spec):
+        if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
+            return SimpleNamespace(path=str(store), spec=spec)
+        return _FakeManager.get_package(self, spec)
+
+    cls.get_package = get_package  # throwaway subclass; nothing to restore
+    removed = []
+    with patch.object(mod.fs, "rmtree", side_effect=removed.append):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert removed == []
+    assert store.exists()
+    assert "Refusing to remove" in capsys.readouterr().out
 
 
 def test_refuses_to_remove_outside_the_store(tmp_path: Path, capsys) -> None:
@@ -748,7 +800,13 @@ def test_unverifiable_removal_fails_the_build(tmp_path: Path) -> None:
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     torn = tmp_path / "packages" / "bad"
     torn.mkdir(parents=True)
-    (torn / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
+
+    def get_package(self, spec):
+        if getattr(cls, "resets", 0):
+            return SimpleNamespace(path=str(torn), spec=spec)
+        return None
+
+    cls.get_package = get_package  # throwaway subclass; nothing to restore
     with (
         patch.object(mod.fs, "rmtree", lambda path: None),
         patch.object(mod.os, "lstat", MagicMock(side_effect=PermissionError("denied"))),
@@ -868,12 +926,24 @@ def test_platformio_surface_for_install_deps_script() -> None:
         "get_tmp_dir",
     ):
         assert callable(getattr(BasePackageManager, name))
-    assert PackageSpec("owner/name @ ^1.0").name == "name"
+    # Losing any of these turns the wave into main()'s silent serial
+    # fallback: ensure_spec runs in the coordinator, the spec attributes
+    # feed the dedupe, cleanup, and dependency filters
+    assert callable(BasePackageManager.ensure_spec)
+    spec = PackageSpec("owner/name @ ^1.0")
+    assert spec.name == "name"
+    assert spec.owner == "owner"
+    assert spec.uri is None
+    assert spec.external is False
+    assert Version("1.5.0") in spec.requirements
     # The failure-cleanup path degrades to a single line if these vanish
     assert callable(fs.rmtree)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)
-    assert callable(LibraryPackageManager.is_builtin_lib)
+    # dependency_specs calls it with one positional argument
+    assert list(inspect.signature(LibraryPackageManager.is_builtin_lib).parameters) == [
+        "name"
+    ]
 
     mod = _load_script()
     # The intact-dir heuristic hand-copies pio's manifest map

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -440,6 +440,69 @@ def test_unlock_failure_after_wave_error_is_fatal(tmp_path: Path) -> None:
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
 
+def test_unlock_failure_after_system_exit_is_fatal(tmp_path: Path) -> None:
+    """A worker SystemExit plus a failed unlock must not fall through to a
+    serial pass that would block on the held flock."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path))
+
+    def exiting_install(self, spec, skip_dependencies, compatibility=None):
+        raise SystemExit(0)
+
+    def bad_unlock(self):
+        raise OSError("flock broke")
+
+    cls._install = exiting_install
+    cls.unlock = bad_unlock
+    with pytest.raises(mod.LockReleaseError, match="after a wave failure"):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+
+
+def test_unlock_failure_with_cleanup_error_stays_fatal(tmp_path: Path) -> None:
+    """A CleanupError body stays in flight; the unlock fault becomes a note."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    torn = tmp_path / "packages" / "bad"
+    torn.mkdir(parents=True)
+
+    def get_package(self, spec):
+        if getattr(cls, "resets", 0):
+            return SimpleNamespace(path=str(torn), spec=spec)
+        return None
+
+    def bad_unlock(self):
+        raise OSError("flock broke")
+
+    cls.get_package = get_package
+    cls.unlock = bad_unlock
+    with (
+        patch.object(mod.fs, "rmtree", lambda path: None),  # leaves torn
+        pytest.raises(mod.CleanupError) as err,
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert any("manager lock" in n for n in err.value.__notes__)
+
+
+def test_piopm_match_removes_manifest_named_torn_dir(tmp_path: Path, capsys) -> None:
+    """A torn dir named by its manifest (not the registry spec) is found
+    through its .piopm and removed."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    torn = tmp_path / "packages" / "ManifestName"
+    torn.mkdir(parents=True)
+    (torn / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
+
+    def real_rmtree(path):
+        import shutil
+
+        shutil.rmtree(path)
+
+    with patch.object(mod.fs, "rmtree", real_rmtree):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert not torn.exists()
+    assert "Removed torn destination" in capsys.readouterr().out
+
+
 def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:
     """A CleanupError must escape main's serial fallback: the clause order
     decides whether a stuck torn package fails the image build."""

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -311,6 +311,7 @@ def test_unverifiable_torn_destination_fails_the_build(tmp_path: Path) -> None:
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     dest = Path(cls.base_dir) / "packages" / "bad"
     dest.mkdir(parents=True)
+    (dest / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
 
     def bad_reset(self):
         raise OSError("scan broken")
@@ -371,12 +372,13 @@ def test_unresolvable_torn_destination_is_printed(tmp_path: Path, capsys) -> Non
 
 
 def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
-    """A torn dir get_package cannot resolve is removed via the predicted
-    destination instead of surviving into the serial pass."""
+    """A torn dir get_package cannot resolve but whose .piopm names the
+    spec is removed instead of surviving into the serial pass."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     dest = Path(cls.base_dir) / "packages" / "bad"
     dest.mkdir(parents=True)
+    (dest / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
 
     def real_rmtree(path):
         Path(path).rmdir()
@@ -540,7 +542,7 @@ def test_chdir_failure_defers_to_pending_lock_fault(
             mod.parallel_install(cls, ["esphome/a @ 1.0"])
     finally:
         monkeypatch.setattr(mod.os, "chdir", real_chdir)
-    assert any("working dir" in n for n in err.value.__notes__)
+    assert any("working dir" in n for n in err.value.__cause__.__notes__)
 
 
 def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -4,10 +4,18 @@ from argparse import Namespace
 import importlib.util
 import inspect
 from pathlib import Path
+import shutil
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from platformio import fs
+from platformio.cache import ContentCache
+from platformio.package.manager._install import PackageManagerInstallMixin
+from platformio.package.manager.base import BasePackageManager
+from platformio.package.manager.library import LibraryPackageManager
+from platformio.package.manager.tool import ToolPackageManager
+from platformio.package.meta import PackageCompatibility, PackageItem, PackageSpec
 import pytest
 
 _SCRIPT = Path(__file__).parents[2] / "script" / "platformio_install_deps.py"
@@ -116,9 +124,6 @@ class _FakeManager:
 
     def get_pkg_dependencies(self, pkg):
         return getattr(type(self), "deps", {}).get(pkg.spec)
-
-    # The real conversion: the fake must not drift from what pio does
-    from platformio.package.manager.base import BasePackageManager
 
     dependency_to_spec = staticmethod(BasePackageManager.dependency_to_spec)
 
@@ -381,8 +386,6 @@ def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
     (dest / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
 
     def real_rmtree(path):
-        import shutil
-
         shutil.rmtree(path)
 
     with patch.object(mod.fs, "rmtree", real_rmtree):
@@ -497,8 +500,6 @@ def test_piopm_match_removes_manifest_named_torn_dir(tmp_path: Path, capsys) -> 
     (torn / ".piopm").write_text('{"spec": {"owner": "esphome", "name": "bad"}}')
 
     def real_rmtree(path):
-        import shutil
-
         shutil.rmtree(path)
 
     with patch.object(mod.fs, "rmtree", real_rmtree):
@@ -586,8 +587,6 @@ def test_main_generic_failure_still_runs_serial_pass(tmp_path: Path) -> None:
 def test_content_cache_creates_its_dir(tmp_path: Path, monkeypatch) -> None:
     """The cold-cache hardening relies on ContentCache.__init__ creating
     the namespace dir; pin the side effect, not mere callability."""
-    from platformio.cache import ContentCache
-
     monkeypatch.setenv("PLATFORMIO_CACHE_DIR", str(tmp_path / "cache"))
     ContentCache("http")
     assert (tmp_path / "cache" / "http").is_dir()
@@ -598,8 +597,6 @@ def test_unresolvable_spec_stays_out_of_the_wave(tmp_path: Path, capsys) -> None
     string key would break the one-per-destination dedupe."""
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
-    from platformio.package.meta import PackageSpec
-
     nameless = PackageSpec(requirements="^1.0")
     mod.parallel_install(cls, [nameless])
     assert cls.calls == []
@@ -628,13 +625,6 @@ def test_parse_specs_unreadable_ini_fails_loudly(tmp_path: Path) -> None:
 def test_platformio_surface_for_install_deps_script() -> None:
     """A PlatformIO bump that changes these members must fail here, not
     silently turn the docker image's parallel preinstall into a no-op."""
-    from platformio import fs
-    from platformio.package.manager._install import PackageManagerInstallMixin
-    from platformio.package.manager.base import BasePackageManager
-    from platformio.package.manager.library import LibraryPackageManager
-    from platformio.package.manager.tool import ToolPackageManager
-    from platformio.package.meta import PackageCompatibility, PackageItem, PackageSpec
-
     # The script calls these positionally; pin the positions, not just
     # membership, so a parameter reorder trips the wire too
     params = inspect.signature(PackageManagerInstallMixin._install).parameters

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -73,6 +73,7 @@ class _FakeManager:
     fail: set = set()
     calls: list = []
     lock_events: list = []
+    base_dir: str = ""  # per-test tmp base; set by _reset_fake
 
     def __init__(self, package_dir) -> None:
         assert package_dir is None
@@ -89,11 +90,15 @@ class _FakeManager:
     def memcache_reset(self) -> None:
         type(self).resets = getattr(type(self), "resets", 0) + 1
 
+    @property
+    def package_dir(self) -> str:
+        return str(Path(type(self).base_dir) / "packages")
+
     def get_download_dir(self) -> str:
-        return "/tmp/fake-downloads"
+        return str(Path(type(self).base_dir) / "downloads")
 
     def get_tmp_dir(self) -> str:
-        return "/tmp/fake-tmp"
+        return str(Path(type(self).base_dir) / "tmp")
 
     def lock(self) -> None:
         type(self).lock_events.append("lock")
@@ -123,13 +128,14 @@ class _FakeManager:
         )
 
 
-def _reset_fake(**kwargs) -> type:
+def _reset_fake(base_dir: str = "", **kwargs) -> type:
     # A fresh subclass per test: nothing leaks between tests through the
     # class-level scripted state
     return type(
         "_ScriptedManager",
         (_FakeManager,),
         {
+            "base_dir": base_dir,
             "installed": kwargs.get("installed", set()),
             "fail": kwargs.get("fail", set()),
             "calls": [],
@@ -139,11 +145,11 @@ def _reset_fake(**kwargs) -> type:
     )
 
 
-def test_parallel_install_behavior() -> None:
+def test_parallel_install_behavior(tmp_path: Path) -> None:
     """Duplicates collapse to one install, installed specs are filtered,
     URL specs stay out of the wave, and the lock wraps the pool."""
     mod = _load_script()
-    cls = _reset_fake(installed={"esphome/already @ 1.0"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/already @ 1.0"})
     mod.parallel_install(
         cls,
         [
@@ -157,11 +163,13 @@ def test_parallel_install_behavior() -> None:
     assert cls.lock_events == ["lock", "unlock"]
 
 
-def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
+def test_parallel_install_failure_cleans_torn_destination(
+    tmp_path: Path, capsys
+) -> None:
     """A failed install resets the memcache, removes what get_package can
     see, and reports; the others still install."""
     mod = _load_script()
-    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
 
     removed = []
 
@@ -180,11 +188,11 @@ def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
     assert "Pre-install failed for 1 of 2 package(s)" in out
 
 
-def test_parallel_install_runs_dependency_waves() -> None:
+def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     """Dependencies of wave-installed packages install in a second wave,
     deduped by name; name-only platform libs stay with the serial pass."""
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     cls.deps = {
         "esphome/noise-c @ 0.1.21": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
@@ -204,11 +212,11 @@ def test_parallel_install_runs_dependency_waves() -> None:
     assert dep_compat is not None  # mirrors pio's install_dependency
 
 
-def test_dependency_wave_excludes_url_specs() -> None:
+def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     """A dependency pinned to a URL surfaces as spec.uri; it must stay out
     of the wave like string URL specs do."""
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     cls.deps = {
         "esphome/noise-c @ 0.1.21": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
@@ -218,11 +226,11 @@ def test_dependency_wave_excludes_url_specs() -> None:
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
-def test_success_without_package_prints_anomaly(capsys) -> None:
+def test_success_without_package_prints_anomaly(tmp_path: Path, capsys) -> None:
     """An install that reported success but resolves to nothing prints the
     anomaly instead of silently pruning its dependency subtree."""
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     real_get = cls.get_package
     cls.get_package = lambda self, spec: None  # never resolvable
     mod.parallel_install(cls, ["esphome/ghost @ 1.0"])
@@ -230,10 +238,10 @@ def test_success_without_package_prints_anomaly(capsys) -> None:
     assert "not resolvable afterwards" in capsys.readouterr().out
 
 
-def test_wave_limit_prints_truncation(capsys) -> None:
+def test_wave_limit_prints_truncation(tmp_path: Path, capsys) -> None:
     """Hitting the cycle backstop announces what is left to pkg install."""
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     cls.deps = {
         "esphome/noise-c @ 0.1.21": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
@@ -250,7 +258,7 @@ def test_failed_cleanup_fails_the_build(tmp_path: Path) -> None:
     fs.rmtree never raises (its onexc handler prints), so only the
     destination's absence proves the cleanup worked."""
     mod = _load_script()
-    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     torn = tmp_path / "torn-pkg"
     torn.mkdir()
 
@@ -272,7 +280,7 @@ def test_api_break_cleans_before_surfacing(tmp_path: Path) -> None:
     """An AttributeError from _install still removes the torn destination
     before propagating to the logged serial fallback."""
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     torn = tmp_path / "torn-pkg"
     torn.mkdir()
 
@@ -300,11 +308,14 @@ def test_api_break_cleans_before_surfacing(tmp_path: Path) -> None:
     assert removed == [str(torn)]
 
 
-def test_unverifiable_torn_destination_fails_the_build() -> None:
-    """An inspect that keeps failing cannot prove the destination is
-    clean; the serial pass would trust it, so the build fails."""
+def test_unverifiable_torn_destination_fails_the_build(tmp_path: Path) -> None:
+    """When the scan keeps failing, the spec's own predicted destination
+    decides: an unremovable leftover fails the build; no leftover means
+    an innocent worker's in-flight copy cannot fail it."""
     mod = _load_script()
-    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    dest = Path(cls.base_dir) / "packages" / "bad"
+    dest.mkdir(parents=True)
 
     def bad_reset(self):
         raise OSError("scan broken")
@@ -312,15 +323,35 @@ def test_unverifiable_torn_destination_fails_the_build() -> None:
     cls.memcache_reset = bad_reset
     with (
         patch.object(mod.time, "sleep", lambda s: None),
-        pytest.raises(mod.CleanupError, match="could not verify"),
+        patch.object(mod.fs, "rmtree", lambda path: None),  # onexc swallowed
+        pytest.raises(mod.CleanupError, match="could not remove"),
     ):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
 
 
-def test_transient_inspect_failure_retries(capsys) -> None:
+def test_unverifiable_scan_without_leftover_degrades(tmp_path: Path, capsys) -> None:
+    """A persistently failing scan with no destination on disk is another
+    worker's problem, never a build failure blaming this spec."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    resets = {"n": 0}
+
+    def bad_reset(self):
+        # Exhaust clean_torn's retries; the coordinator's later reset works
+        resets["n"] += 1
+        if resets["n"] <= 5:
+            raise OSError("scan broken")
+
+    cls.memcache_reset = bad_reset
+    with patch.object(mod.time, "sleep", lambda s: None):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert "no destination to clean" in capsys.readouterr().out
+
+
+def test_transient_inspect_failure_retries(tmp_path: Path, capsys) -> None:
     """A transient read of another worker's copy is retried, not fatal."""
     mod = _load_script()
-    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     attempts: list[int] = []
 
     def flaky_reset(self):
@@ -335,13 +366,30 @@ def test_transient_inspect_failure_retries(capsys) -> None:
     assert "No resolvable destination to clean" in capsys.readouterr().out
 
 
-def test_unresolvable_torn_destination_is_printed(capsys) -> None:
+def test_unresolvable_torn_destination_is_printed(tmp_path: Path, capsys) -> None:
     """A failed install with no resolvable package prints, so an invisible
     torn directory is at least traceable."""
     mod = _load_script()
-    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
     mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert "No resolvable destination to clean" in capsys.readouterr().out
+
+
+def test_unparsable_torn_destination_is_removed(tmp_path: Path, capsys) -> None:
+    """A torn dir get_package cannot resolve is removed via the predicted
+    destination instead of surviving into the serial pass."""
+    mod = _load_script()
+    cls = _reset_fake(str(tmp_path), fail={"esphome/bad @ 1.0"})
+    dest = Path(cls.base_dir) / "packages" / "bad"
+    dest.mkdir(parents=True)
+
+    def real_rmtree(path):
+        Path(path).rmdir()
+
+    with patch.object(mod.fs, "rmtree", real_rmtree):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert not dest.exists()
+    assert "Removed torn destination" in capsys.readouterr().out
 
 
 def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:
@@ -390,11 +438,11 @@ def test_content_cache_creates_its_dir(tmp_path: Path, monkeypatch) -> None:
     assert (tmp_path / "cache" / "http").is_dir()
 
 
-def test_unresolvable_spec_stays_out_of_the_wave(capsys) -> None:
+def test_unresolvable_spec_stays_out_of_the_wave(tmp_path: Path, capsys) -> None:
     """A spec with no derivable name is left to the serial pass; a raw
     string key would break the one-per-destination dedupe."""
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     from platformio.package.meta import PackageSpec
 
     nameless = PackageSpec(requirements="^1.0")
@@ -403,9 +451,9 @@ def test_unresolvable_spec_stays_out_of_the_wave(capsys) -> None:
     assert "Skipping unresolvable spec" in capsys.readouterr().out
 
 
-def test_parallel_install_unlocks_when_pool_fails() -> None:
+def test_parallel_install_unlocks_when_pool_fails(tmp_path: Path) -> None:
     mod = _load_script()
-    cls = _reset_fake()
+    cls = _reset_fake(str(tmp_path))
     with (
         patch.object(mod, "ThreadPoolExecutor", side_effect=RuntimeError("no")),
         pytest.raises(RuntimeError),

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -1,6 +1,63 @@
-"""Contract test for the PlatformIO surface script/platformio_install_deps.py drives."""
+"""Tests for script/platformio_install_deps.py."""
 
+from argparse import Namespace
+import importlib.util
 import inspect
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parents[2] / "script" / "platformio_install_deps.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("platformio_install_deps", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_spec_key_collapses_destinations() -> None:
+    """Two specs delivering one package share a directory and one key."""
+    mod = _load_script()
+    assert mod.spec_key("esphome/noise-c @ 0.1.21") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.21") == "noise-c"
+    assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
+        "esp32async/asynctcp @ 3.5.0"
+    )
+    url = "https://github.com/pioarduino/platform-espressif32/releases/download/{v}/platform-espressif32.zip"
+    assert mod.spec_key(url.format(v="55.03.311")) == mod.spec_key(
+        url.format(v="54.03.20")
+    )
+
+
+def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
+    """Parsing skips unpinned and interpolated entries; the CLI rebuild
+    keeps the original flag pairing."""
+    ini = tmp_path / "platformio.ini"
+    ini.write_text(
+        "[env:a]\n"
+        "platform = fake/platform@1\n"
+        "lib_deps =\n"
+        "    esphome/noise-c @ 0.1.21\n"
+        "    ${common.lib_deps}\n"
+        "    internal_lib\n"
+        "[env:b]\n"
+        "lib_deps =\n"
+        "    esphome/noise-c @ 0.1.21\n"
+    )
+    mod = _load_script()
+    args = Namespace(libraries=True, platforms=True, tools=False)
+    libs, platforms, tools = mod.parse_specs(str(ini), args)
+    assert libs == ["esphome/noise-c @ 0.1.21", "esphome/noise-c @ 0.1.21"]
+    assert platforms == ["fake/platform@1"]
+    assert tools == []
+    assert mod.build_cli_args(libs, platforms, tools) == [
+        "-l",
+        "esphome/noise-c @ 0.1.21",
+        "-l",
+        "esphome/noise-c @ 0.1.21",
+        "-p",
+        "fake/platform@1",
+    ]
 
 
 def test_platformio_surface_for_install_deps_script() -> None:
@@ -9,14 +66,13 @@ def test_platformio_surface_for_install_deps_script() -> None:
     from platformio.package.manager._install import PackageManagerInstallMixin
     from platformio.package.manager.base import BasePackageManager
     from platformio.package.manager.library import LibraryPackageManager
-    from platformio.package.manager.platform import PlatformPackageManager
     from platformio.package.manager.tool import ToolPackageManager
     from platformio.package.meta import PackageSpec
 
     params = inspect.signature(PackageManagerInstallMixin._install).parameters
     assert "spec" in params
     assert "skip_dependencies" in params
-    for cls in (ToolPackageManager, LibraryPackageManager, PlatformPackageManager):
+    for cls in (ToolPackageManager, LibraryPackageManager):
         assert "package_dir" in inspect.signature(cls.__init__).parameters
     for name in ("lock", "unlock", "get_package"):
         assert callable(getattr(BasePackageManager, name))

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -47,12 +47,11 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
-    assert libs == ["esphome/noise-c @ 0.1.21", "esphome/noise-c @ 0.1.21"]
+    # exact-string duplicates collapse; distinct version pins survive
+    assert libs == ["esphome/noise-c @ 0.1.21"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
-        "-l",
-        "esphome/noise-c @ 0.1.21",
         "-l",
         "esphome/noise-c @ 0.1.21",
         "-p",

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -188,6 +188,20 @@ def test_parallel_install_runs_dependency_waves() -> None:
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
 
 
+def test_dependency_wave_excludes_url_specs() -> None:
+    """A dependency pinned to a URL surfaces as spec.uri; it must stay out
+    of the wave like string URL specs do."""
+    mod = _load_script()
+    cls = _reset_fake()
+    cls.deps = {
+        "esphome/noise-c @ 0.1.21": [
+            {"name": "vendored", "version": "https://github.com/x/y.git"},
+        ],
+    }
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
+    assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
+
+
 def test_parallel_install_unlocks_when_pool_fails() -> None:
     mod = _load_script()
     cls = _reset_fake()
@@ -223,6 +237,13 @@ def test_platformio_surface_for_install_deps_script() -> None:
     assert "skip_dependencies" in params
     for cls in (ToolPackageManager, LibraryPackageManager):
         assert list(inspect.signature(cls.__init__).parameters)[1] == "package_dir"
-    for name in ("lock", "unlock", "get_package"):
+    for name in (
+        "lock",
+        "unlock",
+        "get_package",
+        "memcache_reset",
+        "get_pkg_dependencies",
+        "dependency_to_spec",
+    ):
         assert callable(getattr(BasePackageManager, name))
     assert PackageSpec("owner/name @ ^1.0").name == "name"

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -300,6 +300,41 @@ def test_api_break_cleans_before_surfacing(tmp_path: Path) -> None:
     assert removed == [str(torn)]
 
 
+def test_unverifiable_torn_destination_fails_the_build() -> None:
+    """An inspect that keeps failing cannot prove the destination is
+    clean; the serial pass would trust it, so the build fails."""
+    mod = _load_script()
+    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+
+    def bad_reset(self):
+        raise OSError("scan broken")
+
+    cls.memcache_reset = bad_reset
+    with (
+        patch.object(mod.time, "sleep", lambda s: None),
+        pytest.raises(mod.CleanupError, match="could not verify"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+
+
+def test_transient_inspect_failure_retries(capsys) -> None:
+    """A transient read of another worker's copy is retried, not fatal."""
+    mod = _load_script()
+    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    attempts: list[int] = []
+
+    def flaky_reset(self):
+        attempts.append(1)
+        if len(attempts) < 2:
+            raise OSError("mid-copy read")
+
+    cls.memcache_reset = flaky_reset
+    with patch.object(mod.time, "sleep", lambda s: None):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert len(attempts) >= 2
+    assert "No resolvable destination to clean" in capsys.readouterr().out
+
+
 def test_unresolvable_torn_destination_is_printed(capsys) -> None:
     """A failed install with no resolvable package prints, so an invisible
     torn directory is at least traceable."""

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -326,6 +326,25 @@ def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> Non
         mod.main()
 
 
+def test_main_generic_failure_still_runs_serial_pass(tmp_path: Path) -> None:
+    """A non-CleanupError wave failure prints, dumps the traceback, and
+    still reaches the authoritative serial pass with the pinned cwd."""
+    mod = _load_script()
+    ini = tmp_path / "platformio.ini"
+    ini.write_text("[env:t]\nlib_deps =\n    esphome/x @ 1.0\n")
+    with (
+        patch.object(mod, "parallel_install", side_effect=RuntimeError("boom")),
+        patch.object(mod.subprocess, "check_call") as mock_call,
+        patch.object(sys, "argv", ["platformio_install_deps.py", str(ini), "-l"]),
+    ):
+        mod.main()
+    mock_call.assert_called_once()
+    args, kwargs = mock_call.call_args
+    assert args[0][:4] == ["platformio", "pkg", "install", "-g"]
+    assert "esphome/x @ 1.0" in args[0]
+    assert kwargs["cwd"] == Path.cwd()
+
+
 def test_content_cache_creates_its_dir(tmp_path: Path, monkeypatch) -> None:
     """The cold-cache hardening relies on ContentCache.__init__ creating
     the namespace dir; pin the side effect, not mere callability."""

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -92,11 +92,12 @@ class _FakeManager:
     def unlock(self) -> None:
         type(self).lock_events.append("unlock")
 
-    def _install(self, spec, skip_dependencies):
+    def _install(self, spec, skip_dependencies, compatibility=None):
         assert skip_dependencies is True
         if self._key(spec) in self.fail:
             raise RuntimeError("boom")
         type(self).calls.append(spec)
+        type(self).compat_calls.append((self._key(spec), compatibility))
         type(self).installed = type(self).installed | {self._key(spec)}
 
     def get_pkg_dependencies(self, pkg):
@@ -123,6 +124,7 @@ def _reset_fake(**kwargs) -> type:
             "installed": kwargs.get("installed", set()),
             "fail": kwargs.get("fail", set()),
             "calls": [],
+            "compat_calls": [],
             "lock_events": [],
         },
     )
@@ -186,6 +188,11 @@ def test_parallel_install_runs_dependency_waves() -> None:
     mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
+    # Wave-1 strings carry no compatibility; the dependency wave does
+    compats = dict(cls.compat_calls)
+    assert compats["esphome/noise-c @ 0.1.21"] is None
+    dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
+    assert dep_compat is not None  # mirrors pio's install_dependency
 
 
 def test_dependency_wave_excludes_url_specs() -> None:
@@ -224,17 +231,19 @@ def test_parse_specs_unreadable_ini_fails_loudly(tmp_path: Path) -> None:
 def test_platformio_surface_for_install_deps_script() -> None:
     """A PlatformIO bump that changes these members must fail here, not
     silently turn the docker image's parallel preinstall into a no-op."""
+    from platformio import fs
     from platformio.package.manager._install import PackageManagerInstallMixin
     from platformio.package.manager.base import BasePackageManager
     from platformio.package.manager.library import LibraryPackageManager
     from platformio.package.manager.tool import ToolPackageManager
-    from platformio.package.meta import PackageSpec
+    from platformio.package.meta import PackageCompatibility, PackageItem, PackageSpec
 
     # The script calls these positionally; pin the positions, not just
     # membership, so a parameter reorder trips the wire too
     params = inspect.signature(PackageManagerInstallMixin._install).parameters
     assert list(params)[1] == "spec"
     assert "skip_dependencies" in params
+    assert "compatibility" in params
     for cls in (ToolPackageManager, LibraryPackageManager):
         assert list(inspect.signature(cls.__init__).parameters)[1] == "package_dir"
     for name in (
@@ -247,3 +256,7 @@ def test_platformio_surface_for_install_deps_script() -> None:
     ):
         assert callable(getattr(BasePackageManager, name))
     assert PackageSpec("owner/name @ ^1.0").name == "name"
+    # The failure-cleanup path degrades to a single line if these vanish
+    assert callable(fs.rmtree)
+    assert PackageItem("pkg-dir").path == "pkg-dir"
+    assert callable(PackageCompatibility.from_dependency)

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -96,12 +96,18 @@ class _FakeManager:
 
 
 def _reset_fake(**kwargs) -> type:
-    cls = _FakeManager
-    cls.installed = kwargs.get("installed", set())
-    cls.fail = kwargs.get("fail", set())
-    cls.calls = []
-    cls.lock_events = []
-    return cls
+    # A fresh subclass per test: nothing leaks between tests through the
+    # class-level scripted state
+    return type(
+        "_ScriptedManager",
+        (_FakeManager,),
+        {
+            "installed": kwargs.get("installed", set()),
+            "fail": kwargs.get("fail", set()),
+            "calls": [],
+            "lock_events": [],
+        },
+    )
 
 
 def test_parallel_install_behavior() -> None:
@@ -129,19 +135,15 @@ def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
     cls = _reset_fake(fail={"esphome/bad @ 1.0"})
 
     removed = []
-    orig_get = cls.get_package
 
     def get_package(self, spec):
         if spec == "esphome/bad @ 1.0" and "memcache_reset" in cls.calls:
             return SimpleNamespace(path="/tmp/torn-pkg")
-        return orig_get(self, spec)
+        return _FakeManager.get_package(self, spec)
 
-    cls.get_package = get_package
-    try:
-        with patch.object(mod.fs, "rmtree", side_effect=removed.append):
-            mod.parallel_install(cls, ["esphome/bad @ 1.0", "esphome/good @ 1.0"])
-    finally:
-        cls.get_package = orig_get
+    cls.get_package = get_package  # throwaway subclass; nothing to restore
+    with patch.object(mod.fs, "rmtree", side_effect=removed.append):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0", "esphome/good @ 1.0"])
     assert "esphome/good @ 1.0" in cls.calls
     assert removed == ["/tmp/torn-pkg"]
     out = capsys.readouterr().out
@@ -177,11 +179,13 @@ def test_platformio_surface_for_install_deps_script() -> None:
     from platformio.package.manager.tool import ToolPackageManager
     from platformio.package.meta import PackageSpec
 
+    # The script calls these positionally; pin the positions, not just
+    # membership, so a parameter reorder trips the wire too
     params = inspect.signature(PackageManagerInstallMixin._install).parameters
-    assert "spec" in params
+    assert list(params)[1] == "spec"
     assert "skip_dependencies" in params
     for cls in (ToolPackageManager, LibraryPackageManager):
-        assert "package_dir" in inspect.signature(cls.__init__).parameters
+        assert list(inspect.signature(cls.__init__).parameters)[1] == "package_dir"
     for name in ("lock", "unlock", "get_package"):
         assert callable(getattr(BasePackageManager, name))
     assert PackageSpec("owner/name @ ^1.0").name == "name"

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -4,6 +4,10 @@ from argparse import Namespace
 import importlib.util
 import inspect
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
 
 _SCRIPT = Path(__file__).parents[2] / "script" / "platformio_install_deps.py"
 
@@ -57,6 +61,111 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "-p",
         "fake/platform@1",
     ]
+
+
+class _FakeManager:
+    """Scripted manager_cls: records installs, raises on demand."""
+
+    installed: set = set()
+    fail: set = set()
+    calls: list = []
+    lock_events: list = []
+
+    def __init__(self, package_dir) -> None:
+        assert package_dir is None
+
+    def get_package(self, spec):
+        if spec in self.installed:
+            return SimpleNamespace(path="/tmp/fake-pkg")
+        return None
+
+    def memcache_reset(self) -> None:
+        type(self).calls.append("memcache_reset")
+
+    def lock(self) -> None:
+        type(self).lock_events.append("lock")
+
+    def unlock(self) -> None:
+        type(self).lock_events.append("unlock")
+
+    def _install(self, spec, skip_dependencies):
+        assert skip_dependencies is True
+        if spec in self.fail:
+            raise RuntimeError("boom")
+        type(self).calls.append(spec)
+
+
+def _reset_fake(**kwargs) -> type:
+    cls = _FakeManager
+    cls.installed = kwargs.get("installed", set())
+    cls.fail = kwargs.get("fail", set())
+    cls.calls = []
+    cls.lock_events = []
+    return cls
+
+
+def test_parallel_install_behavior() -> None:
+    """Duplicates collapse to one install, installed specs are filtered,
+    URL specs stay out of the wave, and the lock wraps the pool."""
+    mod = _load_script()
+    cls = _reset_fake(installed={"esphome/already @ 1.0"})
+    mod.parallel_install(
+        cls,
+        [
+            "esphome/noise-c @ 0.1.21",
+            "esphome/noise-c @ 0.1.21",
+            "esphome/already @ 1.0",
+            "https://x/framework.tar.xz",
+        ],
+    )
+    assert cls.calls == ["esphome/noise-c @ 0.1.21"]
+    assert cls.lock_events == ["lock", "unlock"]
+
+
+def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
+    """A failed install resets the memcache, removes what get_package can
+    see, and reports; the others still install."""
+    mod = _load_script()
+    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+
+    removed = []
+    orig_get = cls.get_package
+
+    def get_package(self, spec):
+        if spec == "esphome/bad @ 1.0" and "memcache_reset" in cls.calls:
+            return SimpleNamespace(path="/tmp/torn-pkg")
+        return orig_get(self, spec)
+
+    cls.get_package = get_package
+    try:
+        with patch.object(mod.shutil, "rmtree", side_effect=removed.append):
+            mod.parallel_install(cls, ["esphome/bad @ 1.0", "esphome/good @ 1.0"])
+    finally:
+        cls.get_package = orig_get
+    assert "esphome/good @ 1.0" in cls.calls
+    assert removed == ["/tmp/torn-pkg"]
+    out = capsys.readouterr().out
+    assert "Pre-install of esphome/bad @ 1.0 failed" in out
+    assert "Pre-install failed for 1 of 2 package(s)" in out
+
+
+def test_parallel_install_unlocks_when_pool_fails() -> None:
+    mod = _load_script()
+    cls = _reset_fake()
+    with (
+        patch.object(mod, "ThreadPoolExecutor", side_effect=RuntimeError("no")),
+        pytest.raises(RuntimeError),
+    ):
+        mod.parallel_install(cls, ["esphome/a @ 1.0"])
+    assert cls.lock_events == ["lock", "unlock"]
+
+
+def test_parse_specs_unreadable_ini_fails_loudly(tmp_path: Path) -> None:
+    """A bad path must not silently build an image with no dependencies."""
+    mod = _load_script()
+    args = Namespace(libraries=True, platforms=False, tools=False)
+    with pytest.raises(SystemExit):
+        mod.parse_specs(str(tmp_path / "missing.ini"), args)
 
 
 def test_platformio_surface_for_install_deps_script() -> None:

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -1,0 +1,23 @@
+"""Contract test for the PlatformIO surface script/platformio_install_deps.py drives."""
+
+import inspect
+
+
+def test_platformio_surface_for_install_deps_script() -> None:
+    """A PlatformIO bump that changes these members must fail here, not
+    silently turn the docker image's parallel preinstall into a no-op."""
+    from platformio.package.manager._install import PackageManagerInstallMixin
+    from platformio.package.manager.base import BasePackageManager
+    from platformio.package.manager.library import LibraryPackageManager
+    from platformio.package.manager.platform import PlatformPackageManager
+    from platformio.package.manager.tool import ToolPackageManager
+    from platformio.package.meta import PackageSpec
+
+    params = inspect.signature(PackageManagerInstallMixin._install).parameters
+    assert "spec" in params
+    assert "skip_dependencies" in params
+    for cls in (ToolPackageManager, LibraryPackageManager, PlatformPackageManager):
+        assert "package_dir" in inspect.signature(cls.__init__).parameters
+    for name in ("lock", "unlock", "get_package"):
+        assert callable(getattr(BasePackageManager, name))
+    assert PackageSpec("owner/name @ ^1.0").name == "name"

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -74,13 +74,17 @@ class _FakeManager:
     def __init__(self, package_dir) -> None:
         assert package_dir is None
 
+    @staticmethod
+    def _key(spec) -> str:
+        return spec if isinstance(spec, str) else str(spec)
+
     def get_package(self, spec):
-        if spec in self.installed:
-            return SimpleNamespace(path="/tmp/fake-pkg")
+        if self._key(spec) in self.installed:
+            return SimpleNamespace(path="/tmp/fake-pkg", spec=self._key(spec))
         return None
 
     def memcache_reset(self) -> None:
-        type(self).calls.append("memcache_reset")
+        type(self).resets = getattr(type(self), "resets", 0) + 1
 
     def lock(self) -> None:
         type(self).lock_events.append("lock")
@@ -90,9 +94,23 @@ class _FakeManager:
 
     def _install(self, spec, skip_dependencies):
         assert skip_dependencies is True
-        if spec in self.fail:
+        if self._key(spec) in self.fail:
             raise RuntimeError("boom")
         type(self).calls.append(spec)
+        type(self).installed = type(self).installed | {self._key(spec)}
+
+    def get_pkg_dependencies(self, pkg):
+        return getattr(type(self), "deps", {}).get(pkg.spec)
+
+    @staticmethod
+    def dependency_to_spec(dependency):
+        from platformio.package.meta import PackageSpec
+
+        return PackageSpec(
+            owner=dependency.get("owner"),
+            name=dependency.get("name"),
+            requirements=dependency.get("version"),
+        )
 
 
 def _reset_fake(**kwargs) -> type:
@@ -137,8 +155,8 @@ def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
     removed = []
 
     def get_package(self, spec):
-        if spec == "esphome/bad @ 1.0" and "memcache_reset" in cls.calls:
-            return SimpleNamespace(path="/tmp/torn-pkg")
+        if spec == "esphome/bad @ 1.0" and getattr(cls, "resets", 0):
+            return SimpleNamespace(path="/tmp/torn-pkg", spec=spec)
         return _FakeManager.get_package(self, spec)
 
     cls.get_package = get_package  # throwaway subclass; nothing to restore
@@ -149,6 +167,25 @@ def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
     out = capsys.readouterr().out
     assert "Pre-install of esphome/bad @ 1.0 failed" in out
     assert "Pre-install failed for 1 of 2 package(s)" in out
+
+
+def test_parallel_install_runs_dependency_waves() -> None:
+    """Dependencies of wave-installed packages install in a second wave,
+    deduped by name; name-only platform libs stay with the serial pass."""
+    mod = _load_script()
+    cls = _reset_fake()
+    cls.deps = {
+        "esphome/noise-c @ 0.1.21": [
+            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
+            {"name": "SPI"},
+        ],
+        "esphome/wg @ 1.0": [
+            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
+        ],
+    }
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21", "esphome/wg @ 1.0"])
+    assert len(cls.calls) == 3  # the shared dep installs exactly once
+    assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
 
 
 def test_parallel_install_unlocks_when_pool_fails() -> None:

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -16,6 +16,8 @@ def _load_script():
     spec = importlib.util.spec_from_file_location("platformio_install_deps", _SCRIPT)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    # The real ContentCache would create dirs under the user's core dir
+    module.ContentCache = lambda *_: None
     return module
 
 
@@ -85,6 +87,12 @@ class _FakeManager:
 
     def memcache_reset(self) -> None:
         type(self).resets = getattr(type(self), "resets", 0) + 1
+
+    def get_download_dir(self) -> str:
+        return "/tmp/fake-downloads"
+
+    def get_tmp_dir(self) -> str:
+        return "/tmp/fake-tmp"
 
     def lock(self) -> None:
         type(self).lock_events.append("lock")
@@ -209,6 +217,70 @@ def test_dependency_wave_excludes_url_specs() -> None:
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
+def test_success_without_package_prints_anomaly(capsys) -> None:
+    """An install that reported success but resolves to nothing prints the
+    anomaly instead of silently pruning its dependency subtree."""
+    mod = _load_script()
+    cls = _reset_fake()
+    real_get = cls.get_package
+    cls.get_package = lambda self, spec: None  # never resolvable
+    mod.parallel_install(cls, ["esphome/ghost @ 1.0"])
+    cls.get_package = real_get
+    assert "not resolvable afterwards" in capsys.readouterr().out
+
+
+def test_wave_limit_prints_truncation(capsys) -> None:
+    """Hitting the cycle backstop announces what is left to pkg install."""
+    mod = _load_script()
+    cls = _reset_fake()
+    cls.deps = {
+        "esphome/noise-c @ 0.1.21": [
+            {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
+        ],
+    }
+    prior = {f"seen{i}" for i in range(200)}
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"], prior)
+    out = capsys.readouterr().out
+    assert "Dependency wave limit reached; 1 spec(s) left to pkg install" in out
+
+
+def test_failed_cleanup_fails_the_build() -> None:
+    """A torn destination that cannot be removed must fail the build; the
+    serial pass would trust it and bake a corrupt image."""
+    mod = _load_script()
+    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+
+    def get_package(self, spec):
+        if getattr(cls, "resets", 0):
+            return SimpleNamespace(path="/tmp/torn-pkg", spec=spec)
+        return None
+
+    cls.get_package = get_package  # throwaway subclass; nothing to restore
+
+    def broken_rmtree(path):
+        raise OSError("read-only")
+
+    with (
+        patch.object(mod.fs, "rmtree", broken_rmtree),
+        pytest.raises(mod.CleanupError, match="could not remove"),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert cls.lock_events == ["lock", "unlock"]  # still released
+
+
+def test_unresolvable_spec_stays_out_of_the_wave(capsys) -> None:
+    """A spec with no derivable name is left to the serial pass; a raw
+    string key would break the one-per-destination dedupe."""
+    mod = _load_script()
+    cls = _reset_fake()
+    from platformio.package.meta import PackageSpec
+
+    nameless = PackageSpec(requirements="^1.0")
+    mod.parallel_install(cls, [nameless])
+    assert cls.calls == []
+    assert "Skipping unresolvable spec" in capsys.readouterr().out
+
+
 def test_parallel_install_unlocks_when_pool_fails() -> None:
     mod = _load_script()
     cls = _reset_fake()
@@ -253,6 +325,8 @@ def test_platformio_surface_for_install_deps_script() -> None:
         "memcache_reset",
         "get_pkg_dependencies",
         "dependency_to_spec",
+        "get_download_dir",
+        "get_tmp_dir",
     ):
         assert callable(getattr(BasePackageManager, name))
     assert PackageSpec("owner/name @ ^1.0").name == "name"
@@ -260,3 +334,6 @@ def test_platformio_surface_for_install_deps_script() -> None:
     assert callable(fs.rmtree)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)
+    from platformio.cache import ContentCache
+
+    assert callable(ContentCache)

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -138,7 +138,7 @@ def test_parallel_install_failure_cleans_torn_destination(capsys) -> None:
 
     cls.get_package = get_package
     try:
-        with patch.object(mod.shutil, "rmtree", side_effect=removed.append):
+        with patch.object(mod.fs, "rmtree", side_effect=removed.append):
             mod.parallel_install(cls, ["esphome/bad @ 1.0", "esphome/good @ 1.0"])
     finally:
         cls.get_package = orig_get

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 import importlib.util
 import inspect
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -306,6 +307,23 @@ def test_unresolvable_torn_destination_is_printed(capsys) -> None:
     cls = _reset_fake(fail={"esphome/bad @ 1.0"})
     mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert "No resolvable destination to clean" in capsys.readouterr().out
+
+
+def test_main_cleanup_error_fails_before_generic_fallback(tmp_path: Path) -> None:
+    """A CleanupError must escape main's serial fallback: the clause order
+    decides whether a stuck torn package fails the image build."""
+    mod = _load_script()
+    ini = tmp_path / "platformio.ini"
+    ini.write_text("[env:t]\nlib_deps =\n    esphome/x @ 1.0\n")
+    with (
+        patch.object(
+            mod, "parallel_install", side_effect=mod.CleanupError("stuck torn pkg")
+        ),
+        patch.object(mod.subprocess, "check_call"),
+        patch.object(sys, "argv", ["platformio_install_deps.py", str(ini), "-l"]),
+        pytest.raises(mod.CleanupError),
+    ):
+        mod.main()
 
 
 def test_content_cache_creates_its_dir(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit_tests/test_platformio_install_deps.py
+++ b/tests/unit_tests/test_platformio_install_deps.py
@@ -244,28 +244,78 @@ def test_wave_limit_prints_truncation(capsys) -> None:
     assert "Dependency wave limit reached; 1 spec(s) left to pkg install" in out
 
 
-def test_failed_cleanup_fails_the_build() -> None:
-    """A torn destination that cannot be removed must fail the build; the
-    serial pass would trust it and bake a corrupt image."""
+def test_failed_cleanup_fails_the_build(tmp_path: Path) -> None:
+    """A torn destination still on disk after rmtree must fail the build:
+    fs.rmtree never raises (its onexc handler prints), so only the
+    destination's absence proves the cleanup worked."""
     mod = _load_script()
     cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    torn = tmp_path / "torn-pkg"
+    torn.mkdir()
 
     def get_package(self, spec):
         if getattr(cls, "resets", 0):
-            return SimpleNamespace(path="/tmp/torn-pkg", spec=spec)
+            return SimpleNamespace(path=str(torn), spec=spec)
         return None
 
     cls.get_package = get_package  # throwaway subclass; nothing to restore
-
-    def broken_rmtree(path):
-        raise OSError("read-only")
-
     with (
-        patch.object(mod.fs, "rmtree", broken_rmtree),
+        patch.object(mod.fs, "rmtree", lambda path: None),  # onexc swallowed
         pytest.raises(mod.CleanupError, match="could not remove"),
     ):
         mod.parallel_install(cls, ["esphome/bad @ 1.0"])
     assert cls.lock_events == ["lock", "unlock"]  # still released
+
+
+def test_api_break_cleans_before_surfacing(tmp_path: Path) -> None:
+    """An AttributeError from _install still removes the torn destination
+    before propagating to the logged serial fallback."""
+    mod = _load_script()
+    cls = _reset_fake()
+    torn = tmp_path / "torn-pkg"
+    torn.mkdir()
+
+    def bad_install(self, spec, skip_dependencies, compatibility=None):
+        raise AttributeError("_install went away")
+
+    def get_package(self, spec):
+        if getattr(cls, "resets", 0):
+            return SimpleNamespace(path=str(torn), spec=spec)
+        return None
+
+    cls._install = bad_install
+    cls.get_package = get_package
+    removed: list[str] = []
+
+    def fake_rmtree(path):
+        removed.append(path)
+        Path(path).rmdir()
+
+    with (
+        patch.object(mod.fs, "rmtree", fake_rmtree),
+        pytest.raises(AttributeError),
+    ):
+        mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert removed == [str(torn)]
+
+
+def test_unresolvable_torn_destination_is_printed(capsys) -> None:
+    """A failed install with no resolvable package prints, so an invisible
+    torn directory is at least traceable."""
+    mod = _load_script()
+    cls = _reset_fake(fail={"esphome/bad @ 1.0"})
+    mod.parallel_install(cls, ["esphome/bad @ 1.0"])
+    assert "No resolvable destination to clean" in capsys.readouterr().out
+
+
+def test_content_cache_creates_its_dir(tmp_path: Path, monkeypatch) -> None:
+    """The cold-cache hardening relies on ContentCache.__init__ creating
+    the namespace dir; pin the side effect, not mere callability."""
+    from platformio.cache import ContentCache
+
+    monkeypatch.setenv("PLATFORMIO_CACHE_DIR", str(tmp_path / "cache"))
+    ContentCache("http")
+    assert (tmp_path / "cache" / "http").is_dir()
 
 
 def test_unresolvable_spec_stays_out_of_the_wave(capsys) -> None:
@@ -334,6 +384,3 @@ def test_platformio_surface_for_install_deps_script() -> None:
     assert callable(fs.rmtree)
     assert PackageItem("pkg-dir").path == "pkg-dir"
     assert callable(PackageCompatibility.from_dependency)
-    from platformio.cache import ContentCache
-
-    assert callable(ContentCache)


### PR DESCRIPTION
# What does this implement/fix?

The docker image build spends most of its time in `RUN /platformio_install_deps.py /platformio.ini --libraries`, where `platformio pkg install` downloads and unpacks one package at a time on one core while the runners have four.

The script now preinstalls in parallel waves through PlatformIO's own `_install`, with the manager's inter process lock held once and a pool of up to 16 workers built serially and handed out through a queue (downloads release the GIL, so the pool oversubscribes the cores to keep the network busy while unpacks share them). Waves skip dependencies because two packages sharing one must not extract into the same directory from two threads; after a wave the installed manifests are read locally and their registry dependencies feed the next wave, deduped by package name, until nothing new appears. URL specs, name only platform libs, and second versions of a name stay serial. The stock `pkg install` pass then runs unchanged and is the authority on the final state: a failed install is reported and its destination removed (found through `get_package`, or through its own `.piopm` when the storage scan cannot run) so the pass redoes it. Only two shapes fail the image build instead: a torn destination that cannot be removed (the serial pass would trust it and bake a corrupt package) and a manager lock that cannot be released (the serial pass would hang on it). An unreadable platformio.ini exits nonzero instead of silently building an image with no dependencies.

The script runs in the image before esphome is installed, so it stays standalone (stdlib plus platformio); a unit test file covers spec parsing, the dedup key, the CLI rebuild, and the wave behavior through an injected manager, plus a contract test pinning the positional PlatformIO surface the script drives.

Measured on this PR's own docker jobs against the identical matrix with the stock script, `RUN /platformio_install_deps.py` step time:

| image | stock | this PR |
|---|---|---|
| amd64 docker | 103.8s | 46.1s |
| amd64 ha-addon | 97.4s | 44.4s |
| arm64 docker | 97.1s | 46.8s |
| arm64 ha-addon | 95.9s | 46.3s |

About 55 percent off every leg (two waves of 18 and 5 packages, nine by design serial installs left). Cold local A/B on the same set: 98.8s stock, 48.8s now, with a byte identical installed library tree.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Sibling of #18769 and #18775 (same pattern; no shared code because the script predates the esphome install in the image)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (internal build behavior)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes; docker image builds benefit automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).



