### PR TITLE
[modbus] Add a compile-time register value decoder

### DIFF
--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -478,38 +478,19 @@ constexpr uint32_t registers_to_uint32(uint16_t high_word, uint16_t low_word) {
   return (static_cast<uint32_t>(high_word) << 16) | low_word;
 }
 
-/// Registers occupied by a value of the given type; 0 for RAW and BIT, which have no fixed width.
-constexpr uint8_t registers_for_value_type(SensorValueType value_type) {
-  switch (value_type) {
-    case SensorValueType::U_WORD:
-    case SensorValueType::U_WORD_S:
-    case SensorValueType::S_WORD:
-    case SensorValueType::S_WORD_S:
-      return 1;
-    case SensorValueType::U_DWORD:
-    case SensorValueType::U_DWORD_R:
-    case SensorValueType::S_DWORD:
-    case SensorValueType::S_DWORD_R:
-    case SensorValueType::FP32:
-    case SensorValueType::FP32_R:
-      return 2;
-    case SensorValueType::U_QWORD:
-    case SensorValueType::U_QWORD_R:
-    case SensorValueType::S_QWORD:
-    case SensorValueType::S_QWORD_R:
-      return 4;
-    default:
-      return 0;
-  }
-}
-
+// Always false, whatever the type: it exists only to make the static_assert below depend on the
+// template argument. Not a queryable trait.
 template<SensorValueType> inline constexpr bool VALUE_TYPE_SUPPORTED = false;
 
 /** Decode one value whose type is known at compile time, from registers in host byte order.
  * Unlike registers_to_number(), the type is a template argument, so only the one decode is compiled
  * and the caller gets the value's natural type back rather than an int64_t. The "_R" types take the
  * low word first; the rest take the high word first.
- * The caller must supply at least registers_for_value_type(VALUE_TYPE) registers.
+ * Supports the WORD, DWORD and FP32 types, including their _S and _R forms; the QWORD types are
+ * out of scope and fail to compile, so use registers_to_number() for those.
+ * Use register_width_for() for the number of registers the caller must supply.
+ * Note that the FP32 branches are only usable in a constant expression where std::bit_cast is
+ * available; elsewhere bit_cast falls back to a non-constexpr memcpy (see core/helpers.h).
  */
 template<SensorValueType VALUE_TYPE> constexpr auto registers_to_value(const uint16_t *registers) {
   if constexpr (VALUE_TYPE == SensorValueType::U_WORD) {

--- a/esphome/components/modbus/modbus_helpers.h
+++ b/esphome/components/modbus/modbus_helpers.h
@@ -473,6 +473,70 @@ inline int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueTy
  */
 std::optional<int64_t> registers_to_number(const uint16_t *registers, size_t count, SensorValueType sensor_value_type);
 
+/// Combine two register words into a 32-bit value.
+constexpr uint32_t registers_to_uint32(uint16_t high_word, uint16_t low_word) {
+  return (static_cast<uint32_t>(high_word) << 16) | low_word;
+}
+
+/// Registers occupied by a value of the given type; 0 for RAW and BIT, which have no fixed width.
+constexpr uint8_t registers_for_value_type(SensorValueType value_type) {
+  switch (value_type) {
+    case SensorValueType::U_WORD:
+    case SensorValueType::U_WORD_S:
+    case SensorValueType::S_WORD:
+    case SensorValueType::S_WORD_S:
+      return 1;
+    case SensorValueType::U_DWORD:
+    case SensorValueType::U_DWORD_R:
+    case SensorValueType::S_DWORD:
+    case SensorValueType::S_DWORD_R:
+    case SensorValueType::FP32:
+    case SensorValueType::FP32_R:
+      return 2;
+    case SensorValueType::U_QWORD:
+    case SensorValueType::U_QWORD_R:
+    case SensorValueType::S_QWORD:
+    case SensorValueType::S_QWORD_R:
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+template<SensorValueType> inline constexpr bool VALUE_TYPE_SUPPORTED = false;
+
+/** Decode one value whose type is known at compile time, from registers in host byte order.
+ * Unlike registers_to_number(), the type is a template argument, so only the one decode is compiled
+ * and the caller gets the value's natural type back rather than an int64_t. The "_R" types take the
+ * low word first; the rest take the high word first.
+ * The caller must supply at least registers_for_value_type(VALUE_TYPE) registers.
+ */
+template<SensorValueType VALUE_TYPE> constexpr auto registers_to_value(const uint16_t *registers) {
+  if constexpr (VALUE_TYPE == SensorValueType::U_WORD) {
+    return registers[0];
+  } else if constexpr (VALUE_TYPE == SensorValueType::S_WORD) {
+    return static_cast<int16_t>(registers[0]);
+  } else if constexpr (VALUE_TYPE == SensorValueType::U_WORD_S) {
+    return byteswap(registers[0]);
+  } else if constexpr (VALUE_TYPE == SensorValueType::S_WORD_S) {
+    return static_cast<int16_t>(byteswap(registers[0]));
+  } else if constexpr (VALUE_TYPE == SensorValueType::U_DWORD) {
+    return registers_to_uint32(registers[0], registers[1]);
+  } else if constexpr (VALUE_TYPE == SensorValueType::U_DWORD_R) {
+    return registers_to_uint32(registers[1], registers[0]);
+  } else if constexpr (VALUE_TYPE == SensorValueType::S_DWORD) {
+    return static_cast<int32_t>(registers_to_uint32(registers[0], registers[1]));
+  } else if constexpr (VALUE_TYPE == SensorValueType::S_DWORD_R) {
+    return static_cast<int32_t>(registers_to_uint32(registers[1], registers[0]));
+  } else if constexpr (VALUE_TYPE == SensorValueType::FP32) {
+    return bit_cast<float>(registers_to_uint32(registers[0], registers[1]));
+  } else if constexpr (VALUE_TYPE == SensorValueType::FP32_R) {
+    return bit_cast<float>(registers_to_uint32(registers[1], registers[0]));
+  } else {
+    static_assert(VALUE_TYPE_SUPPORTED<VALUE_TYPE>, "registers_to_value() does not support this value type");
+  }
+}
+
 /// The widest standard numeric value (a QWORD) spans 4 registers, so one entity value never writes more.
 static constexpr uint16_t MAX_FEW_REGISTERS = 4;
 

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -438,12 +438,17 @@ TEST(ModbusHelpersTest, RegistersToNumberRejectsTruncatedMultiRegisterValue) {
 
 template<SensorValueType VALUE_TYPE> void expect_matches_registers_to_number(const uint16_t *registers) {
   const auto expected = registers_to_number(registers, registers_for_value_type(VALUE_TYPE), VALUE_TYPE);
-  ASSERT_TRUE(expected.has_value()) << "value_type=" << static_cast<int>(VALUE_TYPE);
+  // Plain control flow rather than ASSERT_TRUE: the optional analysis does not see through the macro.
+  if (!expected.has_value()) {
+    ADD_FAILURE() << "registers_to_number() returned no value for value_type=" << static_cast<int>(VALUE_TYPE);
+    return;
+  }
+  const int64_t number = expected.value();
   if constexpr (VALUE_TYPE == SensorValueType::FP32 || VALUE_TYPE == SensorValueType::FP32_R) {
-    EXPECT_FLOAT_EQ(registers_to_value<VALUE_TYPE>(registers), bit_cast<float>(static_cast<uint32_t>(*expected)))
+    EXPECT_FLOAT_EQ(registers_to_value<VALUE_TYPE>(registers), bit_cast<float>(static_cast<uint32_t>(number)))
         << "value_type=" << static_cast<int>(VALUE_TYPE);
   } else {
-    EXPECT_EQ(static_cast<int64_t>(registers_to_value<VALUE_TYPE>(registers)), *expected)
+    EXPECT_EQ(static_cast<int64_t>(registers_to_value<VALUE_TYPE>(registers)), number)
         << "value_type=" << static_cast<int>(VALUE_TYPE);
   }
 }

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -437,7 +437,7 @@ TEST(ModbusHelpersTest, RegistersToNumberRejectsTruncatedMultiRegisterValue) {
 // so the two implementations cannot drift apart.
 
 template<SensorValueType VALUE_TYPE> void expect_matches_registers_to_number(const uint16_t *registers) {
-  const auto expected = registers_to_number(registers, registers_for_value_type(VALUE_TYPE), VALUE_TYPE);
+  const auto expected = registers_to_number(registers, register_width_for(VALUE_TYPE), VALUE_TYPE);
   // Plain control flow rather than ASSERT_TRUE: the optional analysis does not see through the macro.
   if (!expected.has_value()) {
     ADD_FAILURE() << "registers_to_number() returned no value for value_type=" << static_cast<int>(VALUE_TYPE);
@@ -466,17 +466,6 @@ TEST(ModbusHelpersTest, RegistersToValueMatchesRegistersToNumber) {
   expect_matches_registers_to_number<SensorValueType::S_DWORD_R>(registers);
   expect_matches_registers_to_number<SensorValueType::FP32>(registers);
   expect_matches_registers_to_number<SensorValueType::FP32_R>(registers);
-}
-
-TEST(ModbusHelpersTest, RegistersForValueTypeCoversEveryFixedWidthType) {
-  // Must agree with the widths the byte decoder requires, including the QWORD types.
-  EXPECT_EQ(registers_for_value_type(SensorValueType::U_WORD), 1);
-  EXPECT_EQ(registers_for_value_type(SensorValueType::S_WORD_S), 1);
-  EXPECT_EQ(registers_for_value_type(SensorValueType::U_DWORD_R), 2);
-  EXPECT_EQ(registers_for_value_type(SensorValueType::FP32_R), 2);
-  EXPECT_EQ(registers_for_value_type(SensorValueType::U_QWORD), 4);
-  EXPECT_EQ(registers_for_value_type(SensorValueType::S_QWORD_R), 4);
-  EXPECT_EQ(registers_for_value_type(SensorValueType::RAW), 0);
 }
 
 TEST(ModbusHelpersTest, RegistersToUint32CombinesWordsHighFirst) {

--- a/tests/components/modbus/modbus_helpers_test.cpp
+++ b/tests/components/modbus/modbus_helpers_test.cpp
@@ -432,6 +432,52 @@ TEST(ModbusHelpersTest, RegistersToNumberRejectsTruncatedMultiRegisterValue) {
   EXPECT_FALSE(registers_to_number(registers, 1, SensorValueType::U_DWORD).has_value());
 }
 
+// --- registers_to_value ----------------------------------------------------
+// The compile-time decoder must agree with the runtime one for every type it supports,
+// so the two implementations cannot drift apart.
+
+template<SensorValueType VALUE_TYPE> void expect_matches_registers_to_number(const uint16_t *registers) {
+  const auto expected = registers_to_number(registers, registers_for_value_type(VALUE_TYPE), VALUE_TYPE);
+  ASSERT_TRUE(expected.has_value()) << "value_type=" << static_cast<int>(VALUE_TYPE);
+  if constexpr (VALUE_TYPE == SensorValueType::FP32 || VALUE_TYPE == SensorValueType::FP32_R) {
+    EXPECT_FLOAT_EQ(registers_to_value<VALUE_TYPE>(registers), bit_cast<float>(static_cast<uint32_t>(*expected)))
+        << "value_type=" << static_cast<int>(VALUE_TYPE);
+  } else {
+    EXPECT_EQ(static_cast<int64_t>(registers_to_value<VALUE_TYPE>(registers)), *expected)
+        << "value_type=" << static_cast<int>(VALUE_TYPE);
+  }
+}
+
+TEST(ModbusHelpersTest, RegistersToValueMatchesRegistersToNumber) {
+  // A high bit in each word exercises sign handling and word order together.
+  const uint16_t registers[] = {0x8001, 0xFE02};
+  expect_matches_registers_to_number<SensorValueType::U_WORD>(registers);
+  expect_matches_registers_to_number<SensorValueType::S_WORD>(registers);
+  expect_matches_registers_to_number<SensorValueType::U_WORD_S>(registers);
+  expect_matches_registers_to_number<SensorValueType::S_WORD_S>(registers);
+  expect_matches_registers_to_number<SensorValueType::U_DWORD>(registers);
+  expect_matches_registers_to_number<SensorValueType::U_DWORD_R>(registers);
+  expect_matches_registers_to_number<SensorValueType::S_DWORD>(registers);
+  expect_matches_registers_to_number<SensorValueType::S_DWORD_R>(registers);
+  expect_matches_registers_to_number<SensorValueType::FP32>(registers);
+  expect_matches_registers_to_number<SensorValueType::FP32_R>(registers);
+}
+
+TEST(ModbusHelpersTest, RegistersForValueTypeCoversEveryFixedWidthType) {
+  // Must agree with the widths the byte decoder requires, including the QWORD types.
+  EXPECT_EQ(registers_for_value_type(SensorValueType::U_WORD), 1);
+  EXPECT_EQ(registers_for_value_type(SensorValueType::S_WORD_S), 1);
+  EXPECT_EQ(registers_for_value_type(SensorValueType::U_DWORD_R), 2);
+  EXPECT_EQ(registers_for_value_type(SensorValueType::FP32_R), 2);
+  EXPECT_EQ(registers_for_value_type(SensorValueType::U_QWORD), 4);
+  EXPECT_EQ(registers_for_value_type(SensorValueType::S_QWORD_R), 4);
+  EXPECT_EQ(registers_for_value_type(SensorValueType::RAW), 0);
+}
+
+TEST(ModbusHelpersTest, RegistersToUint32CombinesWordsHighFirst) {
+  EXPECT_EQ(registers_to_uint32(0x1234, 0x5678), 0x12345678u);
+}
+
 // --- packed bit helpers ------------------------------------------------------
 
 TEST(ModbusHelpersTest, PackBitsAppendsToContainer) {


### PR DESCRIPTION
This PR is in a group that modernises the modbus components to use the new modbus client device API.

- #18863
- #18849
- #18850
- #18851
- #18852
- #18853
- #18854
- #18855

---

# What does this implement/fix?

This adds a compile-time register decoder to `modbus_helpers.h`, for components whose value type is fixed in code rather than chosen at runtime.

`registers_to_number()` takes the `SensorValueType` as a runtime argument, so it dispatches through `payload_to_number()` and its switch over every value type.
A component that decodes one known type still links the whole decoder: measured on an ESP8266 build, that is about 1.2 kB of `payload_to_number()`, `mask_and_shift_by_rightbit()`, `required_payload_size()` and friends.

`registers_to_value<VALUE_TYPE>()` takes the type as a template argument instead.
Only the selected branch is compiled, so it inlines to the same handful of instructions as a hand-written shift, and it returns the value's natural type rather than an `int64_t`.
One smaller helper comes with it: `registers_to_uint32()`, for combining a register pair.
The matching bounds check uses the existing `register_width_for()` rather than adding a second width helper.

The QWORD types are out of scope for this decoder and fail to compile; `registers_to_number()` still handles them.

The component PRs listed above each carry an identical copy of this addition so they can be reviewed and merged independently; once this one lands, the duplicate resolves itself when they merge dev.

Nothing existing changes: this is additive, and `registers_to_number()` keeps all its current callers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change: this is a C++ helper for component developers.
# It is exercised by the existing modbus test configurations.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


