### PR TITLE
[ci] Compress the compile-test image with zstd

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -119,16 +119,18 @@ jobs:
       # pushed image) keeps it working for fork PRs, which never push to ghcr.io.
       - name: Export image for compile-test
         if: matrix.os == 'ubuntu-24.04' && matrix.build_type == 'docker'
-        run: docker save "ghcr.io/esphome/esphome-amd64:${{ steps.tag.outputs.tag }}" | gzip > compile-test-image.tar.gz
+        # zstd over gzip: docker load auto-detects it, and every compile-test
+        # job pays the decompress (single-threaded gunzip took ~18s per job)
+        run: docker save "ghcr.io/esphome/esphome-amd64:${{ steps.tag.outputs.tag }}" | zstd -T0 -3 > compile-test-image.tar.zst
 
       - name: Upload compile-test image artifact
         if: matrix.os == 'ubuntu-24.04' && matrix.build_type == 'docker'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # The tar is already gzipped, so upload it as-is. archive: false skips
-          # the redundant zip and makes the file name the artifact name (the
-          # `name` input is ignored in that mode).
-          path: compile-test-image.tar.gz
+          # The tar is already compressed, so upload it as-is. archive: false
+          # skips the redundant zip and makes the file name the artifact name
+          # (the `name` input is ignored in that mode).
+          path: compile-test-image.tar.zst
           retention-days: 1
           archive: false
 
@@ -206,9 +208,9 @@ jobs:
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: compile-test-image.tar.gz
+          name: compile-test-image.tar.zst
       - name: Load image
-        run: docker load --input compile-test-image.tar.gz
+        run: docker load --input compile-test-image.tar.zst
       - name: Compile ${{ matrix.id }}
         run: |
           docker run --rm \

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -119,8 +119,12 @@ jobs:
       # pushed image) keeps it working for fork PRs, which never push to ghcr.io.
       - name: Export image for compile-test
         if: matrix.os == 'ubuntu-24.04' && matrix.build_type == 'docker'
-        # zstd over gzip: docker load auto-detects it, and every compile-test
-        # job pays the decompress (single-threaded gunzip took ~18s per job)
+        # zstd over gzip: docker save is on the critical path for every
+        # compile-test job, and zstd -T0 is multithreaded (export 50s -> 9s).
+        # docker load auto-detects the format; its time is layer extraction,
+        # not decompression, so it is unchanged. shell: bash adds pipefail so
+        # a failed docker save cannot upload a truncated artifact.
+        shell: bash
         run: docker save "ghcr.io/esphome/esphome-amd64:${{ steps.tag.outputs.tag }}" | zstd -T0 -3 > compile-test-image.tar.zst
 
       - name: Upload compile-test image artifact


### PR DESCRIPTION
# What does this implement/fix?

Compresses the compile-test image artifact with zstd instead of gzip.

Measured on this PR's own run against the previous gzip run: the export step (docker save piped through the compressor) drops from 50 seconds to 9 seconds, because zstd is multithreaded where gzip is not. Every compile smoke test job waits on that artifact before it can start, so this takes about 40 seconds off the end to end pipeline per CI run. The artifact also shrinks from 360 MB to 342 MB.

The docker load step itself is unchanged (median 18s before, 17s after, over all matrix jobs): its time goes to layer verification and extraction into storage, not decompression. docker load auto detects zstd and the runners ship it preinstalled.

CI only: the artifact lives one day and is consumed solely by the smoke test jobs in the same workflow. The images published to registries are built and pushed by buildx in a separate step and are not touched.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; CI-only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome.io).
