### PR TITLE
[hlk_fm22x] Make the face recognition integration more complete

### DIFF
--- a/esphome/components/hlk_fm22x/__init__.py
+++ b/esphome/components/hlk_fm22x/__init__.py
@@ -1,3 +1,6 @@
+import logging
+from typing import Any
+
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import uart
@@ -8,7 +11,14 @@ from esphome.const import (
     CONF_NAME,
     CONF_ON_ENROLLMENT_DONE,
     CONF_ON_ENROLLMENT_FAILED,
+    CONF_TIMEOUT,
+    CONF_UPDATE_INTERVAL,
 )
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArguments
+from esphome.types import ConfigType, TemplateArgsType
+
+_LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@OnFreund"]
 DEPENDENCIES = ["uart"]
@@ -17,23 +27,78 @@ MULTI_CONF = True
 
 CONF_HLK_FM22X_ID = "hlk_fm22x_id"
 CONF_FACE_ID = "face_id"
+CONF_ADMIN = "admin"
+CONF_ALLOW_DUPLICATE = "allow_duplicate"
 CONF_ON_FACE_SCAN_MATCHED = "on_face_scan_matched"
 CONF_ON_FACE_SCAN_UNMATCHED = "on_face_scan_unmatched"
 CONF_ON_FACE_SCAN_INVALID = "on_face_scan_invalid"
 CONF_ON_FACE_INFO = "on_face_info"
+CONF_ON_FACE_DETAILS = "on_face_details"
+
+ICON_FACE_RECOGNITION = "mdi:face-recognition"
+
+# The module only talks at this speed; other rates can only be set in its firmware update mode
+BAUD_RATE = 115200
+# The module stores names in a 32 byte field; one byte is kept for the terminating NUL
+MAX_NAME_LENGTH = 31
 
 hlk_fm22x_ns = cg.esphome_ns.namespace("hlk_fm22x")
 HlkFm22xComponent = hlk_fm22x_ns.class_(
-    "HlkFm22xComponent", cg.PollingComponent, uart.UARTDevice
+    "HlkFm22xComponent", cg.Component, uart.UARTDevice
 )
+HlkFm22xFaceDirection = hlk_fm22x_ns.enum("HlkFm22xFaceDirection")
 
 EnrollmentAction = hlk_fm22x_ns.class_("EnrollmentAction", automation.Action)
+ScanAction = hlk_fm22x_ns.class_("ScanAction", automation.Action)
+CancelAction = hlk_fm22x_ns.class_("CancelAction", automation.Action)
 DeleteAction = hlk_fm22x_ns.class_("DeleteAction", automation.Action)
 DeleteAllAction = hlk_fm22x_ns.class_("DeleteAllAction", automation.Action)
-ScanAction = hlk_fm22x_ns.class_("ScanAction", automation.Action)
+GetFaceDetailsAction = hlk_fm22x_ns.class_("GetFaceDetailsAction", automation.Action)
 ResetAction = hlk_fm22x_ns.class_("ResetAction", automation.Action)
 
+FACE_DIRECTIONS = {
+    "middle": HlkFm22xFaceDirection.FACE_DIRECTION_MIDDLE,
+    "right": HlkFm22xFaceDirection.FACE_DIRECTION_RIGHT,
+    "left": HlkFm22xFaceDirection.FACE_DIRECTION_LEFT,
+    "down": HlkFm22xFaceDirection.FACE_DIRECTION_DOWN,
+    "up": HlkFm22xFaceDirection.FACE_DIRECTION_UP,
+}
+
+# Scans and enrollments accept a timeout of 1 to 255 seconds
+TIMEOUT_SCHEMA = cv.All(
+    cv.positive_time_period_seconds,
+    cv.Range(min=cv.TimePeriod(seconds=1), max=cv.TimePeriod(seconds=255)),
+)
+
+
+def validate_direction(value: Any) -> Any:
+    """Accept a direction name or the module's own numeric code."""
+    if isinstance(value, str):
+        return cv.enum(FACE_DIRECTIONS, lower=True)(value)
+    return cv.uint8_t(value)
+
+
+def validate_name(value: Any) -> str:
+    value = cv.string(value)
+    if len(value.encode("utf-8")) > MAX_NAME_LENGTH:
+        raise cv.Invalid(f"Names are limited to {MAX_NAME_LENGTH} bytes of ASCII text")
+    return value
+
+
+def _remove_update_interval(config: Any) -> Any:
+    # Remove before 2027.3.0
+    if isinstance(config, dict) and CONF_UPDATE_INTERVAL in config:
+        _LOGGER.warning(
+            "[hlk_fm22x] 'update_interval' is no longer used because the module is "
+            "read continuously. Will be removed in 2027.3.0"
+        )
+        config = config.copy()
+        del config[CONF_UPDATE_INTERVAL]
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
+    _remove_update_interval,
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(HlkFm22xComponent),
@@ -43,12 +108,17 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_ON_FACE_SCAN_INVALID): automation.validate_automation({}),
             cv.Optional(CONF_ON_FACE_INFO): automation.validate_automation({}),
+            cv.Optional(CONF_ON_FACE_DETAILS): automation.validate_automation({}),
             cv.Optional(CONF_ON_ENROLLMENT_DONE): automation.validate_automation({}),
             cv.Optional(CONF_ON_ENROLLMENT_FAILED): automation.validate_automation({}),
         }
     )
-    .extend(cv.polling_component_schema("50ms"))
+    .extend(cv.COMPONENT_SCHEMA)
     .extend(uart.UART_DEVICE_SCHEMA),
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "hlk_fm22x", baud_rate=BAUD_RATE, require_tx=True, require_rx=True
 )
 
 
