### PR TITLE
[espidf] Emit json2 size data so the link edge is not blocked

### DIFF
--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -92,7 +92,7 @@ def get_project_cmakelists(
 
     # esp_idf_size 2.x (bundled with IDF >=6.0) made NG the default and
     # removed the --ng flag; on 1.x (IDF 5.5) --ng is required to get
-    # --format=raw because the legacy mode doesn't support it.
+    # --format=json2 because the legacy mode doesn't support it.
     size_ng_flag = "--ng" if idf_version() < cv.Version(6, 0, 0) else ""
 
     # Project-wide compile options: -D defines and -W warning flags (skip
@@ -211,10 +211,13 @@ include($ENV{{IDF_PATH}}/tools/cmake/project.cmake)
 
 project({CORE.name})
 
-# Emit raw JSON size data for ESPHome to read post-build.
+# Emit per-memory-type JSON size data for ESPHome to read post-build.
+# json2 only summarizes memory regions; the raw format also dumps every
+# symbol (multi-MB, ~2s on a large map) and this command runs inside the
+# link edge, so everything downstream of the ELF would wait on it.
 add_custom_command(
     TARGET ${{CMAKE_PROJECT_NAME}}.elf POST_BUILD
-    COMMAND ${{PYTHON}} -m esp_idf_size {size_ng_flag} --format=raw
+    COMMAND ${{PYTHON}} -m esp_idf_size {size_ng_flag} --format=json2
             -o ${{CMAKE_BINARY_DIR}}/esp_idf_size.json
             ${{CMAKE_PROJECT_NAME}}.map
     WORKING_DIRECTORY ${{CMAKE_BINARY_DIR}}

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -92,7 +92,9 @@ def get_project_cmakelists(
 
     # esp_idf_size 2.x (bundled with IDF >=6.0) made NG the default and
     # removed the --ng flag; on 1.x (IDF 5.5) --ng is required to get
-    # --format=json2 because the legacy mode doesn't support it.
+    # --format=json2 because the legacy mode doesn't support it. 1.x json2
+    # also lacks total_size, which is why espidf/size_summary.py carries an
+    # ELF fallback; both go away together when 1.x support is dropped.
     size_ng_flag = "--ng" if idf_version() < cv.Version(6, 0, 0) else ""
 
     # Project-wide compile options: -D defines and -W warning flags (skip

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -90,11 +90,10 @@ def get_project_cmakelists(
     """
     idf_target = variant_to_idf_target(get_esp32_variant())
 
-    # esp_idf_size 2.x (bundled with IDF >=6.0) made NG the default and
-    # removed the --ng flag; on 1.x (IDF 5.5) --ng is required to get
-    # --format=json2 because the legacy mode doesn't support it. 1.x json2
-    # also lacks total_size, which is why espidf/size_summary.py carries an
-    # ELF fallback; both go away together when 1.x support is dropped.
+    # esp_idf_size 2.x (IDF >=6.0) made NG the default and removed --ng;
+    # 1.x (IDF 5.5) needs --ng for --format=json2. 1.x json2 also lacks
+    # total_size, hence the ELF fallback in espidf/size_summary.py; both
+    # go away together when 1.x support is dropped.
     size_ng_flag = "--ng" if idf_version() < cv.Version(6, 0, 0) else ""
 
     # Project-wide compile options: -D defines and -W warning flags (skip
@@ -214,9 +213,8 @@ include($ENV{{IDF_PATH}}/tools/cmake/project.cmake)
 project({CORE.name})
 
 # Emit per-memory-type JSON size data for ESPHome to read post-build.
-# json2 only summarizes memory regions; the raw format also dumps every
-# symbol (multi-MB, ~2s on a large map) and this command runs inside the
-# link edge, so everything downstream of the ELF would wait on it.
+# json2 stays small; raw dumps every symbol (~2s on a large map) and
+# this command runs inside the link edge, blocking everything downstream.
 add_custom_command(
     TARGET ${{CMAKE_PROJECT_NAME}}.elf POST_BUILD
     COMMAND ${{PYTHON}} -m esp_idf_size {size_ng_flag} --format=json2

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -11,11 +11,9 @@ byte-identical to PlatformIO's output:
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
 analysis works unchanged on native ESP-IDF builds. RAM usage comes from
 the DRAM (or unified DIRAM) region of the linker map. Flash used is the
-exact image size matching the ``Total image size`` line: the json2
-``total_size`` field when present (esp-idf-size >= 2.1); older 1.x
-json2 lacks it, so we derive the same figure from the ELF by summing
-loadable PROGBITS sections, the rule esp_idf_size itself uses.
-Flash total is taken from
+exact image size matching the ``Total image size`` line: json2
+``total_size`` when present, otherwise derived from the ELF (see
+``_image_size_from_elf``). Flash total is taken from
 ``partitions.csv`` using PlatformIO's rule (first app partition whose
 subtype is ``factory`` or ``ota_0``; see
 ``platform-espressif32/builder/main.py::_update_max_upload_size``).
@@ -82,20 +80,29 @@ def _image_size_from_elf(elf: Path) -> int:
 
     This is the rule ``esp_idf_size.ng.memorymap._get_image_size`` uses for
     its image size figure, so the result is byte-identical to the tool's.
-    Raises ``ValueError`` if the file is not a 32-bit little-endian ELF.
+    esptool's ``ELFFile`` is deliberately not reused: its section filter
+    differs (counts INIT/FINI arrays, skips lma==0 sections) and would
+    report a different number. Reads only the header and section table,
+    not the multi-MB debug payload. Raises ``ValueError`` for anything
+    that is not a well-formed 32-bit little-endian ELF.
     """
-    data = elf.read_bytes()
-    if len(data) < 52 or data[:4] != b"\x7fELF" or data[4] != 1 or data[5] != 1:
-        raise ValueError(f"{elf} is not a 32-bit little-endian ELF")
-    (e_shoff,) = struct.unpack_from("<I", data, 0x20)
-    e_shentsize, e_shnum = struct.unpack_from("<HH", data, 0x2E)
+    with elf.open("rb") as f:
+        header = f.read(52)  # ELF32 header
+        if len(header) < 52 or header[:6] != b"\x7fELF\x01\x01":
+            raise ValueError(f"{elf} is not a 32-bit little-endian ELF")
+        (e_shoff,) = struct.unpack_from("<I", header, 0x20)  # e_shoff
+        e_shentsize, e_shnum = struct.unpack_from("<HH", header, 0x2E)
+        if e_shentsize < 40:  # sizeof(Elf32_Shdr)
+            raise ValueError(f"{elf} has an invalid section header size")
+        f.seek(e_shoff)
+        table = f.read(e_shnum * e_shentsize)
+    if len(table) < e_shnum * e_shentsize:
+        raise ValueError(f"{elf} has a truncated section header table")
     total = 0
-    for i in range(e_shnum):
-        off = e_shoff + i * e_shentsize
-        sh_type, sh_flags = struct.unpack_from("<II", data, off + 4)
-        (sh_size,) = struct.unpack_from("<I", data, off + 20)
-        # SHT_PROGBITS with SHF_ALLOC: sections with data that occupy memory
-        if sh_size and sh_type == 1 and sh_flags & 0x2:
+    for off in range(0, e_shnum * e_shentsize, e_shentsize):
+        sh_type, sh_flags = struct.unpack_from("<II", table, off + 4)
+        (sh_size,) = struct.unpack_from("<I", table, off + 20)
+        if sh_type == 1 and sh_flags & 0x2:  # SHT_PROGBITS with SHF_ALLOC
             total += sh_size
     return total
 
@@ -125,6 +132,8 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
     ram_total = ram_region.get("total")
     if ram_total and ram_used is not None:
         print_size_line("RAM", ram_used, ram_total)
+    else:
+        _LOGGER.debug("Skipping RAM summary: no DRAM/DIRAM region in %s", size_json)
 
     # esp-idf-size >= 2.1 (IDF >= 6.0) reports the exact image size in
     # json2; older 1.x omits it, so derive the same figure from the ELF.
@@ -133,7 +142,12 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
         if flash_used is None:
             flash_used = _image_size_from_elf(firmware_elf)
         app_size = _find_app_partition_size(partitions_csv)
-    except (OSError, ValueError, struct.error) as e:
+    except FileNotFoundError as e:
+        # The ELF must exist after a successful build; a missing
+        # partitions.csv raises ValueError and stays at debug level.
+        _LOGGER.warning("Skipping Flash summary: %s", e)
+        return
+    except (OSError, ValueError) as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)
         return
     print_size_line("Flash", flash_used, app_size)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -10,10 +10,12 @@ byte-identical to PlatformIO's output:
 
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
 analysis works unchanged on native ESP-IDF builds. RAM usage comes from
-the DRAM (or unified DIRAM) region of the linker map; Flash used is the
-size of the app ``.bin`` on disk, which includes esptool's 16-byte
-image padding and appended SHA-256, so it reads slightly above the
-map-derived ``Total image size`` line and moves in 16-byte steps.
+the DRAM (or unified DIRAM) region of the linker map. Flash used is the
+json2 ``total_size`` field when present (esp-idf-size >= 2.1, the exact
+map-derived figure matching the ``Total image size`` line); older 1.x
+json2 lacks it, and the fallback is the size of the app ``.bin`` on
+disk, which includes esptool's 16-byte image padding and appended
+SHA-256 so it reads slightly high and moves in 16-byte steps.
 Flash total is taken from
 ``partitions.csv`` using PlatformIO's rule (first app partition whose
 subtype is ``factory`` or ``ota_0``; see
@@ -101,8 +103,13 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_bin: Path) -> 
     if ram_total and ram_used is not None:
         print_size_line("RAM", ram_used, ram_total)
 
+    # esp-idf-size >= 2.1 (IDF >= 6.0) reports the exact map-derived image
+    # size in json2; older 1.x omits it, so fall back to the padded on-disk
+    # .bin size.
+    flash_used = data.get("total_size")
     try:
-        flash_used = firmware_bin.stat().st_size
+        if flash_used is None:
+            flash_used = firmware_bin.stat().st_size
         app_size = _find_app_partition_size(partitions_csv)
     except (OSError, ValueError) as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -72,9 +72,7 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
     raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
 
 
-def print_summary(
-    size_json: Path, partitions_csv: Path | None, firmware_bin: Path | None
-) -> None:
+def print_summary(size_json: Path, partitions_csv: Path, firmware_bin: Path) -> None:
     """Print PlatformIO-shaped RAM and Flash one-liners.
 
     Failures are non-fatal: the build has already succeeded, we just couldn't
@@ -100,16 +98,10 @@ def print_summary(
     if ram_total and ram_used is not None:
         print_size_line("RAM", ram_used, ram_total)
 
-    if firmware_bin is None or partitions_csv is None:
-        return
     try:
-        image_size = firmware_bin.stat().st_size
-    except OSError as e:
-        _LOGGER.debug("Skipping Flash summary: %s", e)
-        return
-    try:
+        flash_used = firmware_bin.stat().st_size
         app_size = _find_app_partition_size(partitions_csv)
-    except ValueError as e:
+    except (OSError, ValueError) as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)
         return
-    print_size_line("Flash", image_size, app_size)
+    print_size_line("Flash", flash_used, app_size)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -130,7 +130,9 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
     if ram_total and ram_used is not None:
         print_size_line("RAM", ram_used, ram_total)
     else:
-        _LOGGER.debug("Skipping RAM summary: no DRAM/DIRAM region in %s", size_json)
+        # Every chip has a DRAM or DIRAM region, so this firing usually
+        # means the esp_idf_size json schema changed
+        _LOGGER.warning("Skipping RAM summary: no DRAM/DIRAM region in %s", size_json)
 
     # esp-idf-size >= 2.1 (IDF >= 6.0) reports the exact image size in
     # json2; older 1.x omits it, so derive the same figure from the ELF.

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -20,10 +20,8 @@ subtype is ``factory`` or ``ota_0``; see
 
 Structured size data is produced at link time by a CMake POST_BUILD
 custom command (see ``build_gen/espidf.py``) which writes
-``esp_idf_size.json`` (``--format=json2``: a per-memory-type summary,
-``{"version": ..., "layout": [{"name", "total", "used", ...}]}``) next
-to the ELF. We read that file here rather than re-running
-``esp_idf_size`` from Python.
+``esp_idf_size.json`` (``--format=json2``, a per-memory-type summary)
+next to the ELF; we read that rather than re-running ``esp_idf_size``.
 """
 
 from __future__ import annotations
@@ -78,13 +76,9 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
 def _image_size_from_elf(elf: Path) -> int:
     """Sum the loadable PROGBITS section sizes from an ELF32 file.
 
-    This is the rule ``esp_idf_size.ng.memorymap._get_image_size`` uses for
-    its image size figure, so the result is byte-identical to the tool's.
-    esptool's ``ELFFile`` is deliberately not reused: its section filter
-    differs (counts INIT/FINI arrays, skips lma==0 sections) and would
-    report a different number. Reads only the header and section table,
-    not the multi-MB debug payload. Raises ``ValueError`` for anything
-    that is not a well-formed 32-bit little-endian ELF.
+    Matches ``esp_idf_size.ng.memorymap._get_image_size`` byte for byte;
+    esptool's ``ELFFile`` filters sections differently and would not.
+    Raises ``ValueError`` for anything but a well-formed ELF32 LE file.
     """
     with elf.open("rb") as f:
         header = f.read(52)  # ELF32 header

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -11,7 +11,10 @@ byte-identical to PlatformIO's output:
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
 analysis works unchanged on native ESP-IDF builds. RAM usage comes from
 the DRAM (or unified DIRAM) region of the linker map; Flash used is the
-size of the app ``.bin`` on disk, and Flash total is taken from
+size of the app ``.bin`` on disk, which includes esptool's 16-byte
+image padding and appended SHA-256, so it reads slightly above the
+map-derived ``Total image size`` line and moves in 16-byte steps.
+Flash total is taken from
 ``partitions.csv`` using PlatformIO's rule (first app partition whose
 subtype is ``factory`` or ``ota_0``; see
 ``platform-espressif32/builder/main.py::_update_max_upload_size``).

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -74,7 +74,7 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
 
 
 def _image_size_from_elf(elf: Path) -> int:
-    """Sum the loadable PROGBITS section sizes from an ELF32 file.
+    """Sum the allocated PROGBITS section sizes from an ELF32 file.
 
     Matches ``esp_idf_size.ng.memorymap._get_image_size`` byte for byte;
     esptool's ``ELFFile`` filters sections differently and would not.
@@ -98,6 +98,9 @@ def _image_size_from_elf(elf: Path) -> int:
         (sh_size,) = struct.unpack_from("<I", table, off + 20)
         if sh_type == 1 and sh_flags & 0x2:  # SHT_PROGBITS with SHF_ALLOC
             total += sh_size
+    if total == 0:
+        # A used-0-bytes Flash line would read as a real measurement
+        raise ValueError(f"{elf} has no allocated PROGBITS sections")
     return total
 
 
@@ -134,6 +137,9 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
     flash_used = data.get("total_size")
     try:
         if flash_used is None:
+            _LOGGER.debug(
+                "No total_size in %s, deriving from %s", size_json, firmware_elf
+            )
             flash_used = _image_size_from_elf(firmware_elf)
         app_size = _find_app_partition_size(partitions_csv)
     except FileNotFoundError as e:

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -124,32 +124,36 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
         for entry in data.get("layout", [])
         if isinstance(entry, dict)
     }
