### PR TITLE
[core] Make script/setup idempotent and prepare new worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "d=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -x \"$d/venv/bin/python\" ] || { mkdir -p \"$d/.temp\"; env -u VIRTUAL_ENV \"$d/script/setup\" >\"$d/.temp/setup.log\" 2>&1 || echo '{\"systemMessage\":\"script/setup failed; see .temp/setup.log\"}'; }",
+            "statusMessage": "Setting up dev environment (script/setup)...",
+            "timeout": 900
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/script/git-hooks/post-checkout
+++ b/script/git-hooks/post-checkout
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Prepare the dev environment for a new checkout or worktree.
+#
+# Installed into the git hooks directory by script/setup. Deliberately tiny and
+# self-contained: it stays valid on branches where script/setup does not exist,
+# and simply does nothing there.
+
+# $3 is 1 for a branch checkout, 0 for a file checkout.
+[ "$3" = "1" ] || exit 0
+
+top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# This also runs on ordinary branch switches, where there is nothing to do.
+[ -x "$top/venv/bin/python" ] && exit 0
+[ -x "$top/script/setup" ] || exit 0
+
+# Clear VIRTUAL_ENV so a checkout made from a shell with an environment already
+# activated still gets its own, rather than having the active one repointed at
+# this working tree.
+exec env -u VIRTUAL_ENV "$top/script/setup"

--- a/script/setup
+++ b/script/setup
@@ -7,13 +7,19 @@ cd "$(dirname "$0")/.."
 if [ -n "$VIRTUAL_ENV" ]; then
   # A virtual environment is already active (e.g. the devcontainer's pre-provisioned
   # esphome-venv). Install into it rather than creating a ./venv in the workspace.
-  created_venv=false
+  venv_state=active
+elif [ -x venv/bin/python ]; then
+  # Reuse the environment from an earlier run, so this script can be run again
+  # at any time to pick up dependency changes.
+  venv_state=reused
+  source venv/bin/activate
 else
-  created_venv=true
+  venv_state=created
+  # --clear replaces a partial environment left behind by an interrupted run.
   if [ -x "$(command -v uv)" ]; then
-    uv venv --seed venv
+    uv venv --clear --seed venv
   else
-    python3 -m venv venv
+    python3 -m venv --clear venv
   fi
   source venv/bin/activate
 fi
@@ -25,20 +31,41 @@ fi
 uv pip install setuptools wheel
 uv pip install -e ".[dev,test]" --config-settings editable_mode=compat
 
-# --overwrite replaces any hook already in place. Without it, prek finds a
-# previously installed pre-commit hook, moves it aside to
-# .git/hooks/pre-commit.legacy and keeps calling it, so every commit would
-# run both tools.
-prek install --overwrite
+# A worktree shares one git hooks directory with the main checkout it was
+# created from, so hooks are installed from the main checkout only. Installing
+# from a worktree would point the shared hook at that worktree's virtual
+# environment, breaking it for everyone once the worktree is removed.
+git_dir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ "$git_dir" = "$common_dir" ]; then
+  # --overwrite replaces any hook already in place. Without it, prek finds a
+  # previously installed pre-commit hook, moves it aside to
+  # .git/hooks/pre-commit.legacy and keeps calling it, so every commit would
+  # run both tools.
+  prek install --overwrite
+
+  # Prepares the virtual environment for new checkouts and worktrees. Installed
+  # once here, it covers every worktree created from this checkout.
+  if [ -n "$common_dir" ] && [ -d "$common_dir/hooks" ]; then
+    cp script/git-hooks/post-checkout "$common_dir/hooks/post-checkout"
+    chmod +x "$common_dir/hooks/post-checkout"
+  fi
+fi
 
 mkdir -p .temp
 
 echo
 echo
-if [ "$created_venv" = true ]; then
-  echo "Virtual environment created at ./venv. Run 'source venv/bin/activate' to use it."
-else
-  echo "Dependencies installed into the active virtual environment:"
-  echo "  $VIRTUAL_ENV"
-  echo "It is already active in this shell, so no 'source venv/bin/activate' is needed."
-fi
+case "$venv_state" in
+  created)
+    echo "Virtual environment created at ./venv. Run 'source venv/bin/activate' to use it."
+    ;;
+  reused)
+    echo "Dependencies updated in the existing ./venv. Run 'source venv/bin/activate' to use it."
+    ;;
+  active)
+    echo "Dependencies installed into the active virtual environment:"
+    echo "  $VIRTUAL_ENV"
+    echo "It is already active in this shell, so no 'source venv/bin/activate' is needed."
+    ;;
+esac

--- a/script/setup
+++ b/script/setup
@@ -37,7 +37,7 @@ uv pip install -e ".[dev,test]" --config-settings editable_mode=compat
 # environment, breaking it for everyone once the worktree is removed.
 git_dir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
 common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-if [ "$git_dir" = "$common_dir" ]; then
+if [ -n "$common_dir" ] && [ "$git_dir" = "$common_dir" ]; then
   # --overwrite replaces any hook already in place. Without it, prek finds a
   # previously installed pre-commit hook, moves it aside to
   # .git/hooks/pre-commit.legacy and keeps calling it, so every commit would
@@ -46,7 +46,7 @@ if [ "$git_dir" = "$common_dir" ]; then
 
   # Prepares the virtual environment for new checkouts and worktrees. Installed
   # once here, it covers every worktree created from this checkout.
-  if [ -n "$common_dir" ] && [ -d "$common_dir/hooks" ]; then
+  if [ -d "$common_dir/hooks" ]; then
     cp script/git-hooks/post-checkout "$common_dir/hooks/post-checkout"
     chmod +x "$common_dir/hooks/post-checkout"
   fi


### PR DESCRIPTION
# What does this implement/fix?

Three related changes to the development environment setup.

`script/setup` is now safe to re-run. It previously failed on the second run, because `uv venv --seed venv` errors out when the directory already exists, so picking up a dependency change meant deleting `venv/` by hand first. It now reuses an existing environment, and replaces one left half-built by an interrupted run instead of wedging on it permanently.

Git hooks are installed from the main checkout only. All worktrees of a checkout share a single hooks directory, so running `script/setup` inside a worktree rewrote the shared `pre-commit` hook to point at that worktree's virtual environment. Once the worktree was deleted the hook pointed at a path that no longer existed, and commits failed everywhere until it was reinstalled by hand. A worktree inherits the main checkout's hooks anyway, so nothing is lost by skipping the install there.

New `script/git-hooks/post-checkout`, installed by `script/setup`, prepares the environment for a checkout that does not have one. This makes `git worktree add` produce a worktree that is ready to use, rather than one that needs a manual `script/setup`. It does nothing when a virtual environment is already present, so ordinary branch switches are unaffected, and it clears `VIRTUAL_ENV` first so that creating a worktree from a shell with an environment activated does not repoint that environment at the new working tree.

`.claude/settings.json` adds the equivalent for Claude Code sessions, which create worktrees of their own. It has no effect on any other editor or workflow.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).