### PR TITLE
[api] Drop connection instead of crashing when buffer allocation fails

### DIFF
--- a/esphome/components/api/api_buffer.cpp
+++ b/esphome/components/api/api_buffer.cpp
@@ -1,9 +1,13 @@
 #include "api_buffer.h"
+#include <new>
 
 namespace esphome::api {
 
 bool APIBuffer::grow_(size_t n) {
-  auto new_data = make_buffer(n);
+  // nothrow (no zero-fill) so OOM is reportable; plain new aborts instead
+  // (NEW_OOM_ABORT on ESP8266 Arduino, exception stub on ESP-IDF).
+  // RAMAllocator is no fit here: unique_ptr needs delete[]-compatible memory.
+  std::unique_ptr<uint8_t[]> new_data(new (std::nothrow) uint8_t[n]);
   if (new_data == nullptr)
     return false;
   if (this->size_)

--- a/esphome/components/api/api_buffer.cpp
+++ b/esphome/components/api/api_buffer.cpp
@@ -2,12 +2,15 @@
 
 namespace esphome::api {
 
-void APIBuffer::grow_(size_t n) {
+bool APIBuffer::grow_(size_t n) {
   auto new_data = make_buffer(n);
+  if (new_data == nullptr)
+    return false;
   if (this->size_)
     std::memcpy(new_data.get(), this->data_.get(), this->size_);
   this->data_ = std::move(new_data);
   this->capacity_ = n;
+  return true;
 }
 
 }  // namespace esphome::api

--- a/esphome/components/api/api_buffer.h
+++ b/esphome/components/api/api_buffer.h
@@ -3,19 +3,11 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include <new>
 
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome::api {
-
-/// Allocate a buffer without zero-fill. Returns nullptr on allocation failure;
-/// nothrow is required so OOM is reportable — plain new aborts instead
-/// (NEW_OOM_ABORT on ESP8266 Arduino, exception stub on ESP-IDF).
-inline std::unique_ptr<uint8_t[]> make_buffer(size_t n) {
-  return std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[n]);
-}
 
 /// Byte buffer that skips zero-initialization on resize().
 ///
@@ -36,13 +28,8 @@ class APIBuffer {
   void clear() { this->size_ = 0; }
   /// Returns false if allocation fails; the buffer is left unchanged.
   [[nodiscard]] inline bool reserve(size_t n) ESPHOME_ALWAYS_INLINE { return n <= this->capacity_ || this->grow_(n); }
-  /// Returns false if allocation fails; the buffer is left unchanged.
-  [[nodiscard]] inline bool resize(size_t n) ESPHOME_ALWAYS_INLINE {
-    if (!this->reserve(n))
-      return false;
-    this->size_ = n;  // no zero-fill
-    return true;
-  }
+  /// Returns false if allocation fails; the buffer is left unchanged. No zero-fill.
+  [[nodiscard]] inline bool resize(size_t n) ESPHOME_ALWAYS_INLINE { return this->reserve_and_resize(n, n); }
   /// Reserve capacity for max(reserve_size, new_size) bytes, then set size to new_size.
   /// Single grow_ check regardless of argument order.
   /// Returns false if allocation fails; the buffer is left unchanged.

--- a/esphome/components/api/api_buffer.h
+++ b/esphome/components/api/api_buffer.h
@@ -11,8 +11,8 @@
 namespace esphome::api {
 
 /// Allocate a buffer without zero-fill. Returns nullptr on allocation failure;
-/// nothrow is required so OOM is reportable — ESP8266 Arduino's plain new
-/// returns nullptr when out of memory, ESP-IDF's aborts.
+/// nothrow is required so OOM is reportable — plain new aborts instead
+/// (NEW_OOM_ABORT on ESP8266 Arduino, exception stub on ESP-IDF).
 inline std::unique_ptr<uint8_t[]> make_buffer(size_t n) {
   return std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[n]);
 }

--- a/esphome/components/api/api_buffer.h
+++ b/esphome/components/api/api_buffer.h
@@ -42,6 +42,7 @@ class APIBuffer {
   uint8_t *data() { return this->data_.get(); }
   const uint8_t *data() const { return this->data_.get(); }
   size_t size() const { return this->size_; }
+  size_t capacity() const { return this->capacity_; }
   bool empty() const { return this->size_ == 0; }
   uint8_t &operator[](size_t i) { return this->data_[i]; }
   const uint8_t &operator[](size_t i) const { return this->data_[i]; }

--- a/esphome/components/api/api_buffer.h
+++ b/esphome/components/api/api_buffer.h
@@ -3,20 +3,18 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <new>
 
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome::api {
 
-/// Helper to use make_unique_for_overwrite where available (skips zero-fill),
-/// falling back to make_unique on older GCC (ESP8266, LibreTiny).
+/// Allocate a buffer without zero-fill. Returns nullptr on allocation failure;
+/// nothrow is required so OOM is reportable — ESP8266 Arduino's plain new
+/// returns nullptr when out of memory, ESP-IDF's aborts.
 inline std::unique_ptr<uint8_t[]> make_buffer(size_t n) {
-#if defined(USE_ESP8266) || defined(USE_LIBRETINY)
-  return std::make_unique<uint8_t[]>(n);
-#else
-  return std::make_unique_for_overwrite<uint8_t[]>(n);
-#endif
+  return std::unique_ptr<uint8_t[]>(new (std::nothrow) uint8_t[n]);
 }
 
 /// Byte buffer that skips zero-initialization on resize().
@@ -36,19 +34,23 @@ inline std::unique_ptr<uint8_t[]> make_buffer(size_t n) {
 class APIBuffer {
  public:
   void clear() { this->size_ = 0; }
-  inline void reserve(size_t n) ESPHOME_ALWAYS_INLINE {
-    if (n > this->capacity_)
-      this->grow_(n);
-  }
-  inline void resize(size_t n) ESPHOME_ALWAYS_INLINE {
-    this->reserve(n);
+  /// Returns false if allocation fails; the buffer is left unchanged.
+  [[nodiscard]] inline bool reserve(size_t n) ESPHOME_ALWAYS_INLINE { return n <= this->capacity_ || this->grow_(n); }
+  /// Returns false if allocation fails; the buffer is left unchanged.
+  [[nodiscard]] inline bool resize(size_t n) ESPHOME_ALWAYS_INLINE {
+    if (!this->reserve(n))
+      return false;
     this->size_ = n;  // no zero-fill
+    return true;
   }
   /// Reserve capacity for max(reserve_size, new_size) bytes, then set size to new_size.
   /// Single grow_ check regardless of argument order.
-  inline void reserve_and_resize(size_t reserve_size, size_t new_size) ESPHOME_ALWAYS_INLINE {
-    this->reserve(std::max(reserve_size, new_size));
+  /// Returns false if allocation fails; the buffer is left unchanged.
+  [[nodiscard]] inline bool reserve_and_resize(size_t reserve_size, size_t new_size) ESPHOME_ALWAYS_INLINE {
+    if (!this->reserve(std::max(reserve_size, new_size)))
+      return false;
     this->size_ = new_size;
+    return true;
   }
   uint8_t *data() { return this->data_.get(); }
   const uint8_t *data() const { return this->data_.get(); }
@@ -64,7 +66,7 @@ class APIBuffer {
   }
 
  protected:
-  void grow_(size_t n);
+  bool grow_(size_t n);
   std::unique_ptr<uint8_t[]> data_;
   size_t size_{0};
   size_t capacity_{0};

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2297,27 +2297,34 @@ bool APIConnection::schedule_message_front_(EntityBase *entity, uint16_t message
   return this->schedule_batch_();
 }
 
+bool APIConnection::try_send_immediately_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
+                                          uint8_t aux_data_index) {
+  auto &shared_buf = this->parent_->get_shared_buffer_ref();
+  if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) [[unlikely]] {
+    this->fatal_out_of_memory_();
+    return false;
+  }
+  DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
+  if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
+      this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type)) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+    this->log_batch_item_(item);
+#endif
+    return true;
+  }
+  return false;
+}
+
 bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                                         uint8_t aux_data_index) {
   if (this->should_send_immediately_(message_type) && this->helper_->can_write_without_blocking()) {
-    auto &shared_buf = this->parent_->get_shared_buffer_ref();
-    if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) [[unlikely]] {
-      this->fatal_out_of_memory_();
-      return false;
-    }
-    DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
-    if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
-        this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type)) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_batch_item_(item);
-#endif
+    if (this->try_send_immediately_(entity, message_type, estimated_size, aux_data_index))
       return true;
-    }
+    // An OOM during the immediate attempt marks the connection for removal;
+    // don't queue more work (schedule_message_'s push_back may allocate again)
+    if (this->flags_.remove) [[unlikely]]
+      return false;
   }
-  // An OOM during the immediate attempt marks the connection for removal;
-  // don't queue more work (schedule_message_'s push_back may allocate again)
-  if (this->flags_.remove) [[unlikely]]
-    return false;
   return this->schedule_message_(entity, message_type, estimated_size, aux_data_index);
 }
 

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2297,29 +2297,22 @@ bool APIConnection::schedule_message_front_(EntityBase *entity, uint16_t message
   return this->schedule_batch_();
 }
 
