### PR TITLE
[esp32] Exclude the WiFi and Bluetooth IDF components from builds that do not use them

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -214,6 +214,7 @@ COMPILER_OPTIMIZATIONS = {
 # builds that need them.
 DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "app_trace",  # CPU trace/SystemView support - unused by ESPHome
+    "bt",  # Bluetooth stack - re-included by request_bluetooth(); it requires esp_wifi
     "cmock",  # Unit testing mock framework - ESPHome doesn't use IDF's testing
     "console",  # Console REPL - unused by ESPHome; espressif/mdns pulls it back when configured
     "driver",  # Legacy driver shim - only needed by esp32_touch, esp32_can for legacy headers
@@ -233,9 +234,13 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "esp_driver_sdmmc",  # SD/MMC host driver - unused by ESPHome
     "esp_driver_sdspi",  # SD-over-SPI driver - unused by ESPHome
     "esp_driver_touch_sens",  # Touch sensor driver - only needed by esp32_touch
+    "esp_coex",  # WiFi/BT coexistence - esp_wifi, bt and ieee802154 pull it back
     "esp_driver_twai",  # TWAI/CAN driver - only needed by esp32_can component
     "esp_eth",  # Ethernet driver - only needed by ethernet component
     "esp_gdbstub",  # GDB stub panic handler - unused by ESPHome; bt pulls it back
+    "esp_hal_ieee802154",  # 802.15.4 HAL - ieee802154 pulls it back
+    "esp_phy",  # Radio PHY - esp_wifi, bt and ieee802154 pull it back
+    "esp_wifi",  # WiFi stack (and wpa_supplicant/mbedtls with it) - re-included by wifi, espnow; bt pulls it back
     "esp_hid",  # HID host/device support - ESPHome doesn't implement HID functionality
     "esp_http_client",  # HTTP client - only needed by http_request component
     "esp_http_server",  # HTTP server - re-included by web_server_idf, esp32_camera_web_server
@@ -245,6 +250,7 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "esp_local_ctrl",  # Local control over HTTPS/BLE - ESPHome has native API
     "espcoredump",  # Core dump support - ESPHome has its own debug component
     "fatfs",  # FAT filesystem - ESPHome doesn't use filesystem storage
+    "ieee802154",  # 802.15.4 radio - openthread and zigbee pull it back; it requires esp_phy
     "json",  # cJSON library - ESPHome uses ArduinoJson instead
     "mqtt",  # ESP-IDF MQTT library - ESPHome has its own MQTT implementation
     "nvs_sec_provider",  # NVS encryption key provider - re-included when CONFIG_NVS_ENCRYPTION is set
@@ -258,6 +264,7 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "tcp_transport",  # Transport layer - esp_http_client/mqtt pull it back when re-included
     "ulp",  # ULP coprocessor - not currently used by any ESPHome component
     "unity",  # Unit testing framework - ESPHome doesn't use IDF's testing
+    "wpa_supplicant",  # WiFi authentication - esp_wifi pulls it back
     "wear_levelling",  # Flash wear levelling for fatfs - unused since fatfs unused
     "wifi_provisioning",  # WiFi provisioning - ESPHome uses its own improv implementation
 )
@@ -720,6 +727,7 @@ def request_bluetooth() -> None:
     """Request the Bluetooth controller."""
     net = _network_sdkconfig()
     net.bluetooth = True
+    include_builtin_idf_component("bt")
 
 
 def request_software_coexistence() -> None:
@@ -2304,6 +2312,8 @@ async def _reconcile_network_sdkconfig() -> None:
 
     # WiFi stack: disable only when Ethernet is present and WiFi is not. WiFi
     # relies on the IDF default (enabled), so it is never written True here.
+    # On IDF esp_wifi is excluded outright; this still matters where Arduino
+    # or bt pulls it back, and is ignored otherwise.
     wifi_disabled = net.ethernet and not net.wifi
     if wifi_disabled:
         set_idf_sdkconfig_default("CONFIG_ESP_WIFI_ENABLED", False)

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -3,6 +3,7 @@ from typing import Any
 from esphome import automation, core
 import esphome.codegen as cg
 from esphome.components import wifi
