### PR TITLE
[ci] Stream the compile-test image artifact straight into docker load

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -186,6 +186,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read  # actions/checkout to load the test configs
+      actions: read   # gh api to download the image artifact of this run
     strategy:
       fail-fast: false
       matrix:
@@ -209,12 +210,18 @@ jobs:
           - host
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Download image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: compile-test-image.tar.zst
       - name: Load image
-        run: docker load --input compile-test-image.tar.zst
+        # Stream the artifact from the REST API straight into docker load so
+        # the download overlaps with layer extraction instead of running
+        # before it. The artifact was uploaded with archive: false, so the
+        # endpoint returns the raw zstd tar, which docker load auto-detects.
+        # shell: bash adds pipefail so a failed download cannot pass silently.
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts?name=compile-test-image.tar.zst" --jq '.artifacts[0].id')
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" | docker load
       - name: Compile ${{ matrix.id }}
         run: |
           docker run --rm \


### PR DESCRIPTION
# What does this implement/fix?

Streams the compile-test image artifact straight from the artifacts API into docker load instead of downloading it to disk first. The download and the layer extraction now overlap, so each of the 11 compile test jobs no longer pays for both in sequence. The gain is small and partly within runner noise: over 16 recent runs, download plus load had a per run median of 25s to 37s with a worst job of 38s to 64s; two runs of this PR gave medians of 20s and 24s with worst jobs of 33s and 40s. It also removes one action from every job.

Decompression is not the cost; the 991 MB tar decompresses in well under a second, and docker load time is layer extraction. Piping the compressed bytes on stdin measured the same as `--input` locally, while piping uncompressed bytes was slower, so the stream stays zstd compressed and docker load detects it. The artifact is uploaded with `archive: false`, so the API returns the raw zstd tar. The job gains `actions: read`, which is available to the read only token on fork PRs.

CI only; the artifact is consumed solely by the smoke test jobs in the same workflow.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; CI-only.

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