-bool APIConnection::try_send_immediately_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
-                                          uint8_t aux_data_index) {
-  auto &shared_buf = this->parent_->get_shared_buffer_ref();
-  if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) [[unlikely]] {
-    this->fatal_out_of_memory_();
-    return false;
-  }
-  DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
-  if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
-      this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type)) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-    this->log_batch_item_(item);
-#endif
-    return true;
-  }
-  return false;
-}
-
 bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                                         uint8_t aux_data_index) {
   if (this->should_send_immediately_(message_type) && this->helper_->can_write_without_blocking()) {
-    if (this->try_send_immediately_(entity, message_type, estimated_size, aux_data_index))
+    auto &shared_buf = this->parent_->get_shared_buffer_ref();
+    if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) [[unlikely]] {
+      this->fatal_out_of_memory_();
+      return false;
+    }
+    DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
+    if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
+        this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type)) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_batch_item_(item);
+#endif
       return true;
+    }
     // An OOM during the immediate attempt marks the connection for removal;
     // don't queue more work (schedule_message_'s push_back may allocate again)
     if (this->flags_.remove) [[unlikely]]

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2241,8 +2241,8 @@ bool APIConnection::send_message_(uint32_t payload_size, uint16_t message_type, 
   }
 #endif
   auto &shared_buf = this->parent_->get_shared_buffer_ref();
-  if (!this->prepare_first_message_buffer(shared_buf, payload_size)) {
-    this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+  if (!this->prepare_first_message_buffer(shared_buf, payload_size)) [[unlikely]] {
+    this->fatal_out_of_memory_();
     return false;
   }
   size_t write_start = shared_buf.size();
@@ -2283,6 +2283,9 @@ void APIConnection::on_no_setup_connection() {
   this->on_fatal_error();
   this->log_client_(ESPHOME_LOG_LEVEL_DEBUG, LOG_STR("no connection setup"));
 }
+void APIConnection::fatal_out_of_memory_() {
+  this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+}
 void APIConnection::on_fatal_error() {
   // Don't close socket here - keep it open so getpeername() works for logging
   // Socket will be closed when client is removed from the list in APIServer::loop()
@@ -2298,8 +2301,8 @@ bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_typ
                                         uint8_t aux_data_index) {
   if (this->should_send_immediately_(message_type) && this->helper_->can_write_without_blocking()) {
     auto &shared_buf = this->parent_->get_shared_buffer_ref();
-    if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) {
-      this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+    if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) [[unlikely]] {
+      this->fatal_out_of_memory_();
       return false;
     }
     DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
@@ -2311,6 +2314,10 @@ bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_typ
       return true;
     }
   }