-    ram_region = regions.get("DRAM") or regions.get("DIRAM") or {}
-    ram_used = ram_region.get("used")
-    ram_total = ram_region.get("total")
-    if ram_total and ram_used is not None:
+    # Every chip has a DRAM or DIRAM region, so a warning here usually
+    # means the esp_idf_size json schema changed
+    ram_region = regions.get("DRAM") or regions.get("DIRAM")
+    if ram_region is None:
+        _LOGGER.warning("Skipping RAM summary: no DRAM/DIRAM region in %s", size_json)
+    elif (
+        isinstance(ram_total := ram_region.get("total"), int)
+        and ram_total > 0
+        and isinstance(ram_used := ram_region.get("used"), int)
+    ):
         print_size_line("RAM", ram_used, ram_total)
     else:
-        # Every chip has a DRAM or DIRAM region, so this firing usually
-        # means the esp_idf_size json schema changed
-        _LOGGER.warning("Skipping RAM summary: no DRAM/DIRAM region in %s", size_json)
+        _LOGGER.warning(
+            "Skipping RAM summary: unusable region %s in %s", ram_region, size_json
+        )
 
     # esp-idf-size >= 2.1 (IDF >= 6.0) reports the exact image size in
     # json2; older 1.x omits it, so derive the same figure from the ELF.
     flash_used = data.get("total_size")
-    try:
-        if flash_used is None:
-            _LOGGER.debug(
-                "No total_size in %s, deriving from %s", size_json, firmware_elf
-            )
+    if not (isinstance(flash_used, int) and flash_used > 0):
+        _LOGGER.debug("No total_size in %s, deriving from %s", size_json, firmware_elf)
+        try:
             flash_used = _image_size_from_elf(firmware_elf)
+        except (OSError, ValueError) as e:
+            # The ELF must be present and well formed after a successful build
+            _LOGGER.warning("Skipping Flash summary: %s", e)
+            return
+    try:
         app_size = _find_app_partition_size(partitions_csv)
