### PR TITLE
[core] Avoid double promotion in update interval and step formatting

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -336,10 +336,8 @@ void log_update_interval(const char *tag, PollingComponent *component) {
   uint32_t update_interval = component->get_update_interval();
   if (update_interval == SCHEDULER_DONT_RUN) {
     ESP_LOGCONFIG(tag, "  Update Interval: never");
-  } else if (update_interval < 100) {
-    ESP_LOGCONFIG(tag, "  Update Interval: %.3fs", update_interval / 1000.0f);
   } else {
-    ESP_LOGCONFIG(tag, "  Update Interval: %.1fs", update_interval / 1000.0f);
+    ESP_LOGCONFIG(tag, "  Update Interval: %" PRIu32 ".%03" PRIu32 "s", update_interval / 1000, update_interval % 1000);
   }
 }
 float Component::get_actual_setup_priority() const {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -615,7 +615,7 @@ int8_t step_to_accuracy_decimals(float step) {
   }
   if (decimals <= 0)
     return 0;
-  auto digits = static_cast<uint32_t>(mantissa * 10000.0f + 0.5f);
+  auto digits = static_cast<uint32_t>(std::lroundf(mantissa * 10000.0f));
   while (decimals > 0 && digits % 10 == 0) {
     digits /= 10;
     decimals--;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -601,14 +601,21 @@ size_t value_accuracy_with_uom_to_buf(std::span<char, VALUE_ACCURACY_MAX_LEN> bu
 
 int8_t step_to_accuracy_decimals(float step) {
   // Decimals needed to show the step at five significant digits, trailing zeros dropped.
-  if (!std::isnormal(step))
+  if (!std::isfinite(step) || step == 0.0f)
     return 0;
-  float magnitude = std::fabs(step);
-  int8_t exponent = ilog10(magnitude);
-  int8_t decimals = 4 - exponent;
+  float mantissa = std::fabs(step);
+  int8_t decimals = 4;  // decimals needed for five significant digits when mantissa is in [1, 10)
+  while (mantissa >= 10.0f) {
+    mantissa /= 10.0f;
+    decimals--;
+  }
+  while (mantissa < 1.0f) {
+    mantissa *= 10.0f;
+    decimals++;
+  }
   if (decimals <= 0)
     return 0;
-  float scaled = magnitude * pow10_int(-exponent) * 10000.0f;
+  float scaled = mantissa * 10000.0f;
   auto digits = static_cast<uint32_t>(scaled);
   if (scaled - static_cast<float>(digits) >= 0.5f)
     digits++;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -582,7 +582,7 @@ size_t value_accuracy_to_buf(std::span<char, VALUE_ACCURACY_MAX_LEN> buf, float 
   }
 
   // Fallback for NaN/Inf/high accuracy/out-of-range
-  int len = snprintf(buf.data(), buf.size(), "%.*f", accuracy_decimals, value);
+  int len = snprintf(buf.data(), buf.size(), "%.*f", accuracy_decimals, static_cast<double>(value));
   if (len < 0)
     return 0;
   return static_cast<size_t>(len) >= buf.size() ? buf.size() - 1 : static_cast<size_t>(len);
@@ -600,16 +600,27 @@ size_t value_accuracy_with_uom_to_buf(std::span<char, VALUE_ACCURACY_MAX_LEN> bu
 }
 
 int8_t step_to_accuracy_decimals(float step) {
-  // use printf %g to find number of digits based on temperature step
-  char buf[32];
-  snprintf(buf, sizeof buf, "%.5g", step);
-
-  std::string str{buf};
-  size_t dot_pos = str.find('.');
-  if (dot_pos == std::string::npos)
+  // Same result as counting the decimals of "%.5g": five significant digits, trailing zeros dropped.
+  if (!std::isfinite(step) || step == 0.0f)
     return 0;
-
-  return str.length() - dot_pos - 1;
+  float mantissa = std::fabs(step);
+  int8_t decimals = 4;  // decimals needed for five significant digits when mantissa is in [1, 10)
+  while (mantissa >= 10.0f) {
+    mantissa /= 10.0f;
+    decimals--;
+  }
+  while (mantissa < 1.0f) {
+    mantissa *= 10.0f;
+    decimals++;
+  }
+  if (decimals <= 0)
+    return 0;
+  auto digits = static_cast<uint32_t>(mantissa * 10000.0f + 0.5f);
+  while (decimals > 0 && digits % 10 == 0) {
+    digits /= 10;
+    decimals--;
+  }
+  return decimals;
 }
 
 // Map a base64/base64url character to its 6-bit value (0-63) arithmetically.

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -601,21 +601,14 @@ size_t value_accuracy_with_uom_to_buf(std::span<char, VALUE_ACCURACY_MAX_LEN> bu
 
 int8_t step_to_accuracy_decimals(float step) {
   // Decimals needed to show the step at five significant digits, trailing zeros dropped.
-  if (!std::isfinite(step) || step == 0.0f)
+  if (!std::isnormal(step))
     return 0;
-  float mantissa = std::fabs(step);
-  int8_t decimals = 4;  // decimals needed for five significant digits when mantissa is in [1, 10)
-  while (mantissa >= 10.0f) {
-    mantissa /= 10.0f;
-    decimals--;
-  }
-  while (mantissa < 1.0f) {
-    mantissa *= 10.0f;
-    decimals++;
-  }
+  float magnitude = std::fabs(step);
+  int8_t exponent = ilog10(magnitude);
+  int8_t decimals = 4 - exponent;
   if (decimals <= 0)
     return 0;
-  float scaled = mantissa * 10000.0f;
+  float scaled = magnitude * pow10_int(-exponent) * 10000.0f;
   auto digits = static_cast<uint32_t>(scaled);
   if (scaled - static_cast<float>(digits) >= 0.5f)
     digits++;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -600,9 +600,7 @@ size_t value_accuracy_with_uom_to_buf(std::span<char, VALUE_ACCURACY_MAX_LEN> bu
 }
 
 int8_t step_to_accuracy_decimals(float step) {
-  // Matches counting the decimals of "%.5g" (five significant digits, trailing zeros dropped) over the range
-  // where %g prints fixed notation. Outside it %g switched to exponent form and the old count was meaningless;
-  // now steps below 1e-4 report their real decimals and steps of 1e5 and above report 0.
+  // Decimals needed to show the step at five significant digits, trailing zeros dropped.
   if (!std::isfinite(step) || step == 0.0f)
     return 0;
   float mantissa = std::fabs(step);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -600,7 +600,9 @@ size_t value_accuracy_with_uom_to_buf(std::span<char, VALUE_ACCURACY_MAX_LEN> bu
 }
 
 int8_t step_to_accuracy_decimals(float step) {
-  // Same result as counting the decimals of "%.5g": five significant digits, trailing zeros dropped.
+  // Matches counting the decimals of "%.5g" (five significant digits, trailing zeros dropped) over the range
+  // where %g prints fixed notation. Outside it %g switched to exponent form and the old count was meaningless;
+  // now steps below 1e-4 report their real decimals and steps of 1e5 and above report 0.
   if (!std::isfinite(step) || step == 0.0f)
     return 0;
   float mantissa = std::fabs(step);
@@ -615,7 +617,10 @@ int8_t step_to_accuracy_decimals(float step) {
   }
   if (decimals <= 0)
     return 0;
-  auto digits = static_cast<uint32_t>(std::lroundf(mantissa * 10000.0f));
+  float scaled = mantissa * 10000.0f;
+  auto digits = static_cast<uint32_t>(scaled);
+  if (scaled - static_cast<float>(digits) >= 0.5f)
+    digits++;
   while (decimals > 0 && digits % 10 == 0) {
     digits /= 10;
     decimals--;

--- a/tests/benchmarks/core/bench_helpers.cpp
+++ b/tests/benchmarks/core/bench_helpers.cpp
@@ -363,4 +363,45 @@ static void Snprintf_Uint32_Large(benchmark::State &state) {
 }
 BENCHMARK(Snprintf_Uint32_Large);
 
+// --- step_to_accuracy_decimals() ---
+// Called from climate traits and web_server for every number/climate step.
+
+static void StepToAccuracyDecimals_Tenth(benchmark::State &state) {
+  for (auto _ : state) {
+    int result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += step_to_accuracy_decimals(0.1f);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(StepToAccuracyDecimals_Tenth);
+
+static void StepToAccuracyDecimals_Whole(benchmark::State &state) {
+  for (auto _ : state) {
+    int result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += step_to_accuracy_decimals(1.0f);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(StepToAccuracyDecimals_Whole);
+
+static void StepToAccuracyDecimals_Mixed(benchmark::State &state) {
+  static constexpr float steps[] = {0.001f, 0.01f, 0.05f, 0.1f, 0.25f, 0.5f, 1.0f, 2.5f, 5.0f, 10.0f};
+  static constexpr int num_steps = sizeof(steps) / sizeof(steps[0]);
+  for (auto _ : state) {
+    int result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += step_to_accuracy_decimals(steps[i % num_steps]);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(StepToAccuracyDecimals_Mixed);
+
 }  // namespace esphome::benchmarks

--- a/tests/benchmarks/core/bench_helpers.cpp
+++ b/tests/benchmarks/core/bench_helpers.cpp
@@ -391,7 +391,9 @@ static void StepToAccuracyDecimals_Whole(benchmark::State &state) {
 BENCHMARK(StepToAccuracyDecimals_Whole);
 
 static void StepToAccuracyDecimals_Mixed(benchmark::State &state) {
-  static constexpr float steps[] = {0.001f, 0.01f, 0.05f, 0.1f, 0.25f, 0.5f, 1.0f, 2.5f, 5.0f, 10.0f};
+  static constexpr float steps[] = {
+      0.001f, 0.01f, 0.05f, 0.1f, 0.25f, 0.5f, 1.0f, 2.5f, 5.0f, 10.0f,
+  };
   static constexpr int num_steps = sizeof(steps) / sizeof(steps[0]);
   for (auto _ : state) {
     int result = 0;

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -327,6 +327,14 @@ TEST(StepToAccuracyDecimals, RoundsUpToWholeNumber) {
   EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
 }
 
+TEST(StepToAccuracyDecimals, OutsideFixedNotationRange) {
+  // %.5g would print these in exponent form; the count is now the real one rather than a parse of "1e-05".
+  EXPECT_EQ(step_to_accuracy_decimals(0.00001f), 5);
+  EXPECT_EQ(step_to_accuracy_decimals(0.000125f), 6);
+  EXPECT_EQ(step_to_accuracy_decimals(123456.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(1000000.0f), 0);
+}
+
 TEST(StepToAccuracyDecimals, SignIgnored) {
   EXPECT_EQ(step_to_accuracy_decimals(-0.1f), 1);
   EXPECT_EQ(step_to_accuracy_decimals(-0.25f), 2);

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -327,6 +327,14 @@ TEST(StepToAccuracyDecimals, RoundsUpToWholeNumber) {
   EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
 }
 
+TEST(StepToAccuracyDecimals, OutsideFixedNotationRange) {
+  // %.5g prints these in exponent form, so the count comes from parsing "1e-05" or "1.2346e+05".
+  EXPECT_EQ(step_to_accuracy_decimals(0.00001f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(0.000125f), 6);
+  EXPECT_EQ(step_to_accuracy_decimals(123456.0f), 8);
+  EXPECT_EQ(step_to_accuracy_decimals(1000000.0f), 0);
+}
+
 TEST(StepToAccuracyDecimals, SignIgnored) {
   EXPECT_EQ(step_to_accuracy_decimals(-0.1f), 1);
   EXPECT_EQ(step_to_accuracy_decimals(-0.25f), 2);

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -320,6 +320,10 @@ TEST(StepToAccuracyDecimals, TrailingZerosDropped) {
   EXPECT_EQ(step_to_accuracy_decimals(0.7f), 1);
   EXPECT_EQ(step_to_accuracy_decimals(0.125f), 3);
   EXPECT_EQ(step_to_accuracy_decimals(0.0625f), 4);
+}
+
+TEST(StepToAccuracyDecimals, RoundsUpToWholeNumber) {
+  // Rounds to five significant digits first, so this becomes 10 with no decimals.
   EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
 }
 

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include <cstring>
 
 #include "esphome/core/alloc_helpers.h"
@@ -278,6 +279,61 @@ TEST(Base64, Rfc4648Vectors) {
     EXPECT_EQ(len, strlen(v.plain));
     EXPECT_EQ(memcmp(buf, v.plain, len), 0);
   }
+}
+
+// --- step_to_accuracy_decimals() ---
+
+TEST(StepToAccuracyDecimals, TypicalSteps) {
+  EXPECT_EQ(step_to_accuracy_decimals(0.001f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.005f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.01f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(0.025f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.05f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(0.1f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(0.25f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(0.5f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(1.5f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(2.5f), 1);
+}
+
+TEST(StepToAccuracyDecimals, WholeSteps) {
+  EXPECT_EQ(step_to_accuracy_decimals(1.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(2.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(5.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(10.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(100.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(1000.0f), 0);
+}
+
+TEST(StepToAccuracyDecimals, FiveSignificantDigits) {
+  EXPECT_EQ(step_to_accuracy_decimals(1.23456f), 4);
+  EXPECT_EQ(step_to_accuracy_decimals(12.345f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(123.45f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(1234.5f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(12345.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(0.33333f), 5);
+  EXPECT_EQ(step_to_accuracy_decimals(0.0001f), 4);
+}
+
+TEST(StepToAccuracyDecimals, TrailingZerosDropped) {
+  EXPECT_EQ(step_to_accuracy_decimals(0.3f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(0.7f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(0.125f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.0625f), 4);
+  EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
+}
+
+TEST(StepToAccuracyDecimals, SignIgnored) {
+  EXPECT_EQ(step_to_accuracy_decimals(-0.1f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(-0.25f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(-1.0f), 0);
+}
+
+TEST(StepToAccuracyDecimals, NonFiniteAndZero) {
+  EXPECT_EQ(step_to_accuracy_decimals(0.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(NAN), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(INFINITY), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(-INFINITY), 0);
 }
 
 }  // namespace esphome::core::testing


### PR DESCRIPTION
# What does this implement/fix?

The nrf52 build warns about float to double promotion in three places in core. `log_update_interval` now prints exact milliseconds with integer math from one format string; the separate branch for intervals under 100 ms is gone since the loop runs every 16 ms. `step_to_accuracy_decimals` derives the count with float normalization and integer zero stripping instead of `%.5g` and `std::string`. The `snprintf` fallback in `value_accuracy_to_buf` gets an explicit cast.

This also fixes a latent bug: steps outside `[0.0001, 100000)` hit `%g` exponent form, so a step of 0.00001 gave 0 decimals and 123456 gave 8. The tests from #18826 pin the old values and this PR updates those two expectations.

Flash on a build with web_server, a number, a climate and a polling sensor goes from 765999 to 765943 bytes on ESP32 IDF and from 403265 to 403233 on ESP8266, RAM unchanged; CodSpeed shows the new benchmarks about 20x faster.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