+  // An OOM during the immediate attempt marks the connection for removal;
+  // don't queue more work (schedule_message_'s push_back may allocate again)
+  if (this->flags_.remove) [[unlikely]]
+    return false;
   return this->schedule_message_(entity, message_type, estimated_size, aux_data_index);
 }
 
@@ -2359,8 +2366,8 @@ void APIConnection::process_batch_() {
     total_estimated_size = MAX_BATCH_PACKET_SIZE;
   }
 
-  if (!this->prepare_first_message_buffer(shared_buf, header_padding, total_estimated_size)) {
-    this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+  if (!this->prepare_first_message_buffer(shared_buf, header_padding, total_estimated_size)) [[unlikely]] {
+    this->fatal_out_of_memory_();
     this->clear_batch_();
     return;
   }
@@ -2443,8 +2450,8 @@ void APIConnection::process_batch_multi_(APIBuffer &shared_buf, size_t num_items
 
   if (items_processed > 0) {
     // Add footer space for the last message (for Noise protocol MAC)
-    if (footer_size > 0 && !shared_buf.resize(shared_buf.size() + footer_size)) {
-      this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+    if (footer_size > 0 && !shared_buf.resize(shared_buf.size() + footer_size)) [[unlikely]] {
+      this->fatal_out_of_memory_();
       this->clear_batch_();
       return;
     }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2306,8 +2306,11 @@ bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_typ
       return false;
     }
     DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
+    // Re-fetch the shared buffer here instead of reusing the local: keeping it
+    // live across dispatch_message_ costs a register and spills message_type
+    // into the batching path's dedup loop (measured on x86 GCC -Os)
     if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
-        this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type)) {
+        this->send_buffer(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()}, message_type)) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
       this->log_batch_item_(item);
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2241,9 +2241,13 @@ bool APIConnection::send_message_(uint32_t payload_size, uint16_t message_type, 
   }
 #endif
   auto &shared_buf = this->parent_->get_shared_buffer_ref();
-  this->prepare_first_message_buffer(shared_buf, payload_size);
+  if (!this->prepare_first_message_buffer(shared_buf, payload_size)) {
+    this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+    return false;
+  }
   size_t write_start = shared_buf.size();
-  shared_buf.resize(write_start + payload_size);
+  // Capacity reserved above, cannot fail
+  (void) shared_buf.resize(write_start + payload_size);
   ProtoWriteBuffer buffer{&shared_buf, write_start};
   encode_fn(msg, buffer PROTO_ENCODE_DEBUG_INIT(&shared_buf));
   return this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type);