-    except FileNotFoundError as e:
-        # The ELF must exist after a successful build; a missing
-        # partitions.csv raises ValueError and stays at debug level.
-        _LOGGER.warning("Skipping Flash summary: %s", e)
-        return
-    except (OSError, ValueError) as e:
+    except ValueError as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)
         return
     print_size_line("Flash", flash_used, app_size)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -119,10 +119,14 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
     except (OSError, json.JSONDecodeError) as e:
         _LOGGER.debug("Skipping size summary: %s", e)
         return
+    if not isinstance(data, dict):
+        _LOGGER.warning("Skipping size summary: unexpected json shape in %s", size_json)
+        return
 
+    layout = data.get("layout")
     regions = {
         entry.get("name"): entry
-        for entry in data.get("layout", [])
+        for entry in (layout if isinstance(layout, list) else [])
         if isinstance(entry, dict)
     }
     # Every chip has a DRAM or DIRAM region, so a warning here usually
@@ -154,7 +158,10 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
             return
     try:
         app_size = _find_app_partition_size(partitions_csv)
-    except ValueError as e:
+    except (OSError, ValueError) as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)
+        return
+    if app_size <= 0:
+        _LOGGER.debug("Skipping Flash summary: app partition size is 0")
         return
     print_size_line("Flash", flash_used, app_size)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -108,7 +108,8 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> 
     """Print PlatformIO-shaped RAM and Flash one-liners.
 
     Failures are non-fatal: the build has already succeeded, we just couldn't
-    summarize. Logs the cause at debug level.
+    summarize. Anomalies (missing region, unreadable ELF) warn; expected
+    optional inputs (no size json, no partitions.csv) log at debug.
     """
     if not size_json.is_file():
         _LOGGER.debug("Skipping size summary: %s not found", size_json)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -11,11 +11,10 @@ byte-identical to PlatformIO's output:
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
 analysis works unchanged on native ESP-IDF builds. RAM usage comes from
 the DRAM (or unified DIRAM) region of the linker map. Flash used is the
-json2 ``total_size`` field when present (esp-idf-size >= 2.1, the exact
-map-derived figure matching the ``Total image size`` line); older 1.x
-json2 lacks it, and the fallback is the size of the app ``.bin`` on
-disk, which includes esptool's 16-byte image padding and appended
-SHA-256 so it reads slightly high and moves in 16-byte steps.
+exact image size matching the ``Total image size`` line: the json2
+``total_size`` field when present (esp-idf-size >= 2.1); older 1.x
+json2 lacks it, so we derive the same figure from the ELF by summing
+loadable PROGBITS sections, the rule esp_idf_size itself uses.
 Flash total is taken from
 ``partitions.csv`` using PlatformIO's rule (first app partition whose
 subtype is ``factory`` or ``ota_0``; see
@@ -35,6 +34,7 @@ import csv
 import json
 import logging
 from pathlib import Path
+import struct
 
 from esphome.build_helpers.size_summary import print_size_line
 
@@ -77,7 +77,30 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
     raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
 
 
-def print_summary(size_json: Path, partitions_csv: Path, firmware_bin: Path) -> None:
+def _image_size_from_elf(elf: Path) -> int:
+    """Sum the loadable PROGBITS section sizes from an ELF32 file.
+
+    This is the rule ``esp_idf_size.ng.memorymap._get_image_size`` uses for
+    its image size figure, so the result is byte-identical to the tool's.
+    Raises ``ValueError`` if the file is not a 32-bit little-endian ELF.
+    """
+    data = elf.read_bytes()
+    if len(data) < 52 or data[:4] != b"\x7fELF" or data[4] != 1 or data[5] != 1:
+        raise ValueError(f"{elf} is not a 32-bit little-endian ELF")
+    (e_shoff,) = struct.unpack_from("<I", data, 0x20)
+    e_shentsize, e_shnum = struct.unpack_from("<HH", data, 0x2E)
+    total = 0
+    for i in range(e_shnum):
+        off = e_shoff + i * e_shentsize
+        sh_type, sh_flags = struct.unpack_from("<II", data, off + 4)
+        (sh_size,) = struct.unpack_from("<I", data, off + 20)
+        # SHT_PROGBITS with SHF_ALLOC: sections with data that occupy memory
+        if sh_size and sh_type == 1 and sh_flags & 0x2:
+            total += sh_size
+    return total
+
+
+def print_summary(size_json: Path, partitions_csv: Path, firmware_elf: Path) -> None:
     """Print PlatformIO-shaped RAM and Flash one-liners.
 
     Failures are non-fatal: the build has already succeeded, we just couldn't
@@ -103,15 +126,14 @@ def print_summary(size_json: Path, partitions_csv: Path, firmware_bin: Path) -> 
     if ram_total and ram_used is not None:
         print_size_line("RAM", ram_used, ram_total)
 
-    # esp-idf-size >= 2.1 (IDF >= 6.0) reports the exact map-derived image
-    # size in json2; older 1.x omits it, so fall back to the padded on-disk
-    # .bin size.
+    # esp-idf-size >= 2.1 (IDF >= 6.0) reports the exact image size in
+    # json2; older 1.x omits it, so derive the same figure from the ELF.
     flash_used = data.get("total_size")
     try:
         if flash_used is None:
-            flash_used = firmware_bin.stat().st_size
+            flash_used = _image_size_from_elf(firmware_elf)
         app_size = _find_app_partition_size(partitions_csv)
-    except (OSError, ValueError) as e:
+    except (OSError, ValueError, struct.error) as e:
         _LOGGER.debug("Skipping Flash summary: %s", e)
         return
     print_size_line("Flash", flash_used, app_size)

--- a/esphome/espidf/size_summary.py
+++ b/esphome/espidf/size_summary.py
@@ -9,16 +9,19 @@ byte-identical to PlatformIO's output:
     Flash: [===       ]  48.4% (used 888511 bytes from 1835008 bytes)
 
 The format matches ``script/ci_memory_impact_extract.py`` so CI memory
-analysis works unchanged on native ESP-IDF builds. RAM total is the
-DRAM region size from the linker map; Flash total is taken from
+analysis works unchanged on native ESP-IDF builds. RAM usage comes from
+the DRAM (or unified DIRAM) region of the linker map; Flash used is the
+size of the app ``.bin`` on disk, and Flash total is taken from
 ``partitions.csv`` using PlatformIO's rule (first app partition whose
 subtype is ``factory`` or ``ota_0``; see
 ``platform-espressif32/builder/main.py::_update_max_upload_size``).
 
 Structured size data is produced at link time by a CMake POST_BUILD
 custom command (see ``build_gen/espidf.py``) which writes
-``esp_idf_size.json`` next to the ELF. We read that file here rather
-than re-running ``esp_idf_size`` from Python.
+``esp_idf_size.json`` (``--format=json2``: a per-memory-type summary,
+``{"version": ..., "layout": [{"name", "total", "used", ...}]}``) next
+to the ELF. We read that file here rather than re-running
+``esp_idf_size`` from Python.
 """
 
 from __future__ import annotations
@@ -69,7 +72,9 @@ def _find_app_partition_size(partitions_csv: Path) -> int:
     raise ValueError(f"No app+factory or app+ota_0 partition in {partitions_csv}")
 
 
