### PR TITLE
[openthread] on connect and address change logging

### DIFF
--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -47,53 +47,57 @@ void OpenThreadComponent::dump_config() {
 }
 
 void OpenThreadComponent::on_state_changed(otChangedFlags flags, void *context) {
+  auto *self = static_cast<OpenThreadComponent *>(context);
+  // This runs on the OpenThread task thread with the OT lock held,
+  // so we can safely call otThreadGetDeviceRole directly.
+  otInstance *instance = self->get_openthread_instance_();
+
   if (flags & OT_CHANGED_THREAD_ROLE) {
-    auto *self = static_cast<OpenThreadComponent *>(context);
-    // This runs on the OpenThread task thread with the OT lock held,
-    // so we can safely call otThreadGetDeviceRole directly.
-    otInstance *instance = self->get_openthread_instance_();
     otDeviceRole role = otThreadGetDeviceRole(instance);
     bool now_connected = role >= OT_DEVICE_ROLE_CHILD;
     if (!self->connected_ && now_connected) {
-      self->log_connect_params_(instance, role);
+      self->print_connect_params_(instance, role);
     }
     self->connected_ = now_connected;
   }
-}
 
-void OpenThreadComponent::on_address_changed(const otIp6AddressInfo *address_info, bool added, void *context) {
-  char addr_str[OT_IP6_ADDRESS_STRING_SIZE];
-  otIp6AddressToString(address_info->mAddress, addr_str, sizeof(addr_str));
-
-  if (!added) {
-    ESP_LOGD(TAG, "Address removed: %s", addr_str);
-    return;
-  }
-
-  if (!address_info->mPreferred) {
-    // Non-preferred addresses are mostly multicast addresses and don't
-    // really concern the user so log these with ESP_LOGV.
-    ESP_LOGV(TAG, "Address added: %s (non-preferred)", addr_str);
-    return;
-  }
-
-  const uint8_t *address = address_info->mAddress->mFields.m8;
-  const bool link_local = address[0] == 0xFE && (address[1] & 0xC0) == 0x80;
-  if (link_local) {
-    ESP_LOGCONFIG(TAG, "Address added: %s (link-local)", addr_str);
-  } else if (address_info->mMeshLocal) {
-    ESP_LOGCONFIG(TAG, "Address added: %s (mesh-local)", addr_str);
-  } else {
-    ESP_LOGI(TAG, "Address added: %s (off-mesh-routable)", addr_str);
+  if (flags & OT_CHANGED_IP6_ADDRESS_ADDED) {
+    self->print_addresses_(instance);
   }
 }
 
-void OpenThreadComponent::log_connect_params_(otInstance *instance, otDeviceRole role) {
+void OpenThreadComponent::print_connect_params_(otInstance *instance, otDeviceRole role) {
   ESP_LOGI(TAG, "Connected");
   ESP_LOGCONFIG(TAG, "  Network: %s", otThreadGetNetworkName(instance));
   ESP_LOGCONFIG(TAG, "  Role: %s", otThreadDeviceRoleToString(role));
   ESP_LOGCONFIG(TAG, "  Channel: %u", otLinkGetChannel(instance));
   ESP_LOGCONFIG(TAG, "  PAN ID: 0x%04X", otLinkGetPanId(instance));
+}
+
+void OpenThreadComponent::print_addresses_(otInstance *instance) {
+  ESP_LOGI(TAG, "Addresses:");
+
+  const otNetifAddress *unicast_addresses = otIp6GetUnicastAddresses(instance);
+
+  for (const otNetifAddress *addr = unicast_addresses; addr; addr = addr->mNext) {
+    char addr_str[OT_IP6_ADDRESS_STRING_SIZE];
+    otIp6AddressToString(&addr->mAddress, addr_str, sizeof(addr_str));
+
+    const uint8_t *address = addr->mAddress.mFields.m8;
+    const bool link_local = address[0] == 0xFE && (address[1] & 0xC0) == 0x80;
+
+    if (!addr->mPreferred) {
+      ESP_LOGV(TAG, "  %s (non-preferred)", addr_str);
+    } else if (link_local) {
+      ESP_LOGCONFIG(TAG, "  %s (link-local)", addr_str);
+    } else if (addr->mRloc) {
+      ESP_LOGCONFIG(TAG, "  %s (routing-locator)", addr_str);
+    } else if (addr->mMeshLocal) {
+      ESP_LOGCONFIG(TAG, "  %s (mesh-local)", addr_str);
+    } else {
+      ESP_LOGI(TAG, "  %s (off-mesh-routable)", addr_str);
+    }
+  }
 }
 
 // Gets the off-mesh routable address

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -5,6 +5,7 @@
 #include <openthread/cli.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/link.h>
 #include <openthread/logging.h>
 #include <openthread/netdata.h>
 #include <openthread/tasklet.h>
@@ -52,7 +53,29 @@ void OpenThreadComponent::on_state_changed(otChangedFlags flags, void *context) 
     // so we can safely call otThreadGetDeviceRole directly.
     otInstance *instance = self->get_openthread_instance_();
     otDeviceRole role = otThreadGetDeviceRole(instance);
-    self->connected_ = role >= OT_DEVICE_ROLE_CHILD;
+    bool now_connected = role >= OT_DEVICE_ROLE_CHILD;
+    if (!self->connected_ && now_connected) {
+      self->log_connect_params_(instance, role);
+    }
+    self->connected_ = now_connected;
+  }
+}
+
+void OpenThreadComponent::log_connect_params_(otInstance *instance, otDeviceRole role) {
+  ESP_LOGI(TAG, "Connected");
+  ESP_LOGCONFIG(TAG, "  Network: '%s'", otThreadGetNetworkName(instance));
+  ESP_LOGCONFIG(TAG, "  Role: %s", otThreadDeviceRoleToString(role));
+  ESP_LOGCONFIG(TAG, "  Channel: %u", otLinkGetChannel(instance));
+  ESP_LOGCONFIG(TAG, "  PAN ID: 0x%04X", otLinkGetPanId(instance));
+  ESP_LOGCONFIG(TAG, "  Addresses:");
+  char addr_str[OT_IP6_ADDRESS_STRING_SIZE];
+  for (const otNetifAddress *addr = otIp6GetUnicastAddresses(instance); addr; addr = addr->mNext) {
+    otIp6AddressToString(&addr->mAddress, addr_str, sizeof(addr_str));
+    const char *rloc_str = addr->mRloc ? " (routing locator)" : "";
+    if (addr->mValid)
+      ESP_LOGCONFIG(TAG, "    %s%s", addr_str, rloc_str);
+    else
+      ESP_LOGW(TAG, "    [INVALID] %s%s", addr_str, rloc_str);
   }
 }
 

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -61,22 +61,37 @@ void OpenThreadComponent::on_state_changed(otChangedFlags flags, void *context) 
   }
 }
 
