### PR TITLE
[lvgl] Fix on_value/on_update triggers for LVGL select entities

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -558,7 +558,7 @@ static std::string join_string(const FixedVector<const char *> &options) {
 }
 
 void LvSelectable::set_selected_text(const std::string &text, lv_anim_enable_t anim) {
-  auto index = std::find(this->options_.begin(), this->options_.end(), text);
+  auto *index = std::find(this->options_.begin(), this->options_.end(), text);
   if (index != this->options_.end()) {
     this->set_selected_index(index - this->options_.begin(), anim);
     lv_obj_send_event(this->obj, lv_update_event, nullptr);

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -551,10 +551,10 @@ std::string LvSelectable::get_selected_text() {
   return this->options_[selected];
 }
 
-static std::string join_string(std::vector<std::string> options) {
+static std::string join_string(const FixedVector<const char *> &options) {
   return std::accumulate(
       options.begin(), options.end(), std::string(),
-      [](const std::string &a, const std::string &b) -> std::string { return a + (!a.empty() ? "\n" : "") + b; });
+      [](const std::string &a, const char *b) -> std::string { return a + (!a.empty() ? "\n" : "") + b; });
 }
 
 void LvSelectable::set_selected_text(const std::string &text, lv_anim_enable_t anim) {
@@ -565,7 +565,7 @@ void LvSelectable::set_selected_text(const std::string &text, lv_anim_enable_t a
   }
 }
 
-void LvSelectable::set_options(std::vector<std::string> options) {
+void LvSelectable::set_options(FixedVector<const char *> options) {
   auto index = this->get_selected_index();
   if (index >= options.size())
     index = options.size() - 1;

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -518,12 +518,12 @@ class LvSelectable : public LvCompound {
   virtual void set_selected_index(size_t index, lv_anim_enable_t anim) = 0;
   void set_selected_text(const std::string &text, lv_anim_enable_t anim);
   std::string get_selected_text();
-  const std::vector<std::string> &get_options() { return this->options_; }
-  void set_options(std::vector<std::string> options);
+  const FixedVector<const char *> &get_options() { return this->options_; }
+  void set_options(FixedVector<const char *> options);
 
  protected:
   virtual void set_option_string(const char *options) = 0;
-  std::vector<std::string> options_{};
+  FixedVector<const char *> options_{};
 };
 
 #ifdef USE_LVGL_DROPDOWN

--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -53,17 +53,7 @@ class LVGLSelect final : public select::Select, public Component {
     // The update event fires the widget's on_value/on_update triggers
     lv_obj_send_event(this->widget_->obj, lv_update_event, nullptr);
   }
-  void set_options_() {
-    // Widget uses std::vector<std::string>, SelectTraits uses FixedVector<const char*>
-    // Convert by extracting c_str() pointers
-    const auto &opts = this->widget_->get_options();
-    FixedVector<const char *> opt_ptrs;
-    opt_ptrs.init(opts.size());
-    for (const auto &opt : opts) {
-      opt_ptrs.push_back(opt.c_str());
-    }
-    this->traits.set_options(opt_ptrs);
-  }
+  void set_options_() { this->traits.set_options(this->widget_->get_options()); }
 
   LvSelectable *widget_;
   lv_anim_enable_t anim_;

--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -50,9 +50,7 @@ class LVGLSelect final : public select::Select, public Component {
  protected:
   void control(size_t index) override {
     this->widget_->set_selected_index(index, this->anim_);
-    // Sending the update event (rather than calling publish() directly) also fires the widget's
-    // own on_value/on_update triggers, matching documented LVGL behaviour for programmatic
-    // changes. The event listener registered in setup() calls publish() for us.
+    // The update event fires the widget's on_value/on_update triggers
     lv_obj_send_event(this->widget_->obj, lv_update_event, nullptr);
   }
   void set_options_() {

--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -50,7 +50,10 @@ class LVGLSelect final : public select::Select, public Component {
  protected:
   void control(size_t index) override {
     this->widget_->set_selected_index(index, this->anim_);
-    this->publish();
+    // Sending the update event (rather than calling publish() directly) also fires the widget's
+    // own on_value/on_update triggers, matching documented LVGL behaviour for programmatic
+    // changes. The event listener registered in setup() calls publish() for us.
+    lv_obj_send_event(this->widget_->obj, lv_update_event, nullptr);
   }
   void set_options_() {
     // Widget uses std::vector<std::string>, SelectTraits uses FixedVector<const char*>

--- a/esphome/components/lvgl/types.py
+++ b/esphome/components/lvgl/types.py
@@ -3,6 +3,8 @@ from esphome.const import CONF_TEXT, CONF_VALUE
 from esphome.cpp_generator import MockObj
 from esphome.cpp_types import Component, esphome_ns
 
+from .defines import CONF_SELECTED_INDEX
+
 
 class LvType(cg.MockObjClass):
     def __init__(self, *args, **kwargs):
@@ -112,3 +114,4 @@ class LvSelect(LvType):
             parents=parens,
             **kwargs,
         )
+        self.value_property = CONF_SELECTED_INDEX

--- a/tests/component_tests/lvgl/config/dropdown_update_fires_event_test.yaml
+++ b/tests/component_tests/lvgl/config/dropdown_update_fires_event_test.yaml
@@ -1,0 +1,36 @@
+esphome:
+  name: test-dropdown-update-event
+  on_boot:
+    - lvgl.dropdown.update:
+        id: test_dropdown
+        selected_index: 2
+
+esp32:
+  board: lolin_c3_mini
+
+spi:
+  mosi_pin:
+    number: GPIO2
+    ignore_strapping_warning: true
+  clk_pin: GPIO1
+
+display:
+  - platform: mipi_spi
+    data_rate: 20MHz
+    model: st7735
+    cs_pin:
+      number: GPIO8
+      ignore_strapping_warning: true
+    dc_pin: GPIO3
+
+lvgl:
+  widgets:
+    - dropdown:
+        id: test_dropdown
+        options:
+          - First
+          - Second
+          - Third
+        on_update:
+          - lambda: |-
+              ESP_LOGD("test", "dropdown updated");

--- a/tests/component_tests/lvgl/test_dropdown_update_fires_event.py
+++ b/tests/component_tests/lvgl/test_dropdown_update_fires_event.py
@@ -1,0 +1,41 @@
+"""Regression test: lvgl.dropdown.update with selected_index must fire on_value/on_update.
+
+LvSelect (backing both dropdown and roller) did not set `value_property`, so the generic
+update-action machinery in automation.py never sent the synthetic update event for a
+`selected_index:` change made via `lvgl.dropdown.update`/`lvgl.roller.update`, unlike `value:`
+on number widgets or `text:` on text widgets. Fixed by setting `LvSelect.value_property` to
+`CONF_SELECTED_INDEX`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from esphome.__main__ import generate_cpp_contents
+from esphome.config import read_config
+from esphome.core import CORE
+
+
+@pytest.fixture(scope="module")
+def main_cpp(request: pytest.FixtureRequest) -> str:
+    config_path = (
+        Path(request.fspath).parent / "config" / "dropdown_update_fires_event_test.yaml"
+    )
+    original_path = CORE.config_path
+    try:
+        CORE.config_path = config_path
+        CORE.config = read_config({})
+        generate_cpp_contents(CORE.config)
+        return CORE.cpp_main_section
+    finally:
+        CORE.config_path = original_path
+        CORE.reset()
+
+
+def test_dropdown_update_sends_update_event(main_cpp: str) -> None:
+    assert (
+        "lv_obj_send_event(test_dropdown->obj, lvgl::lv_update_event, nullptr)"
+        in main_cpp
+    )


### PR DESCRIPTION
# What does this implement/fix?

When using the LVGL `select` entity, programmatic changes (including by HA API) did not fire the `on_value` and `on_update` triggers as per the docs.

Along with this, the storage for LVGL `dropdown` and `roller` options have been migrated from `std::vector<std::string>` to `FixedVector<const char *>` which eliminates heap allocations and simplifies some related code.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
select:
  - platform: lvgl
    name: lvgl_select
    widget: dropdown_id
    on_value:
      logger.log:
        format: "New select value %s"
        args: [x.c_str()]

lvgl:
  widgets:
    dropdown:
      id: dropdown_id
      options:
        - one
        - two
        - three
      on_value:
        logger.log:
          format: "New value %d"
          args: [x]
      on_update:
        logger.log:
          format: "Updated value %d"
          args: [x]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