-def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
+def print_summary(
+    size_json: Path, partitions_csv: Path | None, firmware_bin: Path | None
+) -> None:
     """Print PlatformIO-shaped RAM and Flash one-liners.
 
     Failures are non-fatal: the build has already succeeded, we just couldn't
@@ -84,15 +89,23 @@ def print_summary(size_json: Path, partitions_csv: Path | None) -> None:
         _LOGGER.debug("Skipping size summary: %s", e)
         return
 
-    memory_types = data.get("memory_types", {})
-    ram_region = memory_types.get("DRAM") or memory_types.get("DIRAM") or {}
+    regions = {
+        entry.get("name"): entry
+        for entry in data.get("layout", [])
+        if isinstance(entry, dict)
+    }
+    ram_region = regions.get("DRAM") or regions.get("DIRAM") or {}
     ram_used = ram_region.get("used")
-    ram_total = ram_region.get("size")
+    ram_total = ram_region.get("total")
     if ram_total and ram_used is not None:
         print_size_line("RAM", ram_used, ram_total)
 
-    image_size = data.get("image_size")
-    if image_size is None or partitions_csv is None:
+    if firmware_bin is None or partitions_csv is None:
+        return
+    try:
+        image_size = firmware_bin.stat().st_size
+    except OSError as e:
+        _LOGGER.debug("Skipping Flash summary: %s", e)
         return
     try:
         app_size = _find_app_partition_size(partitions_csv)

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -542,12 +542,7 @@ def run_compile(config, verbose: bool) -> int:
     if rc == 0:
         size_json = CORE.relative_build_path("build", "esp_idf_size.json")
         partitions = CORE.relative_build_path("partitions.csv")
-        firmware_bin = get_firmware_path()
-        print_summary(
-            size_json,
-            partitions if partitions.is_file() else None,
-            firmware_bin if firmware_bin.is_file() else None,
-        )
+        print_summary(size_json, partitions, get_firmware_path())
     return rc
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -542,7 +542,12 @@ def run_compile(config, verbose: bool) -> int:
     if rc == 0:
         size_json = CORE.relative_build_path("build", "esp_idf_size.json")
         partitions = CORE.relative_build_path("partitions.csv")
-        print_summary(size_json, partitions if partitions.is_file() else None)
+        firmware_bin = get_firmware_path()
+        print_summary(
+            size_json,
+            partitions if partitions.is_file() else None,
+            firmware_bin if firmware_bin.is_file() else None,
+        )
     return rc
 
 

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -580,10 +580,10 @@ def get_ota_firmware_path() -> Path:
 
 
 def get_built_elf_path() -> Path:
-    """Get the path to the ELF that idf.py writes directly, ``<build>/<name>.elf``.
+    """Path to the ELF idf.py writes directly, ``<build>/<name>.elf``.
 
-    Unlike ``get_elf_path``, this file exists as soon as the build finishes,
-    before ``create_elf_copy`` produces the ``firmware.elf`` copy.
+    Exists as soon as the build finishes, unlike the ``firmware.elf``
+    copy that ``create_elf_copy`` makes later.
     """
     build_dir = CORE.relative_build_path("build")
     return build_dir / f"{CORE.name}.elf"

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -542,7 +542,7 @@ def run_compile(config, verbose: bool) -> int:
     if rc == 0:
         size_json = CORE.relative_build_path("build", "esp_idf_size.json")
         partitions = CORE.relative_build_path("partitions.csv")
-        print_summary(size_json, partitions, get_firmware_path())
+        print_summary(size_json, partitions, get_built_elf_path())
     return rc
 
 
@@ -577,6 +577,16 @@ def get_ota_firmware_path() -> Path:
     """
     build_dir = CORE.relative_build_path("build")
     return build_dir / "firmware.ota.bin"
+
+
+def get_built_elf_path() -> Path:
+    """Get the path to the ELF that idf.py writes directly, ``<build>/<name>.elf``.
+
+    Unlike ``get_elf_path``, this file exists as soon as the build finishes,
+    before ``create_elf_copy`` produces the ``firmware.elf`` copy.
+    """
+    build_dir = CORE.relative_build_path("build")
+    return build_dir / f"{CORE.name}.elf"
 
 
 def get_elf_path() -> Path:
@@ -706,8 +716,7 @@ def create_elf_copy() -> bool:
     "download ELF" link requests the literal filename ``firmware.elf``
     (PlatformIO convention), so copy it to that name.
     """
-    build_dir = CORE.relative_build_path("build")
-    src_elf = build_dir / f"{CORE.name}.elf"
+    src_elf = get_built_elf_path()
     dst_elf = get_elf_path()
 
     if not src_elf.is_file():

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -163,6 +163,18 @@ def test_has_discovered_components_after_configure(tmp_path: Path) -> None:
     assert has_discovered_components()
 
 
+def test_get_project_cmakelists_size_command_uses_json2() -> None:
+    """The POST_BUILD size command uses the cheap json2 format, with --ng
+    only on the 1.x tool bundled with IDF < 6."""
+    content = _render()
+    assert "-m esp_idf_size --ng --format=json2" in content
+
+    CORE.data[KEY_ESP32][KEY_IDF_VERSION] = cv.Version(6, 0, 0)
+    content = _render()
+    assert "--ng" not in content
+    assert "--format=json2" in content
+
+
 def test_get_project_cmakelists_uses_supplied_builtin_components() -> None:
     """A cached list replaces project_description.json and is still filtered
     by EXCLUDE_COMPONENTS."""

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -655,7 +655,7 @@ def test_run_compile_passes_size_summary_paths(setup_core: Path) -> None:
     mock_summary.assert_called_once_with(
         CORE.relative_build_path("build", "esp_idf_size.json"),
         CORE.relative_build_path("partitions.csv"),
-        toolchain.get_built_elf_path(),
+        CORE.relative_build_path("build", f"{CORE.name}.elf"),
     )
 
 

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -639,8 +639,8 @@ def test_run_compile_passes_compile_process_limit(setup_core: Path) -> None:
 
 
 def test_run_compile_passes_size_summary_paths(setup_core: Path) -> None:
-    """print_summary receives the size json, partitions.csv, and the firmware
-    bin from get_firmware_path, which must stay in lockstep with the
+    """print_summary receives the size json, partitions.csv, and the built
+    ELF from get_built_elf_path, which must stay in lockstep with the
     project() name in the generated CMakeLists."""
     _setup_build(setup_core)
     config = {CONF_ESPHOME: {}}
@@ -655,7 +655,7 @@ def test_run_compile_passes_size_summary_paths(setup_core: Path) -> None:
     mock_summary.assert_called_once_with(
         CORE.relative_build_path("build", "esp_idf_size.json"),
         CORE.relative_build_path("partitions.csv"),
-        toolchain.get_firmware_path(),
+        toolchain.get_built_elf_path(),
     )
 
 

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -638,6 +638,27 @@ def test_run_compile_passes_compile_process_limit(setup_core: Path) -> None:
     mock_run.assert_called_once_with("build", "size", jobs=1)
 
 
+def test_run_compile_passes_size_summary_paths(setup_core: Path) -> None:
+    """print_summary receives the size json, partitions.csv, and the firmware
+    bin from get_firmware_path, which must stay in lockstep with the
+    project() name in the generated CMakeLists."""
+    _setup_build(setup_core)
+    config = {CONF_ESPHOME: {}}
+
+    with (
+        patch.object(toolchain, "need_reconfigure", return_value=False),
+        patch.object(toolchain, "run_idf_py", return_value=0),
+        patch.object(toolchain, "print_summary") as mock_summary,
+    ):
+        assert toolchain.run_compile(config, verbose=False) == 0
+
+    mock_summary.assert_called_once_with(
+        CORE.relative_build_path("build", "esp_idf_size.json"),
+        CORE.relative_build_path("partitions.csv"),
+        toolchain.get_firmware_path(),
+    )
+
+
 def test_run_compile_without_compile_process_limit(setup_core: Path) -> None:
     """When no compile_process_limit is set, no job limit is passed to idf.py."""
     _setup_build(setup_core)

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -659,6 +659,22 @@ def test_run_compile_passes_size_summary_paths(setup_core: Path) -> None:
     )
 
 
+def test_create_elf_copy(setup_core: Path) -> None:
+    """The built <name>.elf is copied to the firmware.elf dashboard name."""
+    _setup_build(setup_core)
+    src = toolchain.get_built_elf_path()
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"elf")
+    assert toolchain.create_elf_copy() is True
+    assert toolchain.get_elf_path().read_bytes() == b"elf"
+
+
+def test_create_elf_copy_missing_source(setup_core: Path) -> None:
+    """A missing built ELF is a warning and False, not a crash."""
+    _setup_build(setup_core)
+    assert toolchain.create_elf_copy() is False
+
+
 def test_run_compile_without_compile_process_limit(setup_core: Path) -> None:
     """When no compile_process_limit is set, no job limit is passed to idf.py."""
     _setup_build(setup_core)

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import struct
+from unittest.mock import patch
 
 import pytest
 
@@ -246,14 +247,15 @@ def test_print_summary_skips_flash_on_zero_app_partition(
 def test_print_summary_skips_flash_on_unreadable_partitions(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """An unreadable partitions.csv is non-fatal."""
+    """An unreadable partitions.csv is non-fatal (chmod tricks don't work
+    for root in CI containers, so simulate the OSError instead)."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
     partitions = _write_partitions(tmp_path)
-    partitions.chmod(0o000)
-    try:
+    with patch(
+        "esphome.espidf.size_summary._find_app_partition_size",
+        side_effect=PermissionError("denied"),
+    ):
         print_summary(size_json, partitions, tmp_path / "firmware.elf")