@@ -56,7 +126,7 @@ _CALLBACK_AUTOMATIONS = (
     automation.CallbackAutomation(
         CONF_ON_FACE_SCAN_MATCHED,
         "add_on_face_scan_matched_callback",
-        [(cg.int16, "face_id"), (cg.std_string, "name")],
+        [(cg.int16, "face_id"), (cg.std_string, "name"), (cg.bool_, "admin")],
     ),
     automation.CallbackAutomation(
         CONF_ON_FACE_SCAN_UNMATCHED, "add_on_face_scan_unmatched_callback"
@@ -81,6 +151,11 @@ _CALLBACK_AUTOMATIONS = (
         ],
     ),
     automation.CallbackAutomation(
+        CONF_ON_FACE_DETAILS,
+        "add_on_face_details_callback",
+        [(cg.int16, "face_id"), (cg.std_string, "name"), (cg.bool_, "admin")],
+    ),
+    automation.CallbackAutomation(
         CONF_ON_ENROLLMENT_DONE,
         "add_on_enrollment_done_callback",
         [(cg.int16, "face_id"), (cg.uint8, "direction")],
@@ -93,12 +168,20 @@ _CALLBACK_AUTOMATIONS = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
     await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)
+
+
+async def _new_action(
+    config: ConfigType, action_id: ID, template_arg: TemplateArguments
+) -> MockObj:
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
 
 
 @automation.register_action(
@@ -107,22 +190,76 @@ async def to_code(config):
     cv.maybe_simple_value(
         {
             cv.GenerateID(): cv.use_id(HlkFm22xComponent),
-            cv.Required(CONF_NAME): cv.templatable(cv.string),
-            cv.Required(CONF_DIRECTION): cv.templatable(cv.uint8_t),
+            cv.Required(CONF_NAME): cv.templatable(validate_name),
+            cv.Optional(CONF_DIRECTION): cv.templatable(validate_direction),
+            cv.Optional(CONF_ADMIN, default=False): cv.templatable(cv.boolean),
+            cv.Optional(CONF_TIMEOUT, default="10s"): TIMEOUT_SCHEMA,
+            cv.Optional(CONF_ALLOW_DUPLICATE, default=True): cv.templatable(cv.boolean),
         },
         key=CONF_NAME,
     ),
     synchronous=True,
 )
-async def hlk_fm22x_enroll_to_code(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-
+async def hlk_fm22x_enroll_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = await _new_action(config, action_id, template_arg)
     template_ = await cg.templatable(config[CONF_NAME], args, cg.std_string)
     cg.add(var.set_name(template_))
-    template_ = await cg.templatable(config[CONF_DIRECTION], args, cg.uint8)
-    cg.add(var.set_direction(template_))
+    # Without a direction the face is enrolled from a single frame
+    if (direction := config.get(CONF_DIRECTION)) is not None:
+        template_ = await cg.templatable(direction, args, cg.uint8)
+        cg.add(var.set_direction(template_))
+    template_ = await cg.templatable(config[CONF_ADMIN], args, cg.bool_)
+    cg.add(var.set_admin(template_))
+    template_ = await cg.templatable(config[CONF_ALLOW_DUPLICATE], args, cg.bool_)
+    cg.add(var.set_allow_duplicate(template_))
+    cg.add(var.set_timeout_seconds(int(config[CONF_TIMEOUT].total_seconds)))
     return var
+
+
+@automation.register_action(
+    "hlk_fm22x.scan",
+    ScanAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(HlkFm22xComponent),
+            cv.Optional(CONF_TIMEOUT, default="10s"): TIMEOUT_SCHEMA,
+        }
+    ),
+    synchronous=True,
+)
+async def hlk_fm22x_scan_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = await _new_action(config, action_id, template_arg)
+    cg.add(var.set_timeout_seconds(int(config[CONF_TIMEOUT].total_seconds)))
+    return var
+
+
+@automation.register_action(
+    "hlk_fm22x.cancel",
+    CancelAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(HlkFm22xComponent),
+        }
+    ),
+    synchronous=True,
+)
+async def hlk_fm22x_cancel_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    return await _new_action(config, action_id, template_arg)
 
 
 @automation.register_action(
@@ -137,10 +274,13 @@ async def hlk_fm22x_enroll_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def hlk_fm22x_delete_to_code(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-
+async def hlk_fm22x_delete_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = await _new_action(config, action_id, template_arg)
     template_ = await cg.templatable(config[CONF_FACE_ID], args, cg.int16)
     cg.add(var.set_face_id(template_))
     return var
@@ -156,25 +296,36 @@ async def hlk_fm22x_delete_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def hlk_fm22x_delete_all_to_code(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    return var
+async def hlk_fm22x_delete_all_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    return await _new_action(config, action_id, template_arg)
 
 
 @automation.register_action(
-    "hlk_fm22x.scan",
-    ScanAction,
-    cv.Schema(
+    "hlk_fm22x.get_face_details",
+    GetFaceDetailsAction,
+    cv.maybe_simple_value(
         {
             cv.GenerateID(): cv.use_id(HlkFm22xComponent),
-        }
+            cv.Required(CONF_FACE_ID): cv.templatable(cv.int_range(min=0, max=32767)),
+        },
+        key=CONF_FACE_ID,
     ),
     synchronous=True,
 )
-async def hlk_fm22x_scan_to_code(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
+async def hlk_fm22x_get_face_details_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = await _new_action(config, action_id, template_arg)
+    template_ = await cg.templatable(config[CONF_FACE_ID], args, cg.int16)
+    cg.add(var.set_face_id(template_))
     return var
 
 
@@ -188,7 +339,10 @@ async def hlk_fm22x_scan_to_code(config, action_id, template_arg, args):
     ),
     synchronous=True,
 )
-async def hlk_fm22x_reset_to_code(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    return var
+async def hlk_fm22x_reset_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    return await _new_action(config, action_id, template_arg)

--- a/esphome/components/hlk_fm22x/__init__.py
+++ b/esphome/components/hlk_fm22x/__init__.py
@@ -42,6 +42,9 @@ BAUD_RATE = 115200
 # The module stores names in a 32 byte field; one byte is kept for the terminating NUL
 MAX_NAME_LENGTH = 31
 
+# Trigger strings are passed by const reference so nothing is copied per call
+STRING_ARG = cg.std_string_ref.operator("const")
+
 hlk_fm22x_ns = cg.esphome_ns.namespace("hlk_fm22x")
 HlkFm22xComponent = hlk_fm22x_ns.class_(
     "HlkFm22xComponent", cg.Component, uart.UARTDevice
@@ -126,7 +129,7 @@ _CALLBACK_AUTOMATIONS = (
     automation.CallbackAutomation(
         CONF_ON_FACE_SCAN_MATCHED,
         "add_on_face_scan_matched_callback",
-        [(cg.int16, "face_id"), (cg.std_string, "name"), (cg.bool_, "admin")],
+        [(cg.int16, "face_id"), (STRING_ARG, "name"), (cg.bool_, "admin")],
     ),
     automation.CallbackAutomation(
         CONF_ON_FACE_SCAN_UNMATCHED, "add_on_face_scan_unmatched_callback"
@@ -153,7 +156,7 @@ _CALLBACK_AUTOMATIONS = (
     automation.CallbackAutomation(
         CONF_ON_FACE_DETAILS,
         "add_on_face_details_callback",
-        [(cg.int16, "face_id"), (cg.std_string, "name"), (cg.bool_, "admin")],
+        [(cg.int16, "face_id"), (STRING_ARG, "name"), (cg.bool_, "admin")],
     ),
     automation.CallbackAutomation(
         CONF_ON_ENROLLMENT_DONE,

--- a/esphome/components/hlk_fm22x/binary_sensor.py
+++ b/esphome/components/hlk_fm22x/binary_sensor.py
@@ -1,13 +1,38 @@
+import logging
+from typing import Any
+
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ICON, ICON_KEY_PLUS
+from esphome.const import CONF_ICON, CONF_ID, CONF_NAME, ICON_KEY_PLUS
+from esphome.types import ConfigType
 
-from . import CONF_HLK_FM22X_ID, HlkFm22xComponent
+from . import CONF_HLK_FM22X_ID, ICON_FACE_RECOGNITION, HlkFm22xComponent
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["hlk_fm22x"]
 
-CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
+CONF_ENROLLING = "enrolling"
+CONF_SCANNING = "scanning"
+
+SENSOR_KEYS = (CONF_ENROLLING, CONF_SCANNING)
+
+_KEYED_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_HLK_FM22X_ID): cv.use_id(HlkFm22xComponent),
+        cv.Optional(CONF_ENROLLING): binary_sensor.binary_sensor_schema(
+            icon=ICON_KEY_PLUS
+        ),
+        cv.Optional(CONF_SCANNING): binary_sensor.binary_sensor_schema(
+            icon=ICON_FACE_RECOGNITION
+        ),
+    }
+)
+
+# Older configs describe the enrolling sensor directly under the platform entry.
+# Remove before 2027.3.0
+_LEGACY_SCHEMA = binary_sensor.binary_sensor_schema().extend(
     {
         cv.GenerateID(CONF_HLK_FM22X_ID): cv.use_id(HlkFm22xComponent),
         cv.Optional(CONF_ICON, default=ICON_KEY_PLUS): cv.icon,
@@ -15,7 +40,29 @@ CONFIG_SCHEMA = binary_sensor.binary_sensor_schema().extend(
 )
 
 
-async def to_code(config):
+def _validate(config: Any) -> ConfigType:
+    # An entity name or id at the top level can only come from the old single sensor form
+    if isinstance(config, dict) and (CONF_NAME in config or CONF_ID in config):
+        # Remove before 2027.3.0
+        _LOGGER.warning(
+            "[hlk_fm22x] Configuring the enrolling binary sensor directly under the "
+            "platform is deprecated, move its options under 'enrolling:'. "
+            "Will be removed in 2027.3.0"
+        )
+        legacy = _LEGACY_SCHEMA(config)
+        return {
+            CONF_HLK_FM22X_ID: legacy.pop(CONF_HLK_FM22X_ID),
+            CONF_ENROLLING: legacy,
+        }
+    return _KEYED_SCHEMA(config)
+
+
+CONFIG_SCHEMA = _validate
+
+
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_HLK_FM22X_ID])
-    var = await binary_sensor.new_binary_sensor(config)
-    cg.add(hub.set_enrolling_binary_sensor(var))
+    for key in SENSOR_KEYS:
+        if (conf := config.get(key)) is not None:
+            sens = await binary_sensor.new_binary_sensor(conf)
+            cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -7,7 +7,6 @@
 namespace esphome::hlk_fm22x {
 
 static const char *const TAG = "hlk_fm22x";
-static constexpr uint32_t BAUD_RATE = 115200;
 // Longest pause allowed between two bytes of one frame before the parser looks for a new frame
 static constexpr uint32_t FRAME_TIMEOUT_MS = 100;
 // The module answers most commands within 2 s and deletes within 5 s
@@ -223,8 +222,9 @@ void HlkFm22xComponent::enroll_face(const std::string &name, HlkFm22xFaceDirecti
     timeout_s = HLK_FM22X_DEFAULT_TIMEOUT_S;
   }
   const bool single_frame = direction == HlkFm22xFaceDirection::FACE_DIRECTION_UNDEFINED;
-  ESP_LOGI(TAG, "Enrolling '%s'%s, %s, timeout %us", name.c_str(), admin ? " as admin" : "",
-           single_frame ? "single frame" : "one direction", timeout_s);
+  ESP_LOGI(TAG, "Enrolling '%s'%s, %s, timeout %us", name.c_str(),
+           admin ? LOG_STR_LITERAL(" as admin") : LOG_STR_LITERAL(""),
+           single_frame ? LOG_STR_LITERAL("single frame") : LOG_STR_LITERAL("one direction"), timeout_s);
   const uint16_t reply_timeout_s = timeout_s + ALGORITHM_TIMEOUT_MARGIN_S;
 
   uint8_t data[HLK_FM22X_MAX_COMMAND_SIZE]{};
@@ -258,7 +258,7 @@ void HlkFm22xComponent::cancel() {
   this->drop_queued_(is_scan_or_enroll);
   if (is_scan_or_enroll(this->pending_command_)) {
     const bool enrolling = this->pending_command_ != HlkFm22xCommand::VERIFY;
-    ESP_LOGI(TAG, "Cancelling %s", enrolling ? "enrollment" : "scan");
+    ESP_LOGI(TAG, "Cancelling %s", enrolling ? LOG_STR_LITERAL("enrollment") : LOG_STR_LITERAL("scan"));
     // RESET makes the module stop what it is doing; FACE_RESET then forgets the directions captured so far
     this->interrupt_with_(HlkFm22xCommand::RESET);
     if (enrolling) {
@@ -615,7 +615,8 @@ void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
     case HlkFm22xCommand::DELETE_FACE:
     case HlkFm22xCommand::DELETE_ALL_FACES:
       if (result == HlkFm22xResult::SUCCEEDED) {
-        ESP_LOGI(TAG, "%s deleted", command == HlkFm22xCommand::DELETE_FACE ? "Face" : "All faces");
+        ESP_LOGI(TAG, "%s deleted",
+                 command == HlkFm22xCommand::DELETE_FACE ? LOG_STR_LITERAL("Face") : LOG_STR_LITERAL("All faces"));
       }
       this->refresh_face_count_();
       break;
@@ -655,7 +656,8 @@ void HlkFm22xComponent::handle_scan_reply_(uint8_t result, const uint8_t *data, 
       this->face_scan_invalid_callback_.call(HlkFm22xResult::FAILED4_UNKNOWNREASON);
       return;
     }
-    ESP_LOGI(TAG, "Face matched: ID %d, name '%.*s'%s", face_id, (int) name_length, name, admin ? " (admin)" : "");
+    ESP_LOGI(TAG, "Face matched: ID %d, name '%.*s'%s", face_id, (int) name_length, name,
+             admin ? LOG_STR_LITERAL(" (admin)") : LOG_STR_LITERAL(""));
     if (this->last_face_id_sensor_ != nullptr) {
       this->last_face_id_sensor_->publish_state(face_id);
     }
@@ -714,7 +716,8 @@ void HlkFm22xComponent::handle_face_details_reply_(uint8_t result, const uint8_t
     ESP_LOGE(TAG, "Face details reply too short: %zu bytes", length);
     return;
   }
-  ESP_LOGD(TAG, "Face %d: name '%.*s'%s", face_id, (int) name_length, name, admin ? " (admin)" : "");
+  ESP_LOGD(TAG, "Face %d: name '%.*s'%s", face_id, (int) name_length, name,
+           admin ? LOG_STR_LITERAL(" (admin)") : LOG_STR_LITERAL(""));
   this->face_details_callback_.call(face_id, std::string(name, name_length), admin);
 }
 
@@ -867,7 +870,6 @@ void HlkFm22xComponent::publish_face_state_(int16_t state) {
 
 void HlkFm22xComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "HLK-FM22X:");
-  this->check_uart_settings(BAUD_RATE);
   LOG_BINARY_SENSOR("  ", "Enrolling", this->enrolling_binary_sensor_);
   LOG_BINARY_SENSOR("  ", "Scanning", this->scanning_binary_sensor_);
   LOG_SENSOR("  ", "Face Count", this->face_count_sensor_);

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -45,6 +45,28 @@ static constexpr uint8_t READ_OUT_STAGE_DONE = 4;
 static constexpr int16_t FACE_ID_INCOMPLETE = -1;
 static constexpr int16_t FACE_STATE_IDLE = -1;
 
+/// Length of the leading run of printable ASCII in a fixed width text field.
+///
+/// The module pads these fields to a fixed width and is not consistent about what it pads
+/// with: names come back NUL padded, but the serial number is padded with arbitrary bytes
+/// (0xFF and friends). Those bytes are not valid UTF-8, and publishing them produces a
+/// state string that clients such as Home Assistant refuse to decode, so stop at the first
+/// byte that cannot be part of a plain text string.
+static size_t printable_length(const char *text, size_t max_length) {
+  size_t length = 0;
+  while (length < max_length) {
+    const auto c = static_cast<unsigned char>(text[length]);
+    if (c < 0x20 || c > 0x7E) {
+      break;
+    }
+    length++;
+  }
+  while (length > 0 && text[length - 1] == ' ') {
+    length--;
+  }
+  return length;
+}
+
 static const LogString *result_to_string(uint8_t result) {
   switch (result) {
     case HlkFm22xResult::SUCCEEDED:
@@ -266,9 +288,8 @@ bool HlkFm22xComponent::parse_face_record_(const uint8_t *data, size_t length, i
     return false;
   }
   face_id = (int16_t) encode_uint16(data[2], data[3]);
-  // The name is NUL padded to a fixed width
   name = reinterpret_cast<const char *>(data + 4);
-  name_length = strnlen(name, HLK_FM22X_NAME_SIZE);
+  name_length = printable_length(name, HLK_FM22X_NAME_SIZE);
   admin = length > FACE_RECORD_ADMIN_OFFSET && data[FACE_RECORD_ADMIN_OFFSET] != 0;
   return true;
 }
@@ -698,9 +719,8 @@ void HlkFm22xComponent::handle_face_details_reply_(uint8_t result, const uint8_t
 }
 
 void HlkFm22xComponent::publish_text_(text_sensor::TextSensor *text_sensor, const uint8_t *data, size_t length) {
-  // Strings are NUL padded to a fixed width; publish only the text in front of the padding
   const char *text = reinterpret_cast<const char *>(data);
-  const size_t text_length = strnlen(text, length);
+  const size_t text_length = printable_length(text, length);
   ESP_LOGD(TAG, "Module reports: %.*s", (int) text_length, text);
   if (text_sensor != nullptr) {
     text_sensor->publish_state(text, text_length);

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -67,6 +67,35 @@ static size_t printable_length(const char *text, size_t max_length) {
   return length;
 }
 
+static bool is_scan_or_enroll(HlkFm22xCommand command) {
+  return command == HlkFm22xCommand::VERIFY || command == HlkFm22xCommand::ENROLL ||
+         command == HlkFm22xCommand::ENROLL_SINGLE || command == HlkFm22xCommand::ENROLL_ITG;
+}
+
+static bool is_read_out(HlkFm22xCommand command) {
+  return command == HlkFm22xCommand::GET_STATUS || command == HlkFm22xCommand::GET_VERSION ||
+         command == HlkFm22xCommand::GET_SERIAL_NUMBER || command == HlkFm22xCommand::GET_ALL_FACE_IDS;
+}
+
+static uint16_t default_timeout_s(HlkFm22xCommand command) {
+  if (command == HlkFm22xCommand::DELETE_FACE || command == HlkFm22xCommand::DELETE_ALL_FACES) {
+    return DELETE_TIMEOUT_S;
+  }
+  return COMMAND_TIMEOUT_S;
+}
+
+static bool parse_face_record(const uint8_t *data, size_t length, int16_t &face_id, const char *&name,
+                              size_t &name_length, bool &admin) {
+  if (length < FACE_RECORD_MIN_SIZE) {
+    return false;
+  }
+  face_id = (int16_t) encode_uint16(data[2], data[3]);
+  name = reinterpret_cast<const char *>(data + 4);
+  name_length = printable_length(name, HLK_FM22X_NAME_SIZE);
+  admin = length > FACE_RECORD_ADMIN_OFFSET && data[FACE_RECORD_ADMIN_OFFSET] != 0;
+  return true;
+}
+
 static const LogString *result_to_string(uint8_t result) {
   switch (result) {
     case HlkFm22xResult::SUCCEEDED:
@@ -226,8 +255,8 @@ void HlkFm22xComponent::scan_face(uint8_t timeout_s) {
 }
 
 void HlkFm22xComponent::cancel() {
-  this->drop_queued_(is_scan_or_enroll_);
-  if (is_scan_or_enroll_(this->pending_command_)) {
+  this->drop_queued_(is_scan_or_enroll);
+  if (is_scan_or_enroll(this->pending_command_)) {
     const bool enrolling = this->pending_command_ != HlkFm22xCommand::VERIFY;
     ESP_LOGI(TAG, "Cancelling %s", enrolling ? "enrollment" : "scan");
     // RESET makes the module stop what it is doing; FACE_RESET then forgets the directions captured so far
@@ -258,40 +287,11 @@ void HlkFm22xComponent::get_face_details(int16_t face_id) {
 
 void HlkFm22xComponent::reset() {
   ESP_LOGI(TAG, "Resetting module");
-  if (is_scan_or_enroll_(this->pending_command_)) {
+  if (is_scan_or_enroll(this->pending_command_)) {
     this->interrupt_with_(HlkFm22xCommand::RESET);
     return;
   }
   this->enqueue_(HlkFm22xCommand::RESET);
-}
-
-bool HlkFm22xComponent::is_scan_or_enroll_(HlkFm22xCommand command) {
-  return command == HlkFm22xCommand::VERIFY || command == HlkFm22xCommand::ENROLL ||
-         command == HlkFm22xCommand::ENROLL_SINGLE || command == HlkFm22xCommand::ENROLL_ITG;
-}
-
-bool HlkFm22xComponent::is_read_out_(HlkFm22xCommand command) {
-  return command == HlkFm22xCommand::GET_STATUS || command == HlkFm22xCommand::GET_VERSION ||
-         command == HlkFm22xCommand::GET_SERIAL_NUMBER || command == HlkFm22xCommand::GET_ALL_FACE_IDS;
-}
-
-uint16_t HlkFm22xComponent::default_timeout_s_(HlkFm22xCommand command) {
-  if (command == HlkFm22xCommand::DELETE_FACE || command == HlkFm22xCommand::DELETE_ALL_FACES) {
-    return DELETE_TIMEOUT_S;
-  }
-  return COMMAND_TIMEOUT_S;
-}
-
-bool HlkFm22xComponent::parse_face_record_(const uint8_t *data, size_t length, int16_t &face_id, const char *&name,
-                                           size_t &name_length, bool &admin) {
-  if (length < FACE_RECORD_MIN_SIZE) {
-    return false;
-  }
-  face_id = (int16_t) encode_uint16(data[2], data[3]);
-  name = reinterpret_cast<const char *>(data + 4);
-  name_length = printable_length(name, HLK_FM22X_NAME_SIZE);
-  admin = length > FACE_RECORD_ADMIN_OFFSET && data[FACE_RECORD_ADMIN_OFFSET] != 0;
-  return true;
 }
 
 bool HlkFm22xComponent::enqueue_(HlkFm22xCommand command, const uint8_t *data, size_t size, uint16_t timeout_s) {
@@ -302,7 +302,7 @@ bool HlkFm22xComponent::enqueue_(HlkFm22xCommand command, const uint8_t *data, s
   QueuedCommand queued{};
   queued.command = command;
   queued.size = (uint8_t) size;
-  queued.timeout_s = timeout_s != 0 ? timeout_s : default_timeout_s_(command);
+  queued.timeout_s = timeout_s != 0 ? timeout_s : default_timeout_s(command);
   if (size > 0) {
     memcpy(queued.data, data, size);
   }
@@ -341,7 +341,7 @@ void HlkFm22xComponent::send_next_command_() {
   this->pending_timeout_ms_ = queued.timeout_s * 1000UL;
   if (queued.command == HlkFm22xCommand::VERIFY) {
     this->set_scanning_(true);
-  } else if (is_scan_or_enroll_(queued.command)) {
+  } else if (is_scan_or_enroll(queued.command)) {
     this->set_enrolling_(true);
   }
   this->queue_.pop();
@@ -508,7 +508,7 @@ void HlkFm22xComponent::handle_note_(const uint8_t *data, size_t length) {
     case HlkFm22xNoteType::NOTE_READY:
       ESP_LOGI(TAG, "Module ready");
       if (this->pending_command_ != HlkFm22xCommand::NONE) {
-        if (is_scan_or_enroll_(this->pending_command_)) {
+        if (is_scan_or_enroll(this->pending_command_)) {
           // The module may still answer the scan or enrollment it was running; give it a moment
           this->hold_interrupted_(this->pending_command_);
           this->interrupted_deadline_ms_ = millis() + INTERRUPT_GRACE_MS;
@@ -557,7 +557,7 @@ void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
   } else if (command == this->interrupted_command_) {
     this->interrupted_command_ = HlkFm22xCommand::NONE;
     this->interrupted_deadline_set_ = false;
-  } else if (is_scan_or_enroll_(command)) {
+  } else if (is_scan_or_enroll(command)) {
     // Its result has already been reported as a timeout or abort
     ESP_LOGW(TAG, "Unexpected reply for command 0x%02X, ignoring", command);
     return;
@@ -637,7 +637,7 @@ void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
   }
 
   // Only one command is ever outstanding, so an expected read-out reply belongs to the running read-out chain
-  if (expected && is_read_out_(command)) {
+  if (expected && is_read_out(command)) {
     this->continue_read_out_();
   }
 }
@@ -650,7 +650,7 @@ void HlkFm22xComponent::handle_scan_reply_(uint8_t result, const uint8_t *data, 
     const char *name;
     size_t name_length;
     bool admin;
-    if (!parse_face_record_(data, length, face_id, name, name_length, admin)) {
+    if (!parse_face_record(data, length, face_id, name, name_length, admin)) {
       ESP_LOGE(TAG, "Scan reply too short: %zu bytes", length);
       this->face_scan_invalid_callback_.call(HlkFm22xResult::FAILED4_UNKNOWNREASON);
       return;
@@ -710,7 +710,7 @@ void HlkFm22xComponent::handle_face_details_reply_(uint8_t result, const uint8_t
   const char *name;
   size_t name_length;
   bool admin;
-  if (!parse_face_record_(data, length, face_id, name, name_length, admin)) {
+  if (!parse_face_record(data, length, face_id, name, name_length, admin)) {
     ESP_LOGE(TAG, "Face details reply too short: %zu bytes", length);
     return;
   }
@@ -791,7 +791,7 @@ void HlkFm22xComponent::finish_failed_(HlkFm22xCommand command, uint8_t error) {
 
 void HlkFm22xComponent::start_read_out_() {
   // Never let two read-out chains run at the same time
-  this->drop_queued_(is_read_out_);
+  this->drop_queued_(is_read_out);
   this->read_out_stage_ = 0;
   this->continue_read_out_();
 }

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -1,359 +1,870 @@
 #include "hlk_fm22x.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
-#include <cinttypes>
+#include <algorithm>
+#include <cstring>
 
 namespace esphome::hlk_fm22x {
 
 static const char *const TAG = "hlk_fm22x";
-static constexpr uint32_t PAYLOAD_TIMEOUT_MS = 20;
+static constexpr uint32_t BAUD_RATE = 115200;
+// Longest pause allowed between two bytes of one frame before the parser looks for a new frame
+static constexpr uint32_t FRAME_TIMEOUT_MS = 100;
+// The module answers most commands within 2 s and deletes within 5 s
+static constexpr uint16_t COMMAND_TIMEOUT_S = 3;
+static constexpr uint16_t DELETE_TIMEOUT_S = 10;
+// Added on top of the timeout handed to the module for scans and enrollments
+static constexpr uint16_t ALGORITHM_TIMEOUT_MARGIN_S = 5;
+// Time an interrupted scan or enrollment gets to send its own reply
+static constexpr uint32_t INTERRUPT_GRACE_MS = 500;
+// Retry interval while the module does not answer, for example because it is still booting
+static constexpr uint32_t RETRY_INTERVAL_MS = 5000;
+// Unanswered commands in a row before the component reports an error instead of a warning
+static constexpr uint8_t TIMEOUTS_BEFORE_ERROR = 3;
+static constexpr size_t FACE_STATE_NOTE_SIZE = 17;  // note id + 8 x int16
+static constexpr size_t FACE_STATE_FIELDS = 8;
+// Scan and face details replies: command(1) + result(1) + face_id(2) + name(32), then the admin flag
+static constexpr size_t FACE_RECORD_MIN_SIZE = 4 + HLK_FM22X_NAME_SIZE;
+static constexpr size_t FACE_RECORD_ADMIN_OFFSET = FACE_RECORD_MIN_SIZE;
+static constexpr size_t ENROLL_REPLY_MIN_SIZE = 5;  // command + result + face_id + direction
+// Enroll payload shared by ENROLL, ENROLL_SINGLE and ENROLL_ITG
+static constexpr size_t ENROLL_ADMIN_OFFSET = 0;
+static constexpr size_t ENROLL_NAME_OFFSET = 1;
+static constexpr size_t ENROLL_DIRECTION_OFFSET = ENROLL_NAME_OFFSET + HLK_FM22X_NAME_SIZE;
+static constexpr size_t ENROLL_TIMEOUT_OFFSET = ENROLL_DIRECTION_OFFSET + 1;
+static constexpr size_t ENROLL_SIZE = ENROLL_TIMEOUT_OFFSET + 1;
+static constexpr size_t ENROLL_ITG_TYPE_OFFSET = ENROLL_DIRECTION_OFFSET + 1;
+static constexpr size_t ENROLL_ITG_DUPLICATE_OFFSET = ENROLL_ITG_TYPE_OFFSET + 1;
+static constexpr size_t ENROLL_ITG_TIMEOUT_OFFSET = ENROLL_ITG_DUPLICATE_OFFSET + 1;
+static constexpr size_t ENROLL_ITG_RESERVED_SIZE = 3;
+static constexpr size_t ENROLL_ITG_SIZE = ENROLL_ITG_TIMEOUT_OFFSET + 1 + ENROLL_ITG_RESERVED_SIZE;
+static_assert(ENROLL_ITG_SIZE == HLK_FM22X_MAX_COMMAND_SIZE, "command buffer must fit the largest enroll payload");
+// Leave room for the terminating NUL in the module's 32 byte name field
+static constexpr size_t MAX_NAME_LENGTH = HLK_FM22X_NAME_SIZE - 1;
+static constexpr uint8_t READ_OUT_STAGE_DONE = 4;
+static constexpr int16_t FACE_ID_INCOMPLETE = -1;
+static constexpr int16_t FACE_STATE_IDLE = -1;
+
+static const LogString *result_to_string(uint8_t result) {
+  switch (result) {
+    case HlkFm22xResult::SUCCEEDED:
+      return LOG_STR("success");
+    case HlkFm22xResult::REJECTED:
+      return LOG_STR("command rejected");
+    case HlkFm22xResult::ABORTED:
+      return LOG_STR("aborted");
+    case HlkFm22xResult::FAILED4_CAMERA:
+      return LOG_STR("camera failed");
+    case HlkFm22xResult::FAILED4_UNKNOWNREASON:
+      return LOG_STR("unknown error");
+    case HlkFm22xResult::FAILED4_INVALIDPARAM:
+      return LOG_STR("invalid parameter");
+    case HlkFm22xResult::FAILED4_NOMEMORY:
+      return LOG_STR("out of memory");
+    case HlkFm22xResult::FAILED4_UNKNOWNUSER:
+      return LOG_STR("unknown face");
+    case HlkFm22xResult::FAILED4_MAXUSER:
+      return LOG_STR("face storage full");
+    case HlkFm22xResult::FAILED4_FACEENROLLED:
+      return LOG_STR("face already enrolled");
+    case HlkFm22xResult::FAILED4_LIVENESSCHECK:
+      return LOG_STR("liveness check failed");
+    case HlkFm22xResult::FAILED4_TIMEOUT:
+      return LOG_STR("timeout");
+    case HlkFm22xResult::FAILED4_AUTHORIZATION:
+      return LOG_STR("authorization failed");
+    case HlkFm22xResult::FAILED4_READ_FILE:
+      return LOG_STR("read file failed");
+    case HlkFm22xResult::FAILED4_WRITE_FILE:
+      return LOG_STR("write file failed");
+    case HlkFm22xResult::FAILED4_NO_ENCRYPT:
+      return LOG_STR("encryption required");
+    case HlkFm22xResult::FAILED4_NO_RGBIMAGE:
+      return LOG_STR("no RGB image");
+    case HlkFm22xResult::FAILED4_JPGPHOTO_LARGE:
+      return LOG_STR("photo too large");
+    case HlkFm22xResult::FAILED4_JPGPHOTO_SMALL:
+      return LOG_STR("photo too small");
+    default:
+      return LOG_STR("unknown result");
+  }
+}
+
+static const LogString *module_status_to_string(uint8_t status) {
+  switch (status) {
+    case HlkFm22xModuleStatus::MODULE_STATUS_STANDBY:
+      return LOG_STR("standby");
+    case HlkFm22xModuleStatus::MODULE_STATUS_BUSY:
+      return LOG_STR("busy");
+    case HlkFm22xModuleStatus::MODULE_STATUS_ERROR:
+      return LOG_STR("error");
+    case HlkFm22xModuleStatus::MODULE_STATUS_INVALID:
+      return LOG_STR("not initialized");
+    default:
+      return LOG_STR("unknown");
+  }
+}
+
+static const char *face_state_to_string(int16_t state) {
+  switch (state) {
+    case FACE_STATE_IDLE:
+      return "Idle";
+    case HlkFm22xFaceState::FACE_STATE_NORMAL:
+      return "Face detected";
+    case HlkFm22xFaceState::FACE_STATE_NO_FACE:
+      return "No face";
+    case HlkFm22xFaceState::FACE_STATE_TOO_HIGH:
+      return "Too high";
+    case HlkFm22xFaceState::FACE_STATE_TOO_LOW:
+      return "Too low";
+    case HlkFm22xFaceState::FACE_STATE_TOO_LEFT:
+      return "Too far left";
+    case HlkFm22xFaceState::FACE_STATE_TOO_RIGHT:
+      return "Too far right";
+    case HlkFm22xFaceState::FACE_STATE_TOO_FAR:
+      return "Too far away";
+    case HlkFm22xFaceState::FACE_STATE_TOO_CLOSE:
+      return "Too close";
+    case HlkFm22xFaceState::FACE_STATE_EYEBROW_OCCLUSION:
+      return "Eyebrows covered";
+    case HlkFm22xFaceState::FACE_STATE_EYE_OCCLUSION:
+      return "Eyes covered";
+    case HlkFm22xFaceState::FACE_STATE_FACE_OCCLUSION:
+      return "Face covered";
+    case HlkFm22xFaceState::FACE_STATE_DIRECTION_ERROR:
+      return "Wrong direction";
+    case HlkFm22xFaceState::FACE_STATE_EYES_OPEN:
+      return "Eyes open";
+    case HlkFm22xFaceState::FACE_STATE_EYES_CLOSED:
+      return "Eyes closed";
+    case HlkFm22xFaceState::FACE_STATE_EYES_UNKNOWN:
+      return "Eye state unknown";
+    default:
+      return "Unknown";
+  }
+}
 
 void HlkFm22xComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up HLK-FM22X...");
   this->set_enrolling_(false);
+  this->set_scanning_(false);
+  this->publish_face_state_(FACE_STATE_IDLE);
+  // Drop anything the module sent before we started listening
   while (this->available() > 0) {
     this->read();
   }
-  this->defer([this]() { this->send_command_(HlkFm22xCommand::GET_STATUS); });
+  this->start_read_out_();
 }
 
-void HlkFm22xComponent::update() {
-  if (this->active_command_ != HlkFm22xCommand::NONE) {
-    if (this->wait_cycles_ > 600) {
-      ESP_LOGE(TAG, "Command 0x%.2X timed out", this->active_command_);
-      if (HlkFm22xCommand::RESET == this->active_command_) {
-        this->mark_failed();
-      } else {
-        this->reset();
-      }
-    }
-  }
-  this->recv_command_();
+void HlkFm22xComponent::loop() {
+  this->check_timeouts_();
+  this->read_frames_();
+  this->send_next_command_();
 }
 
-void HlkFm22xComponent::enroll_face(const std::string &name, HlkFm22xFaceDirection direction) {
-  if (name.length() > HLK_FM22X_NAME_SIZE - 1) {
-    ESP_LOGE(TAG, "enroll_face(): name too long '%s'", name.c_str());
+void HlkFm22xComponent::enroll_face(const std::string &name, HlkFm22xFaceDirection direction, bool admin,
+                                    uint8_t timeout_s, bool allow_duplicate) {
+  if (name.length() > MAX_NAME_LENGTH) {
+    ESP_LOGE(TAG, "enroll_face(): name too long '%s' (max %u bytes)", name.c_str(), (unsigned) MAX_NAME_LENGTH);
+    this->enrollment_failed_callback_.call(HlkFm22xResult::FAILED4_INVALIDPARAM);
     return;
   }
-  ESP_LOGI(TAG, "Starting enrollment for %s", name.c_str());
-  std::array<uint8_t, 35> data{};
-  data[0] = 0;  // admin
-  std::copy(name.begin(), name.end(), data.begin() + 1);
-  // Remaining bytes are already zero-initialized
-  data[33] = (uint8_t) direction;
-  data[34] = 10;  // timeout
-  this->send_command_(HlkFm22xCommand::ENROLL, data.data(), data.size());
-  this->set_enrolling_(true);
+  if (timeout_s == 0) {
+    timeout_s = HLK_FM22X_DEFAULT_TIMEOUT_S;
+  }
+  const bool single_frame = direction == HlkFm22xFaceDirection::FACE_DIRECTION_UNDEFINED;
+  ESP_LOGI(TAG, "Enrolling '%s'%s, %s, timeout %us", name.c_str(), admin ? " as admin" : "",
+           single_frame ? "single frame" : "one direction", timeout_s);
+  const uint16_t reply_timeout_s = timeout_s + ALGORITHM_TIMEOUT_MARGIN_S;
+
+  uint8_t data[HLK_FM22X_MAX_COMMAND_SIZE]{};
+  data[ENROLL_ADMIN_OFFSET] = admin ? 1 : 0;
+  std::copy(name.begin(), name.end(), data + ENROLL_NAME_OFFSET);
+  data[ENROLL_DIRECTION_OFFSET] = (uint8_t) direction;
+
+  if (!allow_duplicate) {
+    // Only the integrated enroll command can refuse a face that is already enrolled
+    data[ENROLL_ITG_TYPE_OFFSET] = single_frame ? ENROLL_TYPE_SINGLE : ENROLL_TYPE_INTERACTIVE;
+    data[ENROLL_ITG_DUPLICATE_OFFSET] = 0;
+    data[ENROLL_ITG_TIMEOUT_OFFSET] = timeout_s;
+    this->enqueue_(HlkFm22xCommand::ENROLL_ITG, data, ENROLL_ITG_SIZE, reply_timeout_s);
+    return;
+  }
+  data[ENROLL_TIMEOUT_OFFSET] = timeout_s;
+  this->enqueue_(single_frame ? HlkFm22xCommand::ENROLL_SINGLE : HlkFm22xCommand::ENROLL, data, ENROLL_SIZE,
+                 reply_timeout_s);
 }
 
-void HlkFm22xComponent::scan_face() {
-  ESP_LOGI(TAG, "Verify face");
-  static const uint8_t DATA[] = {0, 0};
-  this->send_command_(HlkFm22xCommand::VERIFY, DATA, sizeof(DATA));
+void HlkFm22xComponent::scan_face(uint8_t timeout_s) {
+  if (timeout_s == 0) {
+    timeout_s = HLK_FM22X_DEFAULT_TIMEOUT_S;
+  }
+  ESP_LOGI(TAG, "Scanning for a face, timeout %us", timeout_s);
+  const uint8_t data[] = {0, timeout_s};  // the first byte asks the module not to power down afterwards
+  this->enqueue_(HlkFm22xCommand::VERIFY, data, sizeof(data), timeout_s + ALGORITHM_TIMEOUT_MARGIN_S);
+}
+
+void HlkFm22xComponent::cancel() {
+  this->drop_queued_(is_scan_or_enroll_);
+  if (is_scan_or_enroll_(this->pending_command_)) {
+    const bool enrolling = this->pending_command_ != HlkFm22xCommand::VERIFY;
+    ESP_LOGI(TAG, "Cancelling %s", enrolling ? "enrollment" : "scan");
+    // RESET makes the module stop what it is doing; FACE_RESET then forgets the directions captured so far
+    this->interrupt_with_(HlkFm22xCommand::RESET);
+    if (enrolling) {
+      this->enqueue_(HlkFm22xCommand::FACE_RESET);
+    }
+    return;
+  }
+  ESP_LOGI(TAG, "Clearing enrollment state");
+  this->enqueue_(HlkFm22xCommand::FACE_RESET);
 }
 
 void HlkFm22xComponent::delete_face(int16_t face_id) {
-  ESP_LOGI(TAG, "Deleting face in slot %d", face_id);
-  const uint8_t data[] = {(uint8_t) (face_id >> 8), (uint8_t) (face_id & 0xFF)};
-  this->send_command_(HlkFm22xCommand::DELETE_FACE, data, sizeof(data));
+  ESP_LOGI(TAG, "Deleting face %d", face_id);
+  this->enqueue_face_id_command_(HlkFm22xCommand::DELETE_FACE, face_id);
 }
 
 void HlkFm22xComponent::delete_all_faces() {
-  ESP_LOGI(TAG, "Deleting all stored faces");
-  this->send_command_(HlkFm22xCommand::DELETE_ALL_FACES);
+  ESP_LOGI(TAG, "Deleting all faces");
+  this->enqueue_(HlkFm22xCommand::DELETE_ALL_FACES);
 }
 
-void HlkFm22xComponent::get_face_count_() {
-  ESP_LOGD(TAG, "Getting face count");
-  this->send_command_(HlkFm22xCommand::GET_ALL_FACE_IDS);
+void HlkFm22xComponent::get_face_details(int16_t face_id) {
+  ESP_LOGD(TAG, "Requesting details of face %d", face_id);
+  this->enqueue_face_id_command_(HlkFm22xCommand::GET_FACE_DETAILS, face_id);
 }
 
 void HlkFm22xComponent::reset() {
   ESP_LOGI(TAG, "Resetting module");
-  this->active_command_ = HlkFm22xCommand::NONE;
-  this->wait_cycles_ = 0;
-  this->set_enrolling_(false);
-  this->send_command_(HlkFm22xCommand::RESET);
-}
-
-void HlkFm22xComponent::send_command_(HlkFm22xCommand command, const uint8_t *data, size_t size) {
-  ESP_LOGV(TAG, "Send command: 0x%.2X", command);
-  if (this->active_command_ != HlkFm22xCommand::NONE) {
-    ESP_LOGW(TAG, "Command 0x%.2X already active", this->active_command_);
+  if (is_scan_or_enroll_(this->pending_command_)) {
+    this->interrupt_with_(HlkFm22xCommand::RESET);
     return;
   }
-  this->wait_cycles_ = 0;
-  this->active_command_ = command;
-  while (this->available() > 0)
-    this->read();
-  this->write((uint8_t) (START_CODE >> 8));
-  this->write((uint8_t) (START_CODE & 0xFF));
-  this->write((uint8_t) command);
-  uint16_t data_size = size;
-  this->write((uint8_t) (data_size >> 8));
-  this->write((uint8_t) (data_size & 0xFF));
+  this->enqueue_(HlkFm22xCommand::RESET);
+}
 
-  uint8_t checksum = 0;
-  checksum ^= (uint8_t) command;
-  checksum ^= (data_size >> 8);
-  checksum ^= (data_size & 0xFF);
+bool HlkFm22xComponent::is_scan_or_enroll_(HlkFm22xCommand command) {
+  return command == HlkFm22xCommand::VERIFY || command == HlkFm22xCommand::ENROLL ||
+         command == HlkFm22xCommand::ENROLL_SINGLE || command == HlkFm22xCommand::ENROLL_ITG;
+}
+
+bool HlkFm22xComponent::is_read_out_(HlkFm22xCommand command) {
+  return command == HlkFm22xCommand::GET_STATUS || command == HlkFm22xCommand::GET_VERSION ||
+         command == HlkFm22xCommand::GET_SERIAL_NUMBER || command == HlkFm22xCommand::GET_ALL_FACE_IDS;
+}
+
+uint16_t HlkFm22xComponent::default_timeout_s_(HlkFm22xCommand command) {
+  if (command == HlkFm22xCommand::DELETE_FACE || command == HlkFm22xCommand::DELETE_ALL_FACES) {
+    return DELETE_TIMEOUT_S;
+  }
+  return COMMAND_TIMEOUT_S;
+}
+
+bool HlkFm22xComponent::parse_face_record_(const uint8_t *data, size_t length, int16_t &face_id, const char *&name,
+                                           size_t &name_length, bool &admin) {
+  if (length < FACE_RECORD_MIN_SIZE) {
+    return false;
+  }
+  face_id = (int16_t) encode_uint16(data[2], data[3]);
+  // The name is NUL padded to a fixed width
+  name = reinterpret_cast<const char *>(data + 4);
+  name_length = strnlen(name, HLK_FM22X_NAME_SIZE);
+  admin = length > FACE_RECORD_ADMIN_OFFSET && data[FACE_RECORD_ADMIN_OFFSET] != 0;
+  return true;
+}
+
+bool HlkFm22xComponent::enqueue_(HlkFm22xCommand command, const uint8_t *data, size_t size, uint16_t timeout_s) {
+  if (size > HLK_FM22X_MAX_COMMAND_SIZE) {
+    ESP_LOGE(TAG, "Command 0x%02X payload too large: %zu bytes", command, size);
+    return false;
+  }
+  QueuedCommand queued{};
+  queued.command = command;
+  queued.size = (uint8_t) size;
+  queued.timeout_s = timeout_s != 0 ? timeout_s : default_timeout_s_(command);
+  if (size > 0) {
+    memcpy(queued.data, data, size);
+  }
+  if (!this->queue_.push(queued)) {
+    ESP_LOGE(TAG, "Command queue full, dropping command 0x%02X", command);
+    return false;
+  }
+  return true;
+}
+
+void HlkFm22xComponent::enqueue_face_id_command_(HlkFm22xCommand command, int16_t face_id) {
+  const uint8_t data[] = {(uint8_t) (face_id >> 8), (uint8_t) (face_id & 0xFF)};
+  this->enqueue_(command, data, sizeof(data));
+}
+
+void HlkFm22xComponent::drop_queued_(bool (*predicate)(HlkFm22xCommand)) {
+  // The ring buffer has no erase: take every entry out once and put back the ones that stay
+  const size_t count = this->queue_.size();
+  for (size_t i = 0; i < count; i++) {
+    const QueuedCommand queued = this->queue_.front();
+    this->queue_.pop();
+    if (!predicate(queued.command)) {
+      this->queue_.push(queued);
+    }
+  }
+}
+
+void HlkFm22xComponent::send_next_command_() {
+  if (this->pending_command_ != HlkFm22xCommand::NONE || this->queue_.empty()) {
+    return;
+  }
+  const QueuedCommand &queued = this->queue_.front();
+  this->write_frame_(queued.command, queued.data, queued.size);
+  this->pending_command_ = queued.command;
+  this->pending_sent_ms_ = millis();
+  this->pending_timeout_ms_ = queued.timeout_s * 1000UL;
+  if (queued.command == HlkFm22xCommand::VERIFY) {
+    this->set_scanning_(true);
+  } else if (is_scan_or_enroll_(queued.command)) {
+    this->set_enrolling_(true);
+  }
+  this->queue_.pop();
+}
+
+void HlkFm22xComponent::write_frame_(HlkFm22xCommand command, const uint8_t *data, size_t size) {
+  ESP_LOGV(TAG, "Sending command 0x%02X with %zu bytes", command, size);
+  const uint8_t header[] = {(uint8_t) (START_CODE >> 8), (uint8_t) (START_CODE & 0xFF), (uint8_t) command,
+                            (uint8_t) (size >> 8), (uint8_t) (size & 0xFF)};
+  // The checksum covers everything after the start code
+  uint8_t checksum = header[2] ^ header[3] ^ header[4];
   for (size_t i = 0; i < size; i++) {
-    this->write(data[i]);
     checksum ^= data[i];
   }
-
-  this->write(checksum);
-  this->active_command_ = command;
-  this->wait_cycles_ = 0;
+  this->write_array(header, sizeof(header));
+  if (size > 0) {
+    this->write_array(data, size);
+  }
+  this->write_byte(checksum);
 }
 
-void HlkFm22xComponent::recv_command_() {
-  uint8_t byte, checksum = 0;
-  uint16_t length = 0;
+void HlkFm22xComponent::interrupt_with_(HlkFm22xCommand command) {
+  // The module is busy with a scan or enrollment; this command jumps the queue and the
+  // running scan or enrollment gets a grace period to answer once the module has confirmed the stop
+  this->hold_interrupted_(this->pending_command_);
+  this->write_frame_(command, nullptr, 0);
+  this->pending_command_ = command;
+  this->pending_sent_ms_ = millis();
+  this->pending_timeout_ms_ = COMMAND_TIMEOUT_S * 1000UL;
+}
 
-  if (this->available() < 7) {
-    ++this->wait_cycles_;
+void HlkFm22xComponent::hold_interrupted_(HlkFm22xCommand command) {
+  // Only one interrupted scan or enrollment can wait for its reply; an older one is reported as aborted
+  this->clear_interrupted_(true);
+  this->interrupted_command_ = command;
+  this->interrupted_deadline_set_ = false;
+}
+
+void HlkFm22xComponent::clear_interrupted_(bool aborted) {
+  if (this->interrupted_command_ == HlkFm22xCommand::NONE) {
     return;
   }
-  this->wait_cycles_ = 0;
+  const HlkFm22xCommand command = this->interrupted_command_;
+  this->interrupted_command_ = HlkFm22xCommand::NONE;
+  this->interrupted_deadline_set_ = false;
+  if (aborted) {
+    this->finish_failed_(command, HlkFm22xResult::ABORTED);
+  }
+}
 
-  if ((this->read() != (uint8_t) (START_CODE >> 8)) || (this->read() != (uint8_t) (START_CODE & 0xFF))) {
-    ESP_LOGE(TAG, "Invalid start code");
+void HlkFm22xComponent::read_frames_() {
+  size_t available = this->available();
+  if (available == 0) {
     return;
   }
+  this->recv_last_byte_ms_ = millis();
+  uint8_t buffer[32];
+  while (available > 0) {
+    const size_t to_read = std::min(available, sizeof(buffer));
+    if (!this->read_array(buffer, to_read)) {
+      break;
+    }
+    available -= to_read;
+    for (size_t i = 0; i < to_read; i++) {
+      this->process_byte_(buffer[i]);
+    }
+  }
+}
 
-  byte = this->read();
-  checksum ^= byte;
-  HlkFm22xResponseType response_type = (HlkFm22xResponseType) byte;
-
-  byte = this->read();
-  checksum ^= byte;
-  length = byte << 8;
-  byte = this->read();
-  checksum ^= byte;
-  length |= byte;
-
-  // Wait for remaining data (payload + checksum) to arrive.
-  // Header bytes are already consumed, so we must finish reading this message.
-  uint32_t start = millis();
-  while (this->available() < length + 1) {
-    if (millis() - start > PAYLOAD_TIMEOUT_MS) {
-      ESP_LOGE(TAG, "Timeout waiting for payload (%u bytes)", length);
-      // Drain any partial payload bytes to resync the parser
-      while (this->available() > 0) {
-        this->read();
+void HlkFm22xComponent::process_byte_(uint8_t byte) {
+  switch (this->recv_state_) {
+    case RecvState::RECV_STATE_SYNC_1:
+      if (byte == (uint8_t) (START_CODE >> 8)) {
+        this->recv_state_ = RecvState::RECV_STATE_SYNC_2;
       }
-      return;
-    }
-    delay(1);
+      break;
+    case RecvState::RECV_STATE_SYNC_2:
+      if (byte == (uint8_t) (START_CODE & 0xFF)) {
+        this->recv_checksum_ = 0;
+        this->recv_state_ = RecvState::RECV_STATE_TYPE;
+      } else if (byte != (uint8_t) (START_CODE >> 8)) {
+        this->recv_state_ = RecvState::RECV_STATE_SYNC_1;
+      }
+      break;
+    case RecvState::RECV_STATE_TYPE:
+      this->recv_type_ = byte;
+      this->recv_checksum_ ^= byte;
+      this->recv_state_ = RecvState::RECV_STATE_LENGTH_HIGH;
+      break;
+    case RecvState::RECV_STATE_LENGTH_HIGH:
+      this->recv_length_ = (uint16_t) byte << 8;
+      this->recv_checksum_ ^= byte;
+      this->recv_state_ = RecvState::RECV_STATE_LENGTH_LOW;
+      break;
+    case RecvState::RECV_STATE_LENGTH_LOW:
+      this->recv_length_ |= byte;
+      this->recv_checksum_ ^= byte;
+      this->recv_index_ = 0;
+      this->recv_state_ = this->recv_length_ > 0 ? RecvState::RECV_STATE_DATA : RecvState::RECV_STATE_CHECKSUM;
+      break;
+    case RecvState::RECV_STATE_DATA:
+      this->recv_checksum_ ^= byte;
+      // Keep what fits; long replies only need their first bytes but must be checksummed in full
+      if (this->recv_index_ < HLK_FM22X_MAX_RESPONSE_SIZE) {
+        this->recv_buf_[this->recv_index_] = byte;
+      }
+      if (++this->recv_index_ >= this->recv_length_) {
+        this->recv_state_ = RecvState::RECV_STATE_CHECKSUM;
+      }
+      break;
+    case RecvState::RECV_STATE_CHECKSUM:
+      this->recv_state_ = RecvState::RECV_STATE_SYNC_1;
+      if (byte != this->recv_checksum_) {
+        ESP_LOGE(TAG, "Invalid checksum. Calculated: 0x%02X, received: 0x%02X", this->recv_checksum_, byte);
+        break;
+      }
+      this->handle_frame_();
+      break;
   }
+}
 
-  // Read up to buffer size; discard excess bytes while still computing checksum
-  // GET_ALL_FACE_IDS can return all enrolled face data (hundreds of bytes)
-  // but handlers only need the first few bytes
-  size_t to_store = std::min(static_cast<size_t>(length), HLK_FM22X_MAX_RESPONSE_SIZE);
-  for (uint16_t idx = 0; idx < length; ++idx) {
-    byte = this->read();
-    checksum ^= byte;
-    if (idx < to_store) {
-      this->recv_buf_[idx] = byte;
-    }
-  }
-
+void HlkFm22xComponent::handle_frame_() {
+  const size_t stored = std::min<size_t>(this->recv_length_, HLK_FM22X_MAX_RESPONSE_SIZE);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   char hex_buf[format_hex_pretty_size(HLK_FM22X_MAX_RESPONSE_SIZE)];
-  ESP_LOGV(TAG, "Recv type: 0x%.2X, data: %s", response_type,
-           format_hex_pretty_to(hex_buf, this->recv_buf_.data(), to_store));
+  ESP_LOGV(TAG, "Received type 0x%02X, %u bytes: %s", this->recv_type_, this->recv_length_,
+           format_hex_pretty_to(hex_buf, this->recv_buf_.data(), stored));
 #endif
-
-  byte = this->read();
-  if (byte != checksum) {
-    ESP_LOGE(TAG, "Invalid checksum for data. Calculated: 0x%.2X, Received: 0x%.2X", checksum, byte);
-    return;
-  }
-  switch (response_type) {
-    case HlkFm22xResponseType::NOTE:
-      this->handle_note_(this->recv_buf_.data(), to_store);
-      break;
+  switch (this->recv_type_) {
     case HlkFm22xResponseType::REPLY:
-      this->handle_reply_(this->recv_buf_.data(), to_store);
+      this->handle_reply_(this->recv_buf_.data(), stored);
+      break;
+    case HlkFm22xResponseType::NOTE:
+      this->handle_note_(this->recv_buf_.data(), stored);
       break;
     default:
-      ESP_LOGW(TAG, "Unexpected response type: 0x%.2X", response_type);
+      ESP_LOGW(TAG, "Unexpected response type: 0x%02X", this->recv_type_);
       break;
   }
 }
 
 void HlkFm22xComponent::handle_note_(const uint8_t *data, size_t length) {
   if (length < 1) {
-    ESP_LOGE(TAG, "Empty note data");
+    ESP_LOGE(TAG, "Empty note");
     return;
   }
   switch (data[0]) {
-    case HlkFm22xNoteType::FACE_STATE:
-      if (length < 17) {
-        ESP_LOGE(TAG, "Invalid face note data size: %zu", length);
+    case HlkFm22xNoteType::NOTE_FACE_STATE: {
+      if (length < FACE_STATE_NOTE_SIZE) {
+        ESP_LOGE(TAG, "Face state note too short: %zu bytes", length);
         break;
       }
-      {
-        int16_t info[8];
-        uint8_t offset = 1;
-        for (int16_t &i : info) {
-          i = ((int16_t) data[offset + 1] << 8) | data[offset];
-          offset += 2;
+      // Unlike the rest of the protocol these fields are sent with the low byte first
+      int16_t info[FACE_STATE_FIELDS];
+      for (size_t i = 0; i < FACE_STATE_FIELDS; i++) {
+        info[i] = (int16_t) encode_uint16(data[2 + 2 * i], data[1 + 2 * i]);
+      }
+      ESP_LOGV(TAG, "Face state: %s (%d), left: %d, top: %d, right: %d, bottom: %d, yaw: %d, pitch: %d, roll: %d",
+               face_state_to_string(info[0]), info[0], info[1], info[2], info[3], info[4], info[5], info[6], info[7]);
+      this->publish_face_state_(info[0]);
+      this->face_info_callback_.call(info[0], info[1], info[2], info[3], info[4], info[5], info[6], info[7]);
+      break;
+    }
+    case HlkFm22xNoteType::NOTE_READY:
+      ESP_LOGI(TAG, "Module ready");
+      if (this->pending_command_ != HlkFm22xCommand::NONE) {
+        if (is_scan_or_enroll_(this->pending_command_)) {
+          // The module may still answer the scan or enrollment it was running; give it a moment
+          this->hold_interrupted_(this->pending_command_);
+          this->interrupted_deadline_ms_ = millis() + INTERRUPT_GRACE_MS;
+          this->interrupted_deadline_set_ = true;
         }
-        ESP_LOGV(TAG, "Face state: status: %d, left: %d, top: %d, right: %d, bottom: %d, yaw: %d, pitch: %d, roll: %d",
-                 info[0], info[1], info[2], info[3], info[4], info[5], info[6], info[7]);
-        this->face_info_callback_.call(info[0], info[1], info[2], info[3], info[4], info[5], info[6], info[7]);
+        // Whatever else was sent before the module (re)started will not be answered
+        this->pending_command_ = HlkFm22xCommand::NONE;
+      }
+      this->retry_scheduled_ = false;
+      if (this->read_out_done_) {
+        // Version, serial number and stored faces do not change on a restart; only the status is worth a look
+        this->enqueue_(HlkFm22xCommand::GET_STATUS);
+      } else {
+        this->start_read_out_();
       }
       break;
-    case HlkFm22xNoteType::READY:
-      ESP_LOGE(TAG, "Command 0x%.2X timed out", this->active_command_);
-      switch (this->active_command_) {
-        case HlkFm22xCommand::ENROLL:
-          this->set_enrolling_(false);
-          this->enrollment_failed_callback_.call(HlkFm22xResult::FAILED4_TIMEOUT);
-          break;
-        case HlkFm22xCommand::VERIFY:
-          this->face_scan_invalid_callback_.call(HlkFm22xResult::FAILED4_TIMEOUT);
-          break;
-        default:
-          break;
-      }
-      this->active_command_ = HlkFm22xCommand::NONE;
-      this->wait_cycles_ = 0;
+    case HlkFm22xNoteType::NOTE_UNKNOWN_ERROR:
+      ESP_LOGE(TAG, "Module reported an unknown error");
+      break;
+    case HlkFm22xNoteType::NOTE_OTA_DONE:
+      ESP_LOGI(TAG, "Module firmware update finished");
+      break;
+    case HlkFm22xNoteType::NOTE_EYE_STATE:
+      ESP_LOGD(TAG, "Eye state: %u", length > 1 ? data[1] : 0);
+      break;
+    case HlkFm22xNoteType::NOTE_AUTHORIZATION_FAILED:
+      ESP_LOGE(TAG, "Module license check failed");
       break;
     default:
-      ESP_LOGW(TAG, "Unhandled note: 0x%.2X", data[0]);
+      ESP_LOGW(TAG, "Unhandled note: 0x%02X", data[0]);
       break;
   }
 }
 
 void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
-  auto expected = this->active_command_;
-  this->active_command_ = HlkFm22xCommand::NONE;
   if (length < 2) {
     ESP_LOGE(TAG, "Reply too short: %zu bytes", length);
     return;
   }
-  if (data[0] != (uint8_t) expected) {
-    ESP_LOGE(TAG, "Unexpected response command. Expected: 0x%.2X, Received: 0x%.2X", expected, data[0]);
+  const auto command = (HlkFm22xCommand) data[0];
+  const uint8_t result = data[1];
+
+  bool expected = true;
+  if (command == this->pending_command_) {
+    this->pending_command_ = HlkFm22xCommand::NONE;
+  } else if (command == this->interrupted_command_) {
+    this->interrupted_command_ = HlkFm22xCommand::NONE;
+    this->interrupted_deadline_set_ = false;
+  } else if (is_scan_or_enroll_(command)) {
+    // Its result has already been reported as a timeout or abort
+    ESP_LOGW(TAG, "Unexpected reply for command 0x%02X, ignoring", command);
     return;
+  } else {
+    // For example a delete that took longer than expected; its outcome is still worth recording
+    ESP_LOGD(TAG, "Late reply for command 0x%02X", command);
+    expected = false;
   }
 
-  if (data[1] != HlkFm22xResult::SUCCEEDED) {
-    ESP_LOGE(TAG, "Command <0x%.2X> failed. Error: 0x%.2X", data[0], data[1]);
-    switch (expected) {
-      case HlkFm22xCommand::ENROLL:
-        this->set_enrolling_(false);
-        this->enrollment_failed_callback_.call(data[1]);
+  // The module answered, so it is alive
+  this->consecutive_timeouts_ = 0;
+  this->status_clear_warning();
+  this->status_clear_error();
+
+  if (result != HlkFm22xResult::SUCCEEDED) {
+    ESP_LOGW(TAG, "Command 0x%02X failed: %s (%u)", command, LOG_STR_ARG(result_to_string(result)), result);
+  }
+
+  switch (command) {
+    case HlkFm22xCommand::VERIFY:
+      this->handle_scan_reply_(result, data, length);
+      break;
+    case HlkFm22xCommand::ENROLL:
+    case HlkFm22xCommand::ENROLL_SINGLE:
+    case HlkFm22xCommand::ENROLL_ITG:
+      this->handle_enroll_reply_(result, data, length);
+      break;
+    case HlkFm22xCommand::GET_FACE_DETAILS:
+      this->handle_face_details_reply_(result, data, length);
+      break;
+    case HlkFm22xCommand::GET_STATUS:
+      if (result == HlkFm22xResult::SUCCEEDED && length >= 3) {
+        ESP_LOGD(TAG, "Module status: %s (%u)", LOG_STR_ARG(module_status_to_string(data[2])), data[2]);
+        if (this->status_sensor_ != nullptr) {
+          this->status_sensor_->publish_state(data[2]);
+        }
+      }
+      break;
+    case HlkFm22xCommand::GET_VERSION:
+    case HlkFm22xCommand::GET_SERIAL_NUMBER:
+      if (result == HlkFm22xResult::SUCCEEDED) {
+        this->publish_text_(
+            command == HlkFm22xCommand::GET_VERSION ? this->version_text_sensor_ : this->serial_number_text_sensor_,
+            data + 2, length - 2);
+      }
+      break;
+    case HlkFm22xCommand::GET_ALL_FACE_IDS:
+      if (result == HlkFm22xResult::SUCCEEDED && length >= 3) {
+        ESP_LOGD(TAG, "%u faces enrolled", data[2]);
+        if (this->face_count_sensor_ != nullptr) {
+          this->face_count_sensor_->publish_state(data[2]);
+        }
+      }
+      break;
+    case HlkFm22xCommand::DELETE_FACE:
+    case HlkFm22xCommand::DELETE_ALL_FACES:
+      if (result == HlkFm22xResult::SUCCEEDED) {
+        ESP_LOGI(TAG, "%s deleted", command == HlkFm22xCommand::DELETE_FACE ? "Face" : "All faces");
+      }
+      this->refresh_face_count_();
+      break;
+    case HlkFm22xCommand::FACE_RESET:
+      ESP_LOGD(TAG, "Enrollment state cleared");
+      break;
+    case HlkFm22xCommand::RESET:
+      ESP_LOGD(TAG, "Module reset");
+      if (this->interrupted_command_ != HlkFm22xCommand::NONE) {
+        // The interrupted scan or enrollment gets a short grace period to report that it was aborted
+        this->interrupted_deadline_ms_ = millis() + INTERRUPT_GRACE_MS;
+        this->interrupted_deadline_set_ = true;
+      }
+      this->enqueue_(HlkFm22xCommand::GET_STATUS);
+      break;
+    default:
+      ESP_LOGW(TAG, "Unhandled reply for command 0x%02X", command);
+      break;
+  }
+
+  // Only one command is ever outstanding, so an expected read-out reply belongs to the running read-out chain
+  if (expected && is_read_out_(command)) {
+    this->continue_read_out_();
+  }
+}
+
+void HlkFm22xComponent::handle_scan_reply_(uint8_t result, const uint8_t *data, size_t length) {
+  this->set_scanning_(false);
+  this->publish_face_state_(FACE_STATE_IDLE);
+  if (result == HlkFm22xResult::SUCCEEDED) {
+    int16_t face_id;
+    const char *name;
+    size_t name_length;
+    bool admin;
+    if (!parse_face_record_(data, length, face_id, name, name_length, admin)) {
+      ESP_LOGE(TAG, "Scan reply too short: %zu bytes", length);
+      this->face_scan_invalid_callback_.call(HlkFm22xResult::FAILED4_UNKNOWNREASON);
+      return;
+    }
+    ESP_LOGI(TAG, "Face matched: ID %d, name '%.*s'%s", face_id, (int) name_length, name, admin ? " (admin)" : "");
+    if (this->last_face_id_sensor_ != nullptr) {
+      this->last_face_id_sensor_->publish_state(face_id);
+    }
+    if (this->last_face_name_text_sensor_ != nullptr) {
+      this->last_face_name_text_sensor_->publish_state(name, name_length);
+    }
+    this->face_scan_matched_callback_.call(face_id, std::string(name, name_length), admin);
+    return;
+  }
+  // The module answers REJECTED for a face it does not know; every other result is a failed scan
+  if (result == HlkFm22xResult::REJECTED) {
+    ESP_LOGI(TAG, "Face not recognized");
+    this->face_scan_unmatched_callback_.call();
+    return;
+  }
+  this->face_scan_invalid_callback_.call(result);
+}
+
+void HlkFm22xComponent::handle_enroll_reply_(uint8_t result, const uint8_t *data, size_t length) {
+  this->set_enrolling_(false);
+  this->publish_face_state_(FACE_STATE_IDLE);
+  if (result != HlkFm22xResult::SUCCEEDED) {
+    this->enrollment_failed_callback_.call(result);
+    return;
+  }
+  if (length < ENROLL_REPLY_MIN_SIZE) {
+    ESP_LOGE(TAG, "Enrollment reply too short: %zu bytes", length);
+    this->enrollment_failed_callback_.call(HlkFm22xResult::FAILED4_UNKNOWNREASON);
+    return;
+  }
+  const auto face_id = (int16_t) encode_uint16(data[2], data[3]);
+  uint8_t direction = data[4];
+  const bool complete = face_id != FACE_ID_INCOMPLETE;
+  if (complete) {
+    // A stored face always counts as captured from all directions, also after a single frame enrollment
+    direction = HLK_FM22X_ALL_DIRECTIONS;
+    ESP_LOGI(TAG, "Face enrolled: ID %d", face_id);
+  } else {
+    ESP_LOGI(TAG, "Direction captured, directions so far: 0x%02X", direction);
+  }
+  this->enrollment_done_callback_.call(face_id, direction);
+  if (complete) {
+    this->refresh_face_count_();
+  }
+}
+
+void HlkFm22xComponent::handle_face_details_reply_(uint8_t result, const uint8_t *data, size_t length) {
+  if (result != HlkFm22xResult::SUCCEEDED) {
+    return;
+  }
+  int16_t face_id;
+  const char *name;
+  size_t name_length;
+  bool admin;
+  if (!parse_face_record_(data, length, face_id, name, name_length, admin)) {
+    ESP_LOGE(TAG, "Face details reply too short: %zu bytes", length);
+    return;
+  }
+  ESP_LOGD(TAG, "Face %d: name '%.*s'%s", face_id, (int) name_length, name, admin ? " (admin)" : "");
+  this->face_details_callback_.call(face_id, std::string(name, name_length), admin);
+}
+
+void HlkFm22xComponent::publish_text_(text_sensor::TextSensor *text_sensor, const uint8_t *data, size_t length) {
+  // Strings are NUL padded to a fixed width; publish only the text in front of the padding
+  const char *text = reinterpret_cast<const char *>(data);
+  const size_t text_length = strnlen(text, length);
+  ESP_LOGD(TAG, "Module reports: %.*s", (int) text_length, text);
+  if (text_sensor != nullptr) {
+    text_sensor->publish_state(text, text_length);
+  }
+}
+
+void HlkFm22xComponent::check_timeouts_() {
+  const uint32_t now = millis();
+  if (this->recv_state_ != RecvState::RECV_STATE_SYNC_1 && now - this->recv_last_byte_ms_ > FRAME_TIMEOUT_MS) {
+    ESP_LOGW(TAG, "Incomplete frame discarded");
+    this->recv_state_ = RecvState::RECV_STATE_SYNC_1;
+  }
+
+  if (this->pending_command_ != HlkFm22xCommand::NONE && now - this->pending_sent_ms_ >= this->pending_timeout_ms_) {
+    const HlkFm22xCommand command = this->pending_command_;
+    this->pending_command_ = HlkFm22xCommand::NONE;
+    if (this->consecutive_timeouts_ < TIMEOUTS_BEFORE_ERROR) {
+      this->consecutive_timeouts_++;
+    }
+    if (this->consecutive_timeouts_ >= TIMEOUTS_BEFORE_ERROR) {
+      // Only complain once; the retry below keeps checking whether the module comes back
+      if (!this->status_has_error()) {
+        ESP_LOGE(TAG, "Module is not responding");
+        this->status_set_error();
+      }
+    } else {
+      ESP_LOGW(TAG, "Command 0x%02X timed out", command);
+      this->status_set_warning();
+    }
+    this->finish_failed_(command, HlkFm22xResult::FAILED4_TIMEOUT);
+    // A stop that was never confirmed leaves no hope for the interrupted scan or enrollment either
+    this->clear_interrupted_(true);
+    // Check again later whether the module is alive; this also restarts an interrupted read-out
+    this->retry_at_ms_ = now + RETRY_INTERVAL_MS;
+    this->retry_scheduled_ = true;
+  }
+
+  if (this->interrupted_deadline_set_ && (int32_t) (now - this->interrupted_deadline_ms_) >= 0) {
+    this->clear_interrupted_(true);
+  }
+
+  if (this->retry_scheduled_ && (int32_t) (now - this->retry_at_ms_) >= 0) {
+    this->retry_scheduled_ = false;
+    if (this->pending_command_ == HlkFm22xCommand::NONE && this->queue_.empty()) {
+      this->start_read_out_();
+    }
+  }
+}
+
+void HlkFm22xComponent::finish_failed_(HlkFm22xCommand command, uint8_t error) {
+  switch (command) {
+    case HlkFm22xCommand::VERIFY:
+      this->set_scanning_(false);
+      this->publish_face_state_(FACE_STATE_IDLE);
+      this->face_scan_invalid_callback_.call(error);
+      break;
+    case HlkFm22xCommand::ENROLL:
+    case HlkFm22xCommand::ENROLL_SINGLE:
+    case HlkFm22xCommand::ENROLL_ITG:
+      this->set_enrolling_(false);
+      this->publish_face_state_(FACE_STATE_IDLE);
+      this->enrollment_failed_callback_.call(error);
+      break;
+    default:
+      break;
+  }
+}
+
+void HlkFm22xComponent::start_read_out_() {
+  // Never let two read-out chains run at the same time
+  this->drop_queued_(is_read_out_);
+  this->read_out_stage_ = 0;
+  this->continue_read_out_();
+}
+
+void HlkFm22xComponent::continue_read_out_() {
+  // Read status, version, serial number and face count one after the other, skipping what nobody asked for
+  while (this->read_out_stage_ < READ_OUT_STAGE_DONE) {
+    const uint8_t stage = this->read_out_stage_++;
+    switch (stage) {
+      case 0:
+        this->enqueue_(HlkFm22xCommand::GET_STATUS);
+        return;
+      case 1:
+        if (this->version_text_sensor_ != nullptr) {
+          this->enqueue_(HlkFm22xCommand::GET_VERSION);
+          return;
+        }
         break;
-      case HlkFm22xCommand::VERIFY:
-        if (data[1] == HlkFm22xResult::REJECTED) {
-          this->face_scan_unmatched_callback_.call();
-        } else {
-          this->face_scan_invalid_callback_.call(data[1]);
+      case 2:
+        if (this->serial_number_text_sensor_ != nullptr) {
+          this->enqueue_(HlkFm22xCommand::GET_SERIAL_NUMBER);
+          return;
+        }
+        break;
+      case 3:
+        if (this->face_count_sensor_ != nullptr) {
+          this->enqueue_(HlkFm22xCommand::GET_ALL_FACE_IDS);
+          return;
         }
         break;
       default:
         break;
     }
-    return;
   }
-  switch (expected) {
-    case HlkFm22xCommand::VERIFY: {
-      if (length < 4 + HLK_FM22X_NAME_SIZE) {
-        ESP_LOGE(TAG, "VERIFY response too short: %zu bytes", length);
-        break;
-      }
-      int16_t face_id = ((int16_t) data[2] << 8) | data[3];
-      const char *name_ptr = reinterpret_cast<const char *>(data + 4);
-      ESP_LOGD(TAG, "Face verified. ID: %d, name: %.*s", face_id, (int) HLK_FM22X_NAME_SIZE, name_ptr);
-      if (this->last_face_id_sensor_ != nullptr) {
-        this->last_face_id_sensor_->publish_state(face_id);
-      }
-      if (this->last_face_name_text_sensor_ != nullptr) {
-        this->last_face_name_text_sensor_->publish_state(name_ptr, HLK_FM22X_NAME_SIZE);
-      }
-      this->face_scan_matched_callback_.call(face_id, std::string(name_ptr, HLK_FM22X_NAME_SIZE));
-      break;
-    }
-    case HlkFm22xCommand::ENROLL: {
-      int16_t face_id = ((int16_t) data[2] << 8) | data[3];
-      HlkFm22xFaceDirection direction = (HlkFm22xFaceDirection) data[4];
-      ESP_LOGI(TAG, "Face enrolled. ID: %d, Direction: 0x%.2X", face_id, direction);
-      this->enrollment_done_callback_.call(face_id, (uint8_t) direction);
-      this->set_enrolling_(false);
-      this->defer([this]() { this->get_face_count_(); });
-      break;
-    }
-    case HlkFm22xCommand::GET_STATUS:
-      if (this->status_sensor_ != nullptr) {
-        this->status_sensor_->publish_state(data[2]);
-      }
-      this->defer([this]() { this->send_command_(HlkFm22xCommand::GET_VERSION); });
-      break;
-    case HlkFm22xCommand::GET_VERSION:
-      if (this->version_text_sensor_ != nullptr && length > 2) {
-        this->version_text_sensor_->publish_state(reinterpret_cast<const char *>(data + 2), length - 2);
-      }
-      this->defer([this]() { this->get_face_count_(); });
-      break;
-    case HlkFm22xCommand::GET_ALL_FACE_IDS:
-      if (this->face_count_sensor_ != nullptr) {
-        this->face_count_sensor_->publish_state(data[2]);
-      }
-      break;
-    case HlkFm22xCommand::DELETE_FACE:
-      ESP_LOGI(TAG, "Deleted face");
-      break;
-    case HlkFm22xCommand::DELETE_ALL_FACES:
-      ESP_LOGI(TAG, "Deleted all faces");
-      break;
-    case HlkFm22xCommand::RESET:
-      ESP_LOGI(TAG, "Module reset");
-      this->defer([this]() { this->send_command_(HlkFm22xCommand::GET_STATUS); });
-      break;
-    default:
-      ESP_LOGW(TAG, "Unhandled command: 0x%.2X", this->active_command_);
-      break;
+  this->read_out_done_ = true;
+}
+
+void HlkFm22xComponent::refresh_face_count_() {
+  if (this->face_count_sensor_ != nullptr) {
+    this->enqueue_(HlkFm22xCommand::GET_ALL_FACE_IDS);
   }
 }
 
 void HlkFm22xComponent::set_enrolling_(bool enrolling) {
-  if (this->enrolling_binary_sensor_ != nullptr) {
-    this->enrolling_binary_sensor_->publish_state(enrolling);
+  if (this->enrolling_binary_sensor_ == nullptr) {
+    return;
+  }
+  if (this->enrolling_binary_sensor_->has_state() && this->enrolling_binary_sensor_->state == enrolling) {
+    return;
+  }
+  this->enrolling_binary_sensor_->publish_state(enrolling);
+}
+
+void HlkFm22xComponent::set_scanning_(bool scanning) {
+  if (this->scanning_binary_sensor_ == nullptr) {
+    return;
+  }
+  if (this->scanning_binary_sensor_->has_state() && this->scanning_binary_sensor_->state == scanning) {
+    return;
+  }
+  this->scanning_binary_sensor_->publish_state(scanning);
+}
+
+void HlkFm22xComponent::publish_face_state_(int16_t state) {
+  if (state == this->last_face_state_) {
+    return;
+  }
+  this->last_face_state_ = state;
+  if (this->face_state_text_sensor_ != nullptr) {
+    this->face_state_text_sensor_->publish_state(face_state_to_string(state));
   }
 }
 
 void HlkFm22xComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "HLK_FM22X:");
-  LOG_UPDATE_INTERVAL(this);
-  if (this->version_text_sensor_) {
-    LOG_TEXT_SENSOR("  ", "Version", this->version_text_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %s", this->version_text_sensor_->get_state().c_str());
+  ESP_LOGCONFIG(TAG, "HLK-FM22X:");
+  this->check_uart_settings(BAUD_RATE);
+  LOG_BINARY_SENSOR("  ", "Enrolling", this->enrolling_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Scanning", this->scanning_binary_sensor_);
+  LOG_SENSOR("  ", "Face Count", this->face_count_sensor_);
+  LOG_SENSOR("  ", "Status", this->status_sensor_);
+  LOG_SENSOR("  ", "Last Face ID", this->last_face_id_sensor_);
+  LOG_TEXT_SENSOR("  ", "Version", this->version_text_sensor_);
+  LOG_TEXT_SENSOR("  ", "Serial Number", this->serial_number_text_sensor_);
+  LOG_TEXT_SENSOR("  ", "Last Face Name", this->last_face_name_text_sensor_);
+  LOG_TEXT_SENSOR("  ", "Face State", this->face_state_text_sensor_);
+  if (this->version_text_sensor_ != nullptr && this->version_text_sensor_->has_state()) {
+    ESP_LOGCONFIG(TAG, "  Firmware: %s", this->version_text_sensor_->get_state().c_str());
   }
-  if (this->enrolling_binary_sensor_) {
-    LOG_BINARY_SENSOR("  ", "Enrolling", this->enrolling_binary_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %s",
-                  this->enrolling_binary_sensor_->state ? LOG_STR_LITERAL("ON") : LOG_STR_LITERAL("OFF"));
+  if (this->serial_number_text_sensor_ != nullptr && this->serial_number_text_sensor_->has_state()) {
+    ESP_LOGCONFIG(TAG, "  Serial: %s", this->serial_number_text_sensor_->get_state().c_str());
   }
-  if (this->face_count_sensor_) {
-    LOG_SENSOR("  ", "Face Count", this->face_count_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %u", (uint16_t) this->face_count_sensor_->get_state());
-  }
-  if (this->status_sensor_) {
-    LOG_SENSOR("  ", "Status", this->status_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %u", (uint8_t) this->status_sensor_->get_state());
-  }
-  if (this->last_face_id_sensor_) {
-    LOG_SENSOR("  ", "Last Face ID", this->last_face_id_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %u", (int16_t) this->last_face_id_sensor_->get_state());
-  }
-  if (this->last_face_name_text_sensor_) {
-    LOG_TEXT_SENSOR("  ", "Last Face Name", this->last_face_name_text_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %s", this->last_face_name_text_sensor_->get_state().c_str());
+  if (this->face_count_sensor_ != nullptr && this->face_count_sensor_->has_state()) {
+    ESP_LOGCONFIG(TAG, "  Enrolled faces: %u", (unsigned) this->face_count_sensor_->get_state());
   }
 }
 

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -2,45 +2,64 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
 #include <array>
+#include <cstdint>
+#include <string>
 #include <utility>
 
 namespace esphome::hlk_fm22x {
 
 static const uint16_t START_CODE = 0xEFAA;
 static constexpr size_t HLK_FM22X_NAME_SIZE = 32;
-// Maximum response payload: command(1) + result(1) + face_id(2) + name(32) = 36
-static constexpr size_t HLK_FM22X_MAX_RESPONSE_SIZE = 36;
-enum HlkFm22xCommand {
+// Largest reply that is parsed in full: command(1) + result(1) + face_id(2) + name(32) + admin(1) + unlock_status(1).
+// Longer replies (the list of enrolled face IDs) are checksummed in full but only their first bytes are kept.
+static constexpr size_t HLK_FM22X_MAX_RESPONSE_SIZE = 38;
+// Largest command payload: admin(1) + name(32) + direction(1) + type(1) + duplicate(1) + timeout(1) + reserved(3)
+static constexpr size_t HLK_FM22X_MAX_COMMAND_SIZE = 40;
+static constexpr size_t HLK_FM22X_COMMAND_QUEUE_SIZE = 6;
+static constexpr uint8_t HLK_FM22X_DEFAULT_TIMEOUT_S = 10;
+// Direction bitmask reported once a face has been captured from all five directions
+static constexpr uint8_t HLK_FM22X_ALL_DIRECTIONS = 0x1F;
+
+enum HlkFm22xCommand : uint8_t {
   NONE = 0x00,
   RESET = 0x10,
   GET_STATUS = 0x11,
   VERIFY = 0x12,
   ENROLL = 0x13,
+  ENROLL_SINGLE = 0x1D,
   DELETE_FACE = 0x20,
   DELETE_ALL_FACES = 0x21,
+  GET_FACE_DETAILS = 0x22,
+  FACE_RESET = 0x23,
   GET_ALL_FACE_IDS = 0x24,
+  ENROLL_ITG = 0x26,
   GET_VERSION = 0x30,
   GET_SERIAL_NUMBER = 0x93,
 };
 
-enum HlkFm22xResponseType {
+enum HlkFm22xResponseType : uint8_t {
   REPLY = 0x00,
   NOTE = 0x01,
   IMAGE = 0x02,
 };
 
-enum HlkFm22xNoteType {
-  READY = 0x00,
-  FACE_STATE = 0x01,
+enum HlkFm22xNoteType : uint8_t {
+  NOTE_READY = 0x00,
+  NOTE_FACE_STATE = 0x01,
+  NOTE_UNKNOWN_ERROR = 0x02,
+  NOTE_OTA_DONE = 0x03,
+  NOTE_EYE_STATE = 0x04,
+  NOTE_AUTHORIZATION_FAILED = 0x08,
 };
 
-enum HlkFm22xResult {
+enum HlkFm22xResult : uint8_t {
   SUCCEEDED = 0x00,
   REJECTED = 0x01,
   ABORTED = 0x02,
@@ -62,7 +81,14 @@ enum HlkFm22xResult {
   FAILED4_JPGPHOTO_SMALL = 0x19,
 };
 
-enum HlkFm22xFaceDirection {
+enum HlkFm22xModuleStatus : uint8_t {
+  MODULE_STATUS_STANDBY = 0x00,
+  MODULE_STATUS_BUSY = 0x01,
+  MODULE_STATUS_ERROR = 0x02,
+  MODULE_STATUS_INVALID = 0x03,
+};
+
+enum HlkFm22xFaceDirection : uint8_t {
   FACE_DIRECTION_UNDEFINED = 0x00,
   FACE_DIRECTION_MIDDLE = 0x01,
   FACE_DIRECTION_RIGHT = 0x02,
@@ -71,10 +97,34 @@ enum HlkFm22xFaceDirection {
   FACE_DIRECTION_UP = 0x10,
 };
 
-class HlkFm22xComponent final : public PollingComponent, public uart::UARTDevice {
+enum HlkFm22xEnrollType : uint8_t {
+  ENROLL_TYPE_INTERACTIVE = 0x00,
+  ENROLL_TYPE_SINGLE = 0x01,
+};
+
+// Face state reported by the module while a scan or enrollment is running
+enum HlkFm22xFaceState : int16_t {
+  FACE_STATE_NORMAL = 0,
+  FACE_STATE_NO_FACE = 1,
+  FACE_STATE_TOO_HIGH = 2,
+  FACE_STATE_TOO_LOW = 3,
+  FACE_STATE_TOO_LEFT = 4,
+  FACE_STATE_TOO_RIGHT = 5,
+  FACE_STATE_TOO_FAR = 6,
+  FACE_STATE_TOO_CLOSE = 7,
+  FACE_STATE_EYEBROW_OCCLUSION = 8,
+  FACE_STATE_EYE_OCCLUSION = 9,
+  FACE_STATE_FACE_OCCLUSION = 10,
+  FACE_STATE_DIRECTION_ERROR = 11,
+  FACE_STATE_EYES_OPEN = 12,
+  FACE_STATE_EYES_CLOSED = 13,
+  FACE_STATE_EYES_UNKNOWN = 14,
+};
+
+class HlkFm22xComponent final : public Component, public uart::UARTDevice {
  public:
   void setup() override;
-  void update() override;
+  void loop() override;
   void dump_config() override;
 
   void set_face_count_sensor(sensor::Sensor *face_count_sensor) { this->face_count_sensor_ = face_count_sensor; }
@@ -88,8 +138,17 @@ class HlkFm22xComponent final : public PollingComponent, public uart::UARTDevice
   void set_enrolling_binary_sensor(binary_sensor::BinarySensor *enrolling_binary_sensor) {
     this->enrolling_binary_sensor_ = enrolling_binary_sensor;
   }
+  void set_scanning_binary_sensor(binary_sensor::BinarySensor *scanning_binary_sensor) {
+    this->scanning_binary_sensor_ = scanning_binary_sensor;
+  }
   void set_version_text_sensor(text_sensor::TextSensor *version_text_sensor) {
     this->version_text_sensor_ = version_text_sensor;
+  }
+  void set_serial_number_text_sensor(text_sensor::TextSensor *serial_number_text_sensor) {
+    this->serial_number_text_sensor_ = serial_number_text_sensor;
+  }
+  void set_face_state_text_sensor(text_sensor::TextSensor *face_state_text_sensor) {
+    this->face_state_text_sensor_ = face_state_text_sensor;
   }
   template<typename F> void add_on_face_scan_matched_callback(F &&callback) {
     this->face_scan_matched_callback_.add(std::forward<F>(callback));
@@ -103,6 +162,9 @@ class HlkFm22xComponent final : public PollingComponent, public uart::UARTDevice
   template<typename F> void add_on_face_info_callback(F &&callback) {
     this->face_info_callback_.add(std::forward<F>(callback));
   }
+  template<typename F> void add_on_face_details_callback(F &&callback) {
+    this->face_details_callback_.add(std::forward<F>(callback));
+  }
   template<typename F> void add_on_enrollment_done_callback(F &&callback) {
     this->enrollment_done_callback_.add(std::forward<F>(callback));
   }
@@ -110,57 +172,149 @@ class HlkFm22xComponent final : public PollingComponent, public uart::UARTDevice
     this->enrollment_failed_callback_.add(std::forward<F>(callback));
   }
 
-  void enroll_face(const std::string &name, HlkFm22xFaceDirection direction);
-  void scan_face();
+  /// Start enrolling a face. With FACE_DIRECTION_UNDEFINED the face is captured from a single frame,
+  /// otherwise one direction is captured per call and the face is stored once all five are done.
+  /// With allow_duplicate set to false the module refuses to enroll a face it already knows.
+  void enroll_face(const std::string &name, HlkFm22xFaceDirection direction, bool admin = false,
+                   uint8_t timeout_s = HLK_FM22X_DEFAULT_TIMEOUT_S, bool allow_duplicate = true);
+  /// Look for a face and try to match it against the enrolled faces.
+  void scan_face(uint8_t timeout_s = HLK_FM22X_DEFAULT_TIMEOUT_S);
+  /// Stop the running scan or enrollment and forget any directions captured so far.
+  void cancel();
   void delete_face(int16_t face_id);
   void delete_all_faces();
+  /// Ask for the name and admin flag of an enrolled face; the answer arrives through on_face_details.
+  void get_face_details(int16_t face_id);
+  /// Put the module back into standby. Anything the module was doing is stopped; queued commands still run.
   void reset();
 
  protected:
-  void get_face_count_();
-  void send_command_(HlkFm22xCommand command, const uint8_t *data = nullptr, size_t size = 0);
-  void recv_command_();
+  struct QueuedCommand {
+    HlkFm22xCommand command;
+    uint8_t size;
+    uint16_t timeout_s;  // how long to wait for the reply
+    uint8_t data[HLK_FM22X_MAX_COMMAND_SIZE];
+  };
+
+  enum class RecvState : uint8_t {
+    RECV_STATE_SYNC_1,
+    RECV_STATE_SYNC_2,
+    RECV_STATE_TYPE,
+    RECV_STATE_LENGTH_HIGH,
+    RECV_STATE_LENGTH_LOW,
+    RECV_STATE_DATA,
+    RECV_STATE_CHECKSUM,
+  };
+
+  static bool is_scan_or_enroll_(HlkFm22xCommand command);
+  static bool is_read_out_(HlkFm22xCommand command);
+  static uint16_t default_timeout_s_(HlkFm22xCommand command);
+  static bool parse_face_record_(const uint8_t *data, size_t length, int16_t &face_id, const char *&name,
+                                 size_t &name_length, bool &admin);
+
+  bool enqueue_(HlkFm22xCommand command, const uint8_t *data = nullptr, size_t size = 0, uint16_t timeout_s = 0);
+  void enqueue_face_id_command_(HlkFm22xCommand command, int16_t face_id);
+  void drop_queued_(bool (*predicate)(HlkFm22xCommand));
+  void send_next_command_();
+  void write_frame_(HlkFm22xCommand command, const uint8_t *data, size_t size);
+  void interrupt_with_(HlkFm22xCommand command);
+  void hold_interrupted_(HlkFm22xCommand command);
+  void clear_interrupted_(bool aborted);
+  void read_frames_();
+  void process_byte_(uint8_t byte);
+  void handle_frame_();
   void handle_note_(const uint8_t *data, size_t length);
   void handle_reply_(const uint8_t *data, size_t length);
+  void handle_scan_reply_(uint8_t result, const uint8_t *data, size_t length);
+  void handle_enroll_reply_(uint8_t result, const uint8_t *data, size_t length);
+  void handle_face_details_reply_(uint8_t result, const uint8_t *data, size_t length);
+  void publish_text_(text_sensor::TextSensor *text_sensor, const uint8_t *data, size_t length);
+  void check_timeouts_();
+  void finish_failed_(HlkFm22xCommand command, uint8_t error);
+  void start_read_out_();
+  void continue_read_out_();
+  void refresh_face_count_();
   void set_enrolling_(bool enrolling);
+  void set_scanning_(bool scanning);
+  void publish_face_state_(int16_t state);
 
-  std::array<uint8_t, HLK_FM22X_MAX_RESPONSE_SIZE> recv_buf_;
-  HlkFm22xCommand active_command_ = HlkFm22xCommand::NONE;
-  uint16_t wait_cycles_ = 0;
+  StaticRingBuffer<QueuedCommand, HLK_FM22X_COMMAND_QUEUE_SIZE> queue_;
+  std::array<uint8_t, HLK_FM22X_MAX_RESPONSE_SIZE> recv_buf_{};
+  RecvState recv_state_{RecvState::RECV_STATE_SYNC_1};
+  uint8_t recv_type_{0};
+  uint8_t recv_checksum_{0};
+  uint16_t recv_length_{0};
+  uint16_t recv_index_{0};
+  uint32_t recv_last_byte_ms_{0};
+  HlkFm22xCommand pending_command_{HlkFm22xCommand::NONE};
+  // Scan or enrollment that was interrupted (cancel, reset or module restart) and may still answer
+  HlkFm22xCommand interrupted_command_{HlkFm22xCommand::NONE};
+  uint32_t pending_sent_ms_{0};
+  uint32_t pending_timeout_ms_{0};
+  uint32_t interrupted_deadline_ms_{0};
+  uint32_t retry_at_ms_{0};
+  bool interrupted_deadline_set_{false};
+  bool retry_scheduled_{false};
+  bool read_out_done_{false};
+  uint8_t read_out_stage_{0};
+  uint8_t consecutive_timeouts_{0};
+  int16_t last_face_state_{INT16_MIN};
   sensor::Sensor *face_count_sensor_{nullptr};
   sensor::Sensor *status_sensor_{nullptr};
   sensor::Sensor *last_face_id_sensor_{nullptr};
   binary_sensor::BinarySensor *enrolling_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *scanning_binary_sensor_{nullptr};
   text_sensor::TextSensor *last_face_name_text_sensor_{nullptr};
   text_sensor::TextSensor *version_text_sensor_{nullptr};
-  CallbackManager<void(uint8_t)> face_scan_invalid_callback_;
-  CallbackManager<void(int16_t, std::string)> face_scan_matched_callback_;
-  CallbackManager<void()> face_scan_unmatched_callback_;
-  CallbackManager<void(int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t)> face_info_callback_;
-  CallbackManager<void(int16_t, uint8_t)> enrollment_done_callback_;
-  CallbackManager<void(uint8_t)> enrollment_failed_callback_;
+  text_sensor::TextSensor *serial_number_text_sensor_{nullptr};
+  text_sensor::TextSensor *face_state_text_sensor_{nullptr};
+  LazyCallbackManager<void(uint8_t)> face_scan_invalid_callback_;
+  LazyCallbackManager<void(int16_t, std::string, bool)> face_scan_matched_callback_;
+  LazyCallbackManager<void()> face_scan_unmatched_callback_;
+  LazyCallbackManager<void(int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t)> face_info_callback_;
+  LazyCallbackManager<void(int16_t, std::string, bool)> face_details_callback_;
+  LazyCallbackManager<void(int16_t, uint8_t)> enrollment_done_callback_;
+  LazyCallbackManager<void(uint8_t)> enrollment_failed_callback_;
 };
 
 template<typename... Ts> class EnrollmentAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   TEMPLATABLE_VALUE(std::string, name)
   TEMPLATABLE_VALUE(uint8_t, direction)
+  TEMPLATABLE_VALUE(bool, admin)
+  TEMPLATABLE_VALUE(bool, allow_duplicate)
+
+  void set_timeout_seconds(uint8_t timeout_s) { this->timeout_s_ = timeout_s; }
 
   void play(const Ts &...x) override {
-    auto name = this->name_.value(x...);
-    auto direction = (HlkFm22xFaceDirection) this->direction_.value(x...);
-    this->parent_->enroll_face(name, direction);
+    this->parent_->enroll_face(this->name_.value(x...), (HlkFm22xFaceDirection) this->direction_.value(x...),
+                               this->admin_.value(x...), this->timeout_s_, this->allow_duplicate_.value_or(x..., true));
   }
+
+ protected:
+  uint8_t timeout_s_{HLK_FM22X_DEFAULT_TIMEOUT_S};
+};
+
+template<typename... Ts> class ScanAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+ public:
+  void set_timeout_seconds(uint8_t timeout_s) { this->timeout_s_ = timeout_s; }
+
+  void play(const Ts &...x) override { this->parent_->scan_face(this->timeout_s_); }
+
+ protected:
+  uint8_t timeout_s_{HLK_FM22X_DEFAULT_TIMEOUT_S};
+};
+
+template<typename... Ts> class CancelAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+ public:
+  void play(const Ts &...x) override { this->parent_->cancel(); }
 };
 
 template<typename... Ts> class DeleteAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
   TEMPLATABLE_VALUE(int16_t, face_id)
 
-  void play(const Ts &...x) override {
-    auto face_id = this->face_id_.value(x...);
-    this->parent_->delete_face(face_id);
-  }
+  void play(const Ts &...x) override { this->parent_->delete_face(this->face_id_.value(x...)); }
 };
 
 template<typename... Ts> class DeleteAllAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
@@ -168,9 +322,11 @@ template<typename... Ts> class DeleteAllAction final : public Action<Ts...>, pub
   void play(const Ts &...x) override { this->parent_->delete_all_faces(); }
 };
 
-template<typename... Ts> class ScanAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
+template<typename... Ts> class GetFaceDetailsAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(const Ts &...x) override { this->parent_->scan_face(); }
+  TEMPLATABLE_VALUE(int16_t, face_id)
+
+  void play(const Ts &...x) override { this->parent_->get_face_details(this->face_id_.value(x...)); }
 };
 
 template<typename... Ts> class ResetAction final : public Action<Ts...>, public Parented<HlkFm22xComponent> {

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -206,12 +206,6 @@ class HlkFm22xComponent final : public Component, public uart::UARTDevice {
     RECV_STATE_CHECKSUM,
   };
 
-  static bool is_scan_or_enroll_(HlkFm22xCommand command);
-  static bool is_read_out_(HlkFm22xCommand command);
-  static uint16_t default_timeout_s_(HlkFm22xCommand command);
-  static bool parse_face_record_(const uint8_t *data, size_t length, int16_t &face_id, const char *&name,
-                                 size_t &name_length, bool &admin);
-
   bool enqueue_(HlkFm22xCommand command, const uint8_t *data = nullptr, size_t size = 0, uint16_t timeout_s = 0);
   void enqueue_face_id_command_(HlkFm22xCommand command, int16_t face_id);
   void drop_queued_(bool (*predicate)(HlkFm22xCommand));
@@ -269,10 +263,10 @@ class HlkFm22xComponent final : public Component, public uart::UARTDevice {
   text_sensor::TextSensor *serial_number_text_sensor_{nullptr};
   text_sensor::TextSensor *face_state_text_sensor_{nullptr};
   LazyCallbackManager<void(uint8_t)> face_scan_invalid_callback_;
-  LazyCallbackManager<void(int16_t, std::string, bool)> face_scan_matched_callback_;
+  LazyCallbackManager<void(int16_t, const std::string &, bool)> face_scan_matched_callback_;
   LazyCallbackManager<void()> face_scan_unmatched_callback_;
   LazyCallbackManager<void(int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t, int16_t)> face_info_callback_;
-  LazyCallbackManager<void(int16_t, std::string, bool)> face_details_callback_;
+  LazyCallbackManager<void(int16_t, const std::string &, bool)> face_details_callback_;
   LazyCallbackManager<void(int16_t, uint8_t)> enrollment_done_callback_;
   LazyCallbackManager<void(uint8_t)> enrollment_failed_callback_;
 };

--- a/esphome/components/hlk_fm22x/sensor.py
+++ b/esphome/components/hlk_fm22x/sensor.py
@@ -2,20 +2,22 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_STATUS, ENTITY_CATEGORY_DIAGNOSTIC, ICON_ACCOUNT
+from esphome.types import ConfigType
 
-from . import CONF_HLK_FM22X_ID, HlkFm22xComponent
+from . import CONF_HLK_FM22X_ID, ICON_FACE_RECOGNITION, HlkFm22xComponent
 
 DEPENDENCIES = ["hlk_fm22x"]
 
 CONF_FACE_COUNT = "face_count"
 CONF_LAST_FACE_ID = "last_face_id"
-ICON_FACE = "mdi:face-recognition"
+
+SENSOR_KEYS = (CONF_FACE_COUNT, CONF_STATUS, CONF_LAST_FACE_ID)
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_HLK_FM22X_ID): cv.use_id(HlkFm22xComponent),
         cv.Optional(CONF_FACE_COUNT): sensor.sensor_schema(
-            icon=ICON_FACE,
+            icon=ICON_FACE_RECOGNITION,
             accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
@@ -32,16 +34,9 @@ CONFIG_SCHEMA = cv.Schema(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_HLK_FM22X_ID])
-
-    for key in [
-        CONF_FACE_COUNT,
-        CONF_STATUS,
-        CONF_LAST_FACE_ID,
-    ]:
-        if key not in config:
-            continue
-        conf = config[key]
-        sens = await sensor.new_sensor(conf)
-        cg.add(getattr(hub, f"set_{key}_sensor")(sens))
+    for key in SENSOR_KEYS:
+        if (conf := config.get(key)) is not None:
+            sens = await sensor.new_sensor(conf)
+            cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/esphome/components/hlk_fm22x/text_sensor.py
+++ b/esphome/components/hlk_fm22x/text_sensor.py
@@ -5,14 +5,20 @@ from esphome.const import (
     CONF_VERSION,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_ACCOUNT,
+    ICON_CHIP,
     ICON_RESTART,
 )
+from esphome.types import ConfigType
 
-from . import CONF_HLK_FM22X_ID, HlkFm22xComponent
+from . import CONF_HLK_FM22X_ID, ICON_FACE_RECOGNITION, HlkFm22xComponent
 
 DEPENDENCIES = ["hlk_fm22x"]
 
 CONF_LAST_FACE_NAME = "last_face_name"
+CONF_SERIAL_NUMBER = "serial_number"
+CONF_FACE_STATE = "face_state"
+
+SENSOR_KEYS = (CONF_VERSION, CONF_SERIAL_NUMBER, CONF_LAST_FACE_NAME, CONF_FACE_STATE)
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -21,22 +27,24 @@ CONFIG_SCHEMA = cv.Schema(
             icon=ICON_RESTART,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
+        cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(
+            icon=ICON_CHIP,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         cv.Optional(CONF_LAST_FACE_NAME): text_sensor.text_sensor_schema(
             icon=ICON_ACCOUNT,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_FACE_STATE): text_sensor.text_sensor_schema(
+            icon=ICON_FACE_RECOGNITION,
         ),
     }
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     hub = await cg.get_variable(config[CONF_HLK_FM22X_ID])
-    for key in [
-        CONF_VERSION,
-        CONF_LAST_FACE_NAME,
-    ]:
-        if key not in config:
-            continue
-        conf = config[key]
-        sens = await text_sensor.new_text_sensor(conf)
-        cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))
+    for key in SENSOR_KEYS:
+        if (conf := config.get(key)) is not None:
+            sens = await text_sensor.new_text_sensor(conf)
+            cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))

--- a/tests/component_tests/hlk_fm22x/test_hlk_fm22x.py
+++ b/tests/component_tests/hlk_fm22x/test_hlk_fm22x.py
@@ -1,0 +1,96 @@
+"""Tests for the hlk_fm22x component."""
+
+import logging
+import re
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components import hlk_fm22x
+
+
+def _returned_values(main_cpp: str, setter: str, cpp_type: str) -> list[str]:
+    """Collect the constants returned by the lambdas passed to a templatable setter."""
+    pattern = rf"{setter}\(\[\]\(\) -> {cpp_type} \{{\s*return ([^;]+);"
+    return [match.strip() for match in re.findall(pattern, main_cpp)]
+
+
+def test_hlk_fm22x_entities_and_actions(generate_main) -> None:
+    """Every entity type and action option ends up in the generated code."""
+    main_cpp = generate_main("tests/component_tests/hlk_fm22x/test_hlk_fm22x.yaml")
+
+    assert "new(face_module) hlk_fm22x::HlkFm22xComponent();" in main_cpp
+    # Plain component now, no polling
+    assert "face_module->set_update_interval(" not in main_cpp
+    assert "set_enrolling_binary_sensor(" in main_cpp
+    assert "set_scanning_binary_sensor(" in main_cpp
+    assert "set_face_count_sensor(" in main_cpp
+    assert "set_version_text_sensor(" in main_cpp
+    assert "set_serial_number_text_sensor(" in main_cpp
+    assert "set_face_state_text_sensor(" in main_cpp
+
+    # Templatable values are emitted as small lambdas returning the constant.
+    # Enrollment options, including a numeric and a named direction
+    directions = _returned_values(main_cpp, "set_direction", "uint8_t")
+    assert "1" in directions
+    assert any("FACE_DIRECTION_LEFT" in value for value in directions)
+    assert "true" in _returned_values(main_cpp, "set_admin", "bool")
+    assert "false" in _returned_values(main_cpp, "set_allow_duplicate", "bool")
+    assert "set_timeout_seconds(20)" in main_cpp
+    # A scan with its own timeout and the default one used by the shorthand enroll
+    assert "set_timeout_seconds(15)" in main_cpp
+    assert "set_timeout_seconds(10)" in main_cpp
+
+    assert "hlk_fm22x::CancelAction<>" in main_cpp
+    assert "hlk_fm22x::GetFaceDetailsAction<>" in main_cpp
+    assert "3" in _returned_values(main_cpp, "set_face_id", "int16_t")
+
+
+def test_hlk_fm22x_legacy_config(
+    generate_main, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Deprecated forms still generate working code and warn about the change."""
+    with caplog.at_level(logging.WARNING):
+        main_cpp = generate_main(
+            "tests/component_tests/hlk_fm22x/test_hlk_fm22x_legacy.yaml"
+        )
+
+    assert "face_module->set_enrolling_binary_sensor(" in main_cpp
+    assert "face_module->set_update_interval(" not in main_cpp
+
+    messages = [record.message for record in caplog.records]
+    assert any("'update_interval' is no longer used" in m for m in messages)
+    assert any("move its options under 'enrolling:'" in m for m in messages)
+
+
+def test_direction_validator() -> None:
+    """Directions can be given as the module's codes or as names."""
+    assert hlk_fm22x.validate_direction(4) == 4
+    # Any byte value is passed to the module unchanged, 0 means single frame
+    assert hlk_fm22x.validate_direction(0) == 0
+    left = hlk_fm22x.validate_direction("Left")
+    assert left.enum_value is hlk_fm22x.FACE_DIRECTIONS["left"]
+    with pytest.raises(cv.Invalid):
+        hlk_fm22x.validate_direction(256)
+    with pytest.raises(cv.Invalid):
+        hlk_fm22x.validate_direction("sideways")
+
+
+def test_name_validator() -> None:
+    """Names must fit the module's 32 byte field with room for the terminator."""
+    assert hlk_fm22x.validate_name("a" * 31) == "a" * 31
+    with pytest.raises(cv.Invalid):
+        hlk_fm22x.validate_name("a" * 32)
+    # Multi byte characters count by their encoded size
+    with pytest.raises(cv.Invalid):
+        hlk_fm22x.validate_name("\u00e9" * 16)
+
+
+def test_timeout_schema() -> None:
+    """The module accepts timeouts from 1 to 255 seconds."""
+    assert hlk_fm22x.TIMEOUT_SCHEMA("20s").total_seconds == 20
+    assert hlk_fm22x.TIMEOUT_SCHEMA("2min").total_seconds == 120
+    with pytest.raises(cv.Invalid):
+        hlk_fm22x.TIMEOUT_SCHEMA("0s")
+    with pytest.raises(cv.Invalid):
+        hlk_fm22x.TIMEOUT_SCHEMA("300s")

--- a/tests/component_tests/hlk_fm22x/test_hlk_fm22x.yaml
+++ b/tests/component_tests/hlk_fm22x/test_hlk_fm22x.yaml
@@ -1,0 +1,58 @@
+---
+esphome:
+  name: test
+  on_boot:
+    then:
+      - hlk_fm22x.enroll:
+          name: "Test"
+          direction: 1
+      - hlk_fm22x.enroll:
+          name: "Admin"
+          direction: left
+          admin: true
+          timeout: 20s
+          allow_duplicate: false
+      - hlk_fm22x.enroll: "Single"
+      - hlk_fm22x.scan:
+          timeout: 15s
+      - hlk_fm22x.cancel:
+      - hlk_fm22x.get_face_details: 3
+      - hlk_fm22x.delete: 0
+      - hlk_fm22x.delete_all:
+      - hlk_fm22x.reset:
+
+esp32:
+  board: nodemcu-32s
+
+uart:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+hlk_fm22x:
+  id: face_module
+  on_face_scan_matched:
+    - lambda: 'ESP_LOGI("test", "%d %s %d", face_id, name.c_str(), admin);'
+  on_face_details:
+    - lambda: 'ESP_LOGI("test", "%d %s %d", face_id, name.c_str(), admin);'
+
+binary_sensor:
+  - platform: hlk_fm22x
+    enrolling:
+      name: "Face Enrolling"
+    scanning:
+      name: "Face Scanning"
+
+sensor:
+  - platform: hlk_fm22x
+    face_count:
+      name: "Face Count"
+
+text_sensor:
+  - platform: hlk_fm22x
+    version:
+      name: "Version"
+    serial_number:
+      name: "Serial Number"
+    face_state:
+      name: "Face State"

--- a/tests/component_tests/hlk_fm22x/test_hlk_fm22x_legacy.yaml
+++ b/tests/component_tests/hlk_fm22x/test_hlk_fm22x_legacy.yaml
@@ -1,0 +1,19 @@
+---
+esphome:
+  name: test
+
+esp32:
+  board: nodemcu-32s
+
+uart:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+hlk_fm22x:
+  id: face_module
+  update_interval: 50ms
+
+binary_sensor:
+  - platform: hlk_fm22x
+    name: "Face Enrolling"

--- a/tests/components/hlk_fm22x/common.yaml
+++ b/tests/components/hlk_fm22x/common.yaml
@@ -1,20 +1,46 @@
 esphome:
   on_boot:
     then:
+      # Interactive enrollment, one direction per call; the numeric code is kept for older configs
       - hlk_fm22x.enroll:
           name: "Test"
           direction: 1
+      - hlk_fm22x.enroll:
+          name: !lambda 'return "Lambda";'
+          direction: left
+          admin: true
+          timeout: 20s
+      # Single frame enrollment that refuses faces the module already knows
+      - hlk_fm22x.enroll:
+          name: "Single"
+          allow_duplicate: false
+      - hlk_fm22x.enroll: "Shorthand"
+      - hlk_fm22x.scan:
+          timeout: 15s
+      - hlk_fm22x.scan:
+      - hlk_fm22x.cancel:
+      - hlk_fm22x.get_face_details: 3
+      - hlk_fm22x.get_face_details:
+          face_id: !lambda 'return 4;'
+      - hlk_fm22x.delete: 0
       - hlk_fm22x.delete_all:
+      - hlk_fm22x.reset:
 
 hlk_fm22x:
   on_face_scan_matched:
-    - logger.log: test_hlk_22x_face_scan_matched
+    - logger.log:
+        format: "matched %d %s admin=%d"
+        args: ["face_id", "name.c_str()", "admin"]
   on_face_scan_unmatched:
     - logger.log: test_hlk_22x_face_scan_unmatched
   on_face_scan_invalid:
     - logger.log: test_hlk_22x_face_scan_invalid
   on_face_info:
     - logger.log: test_hlk_22x_face_info
+  on_face_details:
+    - logger.log:
+        format: "face %d is %s admin=%d"
+        args: ["face_id", "name.c_str()", "admin"]
   on_enrollment_done:
     - logger.log: test_hlk_22x_enrollment_done
   on_enrollment_failed:
@@ -31,11 +57,18 @@ sensor:
 
 binary_sensor:
   - platform: hlk_fm22x
-    name: "Face Enrolling"
+    enrolling:
+      name: "Face Enrolling"
+    scanning:
+      name: "Face Scanning"
 
 text_sensor:
   - platform: hlk_fm22x
     version:
       name: "HLK Version"
+    serial_number:
+      name: "HLK Serial Number"
     last_face_name:
       name: "Last Face Name"
+    face_state:
+      name: "Face State"

--- a/tests/components/hlk_fm22x/test.esp32-idf.yaml
+++ b/tests/components/hlk_fm22x/test.esp32-idf.yaml
@@ -1,4 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
-
-<<: !include common.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
+  hlk_fm22x: !include common.yaml

--- a/tests/components/hlk_fm22x/test.esp8266-ard.yaml
+++ b/tests/components/hlk_fm22x/test.esp8266-ard.yaml
@@ -1,4 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
-
-<<: !include common.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp8266-ard.yaml
+  hlk_fm22x: !include common.yaml

--- a/tests/components/hlk_fm22x/test.rp2040-ard.yaml
+++ b/tests/components/hlk_fm22x/test.rp2040-ard.yaml
@@ -1,4 +1,3 @@
 packages:
-  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
-
-<<: !include common.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/rp2040-ard.yaml
+  hlk_fm22x: !include common.yaml

--- a/tests/components/hlk_fm22x/validate-legacy.esp32-idf.yaml
+++ b/tests/components/hlk_fm22x/validate-legacy.esp32-idf.yaml
@@ -1,0 +1,12 @@
+# Deprecated forms: `update_interval` on the hub and the enrolling binary sensor
+# configured directly under the platform entry.
+# Remove before 2027.3.0
+packages:
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
+
+hlk_fm22x:
+  update_interval: 50ms
+
+binary_sensor:
+  - platform: hlk_fm22x
+    name: "Face Enrolling"


### PR DESCRIPTION
# What does this implement/fix?

Reworks the `hlk_fm22x` component so it covers the module's protocol properly and
behaves well when the module is slow, busy or absent. Validated against real
HLK-FM225 hardware.

## Transport

The previous implementation polled every 50ms and, once it had consumed a frame
header, blocked in a `while` loop with `delay(1)` waiting for the payload. Two
consequences:

- Long replies were unreliable. `GET_ALL_FACE_IDS` returns up to 203 bytes and
  could overflow the UART buffer between polls.
- A second action triggered while one was in flight was dropped outright with
  "Command already active".

Replaced with a byte by byte frame parser in `loop()` and a small command queue,
so bytes are consumed as they arrive and queued actions run in order. Each command
now carries its own reply timeout taken from the datasheet (3s for quick commands,
10s for deletes, the scan or enrollment timeout plus 5s for those). An unanswered
command logs a warning, three in a row set the component's error status, and the
component retries every 5s instead of resetting the module or failing permanently.
A module that finishes booting after the ESP is now picked up on its own.

## Bug fixes

- **The matched face name was unusable.** The full 32 byte NUL padded field was
  published verbatim, so `name == "Jonny"` in a lambda never matched.
- **Invalid UTF-8 in text sensor states.** The module pads its fixed width text
  fields inconsistently: names come back NUL padded, but the serial number is
  padded with arbitrary bytes (`0xFF 0xA5 0x08` observed after a 29 character
  serial). Publishing those raw produced a `TextSensorStateResponse` that clients
  cannot decode. Home Assistant threw `google.protobuf.message.DecodeError`,
  dropped the connection and reconnected in a loop, making the device unusable.
  Text is now trimmed to the leading run of printable ASCII rather than to a NUL.

## New features

- Single frame enrollment (`MID_ENROLL_SINGLE`) when no `direction` is given. One
  look at the camera instead of five head turns.
- `admin`, `timeout` and `allow_duplicate` options on `hlk_fm22x.enroll`, and
  `timeout` on `hlk_fm22x.scan`. `allow_duplicate: false` uses `MID_ENROLL_ITG`,
  which refuses a face the module already knows.
- `hlk_fm22x.cancel` stops a running scan or enrollment and clears partially
  captured directions.
- `hlk_fm22x.get_face_details` plus an `on_face_details` trigger
  (`MID_GETUSERINFO`).
- `on_face_scan_matched` also reports whether the face is an administrator.
- New `scanning` binary sensor, `serial_number` text sensor (`MID_GET_SN`) and
  `face_state` text sensor, which turns the module's live feedback into readable
  text (`No face`, `Too far away`, `Eyes covered`) for display during enrollment.
- Directions can be named (`middle`, `right`, `left`, `down`, `up`) as well as
  given as the module's numeric codes.

## Behaviour changes worth a reviewer's attention

- `FINAL_VALIDATE_SCHEMA` now requires the UART bus to run at 115200, the only
  rate the module supports outside firmware update mode. This is the standard
  pattern for fixed rate devices, but it will reject an existing config that set
  another rate. Such a config could never have worked at runtime, and the
  component's own test files had to move from the 9600 bus package to
  `uart_115200`.
- `update_interval` is accepted with a deprecation warning and ignored, since the
  component is no longer a `PollingComponent`. Removal in 2027.3.0.
- The binary sensor moves under an `enrolling:` key to make room for `scanning:`.
  The old flat form still works with a deprecation warning. Removal in 2027.3.0.
- Result code 1 (`MR_REJECTED`) still routes to `on_face_scan_unmatched` and every
  other failure to `on_face_scan_invalid`, unchanged from before. The datasheet is
  ambiguous about whether an unknown face returns 1 or 8, so I have deliberately
  not touched this mapping.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7283

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Run against an HLK-FM225 on an ESP32-S3 with the ESP-IDF framework. ESP8266 and
RP2040 are compile verified only, no hardware.

Confirmed on hardware: module boot handshake and read out, single frame
enrollment, the five direction flow, matching against an enrolled face, cancel,
command queueing, the module's own timeout replies, and recovery after the module
loses power. The bad UTF-8 fix above was found this way.

Two places where the hardware disagreed with the datasheet, both now handled:

- The face state note really is little endian. Real bounding boxes decode to sane
  pixel values that way and to nonsense read big endian, so the datasheet is right
  and the vendor's own Python sample tool is wrong.
- The serial number is longer than the 8 bytes the datasheet says are valid, and
  is padded with junk rather than NULs.

## Example entry for `config.yaml`:

```yaml
uart:
  tx_pin: GPIOXX
  rx_pin: GPIOXX
  baud_rate: 115200

hlk_fm22x:
  on_face_scan_matched:
    - logger.log:
        format: "Recognized %s (id %d), admin %d"
        args: ["name.c_str()", "face_id", "admin"]
  on_face_scan_unmatched:
    - logger.log: "Unknown face"
  on_face_scan_invalid:
    - logger.log:
        format: "Scan failed with error %d"
        args: ["error"]

binary_sensor:
  - platform: hlk_fm22x
    enrolling:
      name: "Face Enrolling"
    scanning:
      name: "Face Scanning"

sensor:
  - platform: hlk_fm22x
    face_count:
      name: "Face Count"
    last_face_id:
      name: "Last Face ID"

text_sensor:
  - platform: hlk_fm22x
    version:
      name: "Face Module Version"
    serial_number:
      name: "Face Module Serial Number"
    last_face_name:
      name: "Last Face Name"
    face_state:
      name: "Face State"

button:
  - platform: template
    name: "Scan"
    on_press:
      - hlk_fm22x.scan:

  - platform: template
    name: "Enroll"
    on_press:
      - hlk_fm22x.enroll:
          name: "My name"
          allow_duplicate: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).