### PR TITLE
[api] Drop connection instead of crashing when overflow buffer allocation fails

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -172,7 +172,7 @@ APIError APIFrameHelper::write_raw_iov_(const struct iovec *iov, int iovcnt, uin
 
   // Queue unsent data into overflow buffer
   if (!this->overflow_buf_.enqueue_iov(iov, iovcnt, total_write_len, static_cast<uint16_t>(sent))) {
-    HELPER_LOG("Overflow buffer full, dropping connection");
+    HELPER_LOG("Overflow buffer full or out of memory, dropping connection");
     this->state_ = State::FAILED;
     return APIError::SOCKET_WRITE_FAILED;
   }

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -1,6 +1,7 @@
 #include "api_overflow_buffer.h"
 #ifdef USE_API
 #include <cstring>
+#include <new>
 
 namespace esphome::api {
 
@@ -61,9 +62,17 @@ bool APIOverflowBuffer::enqueue_iov(const struct iovec *iov, int iovcnt, uint16_
     return false;
 
   uint16_t buffer_size = total_len - skip;
+  // nothrow: on OOM drop the connection instead of crashing — ESP8266 Arduino's
+  // plain new returns nullptr when out of memory, ESP-IDF's aborts
+  auto *data = new (std::nothrow) uint8_t[buffer_size];
+  if (data == nullptr)
+    return false;
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  auto *entry = new Entry{new uint8_t[buffer_size], buffer_size, 0};
-  this->queue_[this->tail_] = entry;
+  auto *entry = new (std::nothrow) Entry{data, buffer_size, 0};
+  if (entry == nullptr) {
+    delete[] data;
+    return false;
+  }
 
   uint16_t to_skip = skip;
   uint16_t write_pos = 0;
@@ -80,6 +89,8 @@ bool APIOverflowBuffer::enqueue_iov(const struct iovec *iov, int iovcnt, uint16_
     }
   }
 
+  // Publish only after the copy completes so a half-built entry is never reachable
+  this->queue_[this->tail_] = entry;
   this->tail_ = (this->tail_ + 1) % API_MAX_SEND_QUEUE;
   this->count_++;
   return true;

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -62,8 +62,9 @@ bool APIOverflowBuffer::enqueue_iov(const struct iovec *iov, int iovcnt, uint16_
     return false;
 
   uint16_t buffer_size = total_len - skip;
-  // nothrow: on OOM drop the connection instead of crashing — ESP8266 Arduino's
-  // plain new returns nullptr when out of memory, ESP-IDF's aborts
+  // nothrow: a failed allocation returns nullptr so the connection is dropped
+  // cleanly instead of plain new's crash or abort on OOM
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   auto *data = new (std::nothrow) uint8_t[buffer_size];
   if (data == nullptr)
     return false;

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -61,7 +61,7 @@ class APIOverflowBuffer {
 
   /// Enqueue unsent IOV data into the backlog.
   /// Copies iov data starting at byte offset `skip` into a new entry.
-  /// Returns false if the queue is full (caller should fail the connection).
+  /// Returns false if the queue is full or allocation fails (caller should fail the connection).
   bool enqueue_iov(const struct iovec *iov, int iovcnt, uint16_t total_len, uint16_t skip);
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

The overflow buffer only allocates when the socket backs up, and lwIP reports `ERR_MEM` as `EWOULDBLOCK`, so `enqueue_iov` allocates exactly when the heap is already exhausted. The allocation was unchecked; on ESP8266 Arduino a failed `new` returns `nullptr` and the memcpy that follows writes to address 0 (StoreProhibit, EXCVADDR=0x00000000), on ESP-IDF a failed `new` aborts and reboots the device.

Allocate with `std::nothrow` and return false on failure, which reuses the existing queue full path that drops the connection cleanly. `std::nothrow` is required here; with `-fno-exceptions` GCC assumes plain `new` never returns null and can optimize away a manual check. Also publish the entry into the queue only after the copy completes, so a half built entry is never reachable.

`APIBuffer::grow_` has a similar unchecked pattern; that needs failure propagation through the `resize()` callers and will be a separate PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18798
- fixes https://github.com/esphome/esphome/issues/18608
- fixes https://github.com/esphome/esphome/issues/18207

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
