### PR TITLE
[mipi_rgb] Add Elecrow Crowpanel Advance 7

### DIFF
--- a/esphome/components/mipi_rgb/models/elecrow.py
+++ b/esphome/components/mipi_rgb/models/elecrow.py
@@ -1,0 +1,28 @@
+from . import RgbDriverChip
+
+# fmt: off
+RgbDriverChip(
+    "CROWPANEL-ADVANCE-7",
+    requires={"psram"},
+    initsequence=(),
+    pclk_frequency="20MHz",
+    hsync_pulse_width=4,
+    hsync_front_porch=8,
+    hsync_back_porch=8,
+    vsync_pulse_width=4,
+    vsync_front_porch=8,
+    vsync_back_porch=8,
+    pclk_inverted=True,
+    color_order="RGB",
+    width=800,
+    height=480,
+    de_pin=42,
+    hsync_pin=40,
+    vsync_pin=41,
+    pclk_pin=39,
+    data_pins={
+        "red": [7, 17, 18, 3, 46],
+        "green": [9, 10, 11, 12, 13, 14],
+        "blue": [21, 47, 48, 45, 38],
+    },
+)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7281

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
