### PR TITLE
[mdns] Skip MDNS.update() while the ESP8266 radio cannot transmit

### DIFF
--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -48,7 +48,7 @@ void MDNSComponent::start_polling_window_() {
     // packet then re-enters LEAmDNS from lwIP and corrupts shared UdpContext state.
     // Skip the tick while the radio cannot transmit (#18760).
     auto *wifi = wifi::global_wifi_component;
-    if (!wifi->is_connected() || wifi->is_roaming_scan_active())
+    if (!wifi->is_connected() || wifi->is_roaming())
       return;
 #endif
     MDNS.update();

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -41,7 +41,18 @@ static void register_esp8266(MDNSComponent *, StaticVector<MDNSService, MDNS_SER
 #ifdef USE_MDNS_EVENT_DRIVEN_POLLING
 void MDNSComponent::start_polling_window_() {
   // uint32_t-ID set_interval/set_timeout already does atomic cancel-and-add.
-  this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() { MDNS.update(); });
+  this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() {
+#ifdef USE_MDNS_WIFI_LISTENER
+    // MDNS.update() can suspend the loop in UdpContext::sendTimeout() while a send is
+    // failing (radio off-channel during a roam scan, or mid reconnect); an incoming
+    // packet then re-enters LEAmDNS from lwIP and corrupts shared UdpContext state.
+    // Skip the tick while the radio cannot transmit (#18760).
+    auto *wifi = wifi::global_wifi_component;
+    if (!wifi->is_connected() || wifi->is_roaming_scan_active())
+      return;
+#endif
+    MDNS.update();
+  });
   this->set_timeout(MDNS_POLL_STOP_ID, MDNS_POLL_WINDOW_MS, [this]() { this->cancel_interval(MDNS_POLL_ID); });
 }
 #endif

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -46,9 +46,10 @@ void MDNSComponent::start_polling_window_() {
     // MDNS.update() can suspend the loop in UdpContext::sendTimeout() while a send is
     // failing (radio off-channel during a roam scan, or mid reconnect); an incoming
     // packet then re-enters LEAmDNS from lwIP and corrupts shared UdpContext state.
-    // Skip the tick while the radio cannot transmit (#18760).
+    // Skip the tick while the radio cannot transmit (#18760), but keep polling while
+    // the AP is serving clients (AP-only or fallback AP with the STA down).
     auto *wifi = wifi::global_wifi_component;
-    if (!wifi->is_connected() || wifi->is_roaming())
+    if (wifi->is_roaming() || (!wifi->is_connected() && !wifi->is_ap_active()))
       return;
 #endif
     MDNS.update();

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -530,7 +530,7 @@ void WiFiComponent::log_discarded_scan_result_(const char *ssid, const uint8_t *
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   // Skip logging during roaming scans to avoid log buffer overflow
   // (roaming scans typically find many networks but only care about same-SSID APs)
-  if (this->roaming_state_ == RoamingState::SCANNING) {
+  if (this->is_roaming_scan_active()) {
     return;
   }
   char bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
@@ -833,7 +833,7 @@ void WiFiComponent::loop() {
 
           // Post-connect roaming: check for better AP
           if (this->post_connect_roaming_) {
-            if (this->roaming_state_ == RoamingState::SCANNING) {
+            if (this->is_roaming_scan_active()) {
               if (this->scan_done_) {
                 this->process_roaming_scan_();
               }
@@ -2144,7 +2144,7 @@ void WiFiComponent::retry_connect() {
     // Roam connection failed - transition to reconnecting
     ESP_LOGD(TAG, "Roam failed, reconnecting (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
     this->roaming_state_ = RoamingState::RECONNECTING;
-  } else if (this->roaming_state_ == RoamingState::SCANNING) {
+  } else if (this->is_roaming_scan_active()) {
     // Disconnected during roam scan - transition to RECONNECTING so the attempts
     // counter is preserved when reconnection succeeds (IDLE would reset it)
     ESP_LOGD(TAG, "Disconnected during roam scan (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -478,6 +478,9 @@ class WiFiComponent final : public Component {
 
   bool is_connected() const { return this->connected_; }
 
+  /// True while a post-connect roaming scan holds the radio off-channel.
+  bool is_roaming_scan_active() const { return this->roaming_state_ == RoamingState::SCANNING; }
+
 #ifdef USE_ESP32
   /// esp_netif handle of the station interface, used by network for default-route
   /// arbitration. nullptr until wifi_lazy_init_() has run.

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -481,6 +481,10 @@ class WiFiComponent final : public Component {
   /// True while a post-connect roaming scan holds the radio off-channel.
   bool is_roaming_scan_active() const { return this->roaming_state_ == RoamingState::SCANNING; }
 
+  /// True while a post-connect roam is in progress (scanning off-channel, reassociating,
+  /// or recovering from a failed roam).
+  bool is_roaming() const { return this->roaming_state_ != RoamingState::IDLE; }
+
 #ifdef USE_ESP32
   /// esp_netif handle of the station interface, used by network for default-route
   /// arbitration. nullptr until wifi_lazy_init_() has run.

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -717,7 +717,7 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   static constexpr uint32_t SCAN_ACTIVE_MAX_DEFAULT_MS = 500;
   static constexpr uint32_t SCAN_ACTIVE_MIN_ROAMING_MS = 100;
   static constexpr uint32_t SCAN_ACTIVE_MAX_ROAMING_MS = 300;
-  bool roaming = this->roaming_state_ == RoamingState::SCANNING;
+  bool roaming = this->is_roaming_scan_active();
   if (passive) {
     config.scan_time.passive = roaming ? SCAN_PASSIVE_ROAMING_MS : SCAN_PASSIVE_DEFAULT_MS;
   } else {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -1059,7 +1059,7 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   // When scanning while connected (roaming), return to home channel between
   // each scanned channel to maintain the connection (helps with BLE/WiFi coexistence)
 #ifdef CONFIG_SOC_WIFI_SUPPORTED
-  if (this->roaming_state_ == RoamingState::SCANNING) {
+  if (this->is_roaming_scan_active()) {
     config.coex_background_scan = true;
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Mitigates the LoadProhibit crash in the Arduino core's LEAmDNS on ESP8266. The library's send path loops `esp_yield()` in `UdpContext::sendTimeout()` while a send keeps failing; when that happens inside `MDNS.update()` from the main loop, an incoming mDNS packet re-enters LEAmDNS from lwIP and both frames share the same UdpContext tx buffer state, which corrupts it and later crashes in `_process()`. Sends fail exactly while a roam scan holds the radio off channel, or around a reconnect, so this skips the `MDNS.update()` polling tick while a roam scan is running or wifi is not connected. A reentrancy guard in LEAmDNS would be the complete fix, but the ESP8266 Arduino core no longer ships releases, so this mitigation is the practical fix; it closes the window that makes the crash likely.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18760

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