+void OpenThreadComponent::on_address_changed(const otIp6AddressInfo *address_info, bool added, void *context) {
+  char addr_str[OT_IP6_ADDRESS_STRING_SIZE];
+  otIp6AddressToString(address_info->mAddress, addr_str, sizeof(addr_str));
+
+  if (!added) {
+    ESP_LOGD(TAG, "Address removed: %s", addr_str);
+    return;
+  }
+
+  if (!address_info->mPreferred) {
+    // Non-preferred addresses are mostly multicast addresses and don't
+    // really concern the user so log these with ESP_LOGV.
+    ESP_LOGV(TAG, "Address added: %s (non-preferred)", addr_str);
+    return;
+  }
+
+  if (otIp6IsLinkLocalUnicast(address_info->mAddress)) {
+    ESP_LOGCONFIG(TAG, "Address added: %s (link-local)", addr_str);
+  } else if (address_info->mMeshLocal) {
+    ESP_LOGCONFIG(TAG, "Address added: %s (mesh-local)", addr_str);
+  } else {
+    ESP_LOGI(TAG, "Address added: %s (off-mesh-routable)", addr_str);
+  }
+}
+
 void OpenThreadComponent::log_connect_params_(otInstance *instance, otDeviceRole role) {
   ESP_LOGI(TAG, "Connected");
-  ESP_LOGCONFIG(TAG, "  Network: '%s'", otThreadGetNetworkName(instance));
+  ESP_LOGCONFIG(TAG, "  Network: %s", otThreadGetNetworkName(instance));
   ESP_LOGCONFIG(TAG, "  Role: %s", otThreadDeviceRoleToString(role));
   ESP_LOGCONFIG(TAG, "  Channel: %u", otLinkGetChannel(instance));
   ESP_LOGCONFIG(TAG, "  PAN ID: 0x%04X", otLinkGetPanId(instance));
-  ESP_LOGCONFIG(TAG, "  Addresses:");
-  char addr_str[OT_IP6_ADDRESS_STRING_SIZE];
-  for (const otNetifAddress *addr = otIp6GetUnicastAddresses(instance); addr; addr = addr->mNext) {
-    otIp6AddressToString(&addr->mAddress, addr_str, sizeof(addr_str));
-    const char *rloc_str = addr->mRloc ? " (routing locator)" : "";
-    if (addr->mValid)
-      ESP_LOGCONFIG(TAG, "    %s%s", addr_str, rloc_str);
-    else
-      ESP_LOGW(TAG, "    [INVALID] %s%s", addr_str, rloc_str);
-  }
 }
 
 // Gets the off-mesh routable address

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -77,7 +77,9 @@ void OpenThreadComponent::on_address_changed(const otIp6AddressInfo *address_inf
     return;
   }
 
