### PR TITLE
[external_components] Log when a source overrides built-in components

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -71,7 +71,30 @@ def _process_git_config(config: dict[str, Any], refresh: TimePeriodSeconds) -> P
     return components_dir
 
 
-def _process_single_config(config: dict[str, Any]) -> None:
+def _log_overridden_components(
+    conf: dict[str, Any], component_names: list[str], raw_source: Any
+) -> None:
+    overridden = [
+        name
+        for name in component_names
+        if (loader.CORE_COMPONENTS_PATH / name / "__init__.py").is_file()
+    ]
+    if not overridden:
+        return
+    if isinstance(raw_source, str):
+        source = raw_source
+    else:
+        source = conf[CONF_URL] if conf[CONF_TYPE] == TYPE_GIT else conf[CONF_PATH]
+    _LOGGER.info(
+        "External components source overrides the built-in component(s):\n"
+        "  source: %s\n"
+        "  components: %s",
+        source,
+        ", ".join(sorted(overridden)),
+    )
+
+
+def _process_single_config(config: dict[str, Any], raw_source: Any = None) -> None:
     conf = config[CONF_SOURCE]
     if conf[CONF_TYPE] == TYPE_GIT:
         with cv.prepend_path([CONF_SOURCE]):
@@ -84,8 +107,8 @@ def _process_single_config(config: dict[str, Any]) -> None:
         raise NotImplementedError
 
     if config[CONF_COMPONENTS] == "all":
-        num_components = len(list(components_dir.glob("*/__init__.py")))
-        if num_components > 100:
+        component_names = [p.parent.name for p in components_dir.glob("*/__init__.py")]
+        if len(component_names) > 100:
             # Prevent accidentally including all components from an esphome fork/branch
             # In this case force the user to manually specify which components they want to include
             raise cv.Invalid(
@@ -102,6 +125,9 @@ def _process_single_config(config: dict[str, Any]) -> None:
                     [CONF_COMPONENTS, i],
                 )
         allowed_components = config[CONF_COMPONENTS]
+        component_names = allowed_components
+
+    _log_overridden_components(conf, component_names, raw_source)
 
     loader.install_meta_finder(components_dir, allowed_components=allowed_components)
 
@@ -110,8 +136,13 @@ def do_external_components_pass(config: dict[str, Any]) -> None:
     conf = config.get(DOMAIN)
     if conf is None:
         return
+    raw_conf = conf if isinstance(conf, list) else [conf]
     with cv.prepend_path(DOMAIN):
         conf = CONFIG_SCHEMA(conf)
         for i, c in enumerate(conf):
+            raw_entry = raw_conf[i] if i < len(raw_conf) else None
+            raw_source = (
+                raw_entry.get(CONF_SOURCE) if isinstance(raw_entry, dict) else None
+            )
             with cv.prepend_path(i):
