### PR TITLE
[mdns] Bump espressif/mdns to 1.12.0

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components.esp32 import add_idf_component
+from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option
 from esphome.config_helpers import filter_source_files_from_platform, get_logger_level
 import esphome.config_validation as cv
 from esphome.const import (
@@ -208,7 +208,9 @@ async def to_code(config: ConfigType) -> None:
                 ethernet.request_ethernet_ip_state_listener()
 
     if CORE.is_esp32:
-        add_idf_component(name="espressif/mdns", ref="1.11.3")
+        add_idf_component(name="espressif/mdns", ref="1.12.0")
+        # ESPHome only advertises; the browse APIs are unused
+        add_idf_sdkconfig_option("CONFIG_MDNS_ENABLE_BROWSE", False)
 
     cg.add_define("USE_MDNS")
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -24,7 +24,7 @@ dependencies:
   espressif/esp32-camera:
     version: 2.1.7
   espressif/mdns:
-    version: 1.11.3
+    version: 1.12.0
   espressif/esp_wifi_remote:
     version: 1.6.3
     rules:


### PR DESCRIPTION
# What does this implement/fix?

Bumps espressif/mdns from 1.11.3 to 1.12.0 in both pin locations. The release makes the component depend on `esp_wifi` only when WiFi is enabled (espressif/esp-protocols#835, espressif/esp-protocols#1135), plus assorted mdns browse and subtype query fixes.

1.12.0 also makes the browse feature optional; ESPHome only advertises and never calls the browse APIs, so this sets `CONFIG_MDNS_ENABLE_BROWSE=n`, which drops `mdns_browser.c` from the build and saves 4400 bytes of flash on an Ethernet plus api config.

The CI memory impact analysis ran on nrf52 where this change is a no-op; measured on a real ESP32 device instead (Olimex POE ISO, Ethernet plus BLE proxy, this PR plus #18599, flashed and verified running):

| | before | after |
|---|---|---|
| Flash | 837735 | 832615 (-5120 bytes) |
| RAM | 52328 | 51984 (-344 bytes) |

Together with #18599 this is what lets Ethernet only builds stop compiling the WiFi stack; on its own it is a straightforward dependency refresh. Verified by compiling Ethernet plus api and WiFi plus api configs on this branch; with #18599 applied on top, the Ethernet build drops from 874 to 765 objects and wpa_supplicant, esp_wifi, esp_phy, esp_coex and bt all disappear from it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- related to #18599 and espressif/esp-protocols#1135

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
