### PR TITLE
[improv_base] Bump Improv library to 1.2.7

### DIFF
--- a/esphome/components/improv_base/__init__.py
+++ b/esphome/components/improv_base/__init__.py
@@ -43,4 +43,4 @@ async def setup_improv_core(var: MockObj, config: ConfigType, component: str) ->
         cg.add(var.set_next_url(_process_next_url(next_url)))
         cg.add_define(f"USE_{component.upper()}_NEXT_URL")
 
-    cg.add_library("improv/Improv", "1.2.6")
+    cg.add_library("improv/Improv", "1.2.7")

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,7 @@ lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
     esphome/noise-c@0.1.21                 ; noise (api, ota)
-    improv/Improv@1.2.6                    ; improv_serial / esp32_improv
+    improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
     https://github.com/bitbank2/JPEGDEC.git#1.8.4    ; online_image
@@ -248,7 +248,7 @@ lib_deps =
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
-    improv/Improv@1.2.6                   ; improv_serial
+    improv/Improv@1.2.7                   ; improv_serial
     kikuchan98/pngle@1.1.0                ; online_image
     https://github.com/bitbank2/JPEGDEC.git#1.8.4    ; online_image
 build_flags =


### PR DESCRIPTION
# What does this implement/fix?

Bumps the bundled Improv library from 1.2.6 to 1.2.7 ([release notes](https://github.com/improv-wifi/sdk-cpp/releases/tag/v1.2.7)).

The new version adds the buffer based `RpcResponseBuilder` (improv-wifi/sdk-cpp#43), which encodes an RPC response into a caller provided fixed size buffer with no heap allocation. All changes are additive; there is no behavior change for existing `improv_serial` / `esp32_improv` code.

Split out of #18793 so the library bump can merge independently; #18793 migrates the components to the new API.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- improv-wifi/sdk-cpp#43

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes; existing configs are unaffected
wifi:
  ssid: MySSID
  password: password1

logger:

improv_serial:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