-                _process_single_config(c)
+                _process_single_config(c, raw_source)

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -72,7 +72,7 @@ def _process_git_config(config: dict[str, Any], refresh: TimePeriodSeconds) -> P
 
 
 def _log_overridden_components(
-    conf: dict[str, Any], component_names: list[str], raw_source: Any
+    conf: dict[str, Any], component_names: list[str]
 ) -> None:
     overridden = [
         name
@@ -81,10 +81,12 @@ def _log_overridden_components(
     ]
     if not overridden:
         return
-    if isinstance(raw_source, str):
-        source = raw_source
+    if conf[CONF_TYPE] == TYPE_GIT:
+        source = conf[CONF_URL]
+        if ref := conf.get(CONF_REF):
+            source = f"{source}@{ref}"
     else:
-        source = conf[CONF_URL] if conf[CONF_TYPE] == TYPE_GIT else conf[CONF_PATH]
+        source = conf[CONF_PATH]
     _LOGGER.info(
         "External components are overriding built-in components:\n"
         "  source: %s\n"
@@ -94,7 +96,7 @@ def _log_overridden_components(
     )
 
 
-def _process_single_config(config: dict[str, Any], raw_source: Any = None) -> None:
+def _process_single_config(config: dict[str, Any]) -> None:
     conf = config[CONF_SOURCE]
     if conf[CONF_TYPE] == TYPE_GIT:
         with cv.prepend_path([CONF_SOURCE]):
@@ -127,7 +129,7 @@ def _process_single_config(config: dict[str, Any], raw_source: Any = None) -> No
         allowed_components = config[CONF_COMPONENTS]
         component_names = allowed_components
 
-    _log_overridden_components(conf, component_names, raw_source)
+    _log_overridden_components(conf, component_names)
 
     loader.install_meta_finder(components_dir, allowed_components=allowed_components)
 
@@ -136,13 +138,8 @@ def do_external_components_pass(config: dict[str, Any]) -> None:
     conf = config.get(DOMAIN)
     if conf is None:
         return
-    raw_conf = conf if isinstance(conf, list) else [conf]
     with cv.prepend_path(DOMAIN):
         conf = CONFIG_SCHEMA(conf)
         for i, c in enumerate(conf):
-            raw_entry = raw_conf[i] if i < len(raw_conf) else None
-            raw_source = (
-                raw_entry.get(CONF_SOURCE) if isinstance(raw_entry, dict) else None
-            )
             with cv.prepend_path(i):
-                _process_single_config(c, raw_source)
+                _process_single_config(c)

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -86,7 +86,7 @@ def _log_overridden_components(
     else:
         source = conf[CONF_URL] if conf[CONF_TYPE] == TYPE_GIT else conf[CONF_PATH]
     _LOGGER.info(
-        "External components source overrides the built-in component(s):\n"
+        "External components are overriding built-in components:\n"
         "  source: %s\n"
         "  components: %s",
         source,

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -85,6 +85,8 @@ def _log_overridden_components(
         source = conf[CONF_URL]
         if ref := conf.get(CONF_REF):
             source = f"{source}@{ref}"
+        if path := conf.get(CONF_PATH):
+            source = f"{source} ({path})"
     else:
         source = conf[CONF_PATH]
     _LOGGER.info(

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -1,4 +1,4 @@
-"""Tests for the external_components skip-update behavior driven by CORE.skip_external_update."""
+"""Tests for the external_components config pass."""
 
 import logging
 from pathlib import Path
@@ -10,10 +10,12 @@ import pytest
 from esphome.components.external_components import do_external_components_pass
 from esphome.const import (
     CONF_EXTERNAL_COMPONENTS,
+    CONF_PATH,
     CONF_REFRESH,
     CONF_SOURCE,
     CONF_URL,
     TYPE_GIT,
+    TYPE_LOCAL,
 )
 from esphome.core import CORE, TimePeriodSeconds
 
@@ -119,6 +121,52 @@ def test_external_components_override_log_includes_ref(
         do_external_components_pass(config)
 
     assert "  source: https://github.com/test/components.git@main\n" in caplog.text
+
+
+def test_external_components_override_log_includes_git_path(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A git source with a subdirectory path logs the path after the url."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_config(tmp_path)
+    config[CONF_EXTERNAL_COMPONENTS][0][CONF_SOURCE][CONF_PATH] = "components"
+
+    component_dir = tmp_path / "components" / "gpio"
+    component_dir.mkdir()
+    (component_dir / "__init__.py").write_text("# Test component")
+
+    with caplog.at_level(logging.INFO):
+        do_external_components_pass(config)
+
+    assert "  source: https://github.com/test/components (components)\n" in caplog.text
+
+
+def test_external_components_override_log_local_source(
+    tmp_path: Path,
+    mock_install_meta_finder: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A local source logs its resolved path."""
+    components_dir = tmp_path / "my_components"
+    gpio_dir = components_dir / "gpio"
+    gpio_dir.mkdir(parents=True)
+    (gpio_dir / "__init__.py").write_text("# Test component")
+
+    CORE.config_path = tmp_path / "dummy.yaml"
+    config = {
+        CONF_EXTERNAL_COMPONENTS: [
+            {CONF_SOURCE: {"type": TYPE_LOCAL, CONF_PATH: "my_components"}}
+        ]
+    }
+
+    with caplog.at_level(logging.INFO):
+        do_external_components_pass(config)
+
+    assert f"  source: {components_dir}\n" in caplog.text
+    assert "  components: gpio" in caplog.text
 
 
 def test_external_components_no_override_no_log(

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -1,8 +1,11 @@
 """Tests for the external_components skip-update behavior driven by CORE.skip_external_update."""
 
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
+
+import pytest
 
 from esphome.components.external_components import do_external_components_pass
 from esphome.const import (
@@ -69,3 +72,67 @@ def test_external_components_normal_refresh(
     mock_clone_or_update.assert_called_once()
     call_args = mock_clone_or_update.call_args
     assert call_args.kwargs["refresh"] == TimePeriodSeconds(days=1)
+
+
+def test_external_components_logs_built_in_override(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A source that provides a component with the same name as a built-in one logs an info message."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_config(tmp_path)
+
+    for name in ("gpio", "some_custom_component"):
+        component_dir = tmp_path / "components" / name
+        component_dir.mkdir()
+        (component_dir / "__init__.py").write_text("# Test component")
+
+    with caplog.at_level(logging.INFO):
+        do_external_components_pass(config)
+
+    assert (
+        "External components source overrides the built-in component(s):\n"
+        "  source: https://github.com/test/components\n"
+        "  components: gpio" in caplog.text
+    )
+    assert "some_custom_component" not in caplog.text
+
+
+def test_external_components_override_log_shows_shorthand_source(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A shorthand source is logged as written in the yaml, not as the normalized git url."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_config(tmp_path)
+    config[CONF_EXTERNAL_COMPONENTS][0][CONF_SOURCE] = "github://test/components@main"
+
+    component_dir = tmp_path / "components" / "gpio"
+    component_dir.mkdir()
+    (component_dir / "__init__.py").write_text("# Test component")
+
+    with caplog.at_level(logging.INFO):
+        do_external_components_pass(config)
+
+    assert "  source: github://test/components@main\n" in caplog.text
+    assert "github.com" not in caplog.text
+
+
+def test_external_components_no_override_no_log(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A source that only provides components not shipped with ESPHome logs nothing."""
+    mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_config(tmp_path)
+
+    with caplog.at_level(logging.INFO):
+        do_external_components_pass(config)
+
+    assert "overrides the built-in component" not in caplog.text

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -93,7 +93,7 @@ def test_external_components_logs_built_in_override(
         do_external_components_pass(config)
 
     assert (
-        "External components source overrides the built-in component(s):\n"
+        "External components are overriding built-in components:\n"
         "  source: https://github.com/test/components\n"
         "  components: gpio" in caplog.text
     )
@@ -135,4 +135,4 @@ def test_external_components_no_override_no_log(
     with caplog.at_level(logging.INFO):
         do_external_components_pass(config)
 
-    assert "overrides the built-in component" not in caplog.text
+    assert "are overriding built-in components" not in caplog.text

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -100,13 +100,13 @@ def test_external_components_logs_built_in_override(
     assert "some_custom_component" not in caplog.text
 
 
-def test_external_components_override_log_shows_shorthand_source(
+def test_external_components_override_log_includes_ref(
     tmp_path: Path,
     mock_clone_or_update: MagicMock,
     mock_install_meta_finder: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A shorthand source is logged as written in the yaml, not as the normalized git url."""
+    """A git source with a ref logs the ref appended to the url."""
     mock_clone_or_update.return_value = (tmp_path, None)
     config = _make_config(tmp_path)
     config[CONF_EXTERNAL_COMPONENTS][0][CONF_SOURCE] = "github://test/components@main"
@@ -118,8 +118,7 @@ def test_external_components_override_log_shows_shorthand_source(
     with caplog.at_level(logging.INFO):
         do_external_components_pass(config)
 
-    assert "  source: github://test/components@main\n" in caplog.text
-    assert "github.com" not in caplog.text
+    assert "  source: https://github.com/test/components.git@main\n" in caplog.text
 
 
 def test_external_components_no_override_no_log(


### PR DESCRIPTION
# What does this implement/fix?

External components can silently shadow built-in components of the same name, and nothing in the build output indicates this is happening. This adds an info log at the start of the build (right after "Reading configuration") listing which built-in components are overridden by each `external_components` source:

```
INFO External components are overriding built-in components:
  source: https://github.com/luar123/zigbee_esphome.git@main
  components: zigbee
```

The ref is appended to the url when set. Sources that don't shadow any built-in component log nothing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
external_components:
  - source: github://luar123/zigbee_esphome@main
    components: [zigbee]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).