-    finally:
-        partitions.chmod(0o644)
     assert "Flash:" not in capsys.readouterr().out
 
 

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -160,6 +160,22 @@ def test_print_summary_flash_line(
     assert "(used 827455 bytes from 1835008 bytes)" in out
 
 
+def test_print_summary_skips_flash_when_bin_unreadable(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A firmware bin that can't be stat'ed skips the Flash line, not the RAM line."""
+    size_json = _write_size_json(tmp_path, _esp32_size_data())
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text(
+        "# name, type, subtype, offset, size, flags\n"
+        "app0, app, ota_0, 0x10000, 0x1C0000,\n"
+    )
+    print_summary(size_json, partitions, tmp_path / "missing.bin")
+    out = capsys.readouterr().out
+    assert "RAM:" in out
+    assert "Flash:" not in out
+
+
 def test_print_summary_skips_flash_without_bin(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -18,63 +18,71 @@ def _write_size_json(tmp_path: Path, data: dict) -> Path:
 
 
 def _esp32_size_data() -> dict:
-    """Synthetic esp_idf_size.json for the original ESP32 (split IRAM/DRAM)."""
+    """Synthetic json2 esp_idf_size.json for the original ESP32 (split IRAM/DRAM)."""
     return {
-        "image_size": 827455,
-        "memory_types": {
-            "DRAM": {
-                "size": 180736,
+        "version": "1.1",
+        "layout": [
+            {
+                "name": "DRAM",
+                "total": 180736,
                 "used": 47332,
-                "sections": {
-                    ".dram0.bss": {"abbrev_name": ".bss", "size": 30616},
-                    ".dram0.data": {"abbrev_name": ".data", "size": 16716},
+                "free": 133404,
+                "parts": {
+                    ".bss": {"size": 30616},
+                    ".data": {"size": 16716},
                 },
             },
-            "IRAM": {
-                "size": 131072,
+            {
+                "name": "IRAM",
+                "total": 131072,
                 "used": 80351,
-                "sections": {
-                    ".iram0.text": {"abbrev_name": ".text", "size": 79323},
-                    ".iram0.vectors": {"abbrev_name": ".vectors", "size": 1028},
+                "free": 50721,
+                "parts": {
+                    ".text": {"size": 79323},
+                    ".vectors": {"size": 1028},
                 },
             },
-        },
+        ],
     }
 
 
 def _s3_size_data() -> dict:
-    """Synthetic esp_idf_size.json for ESP32-S3 (unified DIRAM)."""
+    """Synthetic json2 esp_idf_size.json for ESP32-S3 (unified DIRAM)."""
     return {
-        "image_size": 724215,
-        "memory_types": {
-            "DIRAM": {
-                "size": 341760,
+        "version": "1.1",
+        "layout": [
+            {
+                "name": "DIRAM",
+                "total": 341760,
                 "used": 104999,
-                "sections": {
-                    ".iram0.text": {"abbrev_name": ".text", "size": 58051},
-                    ".dram0.bss": {"abbrev_name": ".bss", "size": 27088},
-                    ".dram0.data": {"abbrev_name": ".data", "size": 19708},
-                    ".noinit": {"abbrev_name": ".noinit", "size": 152},
+                "free": 236761,
+                "parts": {
+                    ".text": {"size": 58051},
+                    ".bss": {"size": 27088},
+                    ".data": {"size": 19708},
+                    ".noinit": {"size": 152},
                 },
             },
-            "IRAM": {
-                "size": 16384,
+            {
+                "name": "IRAM",
+                "total": 16384,
                 "used": 16384,
-                "sections": {
-                    ".iram0.text": {"abbrev_name": ".text", "size": 15356},
-                    ".iram0.vectors": {"abbrev_name": ".vectors", "size": 1028},
+                "free": 0,
+                "parts": {
+                    ".text": {"size": 15356},
+                    ".vectors": {"size": 1028},
                 },
             },
-        },
+        ],
     }
 
 
 def test_print_summary_esp32_uses_dram(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Original ESP32: DRAM has no ``.text``, so RAM = DRAM.used / DRAM.size unchanged."""
+    """Original ESP32: RAM = DRAM.used / DRAM.total."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
-    print_summary(size_json, partitions_csv=None)
+    print_summary(size_json, partitions_csv=None, firmware_bin=None)
     out = capsys.readouterr().out
     assert "RAM:" in out
     assert "used 47332 bytes from 180736 bytes" in out
@@ -83,9 +91,9 @@ def test_print_summary_esp32_uses_dram(
 def test_print_summary_s3_falls_back_to_diram(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """ESP32-S3 with no DRAM key falls back to DIRAM and reports raw region usage."""
+    """ESP32-S3 with no DRAM entry falls back to DIRAM and reports raw region usage."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
-    print_summary(size_json, partitions_csv=None)
+    print_summary(size_json, partitions_csv=None, firmware_bin=None)
     out = capsys.readouterr().out
     assert "used 104999 bytes from 341760 bytes" in out
 
@@ -97,16 +105,19 @@ def test_print_summary_skips_when_diram_total_collapses(
     size_json = _write_size_json(
         tmp_path,
         {
-            "memory_types": {
-                "DIRAM": {
-                    "size": 0,
+            "version": "1.1",
+            "layout": [
+                {
+                    "name": "DIRAM",
+                    "total": 0,
                     "used": 0,
-                    "sections": {},
+                    "free": 0,
+                    "parts": {},
                 },
-            },
+            ],
         },
     )
-    print_summary(size_json, partitions_csv=None)
+    print_summary(size_json, partitions_csv=None, firmware_bin=None)
     out = capsys.readouterr().out
     assert "RAM:" not in out
 
@@ -115,16 +126,18 @@ def test_print_summary_handles_missing_json(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Missing size json is non-fatal and prints nothing."""
-    print_summary(tmp_path / "does_not_exist.json", partitions_csv=None)
+    print_summary(
+        tmp_path / "does_not_exist.json", partitions_csv=None, firmware_bin=None
+    )
     assert capsys.readouterr().out == ""
 
 
-def test_print_summary_handles_no_memory_types(
+def test_print_summary_handles_no_layout(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A size json without ``memory_types`` still doesn't crash."""
-    size_json = _write_size_json(tmp_path, {"image_size": 0})
-    print_summary(size_json, partitions_csv=None)
+    """A size json without ``layout`` still doesn't crash."""
+    size_json = _write_size_json(tmp_path, {"version": "1.1"})
+    print_summary(size_json, partitions_csv=None, firmware_bin=None)
     assert capsys.readouterr().out == ""
 
 
@@ -139,7 +152,25 @@ def test_print_summary_flash_line(
         "# name, type, subtype, offset, size, flags\n"
         "app0, app, ota_0, 0x10000, 0x1C0000,\n"
     )
-    print_summary(size_json, partitions)
+    firmware_bin = tmp_path / "firmware.bin"
+    firmware_bin.write_bytes(b"\x00" * 827455)
+    print_summary(size_json, partitions, firmware_bin)
     out = capsys.readouterr().out
     assert "Flash: " in out
     assert "(used 827455 bytes from 1835008 bytes)" in out
+
+
+def test_print_summary_skips_flash_without_bin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No firmware bin means the RAM line prints but the Flash line is skipped."""
+    size_json = _write_size_json(tmp_path, _esp32_size_data())
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text(
+        "# name, type, subtype, offset, size, flags\n"
+        "app0, app, ota_0, 0x10000, 0x1C0000,\n"
+    )
+    print_summary(size_json, partitions, firmware_bin=None)
+    out = capsys.readouterr().out
+    assert "RAM:" in out
+    assert "Flash:" not in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import struct
 
 import pytest
 
@@ -25,6 +26,25 @@ def _write_partitions(tmp_path: Path) -> Path:
         "app0, app, ota_0, 0x10000, 0x1C0000,\n"
     )
     return out
+
+
+def _write_elf(tmp_path: Path, sections: list[tuple[int, int, int]]) -> Path:
+    """Write a minimal ELF32 LE whose section headers carry the given
+    (sh_type, sh_flags, sh_size) triples."""
+    header = bytearray(52)
+    header[0:4] = b"\x7fELF"
+    header[4] = header[5] = 1  # 32-bit, little-endian
+    struct.pack_into("<I", header, 0x20, 52)  # e_shoff
+    struct.pack_into("<HH", header, 0x2E, 40, len(sections))
+    out = bytearray(header)
+    for sh_type, sh_flags, sh_size in sections:
+        shdr = bytearray(40)
+        struct.pack_into("<II", shdr, 4, sh_type, sh_flags)
+        struct.pack_into("<I", shdr, 20, sh_size)
+        out += shdr
+    elf = tmp_path / "firmware.elf"
+    elf.write_bytes(bytes(out))
+    return elf
 
 
 def _esp32_size_data() -> dict:
@@ -152,43 +172,51 @@ def test_print_summary_handles_no_layout(
 def test_print_summary_flash_line_prefers_total_size(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """With ``total_size`` in the json, the exact figure wins over the padded
-    bin size, in the exact shape script/ci_memory_impact_extract.py greps."""
+    """With ``total_size`` in the json, that figure wins without reading the
+    ELF, in the exact shape script/ci_memory_impact_extract.py greps."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
     partitions = _write_partitions(tmp_path)
-    firmware_bin = tmp_path / "firmware.bin"
-    firmware_bin.write_bytes(b"\x00" * 999999)
-    print_summary(size_json, partitions, firmware_bin)
+    print_summary(size_json, partitions, tmp_path / "firmware.elf")
     out = capsys.readouterr().out
     assert "Flash: " in out
     assert "(used 827455 bytes from 1835008 bytes)" in out
 
 
-def test_print_summary_flash_line_falls_back_to_bin_size(
+def test_print_summary_flash_line_derives_from_elf(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A 1.x json without ``total_size`` uses the on-disk bin size."""
+    """A 1.x json without ``total_size`` sums the ELF's loadable PROGBITS
+    sections; NOBITS and non-alloc sections are excluded."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
     partitions = _write_partitions(tmp_path)
-    firmware_bin = tmp_path / "firmware.bin"
-    firmware_bin.write_bytes(b"\x00" * 724224)
-    print_summary(size_json, partitions, firmware_bin)
+    firmware_elf = _write_elf(
+        tmp_path,
+        [
+            (1, 0x6, 700000),  # PROGBITS, alloc+exec: counted
+            (1, 0x2, 24215),  # PROGBITS, alloc: counted
+            (8, 0x2, 50000),  # NOBITS (.bss): excluded
+            (1, 0x0, 12345),  # PROGBITS, no alloc (.debug_*): excluded
+        ],
+    )
+    print_summary(size_json, partitions, firmware_elf)
     out = capsys.readouterr().out
-    assert "(used 724224 bytes from 1835008 bytes)" in out
+    assert "(used 724215 bytes from 1835008 bytes)" in out
 
 
-@pytest.mark.parametrize("missing", ["bin", "partitions"])
-def test_print_summary_skips_flash_on_missing_input(
-    missing: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize("problem", ["missing_elf", "not_an_elf", "missing_partitions"])
+def test_print_summary_skips_flash_on_bad_input(
+    problem: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A missing firmware bin or partitions.csv skips the Flash line, not the RAM line."""
+    """An unusable ELF or missing partitions.csv skips the Flash line, not the RAM line."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
-    firmware_bin = tmp_path / "firmware.bin"
-    if missing == "bin":
-        _write_partitions(tmp_path)
+    firmware_elf = tmp_path / "firmware.elf"
+    if problem == "missing_partitions":
+        _write_elf(tmp_path, [(1, 0x2, 1024)])
     else:
-        firmware_bin.write_bytes(b"\x00" * 16)
-    print_summary(size_json, tmp_path / "partitions.csv", firmware_bin)
+        _write_partitions(tmp_path)
+        if problem == "not_an_elf":
+            firmware_elf.write_bytes(b"junk")
+    print_summary(size_json, tmp_path / "partitions.csv", firmware_elf)
     out = capsys.readouterr().out
     assert "RAM:" in out
     assert "Flash:" not in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -214,6 +214,8 @@ _GOOD_ELF = _elf_bytes([(1, 0x2, 1024)])
             _elf_bytes([(1, 0x2, 1024)], shentsize=0), True, id="bad_shentsize"
         ),
         pytest.param(_GOOD_ELF[:60], True, id="truncated_table"),
+        pytest.param(_elf_bytes([]), True, id="no_sections"),
+        pytest.param(_elf_bytes([(8, 0x2, 50000)]), True, id="no_progbits"),
         pytest.param(_GOOD_ELF, False, id="missing_partitions"),
     ],
 )

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -28,22 +28,26 @@ def _write_partitions(tmp_path: Path) -> Path:
     return out
 
 
-def _write_elf(tmp_path: Path, sections: list[tuple[int, int, int]]) -> Path:
+def _write_elf(
+    tmp_path: Path,
+    sections: list[tuple[int, int, int]],
+    shentsize: int = 40,
+    truncate: int | None = None,
+) -> Path:
     """Write a minimal ELF32 LE whose section headers carry the given
     (sh_type, sh_flags, sh_size) triples."""
-    header = bytearray(52)
-    header[0:4] = b"\x7fELF"
-    header[4] = header[5] = 1  # 32-bit, little-endian
-    struct.pack_into("<I", header, 0x20, 52)  # e_shoff
-    struct.pack_into("<HH", header, 0x2E, 40, len(sections))
-    out = bytearray(header)
+    out = bytearray(52)
+    out[0:4] = b"\x7fELF"
+    out[4] = out[5] = 1  # 32-bit, little-endian
+    struct.pack_into("<I", out, 0x20, 52)  # e_shoff
+    struct.pack_into("<HH", out, 0x2E, shentsize, len(sections))
     for sh_type, sh_flags, sh_size in sections:
         shdr = bytearray(40)
         struct.pack_into("<II", shdr, 4, sh_type, sh_flags)
         struct.pack_into("<I", shdr, 20, sh_size)
         out += shdr
     elf = tmp_path / "firmware.elf"
-    elf.write_bytes(bytes(out))
+    elf.write_bytes(out if truncate is None else out[:truncate])
     return elf
 
 
@@ -111,8 +115,8 @@ def _s3_size_data() -> dict:
 
 
 def _print_summary_ram_only(tmp_path: Path, size_json: Path) -> None:
-    """Call print_summary with no partitions.csv or firmware bin on disk."""
-    print_summary(size_json, tmp_path / "partitions.csv", tmp_path / "firmware.bin")
+    """Call print_summary with no partitions.csv or ELF on disk."""
+    print_summary(size_json, tmp_path / "partitions.csv", tmp_path / "firmware.elf")
 
 
 def test_print_summary_esp32_uses_dram(
@@ -203,19 +207,32 @@ def test_print_summary_flash_line_derives_from_elf(
     assert "(used 724215 bytes from 1835008 bytes)" in out
 
 
-@pytest.mark.parametrize("problem", ["missing_elf", "not_an_elf", "missing_partitions"])
+@pytest.mark.parametrize(
+    "problem",
+    [
+        "missing_elf",
+        "not_an_elf",
+        "bad_shentsize",
+        "truncated_table",
+        "missing_partitions",
+    ],
+)
 def test_print_summary_skips_flash_on_bad_input(
     problem: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """An unusable ELF or missing partitions.csv skips the Flash line, not the RAM line."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
     firmware_elf = tmp_path / "firmware.elf"
-    if problem == "missing_partitions":
-        _write_elf(tmp_path, [(1, 0x2, 1024)])
-    else:
+    if problem != "missing_partitions":
         _write_partitions(tmp_path)
-        if problem == "not_an_elf":
-            firmware_elf.write_bytes(b"junk")
+    if problem == "not_an_elf":
+        firmware_elf.write_bytes(b"junk")
+    elif problem == "bad_shentsize":
+        _write_elf(tmp_path, [(1, 0x2, 1024)], shentsize=0)
+    elif problem == "truncated_table":
+        _write_elf(tmp_path, [(1, 0x2, 1024)], truncate=60)
+    elif problem == "missing_partitions":
+        _write_elf(tmp_path, [(1, 0x2, 1024)])
     print_summary(size_json, tmp_path / "partitions.csv", firmware_elf)
     out = capsys.readouterr().out
     assert "RAM:" in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -134,7 +134,9 @@ def test_print_summary_s3_falls_back_to_diram(
 
 
 def test_print_summary_skips_when_diram_total_collapses(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A zero-size region drops the RAM line rather than divide by zero."""
     size_json = _write_size_json(
@@ -147,6 +149,7 @@ def test_print_summary_skips_when_diram_total_collapses(
     _print_summary_ram_only(tmp_path, size_json)
     out = capsys.readouterr().out
     assert "RAM:" not in out
+    assert "unusable region" in caplog.text
 
 
 def test_print_summary_handles_missing_json(
@@ -158,12 +161,18 @@ def test_print_summary_handles_missing_json(
 
 
 def test_print_summary_handles_no_layout(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A size json without ``layout`` still doesn't crash."""
+    """A size json without ``layout`` warns so schema drift is visible."""
     size_json = _write_size_json(tmp_path, {"version": "1.1"})
     _print_summary_ram_only(tmp_path, size_json)
     assert capsys.readouterr().out == ""
+    assert any(
+        r.levelname == "WARNING" and "no DRAM/DIRAM region" in r.message
+        for r in caplog.records
+    )
 
 
 def test_print_summary_flash_line_prefers_total_size(
@@ -202,6 +211,22 @@ def test_print_summary_flash_line_derives_from_elf(
     assert "(used 724215 bytes from 1835008 bytes)" in out
 
 
+def test_print_summary_flash_falls_back_on_bad_total_size(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A zero or non-int total_size falls back to the ELF instead of
+    printing a used-0-bytes line CI would read as a real measurement."""
+    data = _s3_size_data()
+    data["total_size"] = 0
+    size_json = _write_size_json(tmp_path, data)
+    partitions = _write_partitions(tmp_path)
+    firmware_elf = tmp_path / "firmware.elf"
+    firmware_elf.write_bytes(_elf_bytes([(1, 0x2, 4096)]))
+    print_summary(size_json, partitions, firmware_elf)
+    out = capsys.readouterr().out
+    assert "(used 4096 bytes from 1835008 bytes)" in out
+
+
 _GOOD_ELF = _elf_bytes([(1, 0x2, 1024)])
 
 
@@ -224,6 +249,7 @@ def test_print_summary_skips_flash_on_bad_input(
     with_partitions: bool,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """An unusable ELF or missing partitions.csv skips the Flash line, not the RAM line."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
@@ -236,3 +262,10 @@ def test_print_summary_skips_flash_on_bad_input(
     out = capsys.readouterr().out
     assert "RAM:" in out
     assert "Flash:" not in out
+    # ELF problems warn (anomaly after a successful build); a missing
+    # partitions.csv stays at debug
+    warned = any(
+        r.levelname == "WARNING" and "Skipping Flash summary" in r.message
+        for r in caplog.records
+    )
+    assert warned == with_partitions

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -28,13 +28,8 @@ def _write_partitions(tmp_path: Path) -> Path:
     return out
 
 
-def _write_elf(
-    tmp_path: Path,
-    sections: list[tuple[int, int, int]],
-    shentsize: int = 40,
-    truncate: int | None = None,
-) -> Path:
-    """Write a minimal ELF32 LE whose section headers carry the given
+def _elf_bytes(sections: list[tuple[int, int, int]], shentsize: int = 40) -> bytes:
+    """Build a minimal ELF32 LE whose section headers carry the given
     (sh_type, sh_flags, sh_size) triples."""
     out = bytearray(52)
     out[0:4] = b"\x7fELF"
@@ -46,9 +41,7 @@ def _write_elf(
         struct.pack_into("<II", shdr, 4, sh_type, sh_flags)
         struct.pack_into("<I", shdr, 20, sh_size)
         out += shdr
-    elf = tmp_path / "firmware.elf"
-    elf.write_bytes(out if truncate is None else out[:truncate])
-    return elf
+    return bytes(out)
 
 
 def _esp32_size_data() -> dict:
@@ -193,46 +186,50 @@ def test_print_summary_flash_line_derives_from_elf(
     sections; NOBITS and non-alloc sections are excluded."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
     partitions = _write_partitions(tmp_path)
-    firmware_elf = _write_elf(
-        tmp_path,
-        [
-            (1, 0x6, 700000),  # PROGBITS, alloc+exec: counted
-            (1, 0x2, 24215),  # PROGBITS, alloc: counted
-            (8, 0x2, 50000),  # NOBITS (.bss): excluded
-            (1, 0x0, 12345),  # PROGBITS, no alloc (.debug_*): excluded
-        ],
+    firmware_elf = tmp_path / "firmware.elf"
+    firmware_elf.write_bytes(
+        _elf_bytes(
+            [
+                (1, 0x6, 700000),  # PROGBITS, alloc+exec: counted
+                (1, 0x2, 24215),  # PROGBITS, alloc: counted
+                (8, 0x2, 50000),  # NOBITS (.bss): excluded
+                (1, 0x0, 12345),  # PROGBITS, no alloc (.debug_*): excluded
+            ]
+        )
     )
     print_summary(size_json, partitions, firmware_elf)
     out = capsys.readouterr().out
     assert "(used 724215 bytes from 1835008 bytes)" in out
 
 
+_GOOD_ELF = _elf_bytes([(1, 0x2, 1024)])
+
+
 @pytest.mark.parametrize(
-    "problem",
+    ("elf_bytes", "with_partitions"),
     [
-        "missing_elf",
-        "not_an_elf",
-        "bad_shentsize",
-        "truncated_table",
-        "missing_partitions",
+        pytest.param(None, True, id="missing_elf"),
+        pytest.param(b"junk", True, id="not_an_elf"),
+        pytest.param(
+            _elf_bytes([(1, 0x2, 1024)], shentsize=0), True, id="bad_shentsize"
+        ),
+        pytest.param(_GOOD_ELF[:60], True, id="truncated_table"),
+        pytest.param(_GOOD_ELF, False, id="missing_partitions"),
     ],
 )
 def test_print_summary_skips_flash_on_bad_input(
-    problem: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    elf_bytes: bytes | None,
+    with_partitions: bool,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """An unusable ELF or missing partitions.csv skips the Flash line, not the RAM line."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
     firmware_elf = tmp_path / "firmware.elf"
-    if problem != "missing_partitions":
+    if elf_bytes is not None:
+        firmware_elf.write_bytes(elf_bytes)
+    if with_partitions:
         _write_partitions(tmp_path)
-    if problem == "not_an_elf":
-        firmware_elf.write_bytes(b"junk")
-    elif problem == "bad_shentsize":
-        _write_elf(tmp_path, [(1, 0x2, 1024)], shentsize=0)
-    elif problem == "truncated_table":
-        _write_elf(tmp_path, [(1, 0x2, 1024)], truncate=60)
-    elif problem == "missing_partitions":
-        _write_elf(tmp_path, [(1, 0x2, 1024)])
     print_summary(size_json, tmp_path / "partitions.csv", firmware_elf)
     out = capsys.readouterr().out
     assert "RAM:" in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -28,9 +28,11 @@ def _write_partitions(tmp_path: Path) -> Path:
 
 
 def _esp32_size_data() -> dict:
-    """Synthetic json2 esp_idf_size.json for the original ESP32 (split IRAM/DRAM)."""
+    """Synthetic json2 for the original ESP32 (split IRAM/DRAM), in the
+    esp-idf-size >= 2.1 shape that carries ``total_size``."""
     return {
         "version": "1.1",
+        "total_size": 827455,
         "layout": [
             {
                 "name": "DRAM",
@@ -57,7 +59,8 @@ def _esp32_size_data() -> dict:
 
 
 def _s3_size_data() -> dict:
-    """Synthetic json2 esp_idf_size.json for ESP32-S3 (unified DIRAM)."""
+    """Synthetic json2 for ESP32-S3 (unified DIRAM), in the esp-idf-size 1.x
+    shape without ``total_size``."""
     return {
         "version": "1.1",
         "layout": [
@@ -146,19 +149,32 @@ def test_print_summary_handles_no_layout(
     assert capsys.readouterr().out == ""
 
 
-def test_print_summary_flash_line(
+def test_print_summary_flash_line_prefers_total_size(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A partition table with an app row yields the Flash line in the exact
-    padded shape script/ci_memory_impact_extract.py greps."""
+    """With ``total_size`` in the json, the exact figure wins over the padded
+    bin size, in the exact shape script/ci_memory_impact_extract.py greps."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
     partitions = _write_partitions(tmp_path)
     firmware_bin = tmp_path / "firmware.bin"
-    firmware_bin.write_bytes(b"\x00" * 827455)
+    firmware_bin.write_bytes(b"\x00" * 999999)
     print_summary(size_json, partitions, firmware_bin)
     out = capsys.readouterr().out
     assert "Flash: " in out
     assert "(used 827455 bytes from 1835008 bytes)" in out
+
+
+def test_print_summary_flash_line_falls_back_to_bin_size(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A 1.x json without ``total_size`` uses the on-disk bin size."""
+    size_json = _write_size_json(tmp_path, _s3_size_data())
+    partitions = _write_partitions(tmp_path)
+    firmware_bin = tmp_path / "firmware.bin"
+    firmware_bin.write_bytes(b"\x00" * 724224)
+    print_summary(size_json, partitions, firmware_bin)
+    out = capsys.readouterr().out
+    assert "(used 724224 bytes from 1835008 bytes)" in out
 
 
 @pytest.mark.parametrize("missing", ["bin", "partitions"])
@@ -166,7 +182,7 @@ def test_print_summary_skips_flash_on_missing_input(
     missing: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A missing firmware bin or partitions.csv skips the Flash line, not the RAM line."""
-    size_json = _write_size_json(tmp_path, _esp32_size_data())
+    size_json = _write_size_json(tmp_path, _s3_size_data())
     firmware_bin = tmp_path / "firmware.bin"
     if missing == "bin":
         _write_partitions(tmp_path)

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -17,6 +17,16 @@ def _write_size_json(tmp_path: Path, data: dict) -> Path:
     return out
 
 
+def _write_partitions(tmp_path: Path) -> Path:
+    """Drop a partitions.csv with a 0x1C0000 (1835008 byte) app slot."""
+    out = tmp_path / "partitions.csv"
+    out.write_text(
+        "# name, type, subtype, offset, size, flags\n"
+        "app0, app, ota_0, 0x10000, 0x1C0000,\n"
+    )
+    return out
+
+
 def _esp32_size_data() -> dict:
     """Synthetic json2 esp_idf_size.json for the original ESP32 (split IRAM/DRAM)."""
     return {
@@ -77,12 +87,17 @@ def _s3_size_data() -> dict:
     }
 
 
+def _print_summary_ram_only(tmp_path: Path, size_json: Path) -> None:
+    """Call print_summary with no partitions.csv or firmware bin on disk."""
+    print_summary(size_json, tmp_path / "partitions.csv", tmp_path / "firmware.bin")
+
+
 def test_print_summary_esp32_uses_dram(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Original ESP32: RAM = DRAM.used / DRAM.total."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
-    print_summary(size_json, partitions_csv=None, firmware_bin=None)
+    _print_summary_ram_only(tmp_path, size_json)
     out = capsys.readouterr().out
     assert "RAM:" in out
     assert "used 47332 bytes from 180736 bytes" in out
@@ -93,7 +108,7 @@ def test_print_summary_s3_falls_back_to_diram(
 ) -> None:
     """ESP32-S3 with no DRAM entry falls back to DIRAM and reports raw region usage."""
     size_json = _write_size_json(tmp_path, _s3_size_data())
-    print_summary(size_json, partitions_csv=None, firmware_bin=None)
+    _print_summary_ram_only(tmp_path, size_json)
     out = capsys.readouterr().out
     assert "used 104999 bytes from 341760 bytes" in out
 
@@ -106,18 +121,10 @@ def test_print_summary_skips_when_diram_total_collapses(
         tmp_path,
         {
             "version": "1.1",
-            "layout": [
-                {
-                    "name": "DIRAM",
-                    "total": 0,
-                    "used": 0,
-                    "free": 0,
-                    "parts": {},
-                },
-            ],
+            "layout": [{"name": "DIRAM", "total": 0, "used": 0}],
         },
     )
-    print_summary(size_json, partitions_csv=None, firmware_bin=None)
+    _print_summary_ram_only(tmp_path, size_json)
     out = capsys.readouterr().out
     assert "RAM:" not in out
 
@@ -126,9 +133,7 @@ def test_print_summary_handles_missing_json(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Missing size json is non-fatal and prints nothing."""
-    print_summary(
-        tmp_path / "does_not_exist.json", partitions_csv=None, firmware_bin=None
-    )
+    _print_summary_ram_only(tmp_path, tmp_path / "does_not_exist.json")
     assert capsys.readouterr().out == ""
 
 
@@ -137,7 +142,7 @@ def test_print_summary_handles_no_layout(
 ) -> None:
     """A size json without ``layout`` still doesn't crash."""
     size_json = _write_size_json(tmp_path, {"version": "1.1"})
-    print_summary(size_json, partitions_csv=None, firmware_bin=None)
+    _print_summary_ram_only(tmp_path, size_json)
     assert capsys.readouterr().out == ""
 
 
@@ -147,11 +152,7 @@ def test_print_summary_flash_line(
     """A partition table with an app row yields the Flash line in the exact
     padded shape script/ci_memory_impact_extract.py greps."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text(
-        "# name, type, subtype, offset, size, flags\n"
-        "app0, app, ota_0, 0x10000, 0x1C0000,\n"
-    )
+    partitions = _write_partitions(tmp_path)
     firmware_bin = tmp_path / "firmware.bin"
     firmware_bin.write_bytes(b"\x00" * 827455)
     print_summary(size_json, partitions, firmware_bin)
@@ -160,33 +161,18 @@ def test_print_summary_flash_line(
     assert "(used 827455 bytes from 1835008 bytes)" in out
 
 
-def test_print_summary_skips_flash_when_bin_unreadable(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize("missing", ["bin", "partitions"])
+def test_print_summary_skips_flash_on_missing_input(
+    missing: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A firmware bin that can't be stat'ed skips the Flash line, not the RAM line."""
+    """A missing firmware bin or partitions.csv skips the Flash line, not the RAM line."""
     size_json = _write_size_json(tmp_path, _esp32_size_data())
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text(
-        "# name, type, subtype, offset, size, flags\n"
-        "app0, app, ota_0, 0x10000, 0x1C0000,\n"
-    )
-    print_summary(size_json, partitions, tmp_path / "missing.bin")
-    out = capsys.readouterr().out
-    assert "RAM:" in out
-    assert "Flash:" not in out
-
-
-def test_print_summary_skips_flash_without_bin(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """No firmware bin means the RAM line prints but the Flash line is skipped."""
-    size_json = _write_size_json(tmp_path, _esp32_size_data())
-    partitions = tmp_path / "partitions.csv"
-    partitions.write_text(
-        "# name, type, subtype, offset, size, flags\n"
-        "app0, app, ota_0, 0x10000, 0x1C0000,\n"
-    )
-    print_summary(size_json, partitions, firmware_bin=None)
+    firmware_bin = tmp_path / "firmware.bin"
+    if missing == "bin":
+        _write_partitions(tmp_path)
+    else:
+        firmware_bin.write_bytes(b"\x00" * 16)
+    print_summary(size_json, tmp_path / "partitions.csv", firmware_bin)
     out = capsys.readouterr().out
     assert "RAM:" in out
     assert "Flash:" not in out

--- a/tests/unit_tests/test_size_summary.py
+++ b/tests/unit_tests/test_size_summary.py
@@ -211,6 +211,52 @@ def test_print_summary_flash_line_derives_from_elf(
     assert "(used 724215 bytes from 1835008 bytes)" in out
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param([1, 2], id="top_level_list"),
+        pytest.param({"version": "1.1", "layout": None}, id="layout_null"),
+        pytest.param({"version": "1.1", "layout": 7}, id="layout_scalar"),
+    ],
+)
+def test_print_summary_handles_unexpected_shapes(
+    data: object, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A foreign-schema size json degrades to a warning, never a traceback."""
+    size_json = _write_size_json(tmp_path, data)
+    _print_summary_ram_only(tmp_path, size_json)
+    assert capsys.readouterr().out == ""
+
+
+def test_print_summary_skips_flash_on_zero_app_partition(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A zero-size app partition skips the Flash line rather than printing
+    a from-0-bytes figure CI would record."""
+    size_json = _write_size_json(tmp_path, _esp32_size_data())
+    partitions = tmp_path / "partitions.csv"
+    partitions.write_text(
+        "# name, type, subtype, offset, size, flags\napp0, app, ota_0, 0x10000, 0x0,\n"
+    )
+    print_summary(size_json, partitions, tmp_path / "firmware.elf")
+    out = capsys.readouterr().out
+    assert "Flash:" not in out
+
+
+def test_print_summary_skips_flash_on_unreadable_partitions(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An unreadable partitions.csv is non-fatal."""
+    size_json = _write_size_json(tmp_path, _esp32_size_data())
+    partitions = _write_partitions(tmp_path)
+    partitions.chmod(0o000)
+    try:
+        print_summary(size_json, partitions, tmp_path / "firmware.elf")
+    finally:
+        partitions.chmod(0o644)
+    assert "Flash:" not in capsys.readouterr().out
+
+
 def test_print_summary_flash_falls_back_on_bad_total_size(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The generated CMakeLists runs `esp_idf_size --format=raw` as a POST_BUILD command on the app ELF to produce `esp_idf_size.json` for the RAM/Flash summary lines. The raw format dumps every symbol (3.8MB, about 2s on a large S3 map) while the summary only needs the per memory type totals; since the command runs inside the link edge, every relink pays that 2s serially. Switching to `--format=json2` produces the per memory type summary in about 0.1s.

json2 originally had no `image_size` field, that was the reason raw was picked in #16394, and the summary numbers stay identical to before. esp-idf-size 2.1 and newer (bundled with IDF 6.0) reports the exact figure as `total_size` in json2 and that is preferred when present; the 1.x tool pinned by IDF 5.x lacks it, so there the same figure is derived from the ELF by summing loadable PROGBITS section sizes, the rule `esp_idf_size` itself uses, verified byte identical on both ESP32 S3 (xtensa) and ESP32 C3 (RISC-V) builds. I also verified `--format=json2` is accepted by every esp-idf-size version the IDF 5.x constraint files allow (valid argparse choice since 1.0.1, works end to end on 1.4.0, the floor for IDF 5.3 and newer), and that 2.3.1's `total_size` matches 1.7.1's raw `image_size` on the same map. `script/ci_memory_impact_extract.py` parses the summary lines unchanged.

Measured on an Apollo R PRO 1 config (ESP32 S3, IDF 5.5.5, Apple M5 Max with fast NVMe); this is close to the best case, on slow hardware like a Home Assistant Green or a Pi running the add-on the raw dump costs far more than 2s (it is CPU bound Python writing a multi MB json), so the absolute saving there is much larger:

| | format=raw (before) | format=json2 (this PR) |
|---|---|---|
| esp_idf_size run on the map | 1.98s | 0.13s |
| ELF link ninja edge (link plus POST_BUILD) | 3.7s | 2.0s |
| touch one file, full `esphome compile` | 8.5s | 7.7s |
| Flash line figure | 797099, exact | 797099, exact |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf
  toolchain: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
