### PR TITLE
[runtime_image] Add check for dimensions in BMP

### DIFF
--- a/esphome/components/runtime_image/bmp_decoder.cpp
+++ b/esphome/components/runtime_image/bmp_decoder.cpp
@@ -80,6 +80,10 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
 
     this->width_ = encode_uint32(buffer[21], buffer[20], buffer[19], buffer[18]);
     this->height_ = encode_uint32(buffer[25], buffer[24], buffer[23], buffer[22]);
+    if (this->width_ == 0 || this->height_ == 0) {
+      ESP_LOGE(TAG, "Invalid image dimensions: (%zux%zu)", this->width_, this->height_);
+      return DECODE_ERROR_INVALID_TYPE;
+    }
     this->bits_per_pixel_ = encode_uint16(buffer[29], buffer[28]);
     this->compression_method_ = encode_uint32(buffer[33], buffer[32], buffer[31], buffer[30]);
     this->image_data_size_ = encode_uint32(buffer[37], buffer[36], buffer[35], buffer[34]);

--- a/esphome/components/runtime_image/bmp_decoder.cpp
+++ b/esphome/components/runtime_image/bmp_decoder.cpp
@@ -81,7 +81,7 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
     this->width_ = encode_uint32(buffer[21], buffer[20], buffer[19], buffer[18]);
     this->height_ = encode_uint32(buffer[25], buffer[24], buffer[23], buffer[22]);
     if (this->width_ <= 0 || this->height_ <= 0) {
-      ESP_LOGE(TAG, "Invalid image dimensions: (%zux%zu)", this->width_, this->height_);
+      ESP_LOGE(TAG, "Invalid image dimensions: (%zdx%zd)", this->width_, this->height_);
       return DECODE_ERROR_UNSUPPORTED_FORMAT;
     }
     this->bits_per_pixel_ = encode_uint16(buffer[29], buffer[28]);

--- a/esphome/components/runtime_image/bmp_decoder.cpp
+++ b/esphome/components/runtime_image/bmp_decoder.cpp
@@ -80,9 +80,9 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
 
     this->width_ = encode_uint32(buffer[21], buffer[20], buffer[19], buffer[18]);
     this->height_ = encode_uint32(buffer[25], buffer[24], buffer[23], buffer[22]);
-    if (this->width_ == 0 || this->height_ == 0) {
+    if (this->width_ <= 0 || this->height_ <= 0) {
       ESP_LOGE(TAG, "Invalid image dimensions: (%zux%zu)", this->width_, this->height_);
-      return DECODE_ERROR_INVALID_TYPE;
+      return DECODE_ERROR_UNSUPPORTED_FORMAT;
     }
     this->bits_per_pixel_ = encode_uint16(buffer[29], buffer[28]);
     this->compression_method_ = encode_uint32(buffer[33], buffer[32], buffer[31], buffer[30]);


### PR DESCRIPTION
# What does this implement/fix?

Add a check, to ensure that the dimenstions of the received image do not cause a division by zero

Detected by esphomebot while reviewing the QOI decoder implementation (#16945); since I fixed it there, I thought I'd use the chance and fix the BMP code as well.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/R

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/R

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/R

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