+from esphome.components.esp32 import include_builtin_idf_component
 from esphome.components.udp import CONF_ON_RECEIVE
 import esphome.config_validation as cv
 from esphome.const import (
@@ -154,6 +155,7 @@ async def to_code(config: ConfigType) -> None:
 
     cg.add_define("USE_ESPNOW")
     cg.add_define("USE_ESPNOW_MAX_PAYLOAD_SIZE", config[CONF_MAX_PAYLOAD_SIZE])
+    include_builtin_idf_component("esp_wifi")
 
     if CONF_WIFI in CORE.config:
         # Track the Wi-Fi channel via connect events instead of polling every loop

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -282,6 +282,7 @@ async def to_code(config: ConfigType) -> None:
     # Re-enable openthread IDF component (excluded by default)
     if CORE.is_esp32:
         include_builtin_idf_component("openthread")
+        include_builtin_idf_component("ieee802154")
 
     cg.add_define("USE_OPENTHREAD")
     if config.get(CONF_FORCE_DATASET):

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -10,6 +10,7 @@ from esphome.components.esp32 import (
     add_idf_sdkconfig_option,
     const,
     get_esp32_variant,
+    include_builtin_idf_component,
     only_on_variant,
     request_wifi,
 )
@@ -652,6 +653,8 @@ async def to_code(config):
     # drops SoftAP support / the LWIP DHCP server when AP mode is unused.
     if CORE.is_esp32:
         request_wifi(ap=CONF_AP in config)
+        include_builtin_idf_component("esp_wifi")
+        include_builtin_idf_component("wpa_supplicant")  # esp_eap_client.h
 
     # Disable Enterprise WiFi support if no EAP is configured
     if CORE.is_esp32:

--- a/esphome/components/zigbee/zigbee_esp32.py
+++ b/esphome/components/zigbee/zigbee_esp32.py
@@ -9,6 +9,7 @@ from esphome.components.esp32 import (
     add_idf_component,
     add_idf_sdkconfig_option,
     add_partition,
+    include_builtin_idf_component,
     require_vfs_select,
 )
 import esphome.config_validation as cv
@@ -287,6 +288,7 @@ async def esp32_to_code(config: ConfigType) -> "MockObj":
         name="espressif/esp-zigbee-lib",
         ref="2.0.4",
     )
+    include_builtin_idf_component("ieee802154")
 
     # add sdkconfigs later so they can overwrite esp32 defaults
     CORE.add_job(_zigbee_add_sdkconfigs, config)

--- a/tests/component_tests/esp32/config/exclusion_reincludes_espnow.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes_espnow.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+espnow:
+  channel: 1

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -298,6 +298,13 @@ def test_esp32_configuration_errors(
             ("esp-tls", "esp_http_client"),
             id="nextion",
         ),
+        pytest.param(
+            "network_wifi_only.yaml", ("esp_wifi", "wpa_supplicant"), id="wifi"
+        ),
+        pytest.param("exclusion_reincludes_espnow.yaml", ("esp_wifi",), id="espnow"),
+        pytest.param(
+            "network_wifi_ble_coexistence.yaml", ("esp_wifi", "bt"), id="wifi_ble"
+        ),
     ],
 )
 def test_default_exclusions_reincluded_by_owning_components(
@@ -322,6 +329,19 @@ def test_default_exclusions_reincluded_by_owning_components(
     assert "fatfs" in excluded
     # The HTTP server only comes back for configs that run one.
     assert ("esp_http_server" in excluded) == ("esp_http_server" not in reincluded)
+
+
+def test_wifi_stack_stays_excluded_without_wifi(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Ethernet-only builds keep the WiFi stack (and mbedtls with it) out."""
+    from esphome.components.esp32.const import KEY_EXCLUDE_COMPONENTS
+
+    generate_main(component_config_path("network_ethernet_only.yaml"))
+    excluded = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
+
+    assert {"esp_wifi", "wpa_supplicant", "esp_phy", "esp_coex", "bt"} <= excluded
 
 
 def test_nvs_sec_provider_stays_excluded_when_encryption_is_off(


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF builds compile the whole WiFi and Bluetooth stack even when the configuration uses neither. The exclusion list is a deny list, the generated `src` component requires every built-in component that is not on it, and `esp_wifi`, `wpa_supplicant`, `esp_phy`, `esp_coex`, `bt` and `ieee802154` were never listed. The logger-only docker smoke config therefore built `wpa_supplicant` (83 objects) plus the rest of the chain for nothing, and so does every ethernet-only device.

Add those six (and `esp_hal_ieee802154`) to the default exclusions. `wifi` re-includes `esp_wifi` and `wpa_supplicant` (it includes `esp_eap_client.h` directly), `espnow` re-includes `esp_wifi`, `request_bluetooth()` re-includes `bt`, `openthread` and `zigbee` re-include `ieee802154`; IDF's requirement expansion then restores the rest of each chain (`bt` requires `esp_wifi`, `ieee802154` requires `esp_phy` and `esp_coex`), so BLE-only and Thread builds keep the same component set they build today (compared `project_description.json` for BLE-only and wifi configs against dev: nothing added, only the empty `bt`, `ieee802154` and `esp_gdbstub` registrations gone). The few sdkconfig writes aimed at the excluded components (`CONFIG_ESP_WIFI_ENABLED`, `CONFIG_ESP_PHY_REDUCE_TX_POWER`) are ignored by kconfgen when the symbol does not exist and still apply where Arduino or `bt` brings the component back.

Two things this cannot remove: `mbedtls` stays because `bootloader_support` requires it in every app build, and any build with mDNS keeps the WiFi chain because the managed `espressif/mdns` component lists `esp_wifi` as a private dependency. So the saving applies to builds without mDNS (the CI smoke configs, devices with `mdns: disabled: true`), ethernet plus `api` builds are unchanged.

Measured on the logger-only smoke config `docker/test_configs/esp32-idf-esp-idf.yaml`, native IDF toolchain, ccache off:

| | before | after |
|---|---|---|
| ninja edges | 799 | 686 |
| compile CPU (sum of ninja edge times) | 109.8s | 96.2s (-12%) |
| esp_wifi / wpa_supplicant / esp_phy / esp_coex / bt objects | 10 / 83 / 6 / 3 / 0 | none |

Verified that wifi with api, ethernet-only, BLE-only and espnow configurations still compile and link, with the wifi chain present only where it is used.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
