### PR TITLE
[core] Use uv for the ESP-IDF Python environment when available

### DIFF
--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -1148,6 +1148,8 @@ def check_esp_idf_install(
     env = {}
     env["IDF_TOOLS_PATH"] = str(get_idf_tools_path())
     env["IDF_PATH"] = ""
+    # uv defaults to 3 HTTP retries; match the pioarduino penv's bump to 10
+    env["UV_HTTP_RETRIES"] = os.environ.get("UV_HTTP_RETRIES", "10")
 
     # An explicit ESPHOME_IDF_DEFAULT_TARGETS wins over the caller's
     # per-variant request (builder-image pre-warm); otherwise the caller's

--- a/esphome/espidf/framework.py
+++ b/esphome/espidf/framework.py
@@ -1053,15 +1053,28 @@ def _check_esp_idf_python_env_install(
             constraint_file_path,
         )
 
-        cmd_pip_install = [
-            str(env_python_path),
-            "-m",
-            "pip",
-            "install",
-            "--upgrade",
-            "--constraint",
-            constraint_file_path,
-        ]
+        # uv (much faster than pip) when available, e.g. in the docker image
+        if uv_path := shutil.which("uv"):
+            cmd_pip_install = [
+                uv_path,
+                "pip",
+                "install",
+                "--python",
+                str(env_python_path),
+                "--upgrade",
+                "--constraint",
+                str(constraint_file_path),
+            ]
+        else:
+            cmd_pip_install = [
+                str(env_python_path),
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--constraint",
+                str(constraint_file_path),
+            ]
 
         _LOGGER.info("Installing ESP-IDF %s Python dependencies ...", version)
         cmd = cmd_pip_install + [

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -520,6 +520,24 @@ def test_check_esp_idf_install_feature_failure(espidf_mocks: SimpleNamespace) ->
         check_esp_idf_install(_IDF_VERSION, force=True, features=["fb"])
 
 
+def test_python_deps_use_uv_when_available(espidf_mocks: SimpleNamespace) -> None:
+    """The python env installs go through uv when on the PATH, pip otherwise."""
+    with patch("esphome.espidf.framework.shutil.which", return_value="/usr/bin/uv"):
+        check_esp_idf_install(_IDF_VERSION, force=True, features=["fb"])
+    upgrade_cmd, feature_cmd = (
+        c.args[0] for c in espidf_mocks.run_ok.call_args_list[1:3]
+    )
+    assert upgrade_cmd[:3] == ["/usr/bin/uv", "pip", "install"]
+    assert "--python" in upgrade_cmd
+    assert feature_cmd[:3] == ["/usr/bin/uv", "pip", "install"]
+
+    espidf_mocks.run_ok.reset_mock()
+    with patch("esphome.espidf.framework.shutil.which", return_value=None):
+        check_esp_idf_install(_IDF_VERSION, force=True, features=["fb"])
+    upgrade_cmd = espidf_mocks.run_ok.call_args_list[1].args[0]
+    assert upgrade_cmd[1:4] == ["-m", "pip", "install"]
+
+
 def _mark_installed() -> None:
     """Create the extracted marker and python-env interpreter so the install
     check takes the already-installed path rather than force-installing."""

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -520,8 +520,11 @@ def test_check_esp_idf_install_feature_failure(espidf_mocks: SimpleNamespace) ->
         check_esp_idf_install(_IDF_VERSION, force=True, features=["fb"])
 
 
-def test_python_deps_use_uv_when_available(espidf_mocks: SimpleNamespace) -> None:
+def test_python_deps_use_uv_when_available(
+    espidf_mocks: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The python env installs go through uv when on the PATH, pip otherwise."""
+    monkeypatch.delenv("UV_HTTP_RETRIES", raising=False)
     with patch(
         "esphome.espidf.framework.shutil.which",
         # Keyed on the name: the same which() also probes the default tools
@@ -536,10 +539,12 @@ def test_python_deps_use_uv_when_available(espidf_mocks: SimpleNamespace) -> Non
     assert upgrade_call.kwargs["env"]["UV_HTTP_RETRIES"] == "10"
 
     espidf_mocks.run_ok.reset_mock()
+    monkeypatch.setenv("UV_HTTP_RETRIES", "3")  # an explicit user value wins
     with patch("esphome.espidf.framework.shutil.which", return_value=None):
         check_esp_idf_install(_IDF_VERSION, force=True, features=["fb"])
-    upgrade_cmd = espidf_mocks.run_ok.call_args_list[1].args[0]
-    assert upgrade_cmd[1:4] == ["-m", "pip", "install"]
+    upgrade_call = espidf_mocks.run_ok.call_args_list[1]
+    assert upgrade_call.args[0][1:4] == ["-m", "pip", "install"]
+    assert upgrade_call.kwargs["env"]["UV_HTTP_RETRIES"] == "3"
 
 
 def _mark_installed() -> None:

--- a/tests/unit_tests/test_espidf_framework.py
+++ b/tests/unit_tests/test_espidf_framework.py
@@ -522,14 +522,18 @@ def test_check_esp_idf_install_feature_failure(espidf_mocks: SimpleNamespace) ->
 
 def test_python_deps_use_uv_when_available(espidf_mocks: SimpleNamespace) -> None:
     """The python env installs go through uv when on the PATH, pip otherwise."""
-    with patch("esphome.espidf.framework.shutil.which", return_value="/usr/bin/uv"):
+    with patch(
+        "esphome.espidf.framework.shutil.which",
+        # Keyed on the name: the same which() also probes the default tools
+        side_effect=lambda name: "/usr/bin/uv" if name == "uv" else None,
+    ):
         check_esp_idf_install(_IDF_VERSION, force=True, features=["fb"])
-    upgrade_cmd, feature_cmd = (
-        c.args[0] for c in espidf_mocks.run_ok.call_args_list[1:3]
-    )
+    upgrade_call, feature_call = espidf_mocks.run_ok.call_args_list[1:3]
+    upgrade_cmd, feature_cmd = upgrade_call.args[0], feature_call.args[0]
     assert upgrade_cmd[:3] == ["/usr/bin/uv", "pip", "install"]
     assert "--python" in upgrade_cmd
     assert feature_cmd[:3] == ["/usr/bin/uv", "pip", "install"]
+    assert upgrade_call.kwargs["env"]["UV_HTTP_RETRIES"] == "10"
 
     espidf_mocks.run_ok.reset_mock()
     with patch("esphome.espidf.framework.shutil.which", return_value=None):


### PR DESCRIPTION
# What does this implement/fix?

The ESP-IDF Python environment installer always used pip. When uv is on the PATH it is now used for the installs, with pip staying the fallback; nothing changes where uv is not installed. The docker image already ships uv for the pioarduino penv, so container builds pick up the faster path automatically.

On a warm cache the core requirements install takes about 0.2 seconds with uv and about 4 seconds with pip locally; in CI the same install dropped from about 14 seconds with pip to under 3 with uv. The pip work is mostly single threaded Python, so on low power hardware like the Home Assistant Green the savings are far larger, and the add-on image already ships uv so those users get the fast path automatically.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
