### PR TITLE
[light] Fix gamma table dead zone collapsing to 0

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -126,12 +126,6 @@ def generate_gamma_table(gamma_correct: float) -> list[HexInt]:
     the invariant that non-zero input always produces non-zero output. Without
     this, small brightness values (e.g. 1%) get quantized to exactly 0.0,
     which breaks zero_means_zero logic in FloatOutput.
-
-    This table is shared verbatim by LightState::gamma_correct_lut() (a float,
-    interpolated path with far more than 8-bit precision) as well as by
-    ESPColorCorrection's 8-bit conversion, so it must not be distorted to
-    accommodate the latter's lower precision -- see gamma_correct_() in
-    esp_color_correction.cpp for that.
     """
     if gamma_correct > 0:
         return [

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -127,22 +127,23 @@ MIN_NONZERO_GAMMA_VALUE = 129
 def generate_gamma_table(gamma_correct: float) -> list[HexInt]:
     """Generate a 256-entry uint16 gamma lookup table.
 
-    Non-zero indices are clamped to a minimum of MIN_NONZERO_GAMMA_VALUE so
-    every non-zero 8-bit input still produces a non-zero 8-bit output.
+    Below the point where the power curve itself would fall under
+    MIN_NONZERO_GAMMA_VALUE, entries ramp linearly up to that point instead of
+    being clamped flat, so higher-resolution FloatOutput consumers (e.g. LEDC)
+    still get distinct steps there rather than one dead, unmoving value.
     """
-    if gamma_correct > 0:
-        return [
-            HexInt(
-                max(
-                    MIN_NONZERO_GAMMA_VALUE,
-                    min(65535, int(round((i / 255.0) ** gamma_correct * 65535))),
-                )
-                if i > 0
-                else HexInt(0)
-            )
-            for i in range(256)
-        ]
-    return [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+    if gamma_correct <= 0:
+        return [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+
+    table = [0] + [
+        min(65535, int(round((i / 255.0) ** gamma_correct * 65535)))
+        for i in range(1, 256)
+    ]
+    n0 = next(i for i in range(1, 256) if table[i] >= MIN_NONZERO_GAMMA_VALUE)
+    span = table[n0] - MIN_NONZERO_GAMMA_VALUE
+    for i in range(1, n0):
+        table[i] = MIN_NONZERO_GAMMA_VALUE + round(span * (i - 1) / (n0 - 1))
+    return [HexInt(v) for v in table]
 
 
 def _get_or_create_gamma_table(gamma_correct):

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -119,18 +119,24 @@ def _get_data() -> LightData:
     return CORE.data[DOMAIN]
 
 
+# Smallest table entry that survives ESPColorCorrection's (value + 128) / 257
+# conversion as a non-zero 8-bit result (esphome/esphome#18842).
+MIN_NONZERO_GAMMA_VALUE = 129
+
+
 def generate_gamma_table(gamma_correct: float) -> list[HexInt]:
     """Generate a 256-entry uint16 gamma lookup table.
 
-    For gamma > 0, non-zero indices are clamped to a minimum of 1 to preserve
-    the invariant that non-zero input always produces non-zero output. Without
-    this, small brightness values (e.g. 1%) get quantized to exactly 0.0,
-    which breaks zero_means_zero logic in FloatOutput.
+    Non-zero indices are clamped to a minimum of MIN_NONZERO_GAMMA_VALUE so
+    every non-zero 8-bit input still produces a non-zero 8-bit output.
     """
     if gamma_correct > 0:
         return [
             HexInt(
-                max(1, min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
+                max(
+                    MIN_NONZERO_GAMMA_VALUE,
+                    min(65535, int(round((i / 255.0) ** gamma_correct * 65535))),
+                )
                 if i > 0
                 else HexInt(0)
             )

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -119,31 +119,30 @@ def _get_data() -> LightData:
     return CORE.data[DOMAIN]
 
 
-# Smallest table entry that survives ESPColorCorrection's (value + 128) / 257
-# conversion as a non-zero 8-bit result (esphome/esphome#18842).
-MIN_NONZERO_GAMMA_VALUE = 129
-
-
 def generate_gamma_table(gamma_correct: float) -> list[HexInt]:
     """Generate a 256-entry uint16 gamma lookup table.
 
