### PR TITLE
[core] Hash downloaded file paths at the default data dir location

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -783,9 +783,8 @@ class EsphomeCore:
         can compare a locally computed hash against the one a device
         advertises. Machine-local data is kept out of the input: build_path
         (which embeds ESPHOME_BUILD_PATH and OS path separators) is excluded,
-        and Path values are dumped relative to the config directory. Paths
-        under the data directory are dumped at the default ``.esphome``
-        location so the add-on's ``/data`` mount hashes the same as the CLI.
+        and Path values are dumped relative to the config directory, with
+        the data directory always at its default ``.esphome`` location.
         """
         if self._config_hash is None:
             from esphome import yaml_util
@@ -796,12 +795,15 @@ class EsphomeCore:
                 esphome_conf = dict(esphome_conf)
                 esphome_conf.pop(CONF_BUILD_PATH, None)
                 config[CONF_ESPHOME] = esphome_conf
+            relative_to = data_dir = None
+            if self.config_path is not None:
+                relative_to, data_dir = self.config_dir, self.data_dir
             config_str = yaml_util.dump(
                 config,
                 show_secrets=True,
                 sort_keys=True,
-                relative_to=self.config_dir if self.config_path is not None else None,
-                data_dir=self.data_dir if self.config_path is not None else None,
+                relative_to=relative_to,
+                data_dir=data_dir,
             )
             self._config_hash = fnv1a_32bit_hash(config_str)
         return self._config_hash

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -783,7 +783,9 @@ class EsphomeCore:
         can compare a locally computed hash against the one a device
         advertises. Machine-local data is kept out of the input: build_path
         (which embeds ESPHOME_BUILD_PATH and OS path separators) is excluded,
-        and Path values are dumped relative to the config directory.
+        and Path values are dumped relative to the config directory. Paths
+        under the data directory are dumped at the default ``.esphome``
+        location so the add-on's ``/data`` mount hashes the same as the CLI.
         """
         if self._config_hash is None:
             from esphome import yaml_util
@@ -799,6 +801,7 @@ class EsphomeCore:
                 show_secrets=True,
                 sort_keys=True,
                 relative_to=self.config_dir if self.config_path is not None else None,
+                data_dir=self.data_dir if self.config_path is not None else None,
             )
             self._config_hash = fnv1a_32bit_hash(config_str)
         return self._config_hash

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -1290,8 +1290,8 @@ class ESPHomeDumper(yaml.SafeDumper):
             if self._data_dir is not None and path.is_relative_to(
                 data_dir := os.path.normpath(self._data_dir)
             ):