@@ -2294,7 +2298,10 @@ bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_typ
                                         uint8_t aux_data_index) {
   if (this->should_send_immediately_(message_type) && this->helper_->can_write_without_blocking()) {
     auto &shared_buf = this->parent_->get_shared_buffer_ref();
-    this->prepare_first_message_buffer(shared_buf, estimated_size);
+    if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) {
+      this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+      return false;
+    }
     DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
     if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
         this->send_buffer(ProtoWriteBuffer{&shared_buf}, message_type)) {
@@ -2352,7 +2359,11 @@ void APIConnection::process_batch_() {
     total_estimated_size = MAX_BATCH_PACKET_SIZE;
   }
 
-  this->prepare_first_message_buffer(shared_buf, header_padding, total_estimated_size);
+  if (!this->prepare_first_message_buffer(shared_buf, header_padding, total_estimated_size)) {
+    this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+    this->clear_batch_();
+    return;
+  }
 
   // Fast path for single message - buffer already allocated above
   if (num_items == 1) {
@@ -2366,8 +2377,9 @@ void APIConnection::process_batch_() {
       this->log_batch_item_(item);
 #endif
       this->clear_batch_();
-    } else if (payload_size == 0) {
-      // Message too large to fit in available space
+    } else if (payload_size == 0 && !this->flags_.remove) {
+      // Message too large to fit in available space (payload_size == 0 with
+      // remove set means encoding hit OOM and the connection is being dropped)
       ESP_LOGW(TAG, "Message too large to send: type=%u", item.message_type);
       this->clear_batch_();
     }
@@ -2431,8 +2443,10 @@ void APIConnection::process_batch_multi_(APIBuffer &shared_buf, size_t num_items
 
   if (items_processed > 0) {
     // Add footer space for the last message (for Noise protocol MAC)
-    if (footer_size > 0) {
-      shared_buf.resize(shared_buf.size() + footer_size);
+    if (footer_size > 0 && !shared_buf.resize(shared_buf.size() + footer_size)) {
+      this->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+      this->clear_batch_();
+      return;
     }
 
     // Send all collected messages

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2246,6 +2246,9 @@ bool APIConnection::send_message_(uint32_t payload_size, uint16_t message_type, 
   }
   auto &shared_buf = this->parent_->get_shared_buffer_ref();
   size_t write_start = shared_buf.size();
+#ifdef ESPHOME_DEBUG_API
+  assert(shared_buf.capacity() >= write_start + payload_size);
+#endif
   // Capacity reserved above, cannot fail
   (void) shared_buf.resize(write_start + payload_size);
   ProtoWriteBuffer buffer{&shared_buf, write_start};
@@ -2386,10 +2389,11 @@ void APIConnection::process_batch_() {
       this->log_batch_item_(item);
 #endif
       this->clear_batch_();
-    } else if (payload_size == 0 && !this->flags_.remove) {
-      // Message too large to fit in available space (payload_size == 0 with
-      // remove set means encoding hit OOM and the connection is being dropped)
-      ESP_LOGW(TAG, "Message too large to send: type=%u", item.message_type);
+    } else if (payload_size == 0) {
+      // payload_size == 0 with remove set means encoding hit OOM and the
+      // connection is being dropped; warn only for a genuinely oversized message
+      if (!this->flags_.remove)
+        ESP_LOGW(TAG, "Message too large to send: type=%u", item.message_type);
       this->clear_batch_();
     }
     return;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1,6 +1,6 @@
 #include "api_connection.h"
 #ifdef USE_API
-#include "api_connection_buffer.h"  // for encode_to_buffer / get_batch_delay_ms_ inlines
+#include "api_connection_buffer.h"  // for the APIServer-dependent APIConnection inlines
 #ifdef USE_API_NOISE
 #include "api_frame_helper_noise.h"
 #endif
@@ -2240,11 +2240,11 @@ bool APIConnection::send_message_(uint32_t payload_size, uint16_t message_type, 
     this->log_send_message_(proto_msg->message_name(), proto_msg->dump_to(dump_buf));
   }
 #endif
-  auto &shared_buf = this->parent_->get_shared_buffer_ref();
-  if (!this->prepare_first_message_buffer(shared_buf, payload_size)) [[unlikely]] {
+  if (!this->prepare_first_message_buffer(payload_size)) [[unlikely]] {
     this->fatal_out_of_memory_();
     return false;
   }
+  auto &shared_buf = this->parent_->get_shared_buffer_ref();
   size_t write_start = shared_buf.size();
   // Capacity reserved above, cannot fail
   (void) shared_buf.resize(write_start + payload_size);
@@ -2300,15 +2300,14 @@ bool APIConnection::schedule_message_front_(EntityBase *entity, uint16_t message
 bool APIConnection::send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                                         uint8_t aux_data_index) {
   if (this->should_send_immediately_(message_type) && this->helper_->can_write_without_blocking()) {
-    auto &shared_buf = this->parent_->get_shared_buffer_ref();
-    if (!this->prepare_first_message_buffer(shared_buf, estimated_size)) [[unlikely]] {
+    // No local for the shared buffer here: keeping it live across
+    // dispatch_message_ costs a register and spills message_type into the
+    // batching path's dedup loop (measured on x86 GCC -Os)
+    if (!this->prepare_first_message_buffer(estimated_size)) [[unlikely]] {
       this->fatal_out_of_memory_();
       return false;
     }
     DeferredBatch::BatchItem item{entity, message_type, estimated_size, aux_data_index};
-    // Re-fetch the shared buffer here instead of reusing the local: keeping it
-    // live across dispatch_message_ costs a register and spills message_type
-    // into the batching path's dedup loop (measured on x86 GCC -Os)
     if (this->dispatch_message_(item, MAX_BATCH_PACKET_SIZE, true) &&
         this->send_buffer(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()}, message_type)) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2369,7 +2368,7 @@ void APIConnection::process_batch_() {
     total_estimated_size = MAX_BATCH_PACKET_SIZE;
   }
 
-  if (!this->prepare_first_message_buffer(shared_buf, header_padding, total_estimated_size)) [[unlikely]] {
+  if (!this->prepare_first_message_buffer(header_padding, total_estimated_size)) [[unlikely]] {
     this->fatal_out_of_memory_();
     this->clear_batch_();
     return;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -352,21 +352,22 @@ class APIConnection final : public APIServerConnectionBase {
     }
   }
 
-  void prepare_first_message_buffer(APIBuffer &shared_buf, size_t header_padding, size_t total_size) {
+  /// Returns false if the shared buffer allocation fails (out of memory).
+  [[nodiscard]] bool prepare_first_message_buffer(APIBuffer &shared_buf, size_t header_padding, size_t total_size) {
     shared_buf.clear();
     // Reserve space for header padding + message + footer
     // - Header padding: space for protocol headers (7 bytes for Noise, 6 for Plaintext)
     // - Footer: space for MAC (16 bytes for Noise, 0 for Plaintext)
     // Reserve full size but only set initial size to header padding
     // so message encoding starts at the correct position
-    shared_buf.reserve_and_resize(total_size, header_padding);
+    return shared_buf.reserve_and_resize(total_size, header_padding);
   }
 
   // Convenience overload - computes frame overhead internally
-  void prepare_first_message_buffer(APIBuffer &shared_buf, size_t payload_size) {
+  [[nodiscard]] bool prepare_first_message_buffer(APIBuffer &shared_buf, size_t payload_size) {
     const uint8_t header_padding = this->helper_->frame_header_padding();
     const uint8_t footer_size = this->helper_->frame_footer_size();
-    this->prepare_first_message_buffer(shared_buf, header_padding, payload_size + header_padding + footer_size);
+    return this->prepare_first_message_buffer(shared_buf, header_padding, payload_size + header_padding + footer_size);
   }
 
   bool try_to_clear_buffer(bool log_out_of_space) {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -352,23 +352,13 @@ class APIConnection final : public APIServerConnectionBase {
     }
   }
 
-  /// Returns false if the shared buffer allocation fails (out of memory).
-  [[nodiscard]] bool prepare_first_message_buffer(APIBuffer &shared_buf, size_t header_padding, size_t total_size) {
-    shared_buf.clear();
-    // Reserve space for header padding + message + footer
-    // - Header padding: space for protocol headers (7 bytes for Noise, 6 for Plaintext)
-    // - Footer: space for MAC (16 bytes for Noise, 0 for Plaintext)
-    // Reserve full size but only set initial size to header padding
-    // so message encoding starts at the correct position
-    return shared_buf.reserve_and_resize(total_size, header_padding);
-  }
+  /// Clear the shared write buffer and reserve space for the first message.
+  /// Returns false if the allocation fails (out of memory).
+  /// Defined in api_connection_buffer.h (needs APIServer complete).
+  [[nodiscard]] bool prepare_first_message_buffer(size_t header_padding, size_t total_size);
 
   // Convenience overload - computes frame overhead internally
-  [[nodiscard]] bool prepare_first_message_buffer(APIBuffer &shared_buf, size_t payload_size) {
-    const uint8_t header_padding = this->helper_->frame_header_padding();
-    const uint8_t footer_size = this->helper_->frame_footer_size();
-    return this->prepare_first_message_buffer(shared_buf, header_padding, payload_size + header_padding + footer_size);
-  }
+  [[nodiscard]] bool prepare_first_message_buffer(size_t payload_size);
 
   bool try_to_clear_buffer(bool log_out_of_space) {
     if (this->flags_.remove)

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -834,6 +834,11 @@ class APIConnection final : public APIServerConnectionBase {
   bool send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                            uint8_t aux_data_index = DeferredBatch::AUX_DATA_UNUSED);
 
+  // The immediate-send attempt for send_message_smart_; noinline keeps the
+  // common batching path small so the compiler can keep it fully inlined
+  bool __attribute__((noinline))
+  try_send_immediately_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size, uint8_t aux_data_index);
+
   // Helper function to schedule a deferred message with known message type
   bool schedule_message_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                          uint8_t aux_data_index = DeferredBatch::AUX_DATA_UNUSED) {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -854,6 +854,9 @@ class APIConnection final : public APIServerConnectionBase {
     this->on_fatal_error();
     this->log_warning_(message, err);
   }
+  // Shared cold path for buffer allocation failures — noinline keeps the
+  // OOM handling out of the hot send paths
+  void __attribute__((noinline)) fatal_out_of_memory_();
 };
 
 }  // namespace esphome::api

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -834,11 +834,6 @@ class APIConnection final : public APIServerConnectionBase {
   bool send_message_smart_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                            uint8_t aux_data_index = DeferredBatch::AUX_DATA_UNUSED);
 
-  // The immediate-send attempt for send_message_smart_; noinline keeps the
-  // common batching path small so the compiler can keep it fully inlined
-  bool __attribute__((noinline))
-  try_send_immediately_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size, uint8_t aux_data_index);
-
   // Helper function to schedule a deferred message with known message type
   bool schedule_message_(EntityBase *entity, uint16_t message_type, uint8_t estimated_size,
                          uint8_t aux_data_index = DeferredBatch::AUX_DATA_UNUSED) {

--- a/esphome/components/api/api_connection_buffer.h
+++ b/esphome/components/api/api_connection_buffer.h
@@ -3,8 +3,8 @@
 #include "esphome/core/defines.h"
 #ifdef USE_API
 
-// Inline APIConnection methods that need APIServer complete. Include this
-// instead of api_connection.h when calling encode_to_buffer or get_batch_delay_ms_.
+// Inline APIConnection members that need APIServer complete. Include this
+// instead of api_connection.h when calling them.
 
 #include "api_connection.h"
 #include "api_server.h"
@@ -52,6 +52,23 @@ inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t c
 }
 
 inline uint32_t APIConnection::get_batch_delay_ms_() const { return this->parent_->get_batch_delay(); }
+
+inline bool APIConnection::prepare_first_message_buffer(size_t header_padding, size_t total_size) {
+  auto &shared_buf = this->parent_->get_shared_buffer_ref();
+  shared_buf.clear();
+  // Reserve space for header padding + message + footer
+  // - Header padding: space for protocol headers (7 bytes for Noise, 6 for Plaintext)
+  // - Footer: space for MAC (16 bytes for Noise, 0 for Plaintext)
+  // Reserve full size but only set initial size to header padding
+  // so message encoding starts at the correct position
+  return shared_buf.reserve_and_resize(total_size, header_padding);
+}
+
+inline bool APIConnection::prepare_first_message_buffer(size_t payload_size) {
+  const uint8_t header_padding = this->helper_->frame_header_padding();
+  const uint8_t footer_size = this->helper_->frame_footer_size();
+  return this->prepare_first_message_buffer(header_padding, payload_size + header_padding + footer_size);
+}
 
 }  // namespace esphome::api
 #endif

--- a/esphome/components/api/api_connection_buffer.h
+++ b/esphome/components/api/api_connection_buffer.h
@@ -41,7 +41,10 @@ inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t c
     return 0;
 
   auto &shared_buf = conn->parent_->get_shared_buffer_ref();
-  shared_buf.resize(shared_buf.size() + to_add);
+  if (!shared_buf.resize(shared_buf.size() + to_add)) {
+    conn->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+    return 0;
+  }
   ProtoWriteBuffer buffer{&shared_buf, shared_buf.size() - calculated_size};
   encode_fn(msg, buffer PROTO_ENCODE_DEBUG_INIT(&shared_buf));
 

--- a/esphome/components/api/api_connection_buffer.h
+++ b/esphome/components/api/api_connection_buffer.h
@@ -41,8 +41,8 @@ inline uint16_t ESPHOME_ALWAYS_INLINE APIConnection::encode_to_buffer(uint32_t c
     return 0;
 
   auto &shared_buf = conn->parent_->get_shared_buffer_ref();
-  if (!shared_buf.resize(shared_buf.size() + to_add)) {
-    conn->fatal_error_with_log_(LOG_STR("Out of memory"), APIError::OUT_OF_MEMORY);
+  if (!shared_buf.resize(shared_buf.size() + to_add)) [[unlikely]] {
+    conn->fatal_out_of_memory_();
     return 0;
   }
   ProtoWriteBuffer buffer{&shared_buf, shared_buf.size() - calculated_size};

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -68,7 +68,10 @@ APIError APINoiseFrameHelper::init() {
 
   // init prologue
   size_t old_size = prologue_.size();
-  prologue_.resize(old_size + PROLOGUE_INIT_LEN);
+  if (!prologue_.resize(old_size + PROLOGUE_INIT_LEN)) {
+    state_ = State::FAILED;
+    return APIError::OUT_OF_MEMORY;
+  }
 #ifdef USE_ESP8266
   memcpy_P(prologue_.data() + old_size, PROLOGUE_INIT, PROLOGUE_INIT_LEN);
 #else
@@ -202,7 +205,10 @@ APIError APINoiseFrameHelper::try_read_frame_() {
   // During handshake, rx_buf_.size() is used in prologue construction, so
   // the buffer must be exactly msg_size to avoid prologue mismatch.)
   uint16_t alloc_size = msg_size + (is_data ? RX_BUF_NULL_TERMINATOR : 0);
-  this->rx_buf_.resize(alloc_size);
+  if (!this->rx_buf_.resize(alloc_size)) {
+    state_ = State::FAILED;
+    return APIError::OUT_OF_MEMORY;
+  }
 
   if (rx_buf_len_ < msg_size) {
     // more data to read
@@ -269,7 +275,10 @@ APIError APINoiseFrameHelper::state_action_client_hello_() {
   // Resize for: existing prologue + 2 size bytes + frame data
   size_t old_size = this->prologue_.size();
   size_t rx_size = this->rx_buf_.size();
-  this->prologue_.resize(old_size + 2 + rx_size);
+  if (!this->prologue_.resize(old_size + 2 + rx_size)) {
+    state_ = State::FAILED;
+    return APIError::OUT_OF_MEMORY;
+  }
   this->prologue_[old_size] = (uint8_t) (rx_size >> 8);
   this->prologue_[old_size + 1] = (uint8_t) rx_size;
   if (rx_size > 0) {

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -486,16 +486,15 @@ APIError APINoiseFrameHelper::write_protobuf_packet(uint16_t type, ProtoWriteBuf
   assert(this->state_ == State::DATA);
 #endif
 
+  APIBuffer *buf = buffer.get_buffer();
   // Resize buffer to include footer space for Noise MAC
-  if (this->frame_footer_size_ && !buffer.get_buffer()->resize(buffer.get_buffer()->size() + this->frame_footer_size_))
-      [[unlikely]] {
+  if (this->frame_footer_size_ && !buf->resize(buf->size() + this->frame_footer_size_)) [[unlikely]] {
     state_ = State::FAILED;
     return APIError::OUT_OF_MEMORY;
   }
 
-  uint16_t payload_size =
-      static_cast<uint16_t>(buffer.get_buffer()->size() - HEADER_PADDING - this->frame_footer_size_);
-  uint8_t *buf_start = buffer.get_buffer()->data();
+  uint16_t payload_size = static_cast<uint16_t>(buf->size() - HEADER_PADDING - this->frame_footer_size_);
+  uint8_t *buf_start = buf->data();
   uint16_t encrypted_len;
   APIError aerr = this->encrypt_noise_message_(buf_start, payload_size, type, encrypted_len);
   if (aerr != APIError::OK)

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -68,7 +68,7 @@ APIError APINoiseFrameHelper::init() {
 
   // init prologue
   size_t old_size = prologue_.size();
-  if (!prologue_.resize(old_size + PROLOGUE_INIT_LEN)) {
+  if (!prologue_.resize(old_size + PROLOGUE_INIT_LEN)) [[unlikely]] {
     state_ = State::FAILED;
     return APIError::OUT_OF_MEMORY;
   }
@@ -205,7 +205,7 @@ APIError APINoiseFrameHelper::try_read_frame_() {
   // During handshake, rx_buf_.size() is used in prologue construction, so
   // the buffer must be exactly msg_size to avoid prologue mismatch.)
   uint16_t alloc_size = msg_size + (is_data ? RX_BUF_NULL_TERMINATOR : 0);
-  if (!this->rx_buf_.resize(alloc_size)) {
+  if (!this->rx_buf_.resize(alloc_size)) [[unlikely]] {
     state_ = State::FAILED;
     return APIError::OUT_OF_MEMORY;
   }
@@ -275,7 +275,7 @@ APIError APINoiseFrameHelper::state_action_client_hello_() {
   // Resize for: existing prologue + 2 size bytes + frame data
   size_t old_size = this->prologue_.size();
   size_t rx_size = this->rx_buf_.size();
-  if (!this->prologue_.resize(old_size + 2 + rx_size)) {
+  if (!this->prologue_.resize(old_size + 2 + rx_size)) [[unlikely]] {
     state_ = State::FAILED;
     return APIError::OUT_OF_MEMORY;
   }
@@ -487,8 +487,11 @@ APIError APINoiseFrameHelper::write_protobuf_packet(uint16_t type, ProtoWriteBuf
 #endif
 
   // Resize buffer to include footer space for Noise MAC
-  if (this->frame_footer_size_)
-    buffer.get_buffer()->resize(buffer.get_buffer()->size() + this->frame_footer_size_);
+  if (this->frame_footer_size_ && !buffer.get_buffer()->resize(buffer.get_buffer()->size() + this->frame_footer_size_))
+      [[unlikely]] {
+    state_ = State::FAILED;
+    return APIError::OUT_OF_MEMORY;
+  }
 
   uint16_t payload_size =
       static_cast<uint16_t>(buffer.get_buffer()->size() - HEADER_PADDING - this->frame_footer_size_);

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -172,7 +172,7 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
 
   // Reserve space for body (+ null terminator so protobuf StringRef fields
   // can be safely null-terminated in-place after decode)
-  if (!this->rx_buf_.resize(this->rx_header_parsed_len_ + RX_BUF_NULL_TERMINATOR)) {
+  if (!this->rx_buf_.resize(this->rx_header_parsed_len_ + RX_BUF_NULL_TERMINATOR)) [[unlikely]] {
     state_ = State::FAILED;
     return APIError::OUT_OF_MEMORY;
   }

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -172,7 +172,10 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
 
   // Reserve space for body (+ null terminator so protobuf StringRef fields
   // can be safely null-terminated in-place after decode)
-  this->rx_buf_.resize(this->rx_header_parsed_len_ + RX_BUF_NULL_TERMINATOR);
+  if (!this->rx_buf_.resize(this->rx_header_parsed_len_ + RX_BUF_NULL_TERMINATOR)) {
+    state_ = State::FAILED;
+    return APIError::OUT_OF_MEMORY;
+  }
 
   if (rx_buf_len_ < rx_header_parsed_len_) {
     // more data to read

--- a/tests/benchmarks/components/api/bench_list_entities.cpp
+++ b/tests/benchmarks/components/api/bench_list_entities.cpp
@@ -49,7 +49,7 @@ static void Encode_ListEntitiesSensorResponse(benchmark::State &state) {
   auto msg = make_sensor_response();
   APIBuffer buffer;
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -69,7 +69,7 @@ static void CalcAndEncode_ListEntitiesSensorResponse(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }
@@ -117,7 +117,7 @@ static void Encode_ListEntitiesBinarySensorResponse(benchmark::State &state) {
   auto msg = make_binary_sensor_response();
   APIBuffer buffer;
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -137,7 +137,7 @@ static void CalcAndEncode_ListEntitiesBinarySensorResponse(benchmark::State &sta
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }
@@ -202,7 +202,7 @@ static void Encode_ListEntitiesLightResponse(benchmark::State &state) {
   auto msg = make_light_response();
   APIBuffer buffer;
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -222,7 +222,7 @@ static void CalcAndEncode_ListEntitiesLightResponse(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }

--- a/tests/benchmarks/components/api/bench_log_response.cpp
+++ b/tests/benchmarks/components/api/bench_log_response.cpp
@@ -23,7 +23,7 @@ static void Encode_LogResponse_Typical(benchmark::State &state) {
   msg.level = enums::LOG_LEVEL_DEBUG;
   msg.set_message(reinterpret_cast<const uint8_t *>(kTypicalLogLine), strlen(kTypicalLogLine));
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -42,7 +42,7 @@ static void Encode_LogResponse_Short(benchmark::State &state) {
   msg.level = enums::LOG_LEVEL_INFO;
   msg.set_message(reinterpret_cast<const uint8_t *>(kShortLogLine), strlen(kShortLogLine));
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -84,7 +84,7 @@ static void CalcAndEncode_LogResponse_Typical(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }
@@ -105,7 +105,7 @@ static void CalcAndEncode_LogResponse_Typical_Fresh(benchmark::State &state) {
     for (int i = 0; i < kInnerIterations; i++) {
       APIBuffer buffer;
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
       benchmark::DoNotOptimize(buffer.data());

--- a/tests/benchmarks/components/api/bench_plaintext_frame.cpp
+++ b/tests/benchmarks/components/api/bench_plaintext_frame.cpp
@@ -33,7 +33,7 @@ static void PlaintextFrame_WriteSensorState(benchmark::State &state) {
   // Pre-init buffer to typical TCP MSS size to avoid benchmarking
   // heap allocation — in real use the buffer is reused across writes.
   APIBuffer buffer;
-  buffer.reserve(1460);
+  (void) buffer.reserve(1460);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -44,7 +44,7 @@ static void PlaintextFrame_WriteSensorState(benchmark::State &state) {
       msg.missing_state = false;
 
       uint32_t size = msg.calculate_size();
-      buffer.resize(padding + size);
+      (void) buffer.resize(padding + size);
       ProtoWriteBuffer writer(&buffer, padding);
       msg.encode(writer);
 
@@ -70,7 +70,7 @@ static void PlaintextFrame_WriteBatch5(benchmark::State &state) {
   // Pre-init buffer to typical TCP MSS size to avoid benchmarking
   // heap allocation — in real use the buffer is reused across writes.
   APIBuffer buffer;
-  buffer.reserve(1460);
+  (void) buffer.reserve(1460);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -85,7 +85,7 @@ static void PlaintextFrame_WriteBatch5(benchmark::State &state) {
         msg.missing_state = false;
 
         uint32_t size = msg.calculate_size();
-        buffer.resize(offset + padding + size + footer);
+        (void) buffer.resize(offset + padding + size + footer);
         ProtoWriteBuffer writer(&buffer, offset + padding);
         msg.encode(writer);
 

--- a/tests/benchmarks/components/api/bench_proto_decode.cpp
+++ b/tests/benchmarks/components/api/bench_proto_decode.cpp
@@ -16,7 +16,7 @@ static constexpr int kInnerIterations = 2000;
 template<typename T> static APIBuffer encode_message(const T &msg) {
   APIBuffer buffer;
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
   ProtoWriteBuffer writer(&buffer, 0);
   msg.encode(writer);
   return buffer;

--- a/tests/benchmarks/components/api/bench_proto_encode.cpp
+++ b/tests/benchmarks/components/api/bench_proto_encode.cpp
@@ -19,7 +19,7 @@ static void Encode_SensorStateResponse(benchmark::State &state) {
   msg.state = 23.5f;
   msg.missing_state = false;
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -60,7 +60,7 @@ static void CalcAndEncode_SensorStateResponse(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }
@@ -84,7 +84,7 @@ static void CalcAndEncode_SensorStateResponse_Fresh(benchmark::State &state) {
     for (int i = 0; i < kInnerIterations; i++) {
       APIBuffer buffer;
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
       benchmark::DoNotOptimize(buffer.data());
@@ -103,7 +103,7 @@ static void Encode_BinarySensorStateResponse(benchmark::State &state) {
   msg.state = true;
   msg.missing_state = false;
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -126,7 +126,7 @@ static void Encode_HelloResponse(benchmark::State &state) {
   msg.server_info = StringRef::from_lit("esphome v2026.3.0");
   msg.name = StringRef::from_lit("living-room-sensor");
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -158,7 +158,7 @@ static void Encode_LightStateResponse(benchmark::State &state) {
   msg.warm_white = 0.0f;
   msg.effect = StringRef::from_lit("rainbow");
   uint32_t size = msg.calculate_size();
-  buffer.resize(size);
+  (void) buffer.resize(size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -243,7 +243,7 @@ static void Encode_DeviceInfoResponse(benchmark::State &state) {
   auto msg = make_device_info_response();
   APIBuffer buffer;
   uint32_t total_size = msg.calculate_size();
-  buffer.resize(total_size);
+  (void) buffer.resize(total_size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -264,7 +264,7 @@ static void CalcAndEncode_DeviceInfoResponse(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }
@@ -285,7 +285,7 @@ static void CalcAndEncode_DeviceInfoResponse_Fresh(benchmark::State &state) {
     for (int i = 0; i < kInnerIterations; i++) {
       APIBuffer buffer;
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
       benchmark::DoNotOptimize(buffer.data());
@@ -335,7 +335,7 @@ static void Encode_BLERawAdvs12(benchmark::State &state) {
   auto msg = make_ble_raw_advs_12();
   APIBuffer buffer;
   uint32_t total_size = msg.calculate_size();
-  buffer.resize(total_size);
+  (void) buffer.resize(total_size);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -355,7 +355,7 @@ static void CalcAndEncode_BLERawAdvs12(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
     }
@@ -372,7 +372,7 @@ static void CalcAndEncode_BLERawAdvs12_Fresh(benchmark::State &state) {
     for (int i = 0; i < kInnerIterations; i++) {
       APIBuffer buffer;
       uint32_t size = msg.calculate_size();
-      buffer.resize(size);
+      (void) buffer.resize(size);
       ProtoWriteBuffer writer(&buffer, 0);
       msg.encode(writer);
       benchmark::DoNotOptimize(buffer.data());

--- a/tests/benchmarks/components/api/bench_proto_proxy.cpp
+++ b/tests/benchmarks/components/api/bench_proto_proxy.cpp
@@ -16,7 +16,7 @@ static constexpr int kInnerIterations = 2000;
 // Encodes `src` into `out`. Caller owns `out` and must keep it alive across
 // the decode loop (decoded messages may store pointers back into its bytes).
 template<typename T> static void encode_into(APIBuffer &out, const T &src) {
-  out.resize(src.calculate_size());
+  (void) out.resize(src.calculate_size());
   ProtoWriteBuffer writer(&out, 0);
   src.encode(writer);
 }
@@ -33,7 +33,7 @@ static void Encode_ZWaveProxyFrame(benchmark::State &state) {
   msg.data = kZWaveFrameData;
   msg.data_len = sizeof(kZWaveFrameData);
   APIBuffer buffer;
-  buffer.resize(msg.calculate_size());
+  (void) buffer.resize(msg.calculate_size());
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -111,7 +111,7 @@ static void Encode_SerialProxyDataReceived(benchmark::State &state) {
   msg.instance = 0;
   msg.set_data(kSerialPayload, kSerialPayloadSize);
   APIBuffer buffer;
-  buffer.resize(msg.calculate_size());
+  (void) buffer.resize(msg.calculate_size());
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -171,7 +171,7 @@ static void Encode_InfraredRFReceiveEvent(benchmark::State &state) {
   msg.key = 0xDEADBEEF;
   msg.timings = &get_ir_timings_100();
   APIBuffer buffer;
-  buffer.resize(msg.calculate_size());
+  (void) buffer.resize(msg.calculate_size());
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -254,7 +254,7 @@ static APIBuffer build_infrared_rf_transmit_wire() {
   put_varint(1);
 
   APIBuffer buf;
-  buf.resize(len);
+  (void) buf.resize(len);
   std::memcpy(buf.data(), bytes, len);
   return buf;
 }

--- a/tests/benchmarks/components/api/bench_proto_varint.cpp
+++ b/tests/benchmarks/components/api/bench_proto_varint.cpp
@@ -58,7 +58,7 @@ BENCHMARK(ProtoVarInt_Parse_FiveByte);
 
 static void Encode_Varint_Small(benchmark::State &state) {
   APIBuffer buffer;
-  buffer.resize(16);
+  (void) buffer.resize(16);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -73,7 +73,7 @@ BENCHMARK(Encode_Varint_Small);
 
 static void Encode_Varint_Large(benchmark::State &state) {
   APIBuffer buffer;
-  buffer.resize(16);
+  (void) buffer.resize(16);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
@@ -88,7 +88,7 @@ BENCHMARK(Encode_Varint_Large);
 
 static void Encode_Varint_MaxUint32(benchmark::State &state) {
   APIBuffer buffer;
-  buffer.resize(16);
+  (void) buffer.resize(16);
 
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {

--- a/tests/components/api/test_proto_mac_varint.cpp
+++ b/tests/components/api/test_proto_mac_varint.cpp
@@ -54,7 +54,7 @@ static void verify_mac(uint64_t mac, size_t expected_bytes) {
   size_t ref_len = reference_encode(mac, ref_buf);
 
   APIBuffer api_buf;
-  api_buf.resize(16);
+  ASSERT_TRUE(api_buf.resize(16));
   uint8_t *pos = api_buf.data();
 #ifdef ESPHOME_DEBUG_API
   uint8_t *proto_debug_end_ = api_buf.data() + api_buf.size();


### PR DESCRIPTION
# What does this implement/fix?

`APIBuffer::grow_` backs the receive buffer, the noise prologue, and the shared protobuf write buffer, and its allocation was unchecked; on ESP8266 Arduino a failed `new` returns `nullptr` and the buffer is then written through the null pointer, on ESP-IDF a failed `new` aborts and reboots the device. This is the same pattern fixed for the overflow buffer in #18802, the send queue grows under memory pressure, so these allocations tend to fail exactly when they are exercised.

`make_buffer` now allocates with `std::nothrow` and `resize`/`reserve`/`reserve_and_resize` return `[[nodiscard]] bool`, so every grow site must handle failure. Frame helpers return the existing `APIError::OUT_OF_MEMORY` (previously defined but unused), connection send paths mark the connection fatal, both end with the connection dropped cleanly instead of a crash. As a side effect `make_buffer` no longer zero-fills on ESP8266 and LibreTiny; callers always overwrite exactly the bytes they resize for, per the class contract, so the memset was pure waste.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/18798, follow up to #18802

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