-    Below the point where the power curve itself would fall under
-    MIN_NONZERO_GAMMA_VALUE, entries ramp linearly up to that point instead of
-    being clamped flat, so higher-resolution FloatOutput consumers (e.g. LEDC)
-    still get distinct steps there rather than one dead, unmoving value.
-    """
-    if gamma_correct <= 0:
-        return [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+    For gamma > 0, non-zero indices are clamped to a minimum of 1 to preserve
+    the invariant that non-zero input always produces non-zero output. Without
+    this, small brightness values (e.g. 1%) get quantized to exactly 0.0,
+    which breaks zero_means_zero logic in FloatOutput.
 
-    table = [0] + [
-        min(65535, int(round((i / 255.0) ** gamma_correct * 65535)))
-        for i in range(1, 256)
-    ]
-    n0 = next(i for i in range(1, 256) if table[i] >= MIN_NONZERO_GAMMA_VALUE)
-    span = table[n0] - MIN_NONZERO_GAMMA_VALUE
-    for i in range(1, n0):
-        table[i] = MIN_NONZERO_GAMMA_VALUE + round(span * (i - 1) / (n0 - 1))
-    return [HexInt(v) for v in table]
+    This table is shared verbatim by LightState::gamma_correct_lut() (a float,
+    interpolated path with far more than 8-bit precision) as well as by
+    ESPColorCorrection's 8-bit conversion, so it must not be distorted to
+    accommodate the latter's lower precision -- see gamma_correct_() in
+    esp_color_correction.cpp for that.
+    """
+    if gamma_correct > 0:
+        return [
+            HexInt(
+                max(1, min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
+                if i > 0
+                else HexInt(0)
+            )
+            for i in range(256)
+        ]
+    return [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
 
 
 def _get_or_create_gamma_table(gamma_correct):

--- a/esphome/components/light/esp_color_correction.cpp
+++ b/esphome/components/light/esp_color_correction.cpp
@@ -5,7 +5,14 @@ namespace esphome::light {
 uint8_t ESPColorCorrection::gamma_correct_(uint8_t value) const {
   if (this->gamma_table_ == nullptr)
     return value;
-  return static_cast<uint8_t>((progmem_read_uint16(&this->gamma_table_[value]) + 128) / 257);
+  uint16_t table_value = progmem_read_uint16(&this->gamma_table_[value]);
+  uint8_t result = (table_value + 128) / 257;
+  // A non-zero table entry must not round down to 0 here -- the table itself is left
+  // untouched (it's shared with LightState's higher-precision float gamma path), so this
+  // is the only place a non-zero input could otherwise go dark (esphome/esphome#18842).
+  if (result == 0 && table_value != 0)
+    return 1;
+  return result;
 }
 
 uint8_t ESPColorCorrection::gamma_uncorrect_(uint8_t value) const {

--- a/esphome/components/light/esp_color_correction.cpp
+++ b/esphome/components/light/esp_color_correction.cpp
@@ -7,9 +7,6 @@ uint8_t ESPColorCorrection::gamma_correct_(uint8_t value) const {
     return value;
   uint16_t table_value = progmem_read_uint16(&this->gamma_table_[value]);
   uint8_t result = (table_value + 128) / 257;
-  // A non-zero table entry must not round down to 0 here -- the table itself is left
-  // untouched (it's shared with LightState's higher-precision float gamma path), so this
-  // is the only place a non-zero input could otherwise go dark (esphome/esphome#18842).
   if (result == 0 && table_value != 0)
     return 1;
   return result;

--- a/tests/components/light/test_gamma_correction.cpp
+++ b/tests/components/light/test_gamma_correction.cpp
@@ -76,7 +76,7 @@ TEST(GammaCorrection, FullBrightnessStaysFull) {
 
 // Reproduces the reporter's own numbers from esphome/esphome#18842 at gamma=2.8: codes
 // 1-27 previously collapsed to an 8-bit output of 0 and must now be non-zero.
-TEST(GammaCorrection, DeadZoneFixedAtGamma2_8) {
+TEST(GammaCorrection, DeadZoneFixedAtGamma28) {
   auto table = build_gamma_table(2.8);
   ESPColorCorrection correction;
   correction.set_gamma_table(table.data());

--- a/tests/components/light/test_gamma_correction.cpp
+++ b/tests/components/light/test_gamma_correction.cpp
@@ -4,7 +4,6 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
-#include <set>
 
 #include "esphome/components/light/esp_color_correction.h"
 
@@ -12,9 +11,8 @@ namespace esphome::light::testing {
 
 namespace {
 
-// Mirrors generate_gamma_table() in esphome/components/light/__init__.py. The table itself
-// is deliberately left as the raw (min-1-clamped) power curve -- ESPColorCorrection is
-// responsible for guaranteeing non-zero 8-bit output, not the table.
+// A representative fixture for ESPColorCorrection/gamma_table_reverse_search tests below --
+// not a spec for generate_gamma_table() itself, which the Python tests own.
 std::array<uint16_t, 256> build_gamma_table(double gamma) {
   std::array<uint16_t, 256> table{};
   table[0] = 0;
@@ -25,21 +23,13 @@ std::array<uint16_t, 256> build_gamma_table(double gamma) {
   return table;
 }
 
-// Mirrors LightState::gamma_correct_lut() in light_state.cpp.
-float gamma_correct_lut(const std::array<uint16_t, 256> &table, float value) {
-  if (value <= 0.0f)
-    return 0.0f;
-  if (value >= 1.0f)
-    return 1.0f;
-  float scaled = value * 255.0f;
-  auto idx = static_cast<uint8_t>(scaled);
-  if (idx >= 255)
-    return table[255] / 65535.0f;
-  float frac = scaled - idx;
-  float a = table[idx];
-  float b = table[idx + 1];
-  return (a + frac * (b - a)) / 65535.0f;
-}
+// Bundles a table with an ESPColorCorrection pointing at it, since the correction only holds
+// a raw pointer into the table and doesn't own it.
+struct GammaFixture {
+  explicit GammaFixture(double gamma) : table(build_gamma_table(gamma)) { correction.set_gamma_table(table.data()); }
+  std::array<uint16_t, 256> table;
+  ESPColorCorrection correction;
+};
 
 }  // namespace
 
@@ -47,73 +37,33 @@ float gamma_correct_lut(const std::array<uint16_t, 256> &table, float value) {
 // conversion must never round a non-zero table entry down to a zero 8-bit output.
 TEST(GammaCorrection, NonZeroInputsSurviveConversion) {
   for (double gamma : {1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0}) {
-    auto table = build_gamma_table(gamma);
-    ESPColorCorrection correction;
-    correction.set_gamma_table(table.data());
+    GammaFixture fixture(gamma);
     for (int i = 1; i < 256; i++) {
-      EXPECT_GE(correction.color_correct_red(i), 1) << "gamma=" << gamma << " index=" << i;
+      EXPECT_GE(fixture.correction.color_correct_red(i), 1) << "gamma=" << gamma << " index=" << i;
     }
   }
 }
 
 TEST(GammaCorrection, ZeroInputStaysZero) {
   for (double gamma : {1.0, 2.2, 2.8, 4.0}) {
-    auto table = build_gamma_table(gamma);
-    ESPColorCorrection correction;
-    correction.set_gamma_table(table.data());
-    EXPECT_EQ(correction.color_correct_red(0), 0) << "gamma=" << gamma;
+    GammaFixture fixture(gamma);
+    EXPECT_EQ(fixture.correction.color_correct_red(0), 0) << "gamma=" << gamma;
   }
 }
 
 TEST(GammaCorrection, FullBrightnessStaysFull) {
   for (double gamma : {1.0, 2.2, 2.8, 4.0}) {
-    auto table = build_gamma_table(gamma);
-    ESPColorCorrection correction;
-    correction.set_gamma_table(table.data());
-    EXPECT_EQ(correction.color_correct_red(255), 255) << "gamma=" << gamma;
+    GammaFixture fixture(gamma);
+    EXPECT_EQ(fixture.correction.color_correct_red(255), 255) << "gamma=" << gamma;
   }
 }
 
 // Reproduces the reporter's own numbers from esphome/esphome#18842 at gamma=2.8: codes
 // 1-27 previously collapsed to an 8-bit output of 0 and must now be non-zero.
 TEST(GammaCorrection, DeadZoneFixedAtGamma28) {
-  auto table = build_gamma_table(2.8);
-  ESPColorCorrection correction;
-  correction.set_gamma_table(table.data());
+  GammaFixture fixture(2.8);
   for (int i = 1; i < 28; i++) {
-    EXPECT_GE(correction.color_correct_red(i), 1) << "index=" << i << " still collapses to 0";
-  }
-}
-
-// Regression test: the 16-bit table itself must stay the untouched power curve. An earlier
-// version of this fix raised the table's own floor to survive 8-bit rounding, which also
-// flattened the low end of LightState::gamma_correct_lut() -- the float, interpolated path
-// shared by every non-addressable (FloatOutput/PWM) light, e.g. LEDC. That path has far more
-// than 8-bit precision and was never affected by #18842, so it must see the raw curve.
-TEST(GammaCorrection, TableMatchesRawPowerCurve) {
-  const double gamma = 2.8;
-  auto table = build_gamma_table(gamma);
-  for (int i = 1; i < 256; i++) {
-    double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
-    uint16_t expected = static_cast<uint16_t>(std::max(1.0, std::min(65535.0, raw)));
-    EXPECT_EQ(table[i], expected) << "index=" << i;
-  }
-
-  // Below the 8-bit conversion's dead zone, table values are tiny (not artificially raised),
-  // so the interpolated float path still produces distinct output across that range.
-  std::set<float> outputs;
-  for (int i = 1; i < 28; i++)
-    outputs.insert(gamma_correct_lut(table, i / 255.0f));
-  EXPECT_GT(outputs.size(), 1u) << "interpolated LUT output should vary, not be flattened";
-}
-
-// gamma_table_reverse_search needs a non-decreasing table.
-TEST(GammaCorrection, TableStaysNonDecreasing) {
-  for (double gamma : {1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0}) {
-    auto table = build_gamma_table(gamma);
-    for (int i = 1; i < 256; i++) {
-      EXPECT_GE(table[i], table[i - 1]) << "gamma=" << gamma << " index=" << i;
-    }
+    EXPECT_GE(fixture.correction.color_correct_red(i), 1) << "index=" << i << " still collapses to 0";
   }
 }
 
@@ -130,13 +80,10 @@ TEST(GammaCorrection, ReverseSearchFindsLargestIndexLessEqualTarget) {
 
 // color_uncorrect_* binary-searches the table via gamma_table_reverse_search().
 TEST(GammaCorrection, UncorrectStaysMonotonic) {
-  auto table = build_gamma_table(2.8);
-  ESPColorCorrection correction;
-  correction.set_gamma_table(table.data());
-
+  GammaFixture fixture(2.8);
   uint8_t prev = 0;
   for (int i = 1; i < 256; i++) {
-    uint8_t result = correction.color_uncorrect_red(i);
+    uint8_t result = fixture.correction.color_uncorrect_red(i);
     EXPECT_GE(result, prev) << "index=" << i;
     prev = result;
   }

--- a/tests/components/light/test_gamma_correction.cpp
+++ b/tests/components/light/test_gamma_correction.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
+#include <set>
 
 #include "esphome/components/light/esp_color_correction.h"
 
@@ -18,8 +20,14 @@ std::array<uint16_t, 256> build_gamma_table(double gamma) {
   table[0] = 0;
   for (int i = 1; i < 256; i++) {
     double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
-    uint16_t clamped = static_cast<uint16_t>(std::min(65535.0, raw));
-    table[i] = std::max(MIN_NONZERO_GAMMA_VALUE, clamped);
+    table[i] = static_cast<uint16_t>(std::min(65535.0, raw));
+  }
+  int n0 = 1;
+  while (n0 < 256 && table[n0] < MIN_NONZERO_GAMMA_VALUE)
+    n0++;
+  int span = table[n0] - MIN_NONZERO_GAMMA_VALUE;
+  for (int i = 1; i < n0; i++) {
+    table[i] = static_cast<uint16_t>(MIN_NONZERO_GAMMA_VALUE + std::lround(span * (i - 1) / double(n0 - 1)));
   }
   return table;
 }
@@ -27,6 +35,22 @@ std::array<uint16_t, 256> build_gamma_table(double gamma) {
 // Largest code where the unclamped power curve would still round to 0.
 int dead_zone_breakpoint(double gamma) {
   return static_cast<int>(std::ceil(255.0 * std::pow(1.0 / 510.0, 1.0 / gamma)));
+}
+
+// Mirrors LightState::gamma_correct_lut() in light_state.cpp.
+float gamma_correct_lut(const std::array<uint16_t, 256> &table, float value) {
+  if (value <= 0.0f)
+    return 0.0f;
+  if (value >= 1.0f)
+    return 1.0f;
+  float scaled = value * 255.0f;
+  auto idx = static_cast<uint8_t>(scaled);
+  if (idx >= 255)
+    return table[255] / 65535.0f;
+  float frac = scaled - idx;
+  float a = table[idx];
+  float b = table[idx + 1];
+  return (a + frac * (b - a)) / 65535.0f;
 }
 
 }  // namespace
@@ -73,7 +97,8 @@ TEST(GammaCorrection, DeadZoneFixedAtGamma2_8) {
 
   for (int i = 1; i < n0; i++) {
     EXPECT_GE(correction.color_correct_red(i), 1) << "index=" << i << " still collapses to 0";
-    EXPECT_EQ(table[i], MIN_NONZERO_GAMMA_VALUE) << "index=" << i;
+    EXPECT_GE(table[i], MIN_NONZERO_GAMMA_VALUE) << "index=" << i;
+    EXPECT_LE(table[i], table[n0]) << "index=" << i;
   }
 
   for (int i = n0; i < 256; i++) {
@@ -81,6 +106,22 @@ TEST(GammaCorrection, DeadZoneFixedAtGamma2_8) {
     uint16_t raw_power_value = static_cast<uint16_t>(std::min(65535.0, raw));
     EXPECT_EQ(table[i], raw_power_value) << "index=" << i << " power curve should be untouched";
   }
+}
+
+// Regression test: a flat dead zone leaves LUT-interpolating FloatOutput consumers (e.g.
+// LEDC) stuck at one duty cycle across a range of brightness. Observed on real hardware.
+TEST(GammaCorrection, DeadZoneRampsInsteadOfFlat) {
+  const double gamma = 2.8;
+  const int n0 = dead_zone_breakpoint(gamma);
+  auto table = build_gamma_table(gamma);
+
+  std::set<uint16_t> table_values(table.begin() + 1, table.begin() + n0);
+  EXPECT_GT(table_values.size(), 1u) << "dead zone is flat; FloatOutput consumers would freeze";
+
+  std::set<float> outputs;
+  for (int i = 1; i < n0; i++)
+    outputs.insert(gamma_correct_lut(table, i / 255.0f));
+  EXPECT_GT(outputs.size(), 1u) << "interpolated LUT output is flat across the dead zone";
 }
 
 // gamma_table_reverse_search needs a non-decreasing table.

--- a/tests/components/light/test_gamma_correction.cpp
+++ b/tests/components/light/test_gamma_correction.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+
+#include "esphome/components/light/esp_color_correction.h"
+
+namespace esphome::light::testing {
+
+namespace {
+
+// Mirrors MIN_NONZERO_GAMMA_VALUE in esphome/components/light/__init__.py.
+constexpr uint16_t MIN_NONZERO_GAMMA_VALUE = 129;
+
+// Mirrors generate_gamma_table() in esphome/components/light/__init__.py.
+std::array<uint16_t, 256> build_gamma_table(double gamma) {
+  std::array<uint16_t, 256> table{};
+  table[0] = 0;
+  for (int i = 1; i < 256; i++) {
+    double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
+    uint16_t clamped = static_cast<uint16_t>(std::min(65535.0, raw));
+    table[i] = std::max(MIN_NONZERO_GAMMA_VALUE, clamped);
+  }
+  return table;
+}
+
+// Largest code where the unclamped power curve would still round to 0.
+int dead_zone_breakpoint(double gamma) {
+  return static_cast<int>(std::ceil(255.0 * std::pow(1.0 / 510.0, 1.0 / gamma)));
+}
+
+}  // namespace
+
+// Regression test for esphome/esphome#18842.
+TEST(GammaCorrection, NonZeroInputsSurviveConversion) {
+  for (double gamma : {1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0}) {
+    auto table = build_gamma_table(gamma);
+    ESPColorCorrection correction;
+    correction.set_gamma_table(table.data());
+    for (int i = 1; i < 256; i++) {
+      EXPECT_GE(correction.color_correct_red(i), 1) << "gamma=" << gamma << " index=" << i;
+    }
+  }
+}
+
+TEST(GammaCorrection, ZeroInputStaysZero) {
+  for (double gamma : {1.0, 2.2, 2.8, 4.0}) {
+    auto table = build_gamma_table(gamma);
+    ESPColorCorrection correction;
+    correction.set_gamma_table(table.data());
+    EXPECT_EQ(correction.color_correct_red(0), 0) << "gamma=" << gamma;
+  }
+}
+
+TEST(GammaCorrection, FullBrightnessStaysFull) {
+  for (double gamma : {1.0, 2.2, 2.8, 4.0}) {
+    auto table = build_gamma_table(gamma);
+    ESPColorCorrection correction;
+    correction.set_gamma_table(table.data());
+    EXPECT_EQ(correction.color_correct_red(255), 255) << "gamma=" << gamma;
+  }
+}
+
+// Reproduces the reporter's own numbers from esphome/esphome#18842 at gamma=2.8.
+TEST(GammaCorrection, DeadZoneFixedAtGamma2_8) {
+  const double gamma = 2.8;
+  const int n0 = dead_zone_breakpoint(gamma);
+  ASSERT_EQ(n0, 28);  // matches the "brightness 28 and above works normally" report
+
+  auto table = build_gamma_table(gamma);
+  ESPColorCorrection correction;
+  correction.set_gamma_table(table.data());
+
+  for (int i = 1; i < n0; i++) {
+    EXPECT_GE(correction.color_correct_red(i), 1) << "index=" << i << " still collapses to 0";
+    EXPECT_EQ(table[i], MIN_NONZERO_GAMMA_VALUE) << "index=" << i;
+  }
+
+  for (int i = n0; i < 256; i++) {
+    double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
+    uint16_t raw_power_value = static_cast<uint16_t>(std::min(65535.0, raw));
+    EXPECT_EQ(table[i], raw_power_value) << "index=" << i << " power curve should be untouched";
+  }
+}
+
+// gamma_table_reverse_search needs a non-decreasing table.
+TEST(GammaCorrection, TableStaysNonDecreasing) {
+  for (double gamma : {1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0}) {
+    auto table = build_gamma_table(gamma);
+    for (int i = 1; i < 256; i++) {
+      EXPECT_GE(table[i], table[i - 1]) << "gamma=" << gamma << " index=" << i;
+    }
+  }
+}
+
+TEST(GammaCorrection, ReverseSearchFindsLargestIndexLessEqualTarget) {
+  auto table = build_gamma_table(2.8);
+  for (uint16_t target : {0, 128, 129, 135, 1000, 32768, 65535}) {
+    uint8_t lo = gamma_table_reverse_search(table.data(), target);
+    EXPECT_LE(table[lo], target) << "target=" << target;
+    if (lo < 255) {
+      EXPECT_GT(table[lo + 1], target) << "target=" << target;
+    }
+  }
+}
+
+// color_uncorrect_* binary-searches the table via gamma_table_reverse_search().
+TEST(GammaCorrection, UncorrectStaysMonotonic) {
+  auto table = build_gamma_table(2.8);
+  ESPColorCorrection correction;
+  correction.set_gamma_table(table.data());
+
+  uint8_t prev = 0;
+  for (int i = 1; i < 256; i++) {
+    uint8_t result = correction.color_uncorrect_red(i);
+    EXPECT_GE(result, prev) << "index=" << i;
+    prev = result;
+  }
+}
+
+}  // namespace esphome::light::testing

--- a/tests/components/light/test_gamma_correction.cpp
+++ b/tests/components/light/test_gamma_correction.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <set>
 
 #include "esphome/components/light/esp_color_correction.h"
@@ -11,30 +12,17 @@ namespace esphome::light::testing {
 
 namespace {
 
-// Mirrors MIN_NONZERO_GAMMA_VALUE in esphome/components/light/__init__.py.
-constexpr uint16_t MIN_NONZERO_GAMMA_VALUE = 129;
-
-// Mirrors generate_gamma_table() in esphome/components/light/__init__.py.
+// Mirrors generate_gamma_table() in esphome/components/light/__init__.py. The table itself
+// is deliberately left as the raw (min-1-clamped) power curve -- ESPColorCorrection is
+// responsible for guaranteeing non-zero 8-bit output, not the table.
 std::array<uint16_t, 256> build_gamma_table(double gamma) {
   std::array<uint16_t, 256> table{};
   table[0] = 0;
   for (int i = 1; i < 256; i++) {
     double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
-    table[i] = static_cast<uint16_t>(std::min(65535.0, raw));
-  }
-  int n0 = 1;
-  while (n0 < 256 && table[n0] < MIN_NONZERO_GAMMA_VALUE)
-    n0++;
-  int span = table[n0] - MIN_NONZERO_GAMMA_VALUE;
-  for (int i = 1; i < n0; i++) {
-    table[i] = static_cast<uint16_t>(MIN_NONZERO_GAMMA_VALUE + std::lround(span * (i - 1) / double(n0 - 1)));
+    table[i] = static_cast<uint16_t>(std::max(1.0, std::min(65535.0, raw)));
   }
   return table;
-}
-
-// Largest code where the unclamped power curve would still round to 0.
-int dead_zone_breakpoint(double gamma) {
-  return static_cast<int>(std::ceil(255.0 * std::pow(1.0 / 510.0, 1.0 / gamma)));
 }
 
 // Mirrors LightState::gamma_correct_lut() in light_state.cpp.
@@ -55,7 +43,8 @@ float gamma_correct_lut(const std::array<uint16_t, 256> &table, float value) {
 
 }  // namespace
 
-// Regression test for esphome/esphome#18842.
+// Regression test for esphome/esphome#18842: ESPColorCorrection's own 16-bit -> 8-bit
+// conversion must never round a non-zero table entry down to a zero 8-bit output.
 TEST(GammaCorrection, NonZeroInputsSurviveConversion) {
   for (double gamma : {1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0}) {
     auto table = build_gamma_table(gamma);
@@ -85,43 +74,37 @@ TEST(GammaCorrection, FullBrightnessStaysFull) {
   }
 }
 
-// Reproduces the reporter's own numbers from esphome/esphome#18842 at gamma=2.8.
+// Reproduces the reporter's own numbers from esphome/esphome#18842 at gamma=2.8: codes
+// 1-27 previously collapsed to an 8-bit output of 0 and must now be non-zero.
 TEST(GammaCorrection, DeadZoneFixedAtGamma2_8) {
-  const double gamma = 2.8;
-  const int n0 = dead_zone_breakpoint(gamma);
-  ASSERT_EQ(n0, 28);  // matches the "brightness 28 and above works normally" report
-
-  auto table = build_gamma_table(gamma);
+  auto table = build_gamma_table(2.8);
   ESPColorCorrection correction;
   correction.set_gamma_table(table.data());
-
-  for (int i = 1; i < n0; i++) {
+  for (int i = 1; i < 28; i++) {
     EXPECT_GE(correction.color_correct_red(i), 1) << "index=" << i << " still collapses to 0";
-    EXPECT_GE(table[i], MIN_NONZERO_GAMMA_VALUE) << "index=" << i;
-    EXPECT_LE(table[i], table[n0]) << "index=" << i;
-  }
-
-  for (int i = n0; i < 256; i++) {
-    double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
-    uint16_t raw_power_value = static_cast<uint16_t>(std::min(65535.0, raw));
-    EXPECT_EQ(table[i], raw_power_value) << "index=" << i << " power curve should be untouched";
   }
 }
 
-// Regression test: a flat dead zone leaves LUT-interpolating FloatOutput consumers (e.g.
-// LEDC) stuck at one duty cycle across a range of brightness. Observed on real hardware.
-TEST(GammaCorrection, DeadZoneRampsInsteadOfFlat) {
+// Regression test: the 16-bit table itself must stay the untouched power curve. An earlier
+// version of this fix raised the table's own floor to survive 8-bit rounding, which also
+// flattened the low end of LightState::gamma_correct_lut() -- the float, interpolated path
+// shared by every non-addressable (FloatOutput/PWM) light, e.g. LEDC. That path has far more
+// than 8-bit precision and was never affected by #18842, so it must see the raw curve.
+TEST(GammaCorrection, TableMatchesRawPowerCurve) {
   const double gamma = 2.8;
-  const int n0 = dead_zone_breakpoint(gamma);
   auto table = build_gamma_table(gamma);
+  for (int i = 1; i < 256; i++) {
+    double raw = std::round(std::pow(i / 255.0, gamma) * 65535.0);
+    uint16_t expected = static_cast<uint16_t>(std::max(1.0, std::min(65535.0, raw)));
+    EXPECT_EQ(table[i], expected) << "index=" << i;
+  }
 
-  std::set<uint16_t> table_values(table.begin() + 1, table.begin() + n0);
-  EXPECT_GT(table_values.size(), 1u) << "dead zone is flat; FloatOutput consumers would freeze";
-
+  // Below the 8-bit conversion's dead zone, table values are tiny (not artificially raised),
+  // so the interpolated float path still produces distinct output across that range.
   std::set<float> outputs;
-  for (int i = 1; i < n0; i++)
+  for (int i = 1; i < 28; i++)
     outputs.insert(gamma_correct_lut(table, i / 255.0f));
-  EXPECT_GT(outputs.size(), 1u) << "interpolated LUT output is flat across the dead zone";
+  EXPECT_GT(outputs.size(), 1u) << "interpolated LUT output should vary, not be flattened";
 }
 
 // gamma_table_reverse_search needs a non-decreasing table.

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -121,19 +121,10 @@ def test_lut_output_monotonically_nondecreasing() -> None:
 
 
 def test_table_matches_raw_power_curve() -> None:
-    """The 16-bit table must stay the untouched power curve, not a floor for 8-bit output.
-
-    Regression test: an earlier version of this fix raised the table's own
-    floor to survive 8-bit rounding, which also flattened the low end of
-    LightState::gamma_correct_lut() -- the float, interpolated path shared by
-    every non-addressable (FloatOutput/PWM) light, e.g. LEDC. That path has
-    far more than 8-bit precision and was never affected by #18842, so the
-    table it reads from must stay exactly the raw, unclamped power curve.
-    """
-    gamma = 2.8
-    table = generate_gamma_table(gamma)
-    for i in range(1, 256):
-        expected = max(1, min(65535, round((i / 255.0) ** gamma * 65535)))
+    """Check the gamma table against known good values for gamma=2.8."""
+    table = generate_gamma_table(2.8)
+    golden = {1: 1, 5: 1, 15: 24, 27: 122, 28: 135, 100: 4766, 200: 33193, 254: 64818}
+    for i, expected in golden.items():
         assert table[i] == expected, (
             f"index {i}: table[{i}]={table[i]} expected {expected}"
         )

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -21,14 +21,6 @@ def _simulate_gamma_correct_lut(table: list[int], value: float) -> float:
     return (a + frac * (b - a)) / 65535.0
 
 
-def _simulate_gamma_correct_8bit(table_value: int) -> int:
-    """Simulate ESPColorCorrection::gamma_correct_'s 16-bit -> 8-bit conversion."""
-    result = (table_value + 128) // 257
-    if result == 0 and table_value != 0:
-        return 1
-    return result
-
-
 def test_table_length() -> None:
     """Table must always have exactly 256 entries."""
     table = generate_gamma_table(2.8)
@@ -61,9 +53,12 @@ def test_nonzero_indices_are_nonzero(gamma: float) -> None:
         assert table[i] >= 1, f"gamma={gamma}, index {i}: got {table[i]}"
 
 
-@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
 def test_table_monotonically_nondecreasing(gamma: float) -> None:
-    """The gamma table must be monotonically non-decreasing."""
+    """The gamma table must be monotonically non-decreasing.
+
+    gamma_table_reverse_search()'s binary search depends on this.
+    """
     table = generate_gamma_table(gamma)
     for i in range(1, 256):
         assert table[i] >= table[i - 1], (
@@ -125,31 +120,6 @@ def test_lut_output_monotonically_nondecreasing() -> None:
         prev = result
 
 
-@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
-def test_nonzero_indices_survive_16_to_8_bit_conversion(gamma: float) -> None:
-    """Regression test for esphome/esphome#18842: low codes must no longer round to 0.
-
-    This exercises ESPColorCorrection's own floor-on-output logic, not the
-    table -- the table's raw values are deliberately left tiny (see
-    test_table_matches_raw_power_curve below).
-    """
-    table = generate_gamma_table(gamma)
-    for i in range(1, 256):
-        assert _simulate_gamma_correct_8bit(table[i]) >= 1, (
-            f"gamma={gamma}, index {i}: table value {table[i]} collapses to 0 "
-            "after (value + 128) / 257"
-        )
-
-
-def test_dead_zone_fixed_at_gamma_2_8() -> None:
-    """Reproduce the reporter's own numbers from esphome/esphome#18842 at gamma=2.8."""
-    table = generate_gamma_table(2.8)
-    for i in range(1, 28):
-        assert _simulate_gamma_correct_8bit(table[i]) >= 1, (
-            f"index {i} still collapses to 0"
-        )
-
-
 def test_table_matches_raw_power_curve() -> None:
     """The 16-bit table must stay the untouched power curve, not a floor for 8-bit output.
 
@@ -167,11 +137,3 @@ def test_table_matches_raw_power_curve() -> None:
         assert table[i] == expected, (
             f"index {i}: table[{i}]={table[i]} expected {expected}"
         )
-
-
-@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
-def test_reverse_search_precondition_nondecreasing(gamma: float) -> None:
-    """gamma_table_reverse_search needs a non-decreasing table; the fix must preserve that."""
-    table = generate_gamma_table(gamma)
-    for i in range(1, 256):
-        assert table[i] >= table[i - 1], f"gamma={gamma}: table[{i}] < table[{i - 1}]"

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -1,8 +1,10 @@
 """Tests for the gamma LUT table generation."""
 
+import math
+
 import pytest
 
-from esphome.components.light import generate_gamma_table
+from esphome.components.light import MIN_NONZERO_GAMMA_VALUE, generate_gamma_table
 
 
 def _simulate_gamma_correct_lut(table: list[int], value: float) -> float:
@@ -115,3 +117,69 @@ def test_lut_output_monotonically_nondecreasing() -> None:
         result = _simulate_gamma_correct_lut(table, value)
         assert result >= prev, f"value={value}: result {result} < previous {prev}"
         prev = result
+
+
+def _dead_zone_breakpoint(gamma: float) -> int:
+    """Smallest code whose power-curve value survives (value + 128) / 257 as non-zero."""
+    return math.ceil(255 * (1 / 510.0) ** (1 / gamma))
+
+
+def _to_8_bit(value: int) -> int:
+    """Simulate ESPColorCorrection::gamma_correct_'s (value + 128) / 257 conversion."""
+    return (value + 128) // 257
+
+
+@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
+def test_nonzero_indices_survive_16_to_8_bit_conversion(gamma: float) -> None:
+    """Regression test for esphome/esphome#18842: low codes must no longer round to 0."""
+    table = generate_gamma_table(gamma)
+    for i in range(1, 256):
+        assert _to_8_bit(table[i]) >= 1, (
+            f"gamma={gamma}, index {i}: table value {table[i]} collapses to 0 "
+            "after (value + 128) / 257"
+        )
+
+
+def test_dead_zone_fixed_at_gamma_2_8() -> None:
+    """Reproduce the reporter's own numbers from esphome/esphome#18842 at gamma=2.8."""
+    gamma = 2.8
+    n0 = _dead_zone_breakpoint(gamma)
+    assert n0 == 28  # matches the "brightness 28 and above works normally" report
+
+    table = generate_gamma_table(gamma)
+    for i in range(1, n0):
+        assert _to_8_bit(table[i]) >= 1, f"index {i} still collapses to 0"
+
+    for i in range(n0, 256):
+        raw_power_value = min(65535, round((i / 255.0) ** gamma * 65535))
+        assert table[i] == raw_power_value, (
+            f"index {i}: table[{i}]={table[i]} differs from the untouched power "
+            f"curve value {raw_power_value}"
+        )
+
+
+@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
+def test_power_curve_untouched_above_dead_zone(gamma: float) -> None:
+    """Above the dead zone, table values must be bit-identical to the raw power curve."""
+    n0 = _dead_zone_breakpoint(gamma)
+    table = generate_gamma_table(gamma)
+    for i in range(n0, 256):
+        raw_power_value = min(65535, round((i / 255.0) ** gamma * 65535))
+        assert table[i] == raw_power_value, f"gamma={gamma}, index {i}"
+
+
+@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
+def test_dead_zone_values_are_min_nonzero_gamma_value(gamma: float) -> None:
+    """Within the dead zone, table values must be clamped to MIN_NONZERO_GAMMA_VALUE."""
+    n0 = _dead_zone_breakpoint(gamma)
+    table = generate_gamma_table(gamma)
+    for i in range(1, n0):
+        assert table[i] == MIN_NONZERO_GAMMA_VALUE, f"gamma={gamma}, index {i}"
+
+
+@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
+def test_reverse_search_precondition_nondecreasing(gamma: float) -> None:
+    """gamma_table_reverse_search needs a non-decreasing table; the fix must preserve that."""
+    table = generate_gamma_table(gamma)
+    for i in range(1, 256):
+        assert table[i] >= table[i - 1], f"gamma={gamma}: table[{i}] < table[{i - 1}]"

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -169,12 +169,36 @@ def test_power_curve_untouched_above_dead_zone(gamma: float) -> None:
 
 
 @pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
-def test_dead_zone_values_are_min_nonzero_gamma_value(gamma: float) -> None:
-    """Within the dead zone, table values must be clamped to MIN_NONZERO_GAMMA_VALUE."""
+def test_dead_zone_ramps_within_bounds(gamma: float) -> None:
+    """Dead-zone entries must ramp from the floor up to (not past) the breakpoint value."""
     n0 = _dead_zone_breakpoint(gamma)
     table = generate_gamma_table(gamma)
+    if n0 > 1:
+        assert table[1] == MIN_NONZERO_GAMMA_VALUE, f"gamma={gamma}"
     for i in range(1, n0):
-        assert table[i] == MIN_NONZERO_GAMMA_VALUE, f"gamma={gamma}, index {i}"
+        assert MIN_NONZERO_GAMMA_VALUE <= table[i] <= table[n0], (
+            f"gamma={gamma}, index {i}"
+        )
+
+
+def test_dead_zone_ramps_instead_of_flat_when_room_exists() -> None:
+    """Regression test: a flat dead zone leaves FloatOutput consumers (e.g. LEDC) stuck.
+
+    A LUT-interpolating consumer like LightState::gamma_correct_lut() only sees
+    distinct output if adjacent table entries differ. A dead zone clamped flat
+    to a single value made every brightness in that range interpolate to the
+    exact same duty cycle -- observed on real hardware as an LEDC output that
+    stopped changing below ~8% brightness at gamma=2.8.
+    """
+    gamma = 2.8
+    n0 = _dead_zone_breakpoint(gamma)
+    table = generate_gamma_table(gamma)
+    assert len(set(table[1:n0])) > 1, (
+        "dead zone is flat; FloatOutput consumers would freeze"
+    )
+
+    outputs = [_simulate_gamma_correct_lut(table, i / 255.0) for i in range(1, n0)]
+    assert len(set(outputs)) > 1, "interpolated LUT output is flat across the dead zone"
 
 
 @pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -1,10 +1,8 @@
 """Tests for the gamma LUT table generation."""
 
-import math
-
 import pytest
 
-from esphome.components.light import MIN_NONZERO_GAMMA_VALUE, generate_gamma_table
+from esphome.components.light import generate_gamma_table
 
 
 def _simulate_gamma_correct_lut(table: list[int], value: float) -> float:
@@ -21,6 +19,14 @@ def _simulate_gamma_correct_lut(table: list[int], value: float) -> float:
     a = float(table[idx])
     b = float(table[idx + 1])
     return (a + frac * (b - a)) / 65535.0
+
+
+def _simulate_gamma_correct_8bit(table_value: int) -> int:
+    """Simulate ESPColorCorrection::gamma_correct_'s 16-bit -> 8-bit conversion."""
+    result = (table_value + 128) // 257
+    if result == 0 and table_value != 0:
+        return 1
+    return result
 
 
 def test_table_length() -> None:
@@ -119,22 +125,17 @@ def test_lut_output_monotonically_nondecreasing() -> None:
         prev = result
 
 
-def _dead_zone_breakpoint(gamma: float) -> int:
-    """Smallest code whose power-curve value survives (value + 128) / 257 as non-zero."""
-    return math.ceil(255 * (1 / 510.0) ** (1 / gamma))
-
-
-def _to_8_bit(value: int) -> int:
-    """Simulate ESPColorCorrection::gamma_correct_'s (value + 128) / 257 conversion."""
-    return (value + 128) // 257
-
-
 @pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
 def test_nonzero_indices_survive_16_to_8_bit_conversion(gamma: float) -> None:
-    """Regression test for esphome/esphome#18842: low codes must no longer round to 0."""
+    """Regression test for esphome/esphome#18842: low codes must no longer round to 0.
+
+    This exercises ESPColorCorrection's own floor-on-output logic, not the
+    table -- the table's raw values are deliberately left tiny (see
+    test_table_matches_raw_power_curve below).
+    """
     table = generate_gamma_table(gamma)
     for i in range(1, 256):
-        assert _to_8_bit(table[i]) >= 1, (
+        assert _simulate_gamma_correct_8bit(table[i]) >= 1, (
             f"gamma={gamma}, index {i}: table value {table[i]} collapses to 0 "
             "after (value + 128) / 257"
         )
@@ -142,63 +143,30 @@ def test_nonzero_indices_survive_16_to_8_bit_conversion(gamma: float) -> None:
 
 def test_dead_zone_fixed_at_gamma_2_8() -> None:
     """Reproduce the reporter's own numbers from esphome/esphome#18842 at gamma=2.8."""
-    gamma = 2.8
-    n0 = _dead_zone_breakpoint(gamma)
-    assert n0 == 28  # matches the "brightness 28 and above works normally" report
-
-    table = generate_gamma_table(gamma)
-    for i in range(1, n0):
-        assert _to_8_bit(table[i]) >= 1, f"index {i} still collapses to 0"
-
-    for i in range(n0, 256):
-        raw_power_value = min(65535, round((i / 255.0) ** gamma * 65535))
-        assert table[i] == raw_power_value, (
-            f"index {i}: table[{i}]={table[i]} differs from the untouched power "
-            f"curve value {raw_power_value}"
+    table = generate_gamma_table(2.8)
+    for i in range(1, 28):
+        assert _simulate_gamma_correct_8bit(table[i]) >= 1, (
+            f"index {i} still collapses to 0"
         )
 
 
-@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
-def test_power_curve_untouched_above_dead_zone(gamma: float) -> None:
-    """Above the dead zone, table values must be bit-identical to the raw power curve."""
-    n0 = _dead_zone_breakpoint(gamma)
-    table = generate_gamma_table(gamma)
-    for i in range(n0, 256):
-        raw_power_value = min(65535, round((i / 255.0) ** gamma * 65535))
-        assert table[i] == raw_power_value, f"gamma={gamma}, index {i}"
+def test_table_matches_raw_power_curve() -> None:
+    """The 16-bit table must stay the untouched power curve, not a floor for 8-bit output.
 
-
-@pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])
-def test_dead_zone_ramps_within_bounds(gamma: float) -> None:
-    """Dead-zone entries must ramp from the floor up to (not past) the breakpoint value."""
-    n0 = _dead_zone_breakpoint(gamma)
-    table = generate_gamma_table(gamma)
-    if n0 > 1:
-        assert table[1] == MIN_NONZERO_GAMMA_VALUE, f"gamma={gamma}"
-    for i in range(1, n0):
-        assert MIN_NONZERO_GAMMA_VALUE <= table[i] <= table[n0], (
-            f"gamma={gamma}, index {i}"
-        )
-
-
-def test_dead_zone_ramps_instead_of_flat_when_room_exists() -> None:
-    """Regression test: a flat dead zone leaves FloatOutput consumers (e.g. LEDC) stuck.
-
-    A LUT-interpolating consumer like LightState::gamma_correct_lut() only sees
-    distinct output if adjacent table entries differ. A dead zone clamped flat
-    to a single value made every brightness in that range interpolate to the
-    exact same duty cycle -- observed on real hardware as an LEDC output that
-    stopped changing below ~8% brightness at gamma=2.8.
+    Regression test: an earlier version of this fix raised the table's own
+    floor to survive 8-bit rounding, which also flattened the low end of
+    LightState::gamma_correct_lut() -- the float, interpolated path shared by
+    every non-addressable (FloatOutput/PWM) light, e.g. LEDC. That path has
+    far more than 8-bit precision and was never affected by #18842, so the
+    table it reads from must stay exactly the raw, unclamped power curve.
     """
     gamma = 2.8
-    n0 = _dead_zone_breakpoint(gamma)
     table = generate_gamma_table(gamma)
-    assert len(set(table[1:n0])) > 1, (
-        "dead zone is flat; FloatOutput consumers would freeze"
-    )
-
-    outputs = [_simulate_gamma_correct_lut(table, i / 255.0) for i in range(1, n0)]
-    assert len(set(outputs)) > 1, "interpolated LUT output is flat across the dead zone"
+    for i in range(1, 256):
+        expected = max(1, min(65535, round((i / 255.0) ** gamma * 65535)))
+        assert table[i] == expected, (
+            f"index {i}: table[{i}]={table[i]} expected {expected}"
+        )
 
 
 @pytest.mark.parametrize("gamma", [1.0, 1.8, 2.0, 2.2, 2.8, 3.0, 4.0])


### PR DESCRIPTION
## What does this implement/fix?

Fixes a low-brightness dead zone in addressable-light gamma correction. Non-zero 8-bit input codes near the bottom of the brightness range (e.g. 1-27 at the default gamma of 2.8) were rounding to an 8-bit output of exactly 0, so the lowest ~10% of the brightness range had the light completely off.


The fix is where the precision is lost: `ESPColorCorrection::gamma_correct_()` returns 1 instead of 0 when a non-zero table entry would otherwise round down.

The user-visible effect is that when dimming an addressable light (8 bit precision, gamma > 1.0) the light will no longer turn off at low brightness values until the brightness reaches 0 - previous behaviour at gamma 2.8 was for the light to turn completely off below about 10% brightness.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #18842

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change -- existing gamma_correct configs are unaffected.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
