### PR TITLE
[core] Add step_to_accuracy_decimals benchmarks

### DIFF
--- a/tests/benchmarks/core/bench_helpers.cpp
+++ b/tests/benchmarks/core/bench_helpers.cpp
@@ -363,4 +363,45 @@ static void Snprintf_Uint32_Large(benchmark::State &state) {
 }
 BENCHMARK(Snprintf_Uint32_Large);
 
+// --- step_to_accuracy_decimals() ---
+// Called from climate traits and web_server for every number/climate step.
+
+static void StepToAccuracyDecimals_Tenth(benchmark::State &state) {
+  for (auto _ : state) {
+    int result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += step_to_accuracy_decimals(0.1f);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(StepToAccuracyDecimals_Tenth);
+
+static void StepToAccuracyDecimals_Whole(benchmark::State &state) {
+  for (auto _ : state) {
+    int result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += step_to_accuracy_decimals(1.0f);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(StepToAccuracyDecimals_Whole);
+
+static void StepToAccuracyDecimals_Mixed(benchmark::State &state) {
+  static constexpr float steps[] = {0.001f, 0.01f, 0.05f, 0.1f, 0.25f, 0.5f, 1.0f, 2.5f, 5.0f, 10.0f};
+  static constexpr int num_steps = sizeof(steps) / sizeof(steps[0]);
+  for (auto _ : state) {
+    int result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += step_to_accuracy_decimals(steps[i % num_steps]);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(StepToAccuracyDecimals_Mixed);
+
 }  // namespace esphome::benchmarks

--- a/tests/benchmarks/core/bench_helpers.cpp
+++ b/tests/benchmarks/core/bench_helpers.cpp
@@ -391,7 +391,9 @@ static void StepToAccuracyDecimals_Whole(benchmark::State &state) {
 BENCHMARK(StepToAccuracyDecimals_Whole);
 
 static void StepToAccuracyDecimals_Mixed(benchmark::State &state) {
-  static constexpr float steps[] = {0.001f, 0.01f, 0.05f, 0.1f, 0.25f, 0.5f, 1.0f, 2.5f, 5.0f, 10.0f};
+  static constexpr float steps[] = {
+      0.001f, 0.01f, 0.05f, 0.1f, 0.25f, 0.5f, 1.0f, 2.5f, 5.0f, 10.0f,
+  };
   static constexpr int num_steps = sizeof(steps) / sizeof(steps[0]);
   for (auto _ : state) {
     int result = 0;

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -327,6 +327,14 @@ TEST(StepToAccuracyDecimals, RoundsUpToWholeNumber) {
   EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
 }
 
+TEST(StepToAccuracyDecimals, OutsideFixedNotationRange) {
+  // %.5g prints these in exponent form, so the count comes from parsing "1e-05" or "1.2346e+05".
+  EXPECT_EQ(step_to_accuracy_decimals(0.00001f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(0.000125f), 6);
+  EXPECT_EQ(step_to_accuracy_decimals(123456.0f), 8);
+  EXPECT_EQ(step_to_accuracy_decimals(1000000.0f), 0);
+}
+
 TEST(StepToAccuracyDecimals, SignIgnored) {
   EXPECT_EQ(step_to_accuracy_decimals(-0.1f), 1);
   EXPECT_EQ(step_to_accuracy_decimals(-0.25f), 2);

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -320,6 +320,10 @@ TEST(StepToAccuracyDecimals, TrailingZerosDropped) {
   EXPECT_EQ(step_to_accuracy_decimals(0.7f), 1);
   EXPECT_EQ(step_to_accuracy_decimals(0.125f), 3);
   EXPECT_EQ(step_to_accuracy_decimals(0.0625f), 4);
+}
+
+TEST(StepToAccuracyDecimals, RoundsUpToWholeNumber) {
+  // Rounds to five significant digits first, so this becomes 10 with no decimals.
   EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
 }
 

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include <cstring>
 
 #include "esphome/core/alloc_helpers.h"
@@ -278,6 +279,61 @@ TEST(Base64, Rfc4648Vectors) {
     EXPECT_EQ(len, strlen(v.plain));
     EXPECT_EQ(memcmp(buf, v.plain, len), 0);
   }
+}
+
+// --- step_to_accuracy_decimals() ---
+
+TEST(StepToAccuracyDecimals, TypicalSteps) {
+  EXPECT_EQ(step_to_accuracy_decimals(0.001f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.005f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.01f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(0.025f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.05f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(0.1f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(0.25f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(0.5f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(1.5f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(2.5f), 1);
+}
+
+TEST(StepToAccuracyDecimals, WholeSteps) {
+  EXPECT_EQ(step_to_accuracy_decimals(1.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(2.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(5.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(10.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(100.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(1000.0f), 0);
+}
+
+TEST(StepToAccuracyDecimals, FiveSignificantDigits) {
+  EXPECT_EQ(step_to_accuracy_decimals(1.23456f), 4);
+  EXPECT_EQ(step_to_accuracy_decimals(12.345f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(123.45f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(1234.5f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(12345.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(0.33333f), 5);
+  EXPECT_EQ(step_to_accuracy_decimals(0.0001f), 4);
+}
+
+TEST(StepToAccuracyDecimals, TrailingZerosDropped) {
+  EXPECT_EQ(step_to_accuracy_decimals(0.3f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(0.7f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(0.125f), 3);
+  EXPECT_EQ(step_to_accuracy_decimals(0.0625f), 4);
+  EXPECT_EQ(step_to_accuracy_decimals(9.999999f), 0);
+}
+
+TEST(StepToAccuracyDecimals, SignIgnored) {
+  EXPECT_EQ(step_to_accuracy_decimals(-0.1f), 1);
+  EXPECT_EQ(step_to_accuracy_decimals(-0.25f), 2);
+  EXPECT_EQ(step_to_accuracy_decimals(-1.0f), 0);
+}
+
+TEST(StepToAccuracyDecimals, NonFiniteAndZero) {
+  EXPECT_EQ(step_to_accuracy_decimals(0.0f), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(NAN), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(INFINITY), 0);
+  EXPECT_EQ(step_to_accuracy_decimals(-INFINITY), 0);
 }
 
 }  // namespace esphome::core::testing


### PR DESCRIPTION
# What does this implement/fix?

Adds CodSpeed benchmarks for `step_to_accuracy_decimals` in `tests/benchmarks/core/bench_helpers.cpp`, covering a tenth step, a whole step and a mix of typical number and climate steps. This lands first so a follow up rewrite of the function gets a proper before and after comparison. It also adds gtest cases for the function in `tests/components/core/test_helpers.cpp` covering typical number and climate steps, whole steps, five significant digit inputs, trailing zero handling, negative steps, non finite values and the two ranges where `%.5g` switches to exponent form, so the rewrite has to keep the same results or change the expectations in plain sight.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