-  if (otIp6IsLinkLocalUnicast(address_info->mAddress)) {
+  const uint8_t *address = address_info->mAddress->mFields.m8;
+  const bool link_local = address[0] == 0xFE && (address[1] & 0xC0) == 0x80;
+  if (link_local) {
     ESP_LOGCONFIG(TAG, "Address added: %s (link-local)", addr_str);
   } else if (address_info->mMeshLocal) {
     ESP_LOGCONFIG(TAG, "Address added: %s (mesh-local)", addr_str);

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -68,10 +68,10 @@ void OpenThreadComponent::on_state_changed(otChangedFlags flags, void *context) 
 
 void OpenThreadComponent::print_connect_params_(otInstance *instance, otDeviceRole role) {
   ESP_LOGI(TAG, "Connected");
-  ESP_LOGCONFIG(TAG, "  Network: %s", otThreadGetNetworkName(instance));
+  ESP_LOGCONFIG(TAG, "  Network: " LOG_SECRET("'%s'"), otThreadGetNetworkName(instance));
   ESP_LOGCONFIG(TAG, "  Role: %s", otThreadDeviceRoleToString(role));
   ESP_LOGCONFIG(TAG, "  Channel: %u", otLinkGetChannel(instance));
-  ESP_LOGCONFIG(TAG, "  PAN ID: 0x%04X", otLinkGetPanId(instance));
+  ESP_LOGCONFIG(TAG, "  PAN ID: " LOG_SECRET("0x%04X"), otLinkGetPanId(instance));
 }
 
 void OpenThreadComponent::print_addresses_(otInstance *instance) {
@@ -83,6 +83,7 @@ void OpenThreadComponent::print_addresses_(otInstance *instance) {
     char addr_str[OT_IP6_ADDRESS_STRING_SIZE];
     otIp6AddressToString(&addr->mAddress, addr_str, sizeof(addr_str));
 
+    // otIp6IsLinkLocalUnicast doesn't work for the zephyr platform
     const uint8_t *address = addr->mAddress.mFields.m8;
     const bool link_local = address[0] == 0xFE && (address[1] & 0xC0) == 0x80;
 
@@ -95,7 +96,7 @@ void OpenThreadComponent::print_addresses_(otInstance *instance) {
     } else if (addr->mMeshLocal) {
       ESP_LOGCONFIG(TAG, "  %s (mesh-local)", addr_str);
     } else {
-      ESP_LOGI(TAG, "  %s (off-mesh-routable)", addr_str);
+      ESP_LOGI(TAG, "  " LOG_SECRET("%s") " (off-mesh-routable)", addr_str);
     }
   }
 }

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -67,6 +67,7 @@ class OpenThreadComponent final : public Component {
    * ot_main() runs on the OpenThread task itself and must not acquire the lock.
    */
   void apply_linkmode_(otInstance *instance);
+  void log_connect_params_(otInstance *instance, otDeviceRole role);
 
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
   otInstance *get_openthread_instance_();

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -56,6 +56,7 @@ class OpenThreadComponent final : public Component {
   void set_output_power(int8_t output_power) { this->output_power_ = output_power; }
   void set_connected(bool connected) { this->connected_ = connected; }
   static void on_state_changed(otChangedFlags flags, void *context);
+  static void on_address_changed(const otIp6AddressInfo *address_info, bool added, void *context);
 
  protected:
   // Actions re-apply link mode under the OT lock; allow them to call apply_linkmode_()

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -56,7 +56,6 @@ class OpenThreadComponent final : public Component {
   void set_output_power(int8_t output_power) { this->output_power_ = output_power; }
   void set_connected(bool connected) { this->connected_ = connected; }
   static void on_state_changed(otChangedFlags flags, void *context);
-  static void on_address_changed(const otIp6AddressInfo *address_info, bool added, void *context);
 
  protected:
   // Actions re-apply link mode under the OT lock; allow them to call apply_linkmode_()
@@ -68,7 +67,8 @@ class OpenThreadComponent final : public Component {
    * ot_main() runs on the OpenThread task itself and must not acquire the lock.
    */
   void apply_linkmode_(otInstance *instance);
-  void log_connect_params_(otInstance *instance, otDeviceRole role);
+  void print_connect_params_(otInstance *instance, otDeviceRole role);
+  void print_addresses_(otInstance *instance);
 
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
   otInstance *get_openthread_instance_();

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -149,19 +149,15 @@ void OpenThreadComponent::ot_main() {
     dataset.mLength = len;
   }
 #endif
-
-  // Register address change callback. Must be done before auto_start, otherwise
-  // the initial addresses will be missed.
-  otIp6SetAddressCallback(instance, OpenThreadComponent::on_address_changed, this);
-
-  // Pass the existing dataset, or NULL which will use the preprocessor definitions
-  ESP_ERROR_CHECK(esp_openthread_auto_start(dataset.mLength > 0 ? &dataset : nullptr));
-
-  // Register state change callback to update connected_ reactively instead of polling
+  // Register state change callback to update connected_ reactively instead of polling. Callback
+  // must be set before auto_start, otherwise the initial addresses will be missed.
   otError ot_err = otSetStateChangedCallback(instance, OpenThreadComponent::on_state_changed, this);
   if (ot_err != OT_ERROR_NONE) {
     ESP_LOGW(TAG, "Failed to register state change callback: %d", ot_err);
   }
+
+  // Pass the existing dataset, or NULL which will use the preprocessor definitions
+  ESP_ERROR_CHECK(esp_openthread_auto_start(dataset.mLength > 0 ? &dataset : nullptr));
 
   esp_openthread_launch_mainloop();
 

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -150,6 +150,10 @@ void OpenThreadComponent::ot_main() {
   }
 #endif
 
+  // Register address change callback. Must be done before auto_start, otherwise
+  // the initial addresses will be missed.
+  otIp6SetAddressCallback(instance, OpenThreadComponent::on_address_changed, this);
+
   // Pass the existing dataset, or NULL which will use the preprocessor definitions
   ESP_ERROR_CHECK(esp_openthread_auto_start(dataset.mLength > 0 ? &dataset : nullptr));
 

--- a/esphome/components/openthread/openthread_zephyr.cpp
+++ b/esphome/components/openthread/openthread_zephyr.cpp
@@ -82,6 +82,7 @@ void OpenThreadComponent::setup() {
     }
   }
   openthread_state_changed_cb_register(context, &ot_state_changed_cb);
+  otIp6SetAddressCallback(context->instance, OpenThreadComponent::on_address_changed, this);
   openthread_start(context);
 }
 

--- a/esphome/components/openthread/openthread_zephyr.cpp
+++ b/esphome/components/openthread/openthread_zephyr.cpp
@@ -11,24 +11,9 @@ static const char *const TAG = "openthread";
 
 namespace esphome::openthread {
 
-static void on_thread_state_changed(otChangedFlags flags, struct openthread_context *ot_context, void *user_data) {
-  // Delegate connection status tracking to common callback
+static void on_thread_state_changed(otChangedFlags flags, struct openthread_context *, void *) {
   if (global_openthread_component != nullptr) {
     OpenThreadComponent::on_state_changed(flags, global_openthread_component);
-  }
-  if (flags & OT_CHANGED_THREAD_ROLE) {
-    otDeviceRole role = otThreadGetDeviceRole(ot_context->instance);
-    ESP_LOGI(TAG, "Thread role changed to %s", otThreadDeviceRoleToString(role));
-  }
-  if (flags & OT_CHANGED_THREAD_NETDATA) {
-    ESP_LOGI(TAG, "Thread network data updated");
-  }
-  if (flags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_NETDATA)) {
-    char buf[NET_IPV6_ADDR_LEN];
-    for (const otNetifAddress *addr = otIp6GetUnicastAddresses(ot_context->instance); addr != nullptr;
-         addr = addr->mNext) {
-      ESP_LOGI(TAG, "  Address: %s", net_addr_ntop(AF_INET6, &addr->mAddress, buf, sizeof(buf)));
-    }
   }
 }
 

--- a/esphome/components/openthread/openthread_zephyr.cpp
+++ b/esphome/components/openthread/openthread_zephyr.cpp
@@ -82,7 +82,6 @@ void OpenThreadComponent::setup() {
     }
   }
   openthread_state_changed_cb_register(context, &ot_state_changed_cb);
-  otIp6SetAddressCallback(context->instance, OpenThreadComponent::on_address_changed, this);
   openthread_start(context);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Adds informative logs messages when openthread makes a connection, similar to what the wifi component already does. On connect, some stats such as the network name are logged.
Address changes are logged by hooking into the on_state_changed callback.

Example log output with redacted addresses:
```
[I][openthread:070][ot_main]: Connected
[C][openthread:071][ot_main]:   Network: ...
[C][openthread:072][ot_main]:   Role: router
[C][openthread:073][ot_main]:   Channel: 26
[C][openthread:074][ot_main]:   PAN ID: 0x...
[I][openthread:151][ot_main]: SRP client has started
[I][openthread:078][ot_main]: Addresses:
[I][openthread:098][ot_main]:   fd87:... (off-mesh-routable)
[C][openthread:094][ot_main]:   fd15:...:ff:fe00:2000 (routing-locator)
[C][openthread:096][ot_main]:   fd15:... (mesh-local)
[C][openthread:092][ot_main]:   fe80:... (link-local)
```

The off-mesh-routable address is the one most relevant to the user so this one is logged at INFO level.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

None

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

None

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

None

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] ~~Tests have been added to verify that the new code works (under `tests/` folder).~~

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~~Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).~~
