### PR TITLE
[light] Add ``effect`` to ``initial_state``

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -19,6 +19,7 @@ from esphome.const import (
     CONF_COLOR_MODE,
     CONF_COLOR_TEMPERATURE,
     CONF_DEFAULT_TRANSITION_LENGTH,
+    CONF_EFFECT,
     CONF_EFFECTS,
     CONF_ENTITY_CATEGORY,
     CONF_FLASH_TRANSITION_LENGTH,
@@ -278,6 +279,25 @@ def _final_validate(config: ConfigType) -> None:
     This runs once per light platform instance. If no light platform is configured,
     this never runs — but the ID validator will catch the missing light ID separately.
     """
+    # initial_state.effect refers to an effect on this same light, so unlike the
+    # action references below it needs no cross-component lookup. Checked before the
+    # early return so it still runs when no action references any effect.
+    # `config` is every instance of this light platform, so iterate.
+    for light_config in config if isinstance(config, list) else [config]:
+        initial_state = light_config.get(CONF_INITIAL_STATE)
+        if initial_state is None:
+            continue
+        effect_name = initial_state.get(CONF_EFFECT)
+        if effect_name is None or effect_name.lower() == "none":
+            continue
+        effects = light_config.get(CONF_EFFECTS, [])
+        if find_effect_index(effects, effect_name) is None:
+            raise cv.Invalid(
+                f"Effect '{effect_name}' is not defined on this light. "
+                f"Available effects: {available_effects_str(effects)}",
+                path=[CONF_INITIAL_STATE, CONF_EFFECT],
+            )
+
     data = _get_data()
     if not data.effect_refs and not data.effect_cycle_refs:
         return
@@ -340,6 +360,16 @@ RESTORE_MODES = {
     "RESTORE_AND_ON": LightRestoreMode.LIGHT_RESTORE_AND_ON,
 }
 
+# initial_state accepts everything a light state has, plus the effect to start
+# with. `effect` is deliberately not part of LIGHT_STATE_SCHEMA because
+# LIGHT_CONTROL_ACTION_SCHEMA already defines it with different (templatable,
+# transformer-exclusive) semantics.
+INITIAL_STATE_SCHEMA = LIGHT_STATE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_EFFECT): cv.string,
+    }
+)
+
 LIGHT_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
@@ -367,7 +397,7 @@ LIGHT_SCHEMA = (
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(LightStateTrigger),
                 }
             ),
-            cv.Optional(CONF_INITIAL_STATE): LIGHT_STATE_SCHEMA,
+            cv.Optional(CONF_INITIAL_STATE): INITIAL_STATE_SCHEMA,
         }
     )
 )
@@ -490,9 +520,20 @@ async def setup_light_core_(light_var, config, output_var):
             initial_state_config.get(CONF_COLD_WHITE, 1.0),
             initial_state_config.get(CONF_WARM_WHITE, 1.0),
         )
+        # LightStateRTCState's constructor does not take the effect index, so assign
+        # the public member afterwards. LightState::setup() applies it via
+        # `if (recovered.effect != 0) call.set_effect(...)`.
+        effect_stmt = ""
+        if (effect_name := initial_state_config.get(CONF_EFFECT)) is not None:
+            effect_index = (
+                0
+                if effect_name.lower() == "none"
+                else find_effect_index(config.get(CONF_EFFECTS, []), effect_name)
+            )
+            effect_stmt = f" s.effect = {effect_index};"
         args = [(LightStateRTCState.operator("ref"), "s")]
         lamb = await cg.process_lambda(
-            Lambda(f"s = {initial_state};"),
+            Lambda(f"s = {initial_state};{effect_stmt}"),
             args,
             return_type=cg.void,
         )

--- a/tests/integration/fixtures/light_initial_state.yaml
+++ b/tests/integration/fixtures/light_initial_state.yaml
@@ -26,6 +26,11 @@ output:
     type: float
     write_action:
       - lambda: ""
+  - platform: template
+    id: test_effect_output
+    type: float
+    write_action:
+      - lambda: ""
 
 light:
   - platform: rgb
@@ -55,3 +60,19 @@ light:
       color_mode: BRIGHTNESS
       state: false
       brightness: 0%
+
+  - platform: monochromatic
+    name: "Test Effect Light"
+    id: test_effect_light
+    output: test_effect_output
+    # ALWAYS_ON so the light resolves to on at boot: an effect is cleared when the
+    # light is turning off ("cannot start effect when turning off"), so initial_state's
+    # effect is only meaningful for a boot state that ends up on.
+    restore_mode: ALWAYS_ON
+    initial_state:
+      color_mode: BRIGHTNESS
+      brightness: 60%
+      effect: "Test Pulse"
+    effects:
+      - pulse:
+          name: "Test Pulse"

--- a/tests/integration/test_light_initial_state.py
+++ b/tests/integration/test_light_initial_state.py
@@ -51,3 +51,10 @@ async def test_light_initial_state(
         restore_and_on_state = helper.initial_states[restore_and_on_light.key]
         assert restore_and_on_state.state is True
         assert restore_and_on_state.brightness == pytest.approx(1.0)
+
+        # initial_state may also name the effect to start with. The light must come up
+        # with that effect already active, without an on_boot automation.
+        effect_light = require_entity(entities, "test_effect_light")
+        effect_state = helper.initial_states[effect_light.key]
+        assert effect_state.state is True
+        assert effect_state.effect == "Test Pulse"


### PR DESCRIPTION
# What does this implement/fix?

`initial_state` can seed every field of `LightStateRTCState` **except** `effect` — even though the struct already carries that member and `LightState::setup()` already consumes it:

```cpp
if (recovered.effect != 0) {
  call.set_effect(recovered.effect);
} else {
  call.set_transition_length_if_supported(0);
}
```

So the plumbing was already in place and only the config surface was missing. Without it, booting a light into a known effect requires an `on_boot` + `light.turn_on` automation, which is a lot of YAML for something `initial_state` otherwise expresses directly.

This PR:

- adds `effect` to the `initial_state` schema
- validates the name in `_final_validate` against the effects defined on that **same** light, with an error listing the available names
- resolves the 1-based index at codegen time (reusing the existing `find_effect_index()`) and assigns it in the existing flash-resident lambda; `none` is accepted and maps to index `0`

Two deliberate choices worth flagging for review:

1. **`effect` is added at the `initial_state` use site, not to `LIGHT_STATE_SCHEMA`.** `LIGHT_CONTROL_ACTION_SCHEMA` already defines `effect` with different semantics — templatable and `cv.Exclusive` with the transformer options — and conflating the two seemed worse than a small extra schema.
2. **Validation lives before the early return in `_final_validate`**, so it still runs when nothing else references an effect. Unlike the action references, `initial_state.effect` names an effect on the same light, so it needs no cross-component lookup — but note `config` there is every instance of the platform, hence the loop.

**Behaviour is unchanged when `effect` is omitted** — the generated lambda is byte-identical to before.

One caveat, documented in the docs PR and in the test fixture: this is only meaningful for a boot state that resolves to **on**. An effect is cleared when the light is turning off (`"cannot start effect when turning off"`), so the fixture uses `restore_mode: ALWAYS_ON`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7279

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host (integration test)

Verified locally:

- `tests/integration/test_light_initial_state.py` extended with a light that boots into an effect; it compiles the host binary, runs it, connects over the API and asserts the reported effect. **Passes.**
- All 11 `tests/integration -k light` tests pass.
- Generated code checked: `s = light::LightStateRTCState(...); s.effect = 1;`
- Bad name rejected at config time: `Effect 'Nonexistent' is not defined on this light. Available effects: 'My Strobe'`
- `ruff check` and `ruff format --check` clean.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: monochromatic
    name: "Porch"
    id: porch
    output: porch_output
    restore_mode: ALWAYS_ON
    initial_state:
      brightness: 60%
      effect: "Slow Pulse"
    effects:
      - pulse:
          name: "Slow Pulse"
          transition_length: 5s
```
