### PR TITLE
[whynter] Fix truncating Fahrenheit temps that should be rounded

### DIFF
--- a/esphome/components/whynter/whynter.cpp
+++ b/esphome/components/whynter/whynter.cpp
@@ -85,7 +85,7 @@ void Whynter::transmit_state() {
   if (fahrenheit_) {
     remote_state |= UNIT_MASK;
     uint8_t temp =
-        (uint8_t) clamp<float>(esphome::celsius_to_fahrenheit(this->target_temperature), TEMP_MIN_F, TEMP_MAX_F);
+        (uint8_t) roundf(clamp<float>(esphome::celsius_to_fahrenheit(this->target_temperature), TEMP_MIN_F, TEMP_MAX_F));
     temp = esphome::reverse_bits(temp);
     remote_state |= temp;
   } else {

--- a/esphome/components/whynter/whynter.cpp
+++ b/esphome/components/whynter/whynter.cpp
@@ -84,8 +84,8 @@ void Whynter::transmit_state() {
 
   if (fahrenheit_) {
     remote_state |= UNIT_MASK;
-    uint8_t temp =
-        (uint8_t) roundf(clamp<float>(esphome::celsius_to_fahrenheit(this->target_temperature), TEMP_MIN_F, TEMP_MAX_F));
+    uint8_t temp = (uint8_t) roundf(
+        clamp<float>(esphome::celsius_to_fahrenheit(this->target_temperature), TEMP_MIN_F, TEMP_MAX_F));
     temp = esphome::reverse_bits(temp);
     remote_state |= temp;
   } else {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a floating-point truncation bug in the `whynter` climate component when `use_fahrenheit: true` is enabled.

ESPHome internally stores `this->target_temperature` in Celsius. When it converts back to Fahrenheit in `transmit_state()`, it uses floating-point arithmetic (e.g., 71°F → 21.6667°C → 70.999999°F) combined with a direct `(uint8_t)` cast and it caused the temperature byte to truncate down to 70 instead of rounding to 71 which simply looks like a oversight, since the Celsius conversion just above it uses `roundf()`. So in practice, each time I set a temp, it would choose one less on the actual A/C.

So this just adds the `roundf()` in the F conversion. Made sure it matched other systems that use Fahrenheit, like [`midea_ir.cpp:20`](https://github.com/esphome/esphome/blob/dev/esphome/components/midea_ir/midea_ir.cpp#L20) (`lroundf(temp)`) and Mitsubishi: [`mitsubishi_cn105_component.h:21`](https://github.com/esphome/esphome/blob/dev/esphome/components/mitsubishi_cn105/mitsubishi_cn105_component.h#L21) (`std::round(value)`).

## Types of changes

 - [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:

```yaml
    climate:
      - platform: whynter
        name: "Portable AC"
        transmitter_id: ir_tx
        use_fahrenheit: true
```
## Checklist:

[✓] The code change is tested and works locally.