-                rel = path.relative_to(data_dir).as_posix()
-                return self.represent_stringify(f".esphome/{rel}")
+                rel = Path(".esphome") / path.relative_to(data_dir)
+                return self.represent_stringify(rel.as_posix())
             with suppress(ValueError):
                 path = path.relative_to(
                     os.path.normpath(self._relative_to), walk_up=True

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -1057,11 +1057,19 @@ def _load_yaml_internal_with_type(
         loader.dispose()
 
 
-def dump(dict_, show_secrets=False, sort_keys=False, relative_to: Path | None = None):
+def dump(
+    dict_,
+    show_secrets=False,
+    sort_keys=False,
+    relative_to: Path | None = None,
+    data_dir: Path | None = None,
+):
     """Dump YAML to a string and remove null.
 
     When ``relative_to`` is given, Path values are dumped relative to that
-    directory (POSIX form) so the output is machine independent.
+    directory (POSIX form) so the output is machine independent. Path values
+    under ``data_dir`` are dumped at the default ``.esphome`` location so the
+    output does not depend on where the data dir is mounted.
     """
     if show_secrets:
         _SECRET_VALUES.clear()
@@ -1073,6 +1081,7 @@ def dump(dict_, show_secrets=False, sort_keys=False, relative_to: Path | None = 
     class _Dumper(ESPHomeDumper):
         _redact_sensitive = not show_secrets
         _relative_to = relative_to
+        _data_dir = data_dir
 
     return yaml.dump(
         dict_,
@@ -1231,6 +1240,10 @@ class ESPHomeDumper(yaml.SafeDumper):
     # directory (in POSIX form) so the output does not depend on where the
     # config lives on the machine that produced it.
     _relative_to: Path | None = None
+    # When set alongside ``_relative_to``, paths under this directory are
+    # dumped as ``.esphome/<rest>`` (the default data dir location) so the
+    # HA add-on's ``/data`` mount produces the same output as the CLI.
+    _data_dir: Path | None = None
 
     def represent_mapping(self, tag, mapping, flow_style=None):
         value = []
@@ -1274,6 +1287,11 @@ class ESPHomeDumper(yaml.SafeDumper):
             # path that still cannot be relativized (e.g. a different drive)
             # keeps its POSIX form so separators stay stable across OSes.
             path = Path(os.path.normpath(value))
+            # Checked first: the default data dir sits inside the config dir.
+            if self._data_dir is not None:
+                with suppress(ValueError):
+                    rel = path.relative_to(os.path.normpath(self._data_dir))
+                    return self.represent_stringify((Path(".esphome") / rel).as_posix())
             with suppress(ValueError):
                 path = path.relative_to(
                     os.path.normpath(self._relative_to), walk_up=True

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -1067,9 +1067,8 @@ def dump(
     """Dump YAML to a string and remove null.
 
     When ``relative_to`` is given, Path values are dumped relative to that
-    directory (POSIX form) so the output is machine independent. Path values
-    under ``data_dir`` are dumped at the default ``.esphome`` location so the
-    output does not depend on where the data dir is mounted.
+    directory (POSIX form) so the output is machine independent; Path values
+    under ``data_dir`` are then dumped as ``.esphome/<rest>``.
     """
     if show_secrets:
         _SECRET_VALUES.clear()
@@ -1240,9 +1239,8 @@ class ESPHomeDumper(yaml.SafeDumper):
     # directory (in POSIX form) so the output does not depend on where the
     # config lives on the machine that produced it.
     _relative_to: Path | None = None
-    # When set alongside ``_relative_to``, paths under this directory are
-    # dumped as ``.esphome/<rest>`` (the default data dir location) so the
-    # HA add-on's ``/data`` mount produces the same output as the CLI.
+    # Paths under this directory are dumped as ``.esphome/<rest>`` so the
+    # add-on's ``/data`` mount matches the CLI layout.
     _data_dir: Path | None = None
 
     def represent_mapping(self, tag, mapping, flow_style=None):
@@ -1288,10 +1286,11 @@ class ESPHomeDumper(yaml.SafeDumper):
             # keeps its POSIX form so separators stay stable across OSes.
             path = Path(os.path.normpath(value))
             # Checked first: the default data dir sits inside the config dir.
-            if self._data_dir is not None:
-                with suppress(ValueError):
-                    rel = path.relative_to(os.path.normpath(self._data_dir))
-                    return self.represent_stringify((Path(".esphome") / rel).as_posix())
+            if self._data_dir is not None and path.is_relative_to(
+                data_dir := os.path.normpath(self._data_dir)
+            ):
+                rel = path.relative_to(data_dir).as_posix()
+                return self.represent_stringify(f".esphome/{rel}")
             with suppress(ValueError):
                 path = path.relative_to(
                     os.path.normpath(self._relative_to), walk_up=True

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -1068,7 +1068,8 @@ def dump(
 
     When ``relative_to`` is given, Path values are dumped relative to that
     directory (POSIX form) so the output is machine independent; Path values
-    under ``data_dir`` are then dumped as ``.esphome/<rest>``.
+    under ``data_dir`` are then dumped as ``.esphome/<rest>``. ``data_dir``
+    has no effect unless ``relative_to`` is also given.
     """
     if show_secrets:
         _SECRET_VALUES.clear()

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -1130,17 +1130,11 @@ def test_config_hash_same_for_different_config_dirs(tmp_path: Path) -> None:
 def test_config_hash_same_for_different_data_dirs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test that downloaded file paths hash the same wherever data_dir lives.
-
-    The CLI keeps downloads under <config>/.esphome while the HA add-on
-    keeps them under /data; the same downloaded file must not change the
-    hash between the two.
-    """
+    """Test that downloaded file paths hash the same wherever data_dir lives."""
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
     CORE.reset()
-    monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
     CORE.config_path = config_dir / "device.yaml"
     CORE.config = {
         "esphome": {"name": "test"},

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -1127,6 +1127,40 @@ def test_config_hash_same_for_different_config_dirs(tmp_path: Path) -> None:
     assert hash1 == hash2
 
 
+def test_config_hash_same_for_different_data_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that downloaded file paths hash the same wherever data_dir lives.
+
+    The CLI keeps downloads under <config>/.esphome while the HA add-on
+    keeps them under /data; the same downloaded file must not change the
+    hash between the two.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    CORE.reset()
+    monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
+    CORE.config_path = config_dir / "device.yaml"
+    CORE.config = {
+        "esphome": {"name": "test"},
+        "file": config_dir / ".esphome" / "image" / "c44630d6",
+    }
+    hash1 = CORE.config_hash
+
+    other_data_dir = tmp_path / "data"
+    CORE.reset()
+    monkeypatch.setenv("ESPHOME_DATA_DIR", str(other_data_dir))
+    CORE.config_path = config_dir / "device.yaml"
+    CORE.config = {
+        "esphome": {"name": "test"},
+        "file": other_data_dir / "image" / "c44630d6",
+    }
+    hash2 = CORE.config_hash
+
+    assert hash1 == hash2
+
+
 def test_make_app_name_cpp_no_mac_simple() -> None:
     """Test simple name without MAC suffix returns string literal."""
     cpp_expr, global_decl, byte_len = make_app_name_cpp(

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -1706,37 +1706,21 @@ def test_dump_path_dotdot_reference_outside_anchor() -> None:
     assert output.strip() == "file: ../shared/font.ttf"
 
 
-def test_dump_path_under_data_dir_uses_default_location() -> None:
-    """Test that Path values under data_dir dump as .esphome/<rest>.
-
-    The HA add-on mounts the data dir at /data, outside the config dir;
-    without this it would dump as ../data/... and hash differently from
-    the CLI, whose data dir is <config>/.esphome.
-    """
+@pytest.mark.parametrize(
+    "data_dir",
+    [
+        pytest.param(Path("/config/.esphome"), id="cli"),
+        pytest.param(Path("/data"), id="addon"),
+    ],
+)
+def test_dump_path_under_data_dir_uses_default_location(data_dir: Path) -> None:
+    """Test that Path values under data_dir dump as .esphome/<rest> for any layout."""
     anchor = Path("/config").absolute()
-    data_dir = Path("/data").absolute()
-    path = data_dir / "image" / "c44630d6"
-    output = yaml_util.dump({"file": path}, relative_to=anchor, data_dir=data_dir)
+    path = data_dir.absolute() / "image" / "c44630d6"
+    output = yaml_util.dump(
+        {"file": path}, relative_to=anchor, data_dir=data_dir.absolute()
+    )
     assert output.strip() == "file: .esphome/image/c44630d6"
-
-
-def test_dump_path_data_dir_layouts_match() -> None:
-    """Test that the add-on /data layout dumps the same as the CLI layout."""
-    anchor = Path("/config").absolute()
-    cli_data_dir = anchor / ".esphome"
-    addon_data_dir = Path("/data").absolute()
-    cli = yaml_util.dump(
-        {"file": cli_data_dir / "image" / "c44630d6"},
-        relative_to=anchor,
-        data_dir=cli_data_dir,
-    )
-    addon = yaml_util.dump(
-        {"file": addon_data_dir / "image" / "c44630d6"},
-        relative_to=anchor,
-        data_dir=addon_data_dir,
-    )
-    assert cli == addon
-    assert cli.strip() == "file: .esphome/image/c44630d6"
 
 
 def test_dump_path_outside_data_dir_still_relative_to_anchor() -> None:

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -1706,6 +1706,57 @@ def test_dump_path_dotdot_reference_outside_anchor() -> None:
     assert output.strip() == "file: ../shared/font.ttf"
 
 
+def test_dump_path_under_data_dir_uses_default_location() -> None:
+    """Test that Path values under data_dir dump as .esphome/<rest>.
+
+    The HA add-on mounts the data dir at /data, outside the config dir;
+    without this it would dump as ../data/... and hash differently from
+    the CLI, whose data dir is <config>/.esphome.
+    """
+    anchor = Path("/config").absolute()
+    data_dir = Path("/data").absolute()
+    path = data_dir / "image" / "c44630d6"
+    output = yaml_util.dump({"file": path}, relative_to=anchor, data_dir=data_dir)
+    assert output.strip() == "file: .esphome/image/c44630d6"
+
+
+def test_dump_path_data_dir_layouts_match() -> None:
+    """Test that the add-on /data layout dumps the same as the CLI layout."""
+    anchor = Path("/config").absolute()
+    cli_data_dir = anchor / ".esphome"
+    addon_data_dir = Path("/data").absolute()
+    cli = yaml_util.dump(
+        {"file": cli_data_dir / "image" / "c44630d6"},
+        relative_to=anchor,
+        data_dir=cli_data_dir,
+    )
+    addon = yaml_util.dump(
+        {"file": addon_data_dir / "image" / "c44630d6"},
+        relative_to=anchor,
+        data_dir=addon_data_dir,
+    )
+    assert cli == addon
+    assert cli.strip() == "file: .esphome/image/c44630d6"
+
+
+def test_dump_path_outside_data_dir_still_relative_to_anchor() -> None:
+    """Test that data_dir does not affect paths that are not under it."""
+    anchor = Path("/config").absolute()
+    path = anchor / "fonts" / "arial.ttf"
+    output = yaml_util.dump(
+        {"file": path}, relative_to=anchor, data_dir=Path("/data").absolute()
+    )
+    assert output.strip() == "file: fonts/arial.ttf"
+
+
+def test_dump_path_data_dir_without_relative_to_is_unchanged() -> None:
+    """Test that data_dir alone does not change the output."""
+    data_dir = Path("/data").absolute()
+    path = data_dir / "image" / "c44630d6"
+    output = yaml_util.dump({"file": path}, data_dir=data_dir)
+    assert output.strip() == f"file: {path}"
+
+
 def test_dump_relative_to_does_not_leak_between_calls() -> None:
     """Test that the relative_to flag is scoped to a single dump call."""
     anchor = Path("/config/esphome").absolute()

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -1723,6 +1723,18 @@ def test_dump_path_under_data_dir_uses_default_location(data_dir: Path) -> None:
     assert output.strip() == "file: .esphome/image/c44630d6"
 
 
+def test_dump_path_equal_to_data_dir() -> None:
+    """Test that the data dir itself dumps as .esphome, matching the default layout."""
+    anchor = Path("/config").absolute()
+    data_dir = Path("/data").absolute()
+    output = yaml_util.dump({"dir": data_dir}, relative_to=anchor, data_dir=data_dir)
+    assert output.strip() == "dir: .esphome"
+    default = yaml_util.dump(
+        {"dir": anchor / ".esphome"}, relative_to=anchor, data_dir=anchor / ".esphome"
+    )
+    assert default == output
+
+
 def test_dump_path_outside_data_dir_still_relative_to_anchor() -> None:
     """Test that data_dir does not affect paths that are not under it."""
     anchor = Path("/config").absolute()


### PR DESCRIPTION
# What does this implement/fix?

`esphome config-hash` still differs between the CLI and the HA add-on when the config references downloaded files (image or font URLs, micro_wake_word models, git packages). #17523 made path values relative to the config directory, but downloaded files live under the data directory; on the CLI that is `<config>/.esphome` and dumps as `.esphome/image/c44630d6`, while the add-on mounts it at `/data` and dumps as `../data/image/c44630d6`, so the hashes can never match.

Paths under the data directory are now dumped at the default `.esphome` location regardless of where the data dir is mounted. Output for the default `<config>/.esphome` layout is unchanged, so devices built from a plain CLI install keep their current hash; devices that use downloaded files and were built in the add-on, or with `ESPHOME_DATA_DIR` pointing outside the config directory, will report out of sync once until rebuilt.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18816

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: hash-repro
esp32:
  board: esp32dev
  framework:
    type: esp-idf

i2c:
  sda: 21
  scl: 22

display:
  - platform: ssd1306_i2c
    model: SSD1306 128x64

image:
  - platform: file
    file: https://github.com/esphome/wake-word-voice-assistants/raw/main/error_box_illustrations/error-no-ha.png
    id: test_image
    resize: 64x64
    type: RGB
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
