### PR TITLE
[espidf] Build the precompiled header inside the ninja graph

### DIFF
--- a/esphome/build_gen/arduino8266.py
+++ b/esphome/build_gen/arduino8266.py
@@ -27,7 +27,6 @@ import sys
 from typing import TYPE_CHECKING, NamedTuple
 
 from esphome.arduino8266.framework import toolchain_tool
-from esphome.build_helpers.ccache import effective_ccache_basedir
 from esphome.build_helpers.idedata import is_joined_include
 from esphome.build_helpers.ninja import (
     escape as _e,
@@ -37,13 +36,14 @@ from esphome.build_helpers.ninja import (
 from esphome.build_helpers.pch import (
     PCH_CORE_HEADER,
     PCH_HEADER_NAME,
+    log_pch_in_use,
     mark_pch_emitted,
-    pch_checksum,
     pch_consumer_escalation,
     pch_degraded,
     pch_disabled_degraded,
     pch_enabled,
     pch_header_text,
+    pch_identity,
     pch_probe_args,
     pch_strict,
 )
@@ -1243,39 +1243,21 @@ def write_project(paths: InstalledPaths, ccache: str | None) -> bool:
         pch_header = build_dir / PCH_HEADER_NAME
         pch_includes = (*src_includes, PCH_CORE_HEADER)
         pch_text = pch_header_text(pch_includes)
-        checksum = None
-        try:
-            if ccache:
-                # The .sum exists only for CCACHE_PCH_EXTSUM; ninja's depfile
-                # handles staleness. Strip resolved and raw build paths
-                # (symlinks) so identical configs share cache entries
-                flags_id = (
-                    " ".join(cxxflags)
-                    .replace(effective_ccache_basedir(), "")
-                    .replace(str(CORE.build_path), "")
-                )
-                # The header text covers include order
-                checksum = pch_checksum(
-                    src_dir,
-                    pch_includes,
-                    (
-                        pch_text,
-                        str(paths.framework),
-                        str(paths.toolchain),
-                        flags_id,
-                    ),
-                )
-        except (OSError, UnicodeError) as err:
-            # Identity unknown: a stale cache entry must never be served
-            _LOGGER.warning(
-                "Could not establish the pch identity; compiling without it: %s", err
+        # The .sum exists only for CCACHE_PCH_EXTSUM; ninja's depfile
+        # handles staleness
+        checksum = (
+            pch_identity(
+                cxxflags,
+                src_dir,
+                pch_includes,
+                (str(paths.framework), str(paths.toolchain)),
             )
-            pch_degraded(f"identity unknown: {err}")
-        else:
-            _LOGGER.info(
-                "Compiling with a precompiled header "
-                "(set ESPHOME_PCH_ENABLE=0 to disable)"
-            )
+            if ccache
+            else None
+        )
+        # Identity unknown under ccache: pch_identity warned and degraded
+        if not ccache or checksum is not None:
+            log_pch_in_use()
             write_file_if_changed(pch_header, pch_text)
             sum_path = build_dir / f"{PCH_HEADER_NAME}.gch.sum"
             if checksum is not None:

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import sys
 
 from esphome.build_helpers import pch
-from esphome.build_helpers.ccache import effective_ccache_basedir
 from esphome.build_helpers.pch import (
     PCH_DEFAULT_HEADERS,
     PCH_HEADER_NAME,
@@ -299,12 +298,15 @@ def _pch_edge_cmake() -> str:
     by a bare custom target: a command adopted by the component target
     would inherit its inter-component dependencies as order-only inputs,
     forcing the pch to wait for every archive and destroying the overlap.
-    The shim derives TU-identical flags from compile_commands.json at edge
-    execution time, so the baked command carries none."""
+    The target must exist before the component lib so it, not the lib,
+    adopts the command; that placement is why the script-mode guard and
+    the .sum touch below are needed. The shim derives TU-identical flags
+    from compile_commands.json at edge execution time."""
     if not pch_enabled():
         return ""
     python = strip_win_long_path_prefix(sys.executable)
-    pkg_root = Path(pch.__file__).parent.parent.parent
+    # The directory containing the esphome package, for the shim's -m import
+    pkg_root = Path(__file__).parents[2]
     return f"""
 # ESPHome precompiled header build edge (see build_helpers/pch_compile.py).
 # Script mode (cmake -P) cannot define commands or targets; skip there.
@@ -337,11 +339,14 @@ def _pch_cmake() -> str:
     """Consumer block for the component CMakeLists. Baked at generation: a
     strict-knob or venv flip rewrites the file and reconfigures; a
     hand-run idf.py keeps the old one."""
-    if not pch_enabled():
+    if not (
+        consumer := pch.pch_cmake_consumer(
+            "${COMPONENT_LIB}",
+            "${app_sources}",
+            object_depends=f"{PCH_HEADER_NAME}.gch",
+        )
+    ):
         return ""
-    consumer = pch.pch_cmake_consumer(
-        "${COMPONENT_LIB}", "${app_sources}", object_depends=f"{PCH_HEADER_NAME}.gch"
-    )
     return f"""{consumer}
 add_dependencies(${{COMPONENT_LIB}} esphome_pch)
 """
@@ -355,13 +360,19 @@ def _write_degraded_sum(reason: str) -> None:
     """Degraded sidecar: the ninja edge then emits a placeholder .gch and
     consumers fall back to the textual include. Never delete the .sum —
     it is an input of the edge."""
-    write_file_if_changed(_pch_sum_path(), f"degraded:{reason[:120]}\n")
+    write_file_if_changed(_pch_sum_path(), pch.degraded_sum_text(reason))
+
+
+def _degrade_sidecars(reason: str, detail: str = "") -> None:
+    """Degrade (strict raises before the write) and mark the .sum."""
+    pch.pch_degraded(f"{reason}{detail}")
+    _write_degraded_sum(reason)
 
 
 def prepare_pch_sidecars() -> None:
     """Write the pch identity sidecar right before ninja, after every
     reconfigure, so compile_commands.json flags and the sdkconfig are the
-    settled ones. The compile itself is a ninja edge (see _pch_cmake);
+    settled ones. The compile itself is a ninja edge (see _pch_edge_cmake);
     ccache keys every consuming TU on this .sum, so it must be final here."""
     build_dir = CORE.relative_build_path("build")
     if not pch_enabled():
@@ -378,42 +389,29 @@ def prepare_pch_sidecars() -> None:
         _LOGGER.warning(
             "Could not read %s; compiling without the pch: %s", sdkconfig_path, err
         )
-        pch.pch_degraded(f"sdkconfig unreadable: {err}")
-        _write_degraded_sum("sdkconfig unreadable")
+        _degrade_sidecars("sdkconfig unreadable", f": {err}")
         return
     header = build_dir / PCH_HEADER_NAME
     gch = Path(f"{header}.gch")
-    cmd_and_dir = pch.pch_compile_command(build_dir, header, gch)
+    src_dir = CORE.relative_src_path()
+    cmd_and_dir = pch.pch_compile_command(build_dir, header, gch, src_dir)
     if cmd_and_dir is None:
-        pch.pch_degraded("no usable compile command")
-        _write_degraded_sum("no usable compile command")
+        _degrade_sidecars("no usable compile command")
         return
     cmd, _ = cmd_and_dir
-    cmd_id = (
-        " ".join(cmd)
-        .replace(effective_ccache_basedir(), "")
-        .replace(str(CORE.build_path), "")
+    checksum = pch.pch_identity(
+        cmd,
+        src_dir,
+        PCH_DEFAULT_HEADERS,
+        (
+            str(idf_version()),
+            CORE.cpp_standard or "",
+            sdkconfig,
+            *get_project_compile_flags(),
+            *get_project_cxx_compile_flags(),
+        ),
     )
-    try:
-        checksum = pch.pch_checksum(
-            CORE.relative_src_path(),
-            PCH_DEFAULT_HEADERS,
-            (
-                pch_header_text(PCH_DEFAULT_HEADERS),
-                str(idf_version()),
-                CORE.cpp_standard or "",
-                sdkconfig,
-                *get_project_compile_flags(),
-                *get_project_cxx_compile_flags(),
-                cmd_id,
-            ),
-        )
-    except (OSError, UnicodeError) as err:
-        # Identity unknown: a stale cache entry must never be served
-        _LOGGER.warning(
-            "Could not establish the pch identity; compiling without it: %s", err
-        )
-        pch.pch_degraded(f"identity unknown: {err}")
+    if checksum is None:
         _write_degraded_sum("identity unknown")
         return
     if pch.read_stamp(Path(f"{gch}.failed")) == checksum:
@@ -422,15 +420,20 @@ def prepare_pch_sidecars() -> None:
             "delete %s.failed to retry",
             gch,
         )
-        pch.pch_degraded("earlier failure latched")
-        _write_degraded_sum("earlier failure latched")
+        _degrade_sidecars("earlier failure latched")
         return
     # A degraded-to-digest rewrite bumps the .sum mtime, which is what
     # makes the ninja edge retry after the latch is deleted
-    if write_file_if_changed(_pch_sum_path(), checksum + "\n") or not gch.is_file():
-        _LOGGER.info(
-            "Compiling with a precompiled header (set ESPHOME_PCH_ENABLE=0 to disable)"
-        )
+    write_file_if_changed(_pch_sum_path(), checksum + "\n")
+    pch.log_pch_in_use()
+
+
+def prepare_pch_sidecars_guarded() -> None:
+    """prepare_pch_sidecars under the shared crash guard: any setup failure
+    leaves a degraded .sum, never a deleted edge input."""
+    pch.guarded_prepare(
+        prepare_pch_sidecars, lambda: _write_degraded_sum("setup failed")
+    )
 
 
 def write_project(

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -3,8 +3,10 @@
 import json
 import logging
 from pathlib import Path
+import sys
 
 from esphome.build_helpers import pch
+from esphome.build_helpers.ccache import effective_ccache_basedir
 from esphome.build_helpers.pch import (
     PCH_DEFAULT_HEADERS,
     PCH_HEADER_NAME,
@@ -25,6 +27,7 @@ from esphome.framework_helpers import (
     get_project_compile_flags,
     get_project_cxx_compile_flags,
     get_project_link_flags,
+    strip_win_long_path_prefix,
 )
 from esphome.helpers import mkdir_p, write_file_if_changed
 
@@ -291,18 +294,61 @@ target_link_options(${{COMPONENT_LIB}} PUBLIC
 
 
 def _pch_cmake() -> str:
-    """Consumer block for the component CMakeLists. Baked at generation:
-    a strict-knob flip takes effect on the next esphome compile; a
-    hand-run idf.py keeps the old one."""
-    return pch.pch_cmake_consumer("${COMPONENT_LIB}", "${app_sources}")
+    """Consumer block plus the .gch build edge for the component
+    CMakeLists. Baked at generation: a strict-knob or venv flip rewrites
+    the file and reconfigures; a hand-run idf.py keeps the old one. The
+    shim derives TU-identical flags from compile_commands.json at edge
+    execution time, so the baked command carries none."""
+    if not pch_enabled():
+        return ""
+    consumer = pch.pch_cmake_consumer(
+        "${COMPONENT_LIB}", "${app_sources}", object_depends=f"{PCH_HEADER_NAME}.gch"
+    )
+    python = strip_win_long_path_prefix(sys.executable)
+    pkg_root = Path(pch.__file__).parent.parent.parent
+    return f"""{consumer}
+# The .sum (identity digest, written pre-ninja) is an edge input; keep it
+# satisfiable when the build system wiped the dir. Empty reads as degraded.
+if(NOT EXISTS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum")
+  file(TOUCH "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum")
+endif()
+cmake_policy(SET CMP0116 NEW)
+add_custom_command(
+    OUTPUT "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch"
+    COMMAND ${{CMAKE_COMMAND}} -E env "PYTHONPATH={pkg_root}"
+            "{python}" -m esphome.build_helpers.pch_compile
+            --build-dir "${{CMAKE_BINARY_DIR}}"
+            --src-dir "${{CMAKE_CURRENT_SOURCE_DIR}}"
+            --header "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}"
+            --gch "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch"
+    DEPENDS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}"
+            "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum"
+    DEPFILE "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.d"
+    COMMENT "PCH {PCH_HEADER_NAME}.gch"
+    VERBATIM)
+"""
 
 
-def prepare_pch() -> None:
-    """Build the .gch right before ninja, after every reconfigure, so the
-    compile_commands.json flags and the sdkconfig are the settled ones."""
+def _pch_sum_path() -> Path:
+    return CORE.relative_build_path("build", f"{PCH_HEADER_NAME}.gch.sum")
+
+
+def _write_degraded_sum(reason: str) -> None:
+    """Degraded sidecar: the ninja edge then emits a placeholder .gch and
+    consumers fall back to the textual include. Never delete the .sum —
+    it is an input of the edge."""
+    write_file_if_changed(_pch_sum_path(), f"degraded:{reason[:120]}\n")
+
+
+def prepare_pch_sidecars() -> None:
+    """Write the pch identity sidecar right before ninja, after every
+    reconfigure, so compile_commands.json flags and the sdkconfig are the
+    settled ones. The compile itself is a ninja edge (see _pch_cmake);
+    ccache keys every consuming TU on this .sum, so it must be final here."""
+    build_dir = CORE.relative_build_path("build")
     if not pch_enabled():
         # Self-cleaning escape hatch: drop any previously built .gch
-        pch.discard_pch(CORE.relative_build_path("build"))
+        pch.discard_pch(build_dir)
         pch.pch_disabled_degraded()
         return
     sdkconfig_path = CORE.relative_build_path(f"sdkconfig.{CORE.name}")
@@ -314,20 +360,59 @@ def prepare_pch() -> None:
         _LOGGER.warning(
             "Could not read %s; compiling without the pch: %s", sdkconfig_path, err
         )
-        pch.discard_pch(CORE.relative_build_path("build"))
         pch.pch_degraded(f"sdkconfig unreadable: {err}")
+        _write_degraded_sum("sdkconfig unreadable")
         return
-    pch.prepare_pch(
-        CORE.relative_build_path("build"),
-        PCH_DEFAULT_HEADERS,
-        (
-            str(idf_version()),
-            CORE.cpp_standard or "",
-            sdkconfig,
-            *get_project_compile_flags(),
-            *get_project_cxx_compile_flags(),
-        ),
+    header = build_dir / PCH_HEADER_NAME
+    gch = Path(f"{header}.gch")
+    cmd_and_dir = pch.pch_compile_command(build_dir, header, gch)
+    if cmd_and_dir is None:
+        pch.pch_degraded("no usable compile command")
+        _write_degraded_sum("no usable compile command")
+        return
+    cmd, _ = cmd_and_dir
+    cmd_id = (
+        " ".join(cmd)
+        .replace(effective_ccache_basedir(), "")
+        .replace(str(CORE.build_path), "")
     )
+    try:
+        checksum = pch.pch_checksum(
+            CORE.relative_src_path(),
+            PCH_DEFAULT_HEADERS,
+            (
+                pch_header_text(PCH_DEFAULT_HEADERS),
+                str(idf_version()),
+                CORE.cpp_standard or "",
+                sdkconfig,
+                *get_project_compile_flags(),
+                *get_project_cxx_compile_flags(),
+                cmd_id,
+            ),
+        )
+    except (OSError, UnicodeError) as err:
+        # Identity unknown: a stale cache entry must never be served
+        _LOGGER.warning(
+            "Could not establish the pch identity; compiling without it: %s", err
+        )
+        pch.pch_degraded(f"identity unknown: {err}")
+        _write_degraded_sum("identity unknown")
+        return
+    if pch.read_stamp(Path(f"{gch}.failed")) == checksum:
+        _LOGGER.info(
+            "Precompiled header disabled after an earlier failure; "
+            "delete %s.failed to retry",
+            gch,
+        )
+        pch.pch_degraded("earlier failure latched")
+        _write_degraded_sum("earlier failure latched")
+        return
+    # A degraded-to-digest rewrite bumps the .sum mtime, which is what
+    # makes the ninja edge retry after the latch is deleted
+    if write_file_if_changed(_pch_sum_path(), checksum + "\n") or not gch.is_file():
+        _LOGGER.info(
+            "Compiling with a precompiled header (set ESPHOME_PCH_ENABLE=0 to disable)"
+        )
 
 
 def write_project(

--- a/esphome/build_gen/espidf.py
+++ b/esphome/build_gen/espidf.py
@@ -280,6 +280,7 @@ else()
     )
 endif()
 
+{_pch_edge_cmake()}
 idf_component_register(
     SRCS ${{app_sources}}
     INCLUDE_DIRS "." "esphome"
@@ -293,39 +294,56 @@ target_link_options(${{COMPONENT_LIB}} PUBLIC
 {_pch_cmake()}"""
 
 
-def _pch_cmake() -> str:
-    """Consumer block plus the .gch build edge for the component
-    CMakeLists. Baked at generation: a strict-knob or venv flip rewrites
-    the file and reconfigures; a hand-run idf.py keeps the old one. The
-    shim derives TU-identical flags from compile_commands.json at edge
+def _pch_edge_cmake() -> str:
+    """The .gch build edge, emitted BEFORE idf_component_register and owned
+    by a bare custom target: a command adopted by the component target
+    would inherit its inter-component dependencies as order-only inputs,
+    forcing the pch to wait for every archive and destroying the overlap.
+    The shim derives TU-identical flags from compile_commands.json at edge
     execution time, so the baked command carries none."""
+    if not pch_enabled():
+        return ""
+    python = strip_win_long_path_prefix(sys.executable)
+    pkg_root = Path(pch.__file__).parent.parent.parent
+    return f"""
+# ESPHome precompiled header build edge (see build_helpers/pch_compile.py).
+# Script mode (cmake -P) cannot define commands or targets; skip there.
+if(NOT CMAKE_SCRIPT_MODE_FILE)
+    # The .sum (identity digest, written pre-ninja) is an edge input; keep
+    # it satisfiable if the build system wiped the dir. Empty = degraded.
+    if(NOT EXISTS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum")
+        file(TOUCH "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum")
+    endif()
+    cmake_policy(SET CMP0116 NEW)
+    add_custom_command(
+        OUTPUT "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch"
+        COMMAND ${{CMAKE_COMMAND}} -E env "PYTHONPATH={pkg_root}"
+                "{python}" -m esphome.build_helpers.pch_compile
+                --build-dir "${{CMAKE_BINARY_DIR}}"
+                --src-dir "${{CMAKE_CURRENT_SOURCE_DIR}}"
+                --header "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}"
+                --gch "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch"
+        DEPENDS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}"
+                "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum"
+        DEPFILE "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.d"
+        COMMENT "PCH {PCH_HEADER_NAME}.gch"
+        VERBATIM)
+    add_custom_target(esphome_pch DEPENDS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch")
+endif()
+"""
+
+
+def _pch_cmake() -> str:
+    """Consumer block for the component CMakeLists. Baked at generation: a
+    strict-knob or venv flip rewrites the file and reconfigures; a
+    hand-run idf.py keeps the old one."""
     if not pch_enabled():
         return ""
     consumer = pch.pch_cmake_consumer(
         "${COMPONENT_LIB}", "${app_sources}", object_depends=f"{PCH_HEADER_NAME}.gch"
     )
-    python = strip_win_long_path_prefix(sys.executable)
-    pkg_root = Path(pch.__file__).parent.parent.parent
     return f"""{consumer}
-# The .sum (identity digest, written pre-ninja) is an edge input; keep it
-# satisfiable when the build system wiped the dir. Empty reads as degraded.
-if(NOT EXISTS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum")
-  file(TOUCH "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum")
-endif()
-cmake_policy(SET CMP0116 NEW)
-add_custom_command(
-    OUTPUT "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch"
-    COMMAND ${{CMAKE_COMMAND}} -E env "PYTHONPATH={pkg_root}"
-            "{python}" -m esphome.build_helpers.pch_compile
-            --build-dir "${{CMAKE_BINARY_DIR}}"
-            --src-dir "${{CMAKE_CURRENT_SOURCE_DIR}}"
-            --header "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}"
-            --gch "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch"
-    DEPENDS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}"
-            "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.sum"
-    DEPFILE "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}.gch.d"
-    COMMENT "PCH {PCH_HEADER_NAME}.gch"
-    VERBATIM)
+add_dependencies(${{COMPONENT_LIB}} esphome_pch)
 """
 
 

--- a/esphome/build_helpers/pch.py
+++ b/esphome/build_helpers/pch.py
@@ -99,6 +99,12 @@ _CCACHE_PCH_ENV = {
 # Compiler failures that clear on their own must not latch the .failed marker
 _TRANSIENT_ERRORS = ("No space left", "Cannot allocate", "Resource temporarily")
 
+
+def is_transient_error(text: str) -> bool:
+    """True for failures that clear on their own and must not latch."""
+    return any(marker in text for marker in _TRANSIENT_ERRORS)
+
+
 _INCLUDE_RE = re.compile(rb'^\s*#\s*include\s+["<]([^">]+)[">]', re.MULTILINE)
 
 
@@ -156,14 +162,19 @@ def pch_consumer_escalation() -> str:
     return "-Werror=invalid-pch" if pch_strict() else "-Wno-error=invalid-pch"
 
 
-def pch_cmake_consumer(target: str, sources_var: str) -> str:
+def pch_cmake_consumer(
+    target: str, sources_var: str, object_depends: str | None = None
+) -> str:
     """Emit the CMake block making ``target``'s C++ sources consume the
-    pch; empty when disabled. OBJECT_DEPENDS is on the header, not the
-    .gch (pch-baked headers drop out of TU depfiles); the -include stays
-    relative — an absolute path would poison ccache keys."""
+    pch; empty when disabled. OBJECT_DEPENDS defaults to the header, not
+    the .gch (pch-baked headers drop out of TU depfiles); a backend that
+    builds the .gch inside its build graph passes the .gch name instead
+    so TUs order after the edge. The -include stays relative — an
+    absolute path would poison ccache keys."""
     if not pch_enabled():
         return ""
     escalation = pch_consumer_escalation()
+    object_depends = object_depends or PCH_HEADER_NAME
     return f"""
 # ESPHome precompiled header (see esphome/build_helpers/pch.py).
 # The touch keeps OBJECT_DEPENDS satisfiable when the build system itself
@@ -178,7 +189,7 @@ target_compile_options({target} PRIVATE
     "$<$<COMPILE_LANGUAGE:CXX>:{PCH_HEADER_NAME}>"
 )
 set_source_files_properties({sources_var} PROPERTIES
-    OBJECT_DEPENDS "${{CMAKE_BINARY_DIR}}/{PCH_HEADER_NAME}")
+    OBJECT_DEPENDS "${{CMAKE_BINARY_DIR}}/{object_depends}")
 """
 
 
@@ -212,15 +223,32 @@ def ccache_pch_env() -> dict[str, str]:
     return env
 
 
-def guarded_prepare(build_dir: Path, prepare: Callable[[], None]) -> None:
+def guarded_prepare(
+    build_dir: Path,
+    prepare: Callable[[], None],
+    fallback: Callable[[], None] | None = None,
+) -> None:
     """Run a backend's pch preparation; an optional speedup must never
     abort the build. Strict is read first so its own knob error cannot
-    mask the real failure; discard_pch raises if a stale .gch survives;
-    the header is ensured so OBJECT_DEPENDS stays satisfiable."""
+    mask the real failure; ``fallback`` (when given) leaves the sidecars
+    in a degraded-but-consistent state instead of discarding them, for
+    backends whose build graph declares the sidecars as inputs;
+    discard_pch raises if a stale .gch survives; the header is ensured so
+    OBJECT_DEPENDS stays satisfiable."""
     try:
         prepare()
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         strict = pch_strict()
+        if fallback is not None:
+            if strict:
+                raise
+            with suppress(Exception):
+                fallback()
+            _LOGGER.warning(
+                "Precompiled header setup failed; compiling without it",
+                exc_info=True,
+            )
+            return
         discard_pch(build_dir)
         if strict:
             raise
@@ -320,13 +348,13 @@ _PCH_STRIP_FLAGS = frozenset({"-MD", "-MMD", "-MP", "-MM", "-M"})
 
 
 def pch_compile_command(
-    build_dir: Path, header: Path, gch: Path
+    build_dir: Path, header: Path, gch: Path, src_dir: Path | None = None
 ) -> tuple[list[str], Path] | None:
     """The exact src C++ flags from compile_commands.json retargeted at the
     header, with the directory they resolve against (relative -I paths must
     be expanded and executed from the same root); None (logged) when no
-    configured C++ TU is available yet."""
-    from esphome.core import CORE
+    configured C++ TU is available yet. ``src_dir`` overrides the CORE
+    lookup for callers running outside an esphome process (the ninja shim)."""
 
     try:
         entries = json.loads(
@@ -341,7 +369,11 @@ def pch_compile_command(
         return None
     # CMake may spell paths through a symlink differently than CORE does
     # (macOS /tmp vs /private/tmp), so compare resolved paths
-    src_root = Path(CORE.relative_src_path()).resolve()
+    if src_dir is None:
+        from esphome.core import CORE
+
+        src_dir = Path(CORE.relative_src_path())
+    src_root = src_dir.resolve()
     entry = next(
         (
             e
@@ -397,12 +429,16 @@ def _log_pch_in_use() -> None:
     )
 
 
-def _read_stamp(path: Path) -> str:
+def read_stamp(path: Path) -> str:
     """A corrupt sidecar must read as stale, not kill the pch forever."""
     try:
         return path.read_text(encoding="utf-8").strip()
     except (OSError, UnicodeDecodeError):
         return ""
+
+
+# Kept for callers written against the private name
+_read_stamp = read_stamp
 
 
 def discard_pch(build_dir: Path) -> None:

--- a/esphome/build_helpers/pch.py
+++ b/esphome/build_helpers/pch.py
@@ -94,8 +94,6 @@ _CCACHE_PCH_ENV = {
     "CCACHE_PCH_EXTSUM": "true",
 }
 
-# Both include forms: an angle include resolving under src/ must enter the
-# digest too; ones that do not resolve simply end the walk
 # Compiler failures that clear on their own must not latch the .failed marker
 _TRANSIENT_ERRORS = ("No space left", "Cannot allocate", "Resource temporarily")
 
@@ -105,6 +103,8 @@ def is_transient_error(text: str) -> bool:
     return any(marker in text for marker in _TRANSIENT_ERRORS)
 
 
+# Both include forms: an angle include resolving under src/ must enter the
+# digest too; ones that do not resolve simply end the walk
 _INCLUDE_RE = re.compile(rb'^\s*#\s*include\s+["<]([^">]+)[">]', re.MULTILINE)
 
 
@@ -163,7 +163,7 @@ def pch_consumer_escalation() -> str:
 
 
 def pch_cmake_consumer(
-    target: str, sources_var: str, object_depends: str | None = None
+    target: str, sources_var: str, object_depends: str = PCH_HEADER_NAME
 ) -> str:
     """Emit the CMake block making ``target``'s C++ sources consume the
     pch; empty when disabled. OBJECT_DEPENDS defaults to the header, not
@@ -174,7 +174,6 @@ def pch_cmake_consumer(
     if not pch_enabled():
         return ""
     escalation = pch_consumer_escalation()
-    object_depends = object_depends or PCH_HEADER_NAME
     return f"""
 # ESPHome precompiled header (see esphome/build_helpers/pch.py).
 # The touch keeps OBJECT_DEPENDS satisfiable when the build system itself
@@ -223,42 +222,34 @@ def ccache_pch_env() -> dict[str, str]:
     return env
 
 
-def guarded_prepare(
-    build_dir: Path,
-    prepare: Callable[[], None],
-    fallback: Callable[[], None] | None = None,
-) -> None:
-    """Run a backend's pch preparation; an optional speedup must never
-    abort the build. Strict is read first so its own knob error cannot
-    mask the real failure; ``fallback`` (when given) leaves the sidecars
-    in a degraded-but-consistent state instead of discarding them, for
-    backends whose build graph declares the sidecars as inputs;
-    discard_pch raises if a stale .gch survives; the header is ensured so
+def discard_pch_cleanup(build_dir: Path) -> None:
+    """Failure cleanup for backends without a pch build edge: drop the
+    sidecars (raises if a stale .gch survives) and keep the header so
     OBJECT_DEPENDS stays satisfiable."""
+    discard_pch(build_dir)
+    header = build_dir / PCH_HEADER_NAME
+    if not header.exists():
+        try:
+            header.touch()
+        except OSError as err:
+            # The coming OBJECT_DEPENDS error would hide the real cause
+            _LOGGER.warning("Could not create the pch placeholder: %s", err)
+
+
+def guarded_prepare(prepare: Callable[[], None], cleanup: Callable[[], None]) -> None:
+    """Run a backend's pch preparation; an optional speedup must never
+    abort the build. ``cleanup`` restores a consistent no-pch state
+    (discard_pch_cleanup, or a degraded .sum for backends whose build
+    graph declares the sidecars as inputs); its own failure propagates —
+    an inconsistent pch state must not be built on. Strict is read first
+    so its own knob error cannot mask the real failure."""
     try:
         prepare()
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         strict = pch_strict()
-        if fallback is not None:
-            if strict:
-                raise
-            with suppress(Exception):
-                fallback()
-            _LOGGER.warning(
-                "Precompiled header setup failed; compiling without it",
-                exc_info=True,
-            )
-            return
-        discard_pch(build_dir)
+        cleanup()
         if strict:
             raise
-        header = build_dir / PCH_HEADER_NAME
-        if not header.exists():
-            try:
-                header.touch()
-            except OSError as err:
-                # The coming OBJECT_DEPENDS error would hide the real cause
-                _LOGGER.warning("Could not create the pch placeholder: %s", err)
         _LOGGER.warning(
             "Precompiled header setup failed; compiling without it", exc_info=True
         )
@@ -348,13 +339,13 @@ _PCH_STRIP_FLAGS = frozenset({"-MD", "-MMD", "-MP", "-MM", "-M"})
 
 
 def pch_compile_command(
-    build_dir: Path, header: Path, gch: Path, src_dir: Path | None = None
+    build_dir: Path, header: Path, gch: Path, src_dir: Path
 ) -> tuple[list[str], Path] | None:
     """The exact src C++ flags from compile_commands.json retargeted at the
     header, with the directory they resolve against (relative -I paths must
     be expanded and executed from the same root); None (logged) when no
-    configured C++ TU is available yet. ``src_dir`` overrides the CORE
-    lookup for callers running outside an esphome process (the ninja shim)."""
+    configured C++ TU is available yet. ``src_dir`` is passed in because
+    the ninja edge shim runs outside an esphome process (no CORE)."""
 
     try:
         entries = json.loads(
@@ -367,12 +358,8 @@ def pch_compile_command(
     if not isinstance(entries, list):
         _LOGGER.warning("Malformed compile database, skipping pch")
         return None
-    # CMake may spell paths through a symlink differently than CORE does
-    # (macOS /tmp vs /private/tmp), so compare resolved paths
-    if src_dir is None:
-        from esphome.core import CORE
-
-        src_dir = Path(CORE.relative_src_path())
+    # CMake may spell paths through a symlink differently than the caller
+    # does (macOS /tmp vs /private/tmp), so compare resolved paths
     src_root = src_dir.resolve()
     entry = next(
         (
@@ -421,7 +408,76 @@ def pch_compile_command(
     return [*args, "-x", "c++-header", "-c", str(header), "-o", str(gch)], cmd_dir
 
 
-def _log_pch_in_use() -> None:
+def pch_probe_base(cmd: list[str]) -> list[str] | None:
+    """``cmd`` minus pch_compile_command's fixed "-x c++-header -c <hdr>
+    -o <gch>" tail, for probe compiles; None when the shape is unexpected."""
+    if cmd[-6:-4] != ["-x", "c++-header"]:
+        return None
+    return cmd[:-6]
+
+
+def flags_identity(tokens: Iterable[str]) -> str:
+    """Flag string normalized for digest use: strip like ccache's rewriting
+    (user CCACHE_BASEDIR wins); the raw build path covers unresolved
+    (symlinked) spellings."""
+    from esphome.core import CORE
+
+    return (
+        " ".join(tokens)
+        .replace(effective_ccache_basedir(), "")
+        .replace(str(CORE.build_path), "")
+    )
+
+
+def pch_identity(
+    tokens: Iterable[str],
+    src_dir: Path,
+    include_headers: tuple[str, ...],
+    extra: Iterable[str],
+) -> str | None:
+    """The .sum digest naming this exact pch build: include closure, header
+    text, backend identity strings, and the normalized compile command or
+    flags (``tokens``). None (warned and degraded) when the identity
+    cannot be established."""
+    try:
+        return pch_checksum(
+            src_dir,
+            include_headers,
+            (
+                # The closure is sorted, so root order only enters via the text
+                pch_header_text(include_headers),
+                *extra,
+                flags_identity(tokens),
+            ),
+        )
+    except (OSError, UnicodeError) as err:
+        # Identity unknown: a stale cache entry must never be served
+        _LOGGER.warning(
+            "Could not establish the pch identity; compiling without it: %s", err
+        )
+        pch_degraded(f"identity unknown: {err}")
+        return None
+
+
+def pch_run_tool(
+    cmd: list[str], cwd: Path, stdin: str | None = None
+) -> subprocess.CompletedProcess:
+    """One pch tool step; the C locale keeps diagnostics matchable by
+    _TRANSIENT_ERRORS. Spawn failures (OSError/SubprocessError) propagate:
+    environmental, never latched."""
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env={**os.environ, "LC_ALL": "C"},
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+
+def log_pch_in_use() -> None:
     # The only place a user can discover the knob; emitted only once a
     # .gch is actually fresh or being built
     _LOGGER.info(
@@ -437,8 +493,18 @@ def read_stamp(path: Path) -> str:
         return ""
 
 
-# Kept for callers written against the private name
-_read_stamp = read_stamp
+# The .sum wire format shared by the pre-ninja writer and the ninja edge shim.
+PCH_DEGRADED_PREFIX = "degraded:"
+
+
+def degraded_sum_text(reason: str) -> str:
+    """.sum content marking the pch degraded, so ccache keys consuming TUs
+    on the marker rather than a broken .gch; the reason is diagnostic."""
+    return f"{PCH_DEGRADED_PREFIX}{reason[:120]}\n"
+
+
+def is_degraded_sum(text: str) -> bool:
+    return text.startswith(PCH_DEGRADED_PREFIX)
 
 
 def discard_pch(build_dir: Path) -> None:
@@ -488,59 +554,27 @@ def prepare_pch(
     header = build_dir / PCH_HEADER_NAME
     gch = Path(f"{header}.gch")
     sum_path = Path(f"{gch}.sum")
-    cmd_and_dir = pch_compile_command(build_dir, header, gch)
+    src_dir = CORE.relative_src_path()
+    cmd_and_dir = pch_compile_command(build_dir, header, gch, src_dir)
     if cmd_and_dir is None:
         # Freshness cannot be validated; a leftover .gch must not be consumed
         discard_pch(build_dir)
         pch_degraded("no usable compile command")
         return
     cmd, cmd_dir = cmd_and_dir
-    # Strip like ccache's rewriting (user CCACHE_BASEDIR wins); the raw
-    # build path covers unresolved (symlinked) spellings
-    cmd_id = (
-        " ".join(cmd)
-        .replace(effective_ccache_basedir(), "")
-        .replace(str(CORE.build_path), "")
-    )
-    try:
-        checksum = pch_checksum(
-            CORE.relative_src_path(),
-            include_headers,
-            (
-                # The closure is sorted, so root order only enters via the text
-                pch_header_text(include_headers),
-                *extra,
-                cmd_id,
-            ),
-        )
-    except (OSError, UnicodeError) as err:
-        # Identity unknown: a stale cache entry must never be served
-        _LOGGER.warning(
-            "Could not establish the pch identity; compiling without it: %s", err
-        )
+    checksum = pch_identity(cmd, src_dir, include_headers, extra)
+    if checksum is None:
         discard_pch(build_dir)
-        pch_degraded(f"identity unknown: {err}")
         return
     failed_marker = Path(f"{gch}.failed")
 
     def _run(
         run_cmd: list[str], what: str, stdin: str | None = None
     ) -> subprocess.CompletedProcess | None:
-        """Spawn one pch tool step; environmental failures discard and
-        degrade (None): spawn/IO/timeout errors and signal kills never
-        latch the marker."""
+        """One pch tool step; environmental failures discard and degrade
+        (None): spawn/IO/timeout errors and signal kills never latch."""
         try:
-            proc = subprocess.run(
-                run_cmd,
-                cwd=cmd_dir,
-                # C locale keeps diagnostics matchable by _TRANSIENT_ERRORS
-                env={**os.environ, "LC_ALL": "C"},
-                input=stdin,
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=300,
-            )
+            proc = pch_run_tool(run_cmd, cmd_dir, stdin)
         except (OSError, subprocess.SubprocessError) as err:
             _LOGGER.warning("Precompiled header %s did not run: %s", what, err)
             discard_pch(build_dir)
@@ -566,7 +600,7 @@ def prepare_pch(
         # Latching paths keep the full compiler output recoverable
         _LOGGER.debug("Full pch output: %s", error)
         discard_pch(build_dir)
-        if latch and not any(m in error for m in _TRANSIENT_ERRORS):
+        if latch and not is_transient_error(error):
             # Skip retries until a header/flag/backend-identity/command change
             failed_marker.write_text(checksum + "\n", encoding="utf-8")
             os.utime(header)
@@ -575,16 +609,14 @@ def prepare_pch(
     def _probe(latch: bool = True) -> None:
         """Load-check the built .gch: some toolchains build one they then
         refuse to load (per-process ASLR). Dep flags are already stripped
-        from cmd, so no -MF is needed; cmd ends with the fixed
-        "-x c++-header -c -o" tail. A cached-header rejection may not
+        from cmd, so no -MF is needed. A cached-header rejection may not
         reproduce (per-process), so that caller passes latch=False."""
-        if cmd[-6:-4] != ["-x", "c++-header"]:
-            # The slice below depends on pch_compile_command's fixed tail
+        base = pch_probe_base(cmd)
+        if base is None:
             _LOGGER.warning("Unexpected pch command shape: %s", cmd[-6:])
             discard_pch(build_dir)
             pch_degraded("unexpected pch command shape")
             return
-        base = cmd[:-6]
         probe = _run([*base, *pch_probe_args(str(header))], "probe", stdin="")
         if probe is None:
             return
@@ -601,22 +633,22 @@ def prepare_pch(
                 error = baseline.stderr.strip() or f"exit code {baseline.returncode}"
                 _fail(error, "probe cannot run at all", latch=latch)
 
-    if gch.is_file() and _read_stamp(sum_path) == checksum:
-        _log_pch_in_use()
+    if gch.is_file() and read_stamp(sum_path) == checksum:
+        log_pch_in_use()
         if pch_strict():
             # Rejection is per-process, so a cached .gch must re-prove
             # loadability for the strict gate (CI-only cost); no latch,
             # since the rejection may not reproduce either
             _probe(latch=False)
         return
-    if _read_stamp(failed_marker) == checksum:
+    if read_stamp(failed_marker) == checksum:
         _LOGGER.info(
             "Precompiled header disabled after an earlier failure; delete %s to retry",
             failed_marker,
         )
         pch_degraded("earlier failure latched")
         return
-    _log_pch_in_use()
+    log_pch_in_use()
     result = _run(cmd, "compile")
     if result is None:
         return

--- a/esphome/build_helpers/pch_compile.py
+++ b/esphome/build_helpers/pch_compile.py
@@ -1,40 +1,38 @@
 """Ninja edge that compiles the precompiled header inside the build graph.
 
-Invoked as ``python -m esphome.build_helpers.pch_compile`` by the custom
-command the espidf backend bakes into the src component CMakeLists. The
-pre-ninja side (``prepare_pch_sidecars``) owns the identity digest and
-writes ``.sum``; this edge reads it, compiles and probes the .gch, and on
-failure degrades exactly like the pre-build flow: placeholder .gch (its
-``-Winvalid-pch`` warning makes consumers parse the header textually),
-``degraded:`` ``.sum`` so ccache never keys on a broken pch, and the
-``.failed`` latch for deterministic errors. Exit 0 keeps the build going;
+Run as ``python -m esphome.build_helpers.pch_compile`` by the command
+_pch_edge_cmake bakes into the src CMakeLists; ``-m`` (not a plain script)
+so it reuses the pch helpers instead of carrying copies. Degrades exactly
+like the pre-build flow; exit 0 keeps the build going and
 ``ESPHOME_PCH_STRICT`` turns every degrade into a nonzero exit.
 """
 
 from __future__ import annotations
 
 import argparse
-import os
+import logging
 from pathlib import Path
 import subprocess
 import sys
 
 from esphome.build_helpers.pch import (
+    degraded_sum_text,
+    is_degraded_sum,
     is_transient_error,
     pch_compile_command,
     pch_probe_args,
+    pch_probe_base,
     pch_probe_tail,
+    pch_run_tool,
     pch_strict,
     read_stamp,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 # Deliberately not a valid GCH: consumers warn via -Winvalid-pch and fall
 # back to the textual include, matching the pre-build degrade behavior
 PLACEHOLDER = b"ESPHome degraded precompiled header placeholder\n"
-
-
-def _log(msg: str) -> None:
-    print(f"esphome pch: {msg}", file=sys.stderr)
 
 
 def _write_depfile(depfile: Path, gch: Path, header: Path) -> None:
@@ -44,17 +42,16 @@ def _write_depfile(depfile: Path, gch: Path, header: Path) -> None:
 
 
 def _degrade(
-    args: argparse.Namespace, reason: str, latch_digest: str | None = None
+    gch: Path, header: Path, reason: str, latch_digest: str | None = None
 ) -> int:
-    gch = Path(args.gch)
-    header = Path(args.header)
-    _log(f"compiling without the precompiled header: {reason}")
+    _LOGGER.warning("compiling without the precompiled header: %s", reason)
     if pch_strict():
-        _log("ESPHOME_PCH_STRICT is set; failing the build")
+        _LOGGER.warning("ESPHOME_PCH_STRICT is set; failing the build")
         return 1
     sum_path = Path(f"{gch}.sum")
-    if not read_stamp(sum_path).startswith("degraded:"):
-        sum_path.write_text(f"degraded:{reason[:120]}\n", encoding="utf-8")
+    # Never clobber the pre-ninja side's own degrade reason
+    if not is_degraded_sum(read_stamp(sum_path)):
+        sum_path.write_text(degraded_sum_text(reason), encoding="utf-8")
     if latch_digest is not None:
         Path(f"{gch}.failed").write_text(latch_digest + "\n", encoding="utf-8")
     gch.write_bytes(PLACEHOLDER)
@@ -65,24 +62,16 @@ def _degrade(
 def _run(
     cmd: list[str], cwd: Path, stdin: str | None = None
 ) -> subprocess.CompletedProcess | None:
-    """One tool step; None for environmental failures (never latched)."""
+    """None for environmental spawn failures (never latched)."""
     try:
-        return subprocess.run(
-            cmd,
-            cwd=cwd,
-            env={**os.environ, "LC_ALL": "C"},
-            input=stdin,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=300,
-        )
+        return pch_run_tool(cmd, cwd, stdin)
     except (OSError, subprocess.SubprocessError) as err:
-        _log(f"tool did not run: {err}")
+        _LOGGER.warning("tool did not run: %s", err)
         return None
 
 
 def main() -> int:
+    logging.basicConfig(format="esphome pch: %(message)s")
     parser = argparse.ArgumentParser()
     parser.add_argument("--build-dir", required=True)
     parser.add_argument("--src-dir", required=True)
@@ -94,19 +83,19 @@ def main() -> int:
     header = Path(args.header)
     gch = Path(args.gch)
     digest = read_stamp(Path(f"{gch}.sum"))
-    if not digest or digest.startswith("degraded:"):
+    if is_degraded_sum(digest):
         # The pre-ninja side already decided to degrade this build
-        return _degrade(args, "sidecar marks the pch degraded")
+        return _degrade(gch, header, "sidecar marks the pch degraded")
+    if not digest:
+        return _degrade(gch, header, "no digest sidecar")
 
-    cmd_and_dir = pch_compile_command(
-        build_dir, header, gch, src_dir=Path(args.src_dir)
-    )
+    cmd_and_dir = pch_compile_command(build_dir, header, gch, Path(args.src_dir))
     if cmd_and_dir is None:
-        return _degrade(args, "no usable compile command")
+        return _degrade(gch, header, "no usable compile command")
     cmd, cmd_dir = cmd_and_dir
-    if cmd[-6:-4] != ["-x", "c++-header"]:
-        # The probe slice below depends on pch_compile_command's fixed tail
-        return _degrade(args, "unexpected pch command shape")
+    base = pch_probe_base(cmd)
+    if base is None:
+        return _degrade(gch, header, "unexpected pch command shape")
     # The graph edge owns dependency tracking; the -MT target must be the
     # absolute output path so cmake's depfile transform (CMP0116) maps it
     # to ninja's spelling — a relative name resolves against the component
@@ -116,31 +105,34 @@ def main() -> int:
 
     result = _run(compile_cmd, cmd_dir)
     if result is None:
-        return _degrade(args, "compiler did not run")
+        return _degrade(gch, header, "compiler did not run")
     if result.returncode < 0:
-        return _degrade(args, f"compiler killed by signal {-result.returncode}")
+        return _degrade(gch, header, f"compiler killed by signal {-result.returncode}")
     if result.returncode != 0 or not gch.is_file():
         error = result.stderr.strip() or f"exit code {result.returncode}"
-        _log(error[:1000])
+        _LOGGER.warning("%s", error[:1000])
         latch = None if is_transient_error(error) else digest
-        return _degrade(args, "compile failed", latch_digest=latch)
+        return _degrade(gch, header, "compile failed", latch_digest=latch)
 
-    base = cmd[:-6]  # strip the fixed "-x c++-header -c <hdr> -o <gch>" tail
     probe = _run([*base, *pch_probe_args(str(header))], cmd_dir, stdin="")
     if probe is None:
-        return _degrade(args, "probe did not run")
+        return _degrade(gch, header, "probe did not run")
     if probe.returncode != 0:
-        # Only blame the pch when the same compile passes without it
+        # Blame the pch only when the same compile passes without it
         baseline = _run([*base, *pch_probe_tail()], cmd_dir, stdin="")
-        error = probe.stderr.strip() or f"exit code {probe.returncode}"
-        _log(error[:1000])
-        latch = None if is_transient_error(error) else digest
         if baseline is not None and baseline.returncode != 0:
-            latch = None if is_transient_error(baseline.stderr) else digest
-        return _degrade(args, "toolchain cannot load the pch", latch_digest=latch)
+            error = baseline.stderr.strip() or f"exit code {baseline.returncode}"
+            reason = "probe cannot run at all"
+        else:
+            error = probe.stderr.strip() or f"exit code {probe.returncode}"
+            reason = "toolchain cannot load the pch"
+        _LOGGER.warning("%s", error[:1000])
+        latch = None if is_transient_error(error) else digest
+        return _degrade(gch, header, reason, latch_digest=latch)
 
     Path(f"{gch}.failed").unlink(missing_ok=True)
     if not depfile.is_file():
+        # Only if the compiler ignored -MD; ninja hard-errors without one
         _write_depfile(depfile, gch, header)
     return 0
 

--- a/esphome/build_helpers/pch_compile.py
+++ b/esphome/build_helpers/pch_compile.py
@@ -39,8 +39,8 @@ def _log(msg: str) -> None:
 
 def _write_depfile(depfile: Path, gch: Path, header: Path) -> None:
     """Ninja errors on a declared-but-missing depfile; keep a minimal one
-    on every non-compile path. The target is the ninja-relative output."""
-    depfile.write_text(f"{gch.name}: {header}\n", encoding="utf-8")
+    on every non-compile path. Absolute target, as the compile's -MT."""
+    depfile.write_text(f"{gch}: {header}\n", encoding="utf-8")
 
 
 def _degrade(
@@ -107,10 +107,12 @@ def main() -> int:
     if cmd[-6:-4] != ["-x", "c++-header"]:
         # The probe slice below depends on pch_compile_command's fixed tail
         return _degrade(args, "unexpected pch command shape")
-    # The graph edge owns dependency tracking; the target name must match
-    # ninja's spelling of the output (build-dir relative)
+    # The graph edge owns dependency tracking; the -MT target must be the
+    # absolute output path so cmake's depfile transform (CMP0116) maps it
+    # to ninja's spelling — a relative name resolves against the component
+    # binary dir and never matches, leaving the edge forever dirty
     depfile = Path(f"{gch}.d")
-    compile_cmd = [*cmd, "-MD", "-MF", str(depfile), "-MT", gch.name]
+    compile_cmd = [*cmd, "-MD", "-MF", str(depfile), "-MT", str(gch)]
 
     result = _run(compile_cmd, cmd_dir)
     if result is None:

--- a/esphome/build_helpers/pch_compile.py
+++ b/esphome/build_helpers/pch_compile.py
@@ -1,0 +1,147 @@
+"""Ninja edge that compiles the precompiled header inside the build graph.
+
+Invoked as ``python -m esphome.build_helpers.pch_compile`` by the custom
+command the espidf backend bakes into the src component CMakeLists. The
+pre-ninja side (``prepare_pch_sidecars``) owns the identity digest and
+writes ``.sum``; this edge reads it, compiles and probes the .gch, and on
+failure degrades exactly like the pre-build flow: placeholder .gch (its
+``-Winvalid-pch`` warning makes consumers parse the header textually),
+``degraded:`` ``.sum`` so ccache never keys on a broken pch, and the
+``.failed`` latch for deterministic errors. Exit 0 keeps the build going;
+``ESPHOME_PCH_STRICT`` turns every degrade into a nonzero exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from esphome.build_helpers.pch import (
+    is_transient_error,
+    pch_compile_command,
+    pch_probe_args,
+    pch_probe_tail,
+    pch_strict,
+    read_stamp,
+)
+
+# Deliberately not a valid GCH: consumers warn via -Winvalid-pch and fall
+# back to the textual include, matching the pre-build degrade behavior
+PLACEHOLDER = b"ESPHome degraded precompiled header placeholder\n"
+
+
+def _log(msg: str) -> None:
+    print(f"esphome pch: {msg}", file=sys.stderr)
+
+
+def _write_depfile(depfile: Path, gch: Path, header: Path) -> None:
+    """Ninja errors on a declared-but-missing depfile; keep a minimal one
+    on every non-compile path. The target is the ninja-relative output."""
+    depfile.write_text(f"{gch.name}: {header}\n", encoding="utf-8")
+
+
+def _degrade(
+    args: argparse.Namespace, reason: str, latch_digest: str | None = None
+) -> int:
+    gch = Path(args.gch)
+    header = Path(args.header)
+    _log(f"compiling without the precompiled header: {reason}")
+    if pch_strict():
+        _log("ESPHOME_PCH_STRICT is set; failing the build")
+        return 1
+    sum_path = Path(f"{gch}.sum")
+    if not read_stamp(sum_path).startswith("degraded:"):
+        sum_path.write_text(f"degraded:{reason[:120]}\n", encoding="utf-8")
+    if latch_digest is not None:
+        Path(f"{gch}.failed").write_text(latch_digest + "\n", encoding="utf-8")
+    gch.write_bytes(PLACEHOLDER)
+    _write_depfile(Path(f"{gch}.d"), gch, header)
+    return 0
+
+
+def _run(
+    cmd: list[str], cwd: Path, stdin: str | None = None
+) -> subprocess.CompletedProcess | None:
+    """One tool step; None for environmental failures (never latched)."""
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            env={**os.environ, "LC_ALL": "C"},
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=300,
+        )
+    except (OSError, subprocess.SubprocessError) as err:
+        _log(f"tool did not run: {err}")
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--src-dir", required=True)
+    parser.add_argument("--header", required=True)
+    parser.add_argument("--gch", required=True)
+    args = parser.parse_args()
+
+    build_dir = Path(args.build_dir)
+    header = Path(args.header)
+    gch = Path(args.gch)
+    digest = read_stamp(Path(f"{gch}.sum"))
+    if not digest or digest.startswith("degraded:"):
+        # The pre-ninja side already decided to degrade this build
+        return _degrade(args, "sidecar marks the pch degraded")
+
+    cmd_and_dir = pch_compile_command(
+        build_dir, header, gch, src_dir=Path(args.src_dir)
+    )
+    if cmd_and_dir is None:
+        return _degrade(args, "no usable compile command")
+    cmd, cmd_dir = cmd_and_dir
+    if cmd[-6:-4] != ["-x", "c++-header"]:
+        # The probe slice below depends on pch_compile_command's fixed tail
+        return _degrade(args, "unexpected pch command shape")
+    # The graph edge owns dependency tracking; the target name must match
+    # ninja's spelling of the output (build-dir relative)
+    depfile = Path(f"{gch}.d")
+    compile_cmd = [*cmd, "-MD", "-MF", str(depfile), "-MT", gch.name]
+
+    result = _run(compile_cmd, cmd_dir)
+    if result is None:
+        return _degrade(args, "compiler did not run")
+    if result.returncode < 0:
+        return _degrade(args, f"compiler killed by signal {-result.returncode}")
+    if result.returncode != 0 or not gch.is_file():
+        error = result.stderr.strip() or f"exit code {result.returncode}"
+        _log(error[:1000])
+        latch = None if is_transient_error(error) else digest
+        return _degrade(args, "compile failed", latch_digest=latch)
+
+    base = cmd[:-6]  # strip the fixed "-x c++-header -c <hdr> -o <gch>" tail
+    probe = _run([*base, *pch_probe_args(str(header))], cmd_dir, stdin="")
+    if probe is None:
+        return _degrade(args, "probe did not run")
+    if probe.returncode != 0:
+        # Only blame the pch when the same compile passes without it
+        baseline = _run([*base, *pch_probe_tail()], cmd_dir, stdin="")
+        error = probe.stderr.strip() or f"exit code {probe.returncode}"
+        _log(error[:1000])
+        latch = None if is_transient_error(error) else digest
+        if baseline is not None and baseline.returncode != 0:
+            latch = None if is_transient_error(baseline.stderr) else digest
+        return _degrade(args, "toolchain cannot load the pch", latch_digest=latch)
+
+    Path(f"{gch}.failed").unlink(missing_ok=True)
+    if not depfile.is_file():
+        _write_depfile(depfile, gch, header)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -995,7 +995,9 @@ def run_compile(args, config: ConfigType) -> bool:
         app_dir = _app_build_dir(build_dir)
 
     if prepare:
-        pch.guarded_prepare(app_dir, partial(_prepare_pch, app_dir))
+        pch.guarded_prepare(
+            partial(_prepare_pch, app_dir), partial(pch.discard_pch_cleanup, app_dir)
+        )
 
     if not run_command_ok(
         west_cmd,

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -529,10 +529,14 @@ def run_compile(config, verbose: bool) -> int:
         _patch_memory_segments()
 
     # After every reconfigure so compile_commands and sdkconfig are settled
-    from esphome.build_gen.espidf import prepare_pch
+    from esphome.build_gen.espidf import _write_degraded_sum, prepare_pch_sidecars
     from esphome.build_helpers.pch import guarded_prepare
 
-    guarded_prepare(CORE.relative_build_path("build"), prepare_pch)
+    guarded_prepare(
+        CORE.relative_build_path("build"),
+        prepare_pch_sidecars,
+        fallback=lambda: _write_degraded_sum("setup failed"),
+    )
 
     # Build
     args = []

--- a/esphome/espidf/toolchain.py
+++ b/esphome/espidf/toolchain.py
@@ -529,14 +529,9 @@ def run_compile(config, verbose: bool) -> int:
         _patch_memory_segments()
 
     # After every reconfigure so compile_commands and sdkconfig are settled
-    from esphome.build_gen.espidf import _write_degraded_sum, prepare_pch_sidecars
-    from esphome.build_helpers.pch import guarded_prepare
+    from esphome.build_gen.espidf import prepare_pch_sidecars_guarded
 
-    guarded_prepare(
-        CORE.relative_build_path("build"),
-        prepare_pch_sidecars,
-        fallback=lambda: _write_degraded_sum("setup failed"),
-    )
+    prepare_pch_sidecars_guarded()
 
     # Build
     args = []

--- a/tests/unit_tests/build_gen/test_arduino8266.py
+++ b/tests/unit_tests/build_gen/test_arduino8266.py
@@ -410,7 +410,7 @@ def test_write_project_pch_identity_unknown_skips_pch(
     paths = _make_framework(tmp_path)
     _set_flags("-DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH")
     with patch(
-        "esphome.build_gen.arduino8266.pch_checksum",
+        "esphome.build_helpers.pch.pch_checksum",
         side_effect=OSError("stat failed"),
     ):
         content = _write_ninja(paths, ccache="/usr/bin/ccache")

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -924,6 +924,14 @@ def test_component_cmakelists_pch_edge(monkeypatch: pytest.MonkeyPatch) -> None:
     assert 'DEPFILE "${CMAKE_BINARY_DIR}/esphome_pch.h.gch.d"' in content
     assert "esphome_pch.h.gch.sum" in content
     assert "cmake_policy(SET CMP0116 NEW)" in content
+    # The edge is owned by a bare target BEFORE idf_component_register so
+    # it never inherits inter-component deps as order-only inputs
+    assert "add_custom_target(esphome_pch" in content
+    assert content.index("add_custom_command(") < content.index(
+        "idf_component_register("
+    )
+    assert "if(NOT CMAKE_SCRIPT_MODE_FILE)" in content
+    assert "add_dependencies(${COMPONENT_LIB} esphome_pch)" in content
     monkeypatch.setenv("ESPHOME_PCH_ENABLE", "0")
     disabled = get_component_cmakelists()
     assert "pch_compile" not in disabled

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -542,41 +542,32 @@ def _make_pch_device(tmp_path: Path, name: str) -> Path:
     return dev
 
 
-def test_prepare_pch_writes_header_and_sum(tmp_path: Path) -> None:
-    from esphome.build_gen.espidf import prepare_pch
+def test_prepare_pch_sidecars_writes_sum(tmp_path: Path) -> None:
+    """The digest sidecar is written pre-ninja with no compiler spawn."""
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
     dev = _make_pch_device(tmp_path, "dev_a")
     CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
+    sum_path = dev / "build" / "esphome_pch.h.gch.sum"
 
-    def fake_compile(cmd, **kwargs):
-        if "-fsyntax-only" in cmd:
-            # The load probe follows a successful .gch build
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-        # The compile must target the header, not the stub TU
-        assert cmd[-5:-3] == ["c++-header", "-c"]
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
-    ):
-        prepare_pch()
-    checksum = (dev / "build" / "esphome_pch.h.gch.sum").read_text().strip()
-    assert len(checksum) == 64
-    # Unchanged inputs: the second call must not recompile
     with (
         patch.object(CORE, "name", "test"),
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
-        prepare_pch()
+        prepare_pch_sidecars()
+        checksum = sum_path.read_text().strip()
+        assert len(checksum) == 64
+        # Unchanged inputs: the second call must not rewrite (no mtime bump,
+        # so the ninja edge does not rerun)
+        before = sum_path.stat().st_mtime_ns
+        prepare_pch_sidecars()
+    assert sum_path.stat().st_mtime_ns == before
 
 
 def test_pch_no_device_path_poison(tmp_path: Path) -> None:
     """Regression: neither the injected -include nor the .sum may carry the
     per-device build path, or cross-device ccache sharing breaks."""
-    from esphome.build_gen.espidf import get_component_cmakelists, prepare_pch
+    from esphome.build_gen.espidf import get_component_cmakelists, prepare_pch_sidecars
 
     sums = []
     for name in ("dev_a", "dev_b"):
@@ -592,7 +583,7 @@ def test_pch_no_device_path_poison(tmp_path: Path) -> None:
             patch.object(CORE, "name", name),
             patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
         ):
-            prepare_pch()
+            prepare_pch_sidecars()
             content = get_component_cmakelists()
         assert str(dev) not in content
         sums.append((dev / "build" / "esphome_pch.h.gch.sum").read_text())
@@ -760,94 +751,22 @@ def test_pch_header_list_order_is_in_checksum(
         patch.object(CORE, "name", "test"),
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
     ):
-        espidf_mod.prepare_pch()
+        espidf_mod.prepare_pch_sidecars()
         first = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
         monkeypatch.setattr(
             espidf_mod,
             "PCH_DEFAULT_HEADERS",
             tuple(reversed(espidf_mod.PCH_DEFAULT_HEADERS)),
         )
-        espidf_mod.prepare_pch()
+        espidf_mod.prepare_pch_sidecars()
     assert (dev / "build" / "esphome_pch.h.gch.sum").read_text() != first
 
 
-def test_prepare_pch_failure_writes_marker_and_skips_retry(tmp_path: Path) -> None:
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_f")
-    CORE.build_path = dev
-    calls = []
-
-    def failing_compile(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 1, "", "boom")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=failing_compile),
-    ):
-        prepare_pch()
-        prepare_pch()
-    assert len(calls) == 1
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-    assert (dev / "build" / "esphome_pch.h.gch.failed").exists()
-
-
-def test_prepare_pch_spawn_oserror_is_transient(tmp_path: Path) -> None:
-    """Spawn/IO failures retry on the next build instead of latching."""
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_o")
-    CORE.build_path = dev
-    calls = []
-
-    def raising(cmd, **kwargs):
-        calls.append(cmd)
-        raise OSError("no such compiler")
-
-    header = dev / "build" / "esphome_pch.h"
-    before = header.stat().st_mtime_ns
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=raising),
-    ):
-        prepare_pch()
-        prepare_pch()
-    assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-    assert len(calls) == 2
-    # No .gch was ever in play, so the header must not be re-touched into
-    # forcing a full rebuild on every failing build
-    assert header.stat().st_mtime_ns == before
-
-
-def test_prepare_pch_transient_with_stale_gch_bumps_header(tmp_path: Path) -> None:
-    """A stale .gch removed on a transient failure must dirty its consumers."""
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_s")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-    gch.write_bytes(b"stale")
-    header = dev / "build" / "esphome_pch.h"
-    os.utime(header, (1, 1))
-    with (
-        patch.object(CORE, "name", "test"),
-        patch(
-            "esphome.build_helpers.pch.subprocess.run",
-            side_effect=OSError("no such compiler"),
-        ),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-    assert header.stat().st_mtime_ns > 1_000_000_000
-
-
-def test_prepare_pch_disabled_discards_and_skips_compile(
+def test_prepare_pch_sidecars_disabled_discards(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The escape hatch is self-cleaning: a leftover .gch is removed."""
-    from esphome.build_gen.espidf import prepare_pch
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
     monkeypatch.setenv("ESPHOME_PCH_ENABLE", "0")
     dev = _make_pch_device(tmp_path, "dev_d")
@@ -855,139 +774,32 @@ def test_prepare_pch_disabled_discards_and_skips_compile(
     stale = dev / "build" / "esphome_pch.h.gch"
     stale.write_bytes(b"stale")
     with patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError):
-        prepare_pch()
+        prepare_pch_sidecars()
     assert not stale.exists()
 
 
-def test_prepare_pch_missing_sdkconfig_fails_closed(tmp_path: Path) -> None:
-    """No sdkconfig means no config identity for the .sum: no pch at all."""
-    from esphome.build_gen.espidf import prepare_pch
+def test_prepare_pch_sidecars_missing_sdkconfig_degrades(tmp_path: Path) -> None:
+    """No sdkconfig means no config identity: the sum marks degraded so the
+    ninja edge emits a placeholder instead of a keyed .gch."""
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
     dev = _make_pch_device(tmp_path, "dev_m")
     (dev / "sdkconfig.test").unlink()
     CORE.build_path = dev
-    stale = dev / "build" / "esphome_pch.h.gch"
-    stale.write_bytes(b"stale")
     with (
         patch.object(CORE, "name", "test"),
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
-        prepare_pch()
-    assert not stale.exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-
-
-def test_prepare_pch_signal_kill_is_transient(tmp_path: Path) -> None:
-    """A signal-killed compile (OOM) must not latch the .failed marker."""
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_k")
-    CORE.build_path = dev
-    calls = []
-
-    def killed(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, -9, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=killed),
-    ):
-        prepare_pch()
-        prepare_pch()
-    assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
-    assert len(calls) == 2
-
-
-def test_prepare_pch_probe_spawn_failure_degrades(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A probe that cannot run discards the pch; strict raises."""
-    from esphome.build_gen.espidf import prepare_pch
-    from esphome.core import EsphomeError
-
-    dev = _make_pch_device(tmp_path, "dev_pf")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def probe_dies(cmd, **kwargs):
-        if "-fsyntax-only" in cmd:
-            raise OSError("probe spawn failed")
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=probe_dies),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-
-    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=probe_dies),
-        pytest.raises(EsphomeError, match="probe did not run"),
-    ):
-        prepare_pch()
-
-
-@pytest.mark.parametrize(
-    ("stderr", "code"),
-    [("", -9), ("fatal: No space left on device", 1)],
-    ids=("signal-kill", "enospc"),
-)
-def test_prepare_pch_probe_environmental_failures_do_not_latch(
-    tmp_path: Path, stderr: str, code: int
-) -> None:
-    """A signal-killed or ENOSPC probe retries next build, no marker."""
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_pe")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def env_probe(cmd, **kwargs):
-        if "-fsyntax-only" in cmd:
-            return subprocess.CompletedProcess(cmd, code, "", stderr)
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=env_probe),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
-
-
-def test_prepare_pch_signal_kill_strict_raises(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from esphome.build_gen.espidf import prepare_pch
-    from esphome.core import EsphomeError
-
-    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
-    dev = _make_pch_device(tmp_path, "dev_ks")
-    CORE.build_path = dev
-    with (
-        patch.object(CORE, "name", "test"),
-        patch(
-            "esphome.build_helpers.pch.subprocess.run",
-            side_effect=lambda cmd, **kw: subprocess.CompletedProcess(cmd, -9, "", ""),
-        ),
-        pytest.raises(EsphomeError, match="killed by signal"),
-    ):
-        prepare_pch()
+        prepare_pch_sidecars()
+    sum_text = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
+    assert sum_text.startswith("degraded:")
 
 
 def test_prepare_pch_strict_raises_when_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Strict must not read a disabled pch as success."""
-    from esphome.build_gen.espidf import prepare_pch
+    from esphome.build_gen.espidf import prepare_pch_sidecars
     from esphome.core import EsphomeError
 
     monkeypatch.setenv("ESPHOME_PCH_ENABLE", "0")
@@ -998,13 +810,13 @@ def test_prepare_pch_strict_raises_when_disabled(
         patch.object(CORE, "name", "test"),
         pytest.raises(EsphomeError, match="disabled"),
     ):
-        prepare_pch()
+        prepare_pch_sidecars()
 
 
 def test_prepare_pch_missing_sdkconfig_strict_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from esphome.build_gen.espidf import prepare_pch
+    from esphome.build_gen.espidf import prepare_pch_sidecars
     from esphome.core import EsphomeError
 
     monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
@@ -1015,12 +827,13 @@ def test_prepare_pch_missing_sdkconfig_strict_raises(
         patch.object(CORE, "name", "test"),
         pytest.raises(EsphomeError, match="sdkconfig unreadable"),
     ):
-        prepare_pch()
+        prepare_pch_sidecars()
 
 
-def test_prepare_pch_without_compile_commands(tmp_path: Path) -> None:
-    """Stale checksum but no configured TU yet: no compile, no sidecars."""
-    from esphome.build_gen.espidf import prepare_pch
+def test_prepare_pch_sidecars_without_compile_commands(tmp_path: Path) -> None:
+    """No configured TU yet: the sum marks degraded, never deleted (it is
+    an input of the ninja edge)."""
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
     dev = _make_pch_device(tmp_path, "dev_n")
     (dev / "build" / "compile_commands.json").unlink()
@@ -1029,8 +842,9 @@ def test_prepare_pch_without_compile_commands(tmp_path: Path) -> None:
         patch.object(CORE, "name", "test"),
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
-        prepare_pch()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
+        prepare_pch_sidecars()
+    sum_text = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
+    assert sum_text.startswith("degraded:")
     assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
 
 
@@ -1068,76 +882,57 @@ def test_write_project_writes_pch_header(tmp_path: Path) -> None:
     )
 
 
-def test_prepare_pch_stale_bailout_removes_gch(tmp_path: Path) -> None:
-    """A stale .gch must not survive when no compile command is available."""
-    from esphome.build_gen.espidf import prepare_pch
+def test_prepare_pch_sidecars_latched_keeps_degraded_sum(tmp_path: Path) -> None:
+    """A latched failure keeps the sum degraded (edge stays quiet); deleting
+    the latch rewrites the plain digest, whose mtime bump retries the edge."""
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
-    dev = _make_pch_device(tmp_path, "dev_s")
+    dev = _make_pch_device(tmp_path, "dev_l")
     CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-    gch.write_bytes(b"stale")
-    (dev / "build" / "esphome_pch.h.gch.sum").write_text("stale-sum\n")
-    (dev / "build" / "compile_commands.json").unlink()
-    with patch.object(CORE, "name", "test"):
-        prepare_pch()
-    assert not gch.exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-
-
-def test_prepare_pch_zero_exit_without_gch_is_failure(tmp_path: Path) -> None:
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_z")
-    CORE.build_path = dev
-
-    def no_output(cmd, **kwargs):
-        return subprocess.CompletedProcess(cmd, 0, "", "")
+    sum_path = dev / "build" / "esphome_pch.h.gch.sum"
+    failed = dev / "build" / "esphome_pch.h.gch.failed"
 
     with (
         patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=no_output),
+        patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
-        prepare_pch()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-    assert (dev / "build" / "esphome_pch.h.gch.failed").exists()
-
-
-def test_prepare_pch_bumps_header_for_object_depends(tmp_path: Path) -> None:
-    """The OBJECT_DEPENDS edge watches the header; a rebuilt .gch must bump
-    it so pch-consuming TUs recompile."""
-    import os as _os
-
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_t")
-    CORE.build_path = dev
-    header = dev / "build" / "esphome_pch.h"
-    gch = dev / "build" / "esphome_pch.h.gch"
-    _os.utime(header, (0, 0))
-    before = header.stat().st_mtime
-
-    def fake_compile(cmd, **kwargs):
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
-    ):
-        prepare_pch()
-    assert header.stat().st_mtime > before
+        prepare_pch_sidecars()
+        digest = sum_path.read_text().strip()
+        failed.write_text(digest + "\n")
+        sum_path.write_text("degraded:earlier failure latched\n")
+        prepare_pch_sidecars()
+        assert sum_path.read_text().startswith("degraded:")
+        failed.unlink()
+        prepare_pch_sidecars()
+    assert sum_path.read_text().strip() == digest
 
 
 def test_component_cmakelists_pch_object_depends() -> None:
+    """Consumers order after the ninja pch edge via the .gch."""
     from esphome.build_gen.espidf import get_component_cmakelists
 
     content = get_component_cmakelists()
-    assert 'OBJECT_DEPENDS "${CMAKE_BINARY_DIR}/esphome_pch.h"' in content
+    assert 'OBJECT_DEPENDS "${CMAKE_BINARY_DIR}/esphome_pch.h.gch"' in content
+
+
+def test_component_cmakelists_pch_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The .gch build edge is baked with the shim command and depfile."""
+    from esphome.build_gen.espidf import get_component_cmakelists
+
+    content = get_component_cmakelists()
+    assert "esphome.build_helpers.pch_compile" in content
+    assert 'DEPFILE "${CMAKE_BINARY_DIR}/esphome_pch.h.gch.d"' in content
+    assert "esphome_pch.h.gch.sum" in content
+    assert "cmake_policy(SET CMP0116 NEW)" in content
+    monkeypatch.setenv("ESPHOME_PCH_ENABLE", "0")
+    disabled = get_component_cmakelists()
+    assert "pch_compile" not in disabled
+    assert "OBJECT_DEPENDS" not in disabled
 
 
 def test_prepare_pch_command_change_invalidates_sum(tmp_path: Path) -> None:
     """A flag-only change in the compile DB must rebuild the .gch."""
-    from esphome.build_gen.espidf import prepare_pch
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
     dev = _make_pch_device(tmp_path, "dev_c")
     CORE.build_path = dev
@@ -1151,11 +946,11 @@ def test_prepare_pch_command_change_invalidates_sum(tmp_path: Path) -> None:
         patch.object(CORE, "name", "test"),
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
     ):
-        prepare_pch()
+        prepare_pch_sidecars()
         first = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
         db = dev / "build" / "compile_commands.json"
         db.write_text(db.read_text().replace("-DX=1", "-DX=2"))
-        prepare_pch()
+        prepare_pch_sidecars()
     assert (dev / "build" / "esphome_pch.h.gch.sum").read_text() != first
 
 
@@ -1185,14 +980,13 @@ def test_prepare_pch_keeps_user_force_includes(tmp_path: Path) -> None:
     assert "esphome_pch.h" not in " ".join(cmd[:-3])
 
 
-def test_prepare_pch_identity_unknown_discards(tmp_path: Path) -> None:
-    """An OSError from the checksum discards artifacts and skips the pch."""
-    from esphome.build_gen.espidf import prepare_pch
+def test_prepare_pch_identity_unknown_degrades(tmp_path: Path) -> None:
+    """An OSError from the checksum degrades the sum; a stale .gch is then
+    replaced with a placeholder by the ninja edge (sum mtime bumped)."""
+    from esphome.build_gen.espidf import prepare_pch_sidecars
 
     dev = _make_pch_device(tmp_path, "dev_i")
     CORE.build_path = dev
-    stale = dev / "build" / "esphome_pch.h.gch"
-    stale.write_bytes(b"stale")
     with (
         patch.object(CORE, "name", "test"),
         patch(
@@ -1201,42 +995,16 @@ def test_prepare_pch_identity_unknown_discards(tmp_path: Path) -> None:
         ),
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
-        prepare_pch()
-    assert not stale.exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.sum").exists()
-
-
-def test_prepare_pch_transient_compiler_failure_does_not_latch(
-    tmp_path: Path,
-) -> None:
-    """ENOSPC-style failures clear on their own; no .failed marker."""
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_e")
-    CORE.build_path = dev
-    calls = []
-
-    def enospc(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(
-            cmd, 1, "", "fatal error: No space left on device"
-        )
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=enospc),
-    ):
-        prepare_pch()
-        prepare_pch()
-    assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
-    assert len(calls) == 2
+        prepare_pch_sidecars()
+    sum_text = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
+    assert sum_text.startswith("degraded:")
 
 
 def test_prepare_pch_strict_raises_on_missing_db(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """ESPHOME_PCH_STRICT turns the silent skip into a failure."""
-    from esphome.build_gen.espidf import prepare_pch
+    from esphome.build_gen.espidf import prepare_pch_sidecars
     from esphome.core import EsphomeError
 
     monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
@@ -1248,164 +1016,4 @@ def test_prepare_pch_strict_raises_on_missing_db(
         patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
         pytest.raises(EsphomeError, match="no usable compile command"),
     ):
-        prepare_pch()
-
-
-def test_prepare_pch_probe_rejection_latches_and_degrades(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A toolchain that cannot load its own .gch discards it, latches the
-    marker, and fails strict mode."""
-    from esphome.build_gen.espidf import prepare_pch
-    from esphome.core import EsphomeError
-
-    dev = _make_pch_device(tmp_path, "dev_p")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def rejecting(cmd, **kwargs):
-        if "-fsyntax-only" in cmd:
-            if "-include" not in cmd:
-                # Baseline without the pch passes: the pch is to blame
-                return subprocess.CompletedProcess(cmd, 0, "", "")
-            return subprocess.CompletedProcess(
-                cmd, 1, "", "error: esphome_pch.h.gch: had text segment "
-            )
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=rejecting),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-    assert (dev / "build" / "esphome_pch.h.gch.failed").exists()
-
-    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
-    (dev / "build" / "esphome_pch.h.gch.failed").unlink()
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=rejecting),
-        pytest.raises(EsphomeError, match="cannot load the pch"),
-    ):
-        prepare_pch()
-
-
-def test_prepare_pch_strict_reprobes_cached_gch(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Rejection is per-process: strict must re-prove a cached .gch loads."""
-    from esphome.build_gen.espidf import prepare_pch
-    from esphome.core import EsphomeError
-
-    dev = _make_pch_device(tmp_path, "dev_rc")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def ok(cmd, **kwargs):
-        if "-fsyntax-only" not in cmd:
-            gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=ok),
-    ):
-        prepare_pch()
-    assert gch.exists()
-
-    def reject(cmd, **kwargs):
-        assert "-fsyntax-only" in cmd, "cached path must not recompile"
-        if "-include" not in cmd:
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-        return subprocess.CompletedProcess(
-            cmd, 1, "", "error: esphome_pch.h.gch: had text segment "
-        )
-
-    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=reject),
-        pytest.raises(EsphomeError, match="cannot load the pch"),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-    # Per-process rejection may not reproduce: the cached path must not
-    # latch the pch off for later non-strict builds
-    assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
-
-
-def test_prepare_pch_unexpected_command_shape_degrades(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A tail the probe slice cannot trust discards and degrades."""
-    from esphome.build_gen.espidf import prepare_pch
-    from esphome.core import EsphomeError
-
-    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
-    dev = _make_pch_device(tmp_path, "dev_sh")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def ok(cmd, **kwargs):
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=ok),
-        patch(
-            "esphome.build_helpers.pch.pch_compile_command",
-            return_value=(
-                ["g++", "-DX=1", "-c", "x", "-o", "y", "extra"],
-                dev / "build",
-            ),
-        ),
-        pytest.raises(EsphomeError, match="command shape"),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-
-    # Non-strict: same shape problem degrades without raising
-    monkeypatch.delenv("ESPHOME_PCH_STRICT")
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=ok),
-        patch(
-            "esphome.build_helpers.pch.pch_compile_command",
-            return_value=(
-                ["g++", "-DX=1", "-c", "x", "-o", "y", "extra"],
-                dev / "build",
-            ),
-        ),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-
-
-def test_prepare_pch_probe_baseline_spawn_failure_is_transient(
-    tmp_path: Path,
-) -> None:
-    """A baseline that cannot spawn is environmental: no marker."""
-    from esphome.build_gen.espidf import prepare_pch
-
-    dev = _make_pch_device(tmp_path, "dev_bs")
-    CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def flaky(cmd, **kwargs):
-        if "-fsyntax-only" in cmd:
-            if "-include" in cmd:
-                return subprocess.CompletedProcess(cmd, 1, "", "boom")
-            raise OSError("baseline spawn failed")
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=flaky),
-    ):
-        prepare_pch()
-    assert not gch.exists()
-    assert not (dev / "build" / "esphome_pch.h.gch.failed").exists()
+        prepare_pch_sidecars()

--- a/tests/unit_tests/build_gen/test_espidf.py
+++ b/tests/unit_tests/build_gen/test_espidf.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 from pathlib import Path
-import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -573,15 +572,12 @@ def test_pch_no_device_path_poison(tmp_path: Path) -> None:
     for name in ("dev_a", "dev_b"):
         dev = _make_pch_device(tmp_path, name)
         CORE.build_path = dev
-        gch = dev / "build" / "esphome_pch.h.gch"
-
-        def fake_compile(cmd, _gch=gch, **kwargs):
-            _gch.write_bytes(b"gch")
-            return subprocess.CompletedProcess(cmd, 0, "", "")
 
         with (
             patch.object(CORE, "name", name),
-            patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
+            patch(
+                "esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError
+            ),
         ):
             prepare_pch_sidecars()
             content = get_component_cmakelists()
@@ -613,7 +609,8 @@ def test_pch_compile_command_variants(tmp_path: Path) -> None:
     build.mkdir()
     header = build / "esphome_pch.h"
     gch = build / "esphome_pch.h.gch"
-    assert pch_compile_command(build, header, gch) is None
+    src = tmp_path / "src"
+    assert pch_compile_command(build, header, gch, src) is None
 
     (build / "compile_commands.json").write_text(
         json.dumps(
@@ -622,7 +619,7 @@ def test_pch_compile_command_variants(tmp_path: Path) -> None:
             ]
         )
     )
-    assert pch_compile_command(build, header, gch) is None
+    assert pch_compile_command(build, header, gch, src) is None
 
     src_file = str(tmp_path / "src" / "esphome" / "a.cpp")
     (build / "compile_commands.json").write_text(
@@ -641,7 +638,7 @@ def test_pch_compile_command_variants(tmp_path: Path) -> None:
         )
     )
     # Launcher stripped; -include/-o/-c and depfile flags removed
-    cmd, cmd_dir = pch_compile_command(build, header, gch)
+    cmd, cmd_dir = pch_compile_command(build, header, gch, src)
     assert cmd == [
         "g++",
         "-DX=1",
@@ -675,7 +672,7 @@ def test_pch_compile_command_matches_src_through_symlink(tmp_path: Path) -> None
         json.dumps([{"command": f"g++ -DX=1 -o a.obj -c {src_file}", "file": src_file}])
     )
 
-    cmd, cmd_dir = pch_compile_command(build, header, gch)
+    cmd, cmd_dir = pch_compile_command(build, header, gch, real / "src")
 
     assert cmd[:2] == ["g++", "-DX=1"]
     assert cmd_dir == build
@@ -691,13 +688,14 @@ def test_pch_compile_command_rejects_unusable_entries(tmp_path: Path) -> None:
     header = build / "esphome_pch.h"
     gch = build / "esphome_pch.h.gch"
     db = build / "compile_commands.json"
-    src_file = str(tmp_path / "src" / "esphome" / "a.cpp")
+    src = tmp_path / "src"
+    src_file = str(src / "esphome" / "a.cpp")
 
     db.write_text(json.dumps({"not": "a list"}))
-    assert pch_compile_command(build, header, gch) is None
+    assert pch_compile_command(build, header, gch, src) is None
 
     db.write_text(json.dumps(["just a string"]))
-    assert pch_compile_command(build, header, gch) is None
+    assert pch_compile_command(build, header, gch, src) is None
 
     # An empty-string directory must fall back to the build dir, not cwd
     db.write_text(
@@ -711,7 +709,7 @@ def test_pch_compile_command_rejects_unusable_entries(tmp_path: Path) -> None:
             ]
         )
     )
-    _, cmd_dir = pch_compile_command(build, header, gch)
+    _, cmd_dir = pch_compile_command(build, header, gch, src)
     assert cmd_dir == build
 
     # Corrupted entries with null fields must skip, not raise
@@ -723,13 +721,13 @@ def test_pch_compile_command_rejects_unusable_entries(tmp_path: Path) -> None:
             ]
         )
     )
-    assert pch_compile_command(build, header, gch) is None
+    assert pch_compile_command(build, header, gch, src) is None
 
     # arguments-style entry (allowed by the spec, unused by CMake)
     db.write_text(
         json.dumps([{"arguments": ["g++", "-c", src_file], "file": src_file}])
     )
-    assert pch_compile_command(build, header, gch) is None
+    assert pch_compile_command(build, header, gch, src) is None
 
 
 def test_pch_header_list_order_is_in_checksum(
@@ -741,15 +739,10 @@ def test_pch_header_list_order_is_in_checksum(
 
     dev = _make_pch_device(tmp_path, "dev_r")
     CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def fake_compile(cmd, **kwargs):
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
 
     with (
         patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
+        patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
         espidf_mod.prepare_pch_sidecars()
         first = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
@@ -886,6 +879,7 @@ def test_prepare_pch_sidecars_latched_keeps_degraded_sum(tmp_path: Path) -> None
     """A latched failure keeps the sum degraded (edge stays quiet); deleting
     the latch rewrites the plain digest, whose mtime bump retries the edge."""
     from esphome.build_gen.espidf import prepare_pch_sidecars
+    from esphome.build_helpers.pch import degraded_sum_text
 
     dev = _make_pch_device(tmp_path, "dev_l")
     CORE.build_path = dev
@@ -899,7 +893,7 @@ def test_prepare_pch_sidecars_latched_keeps_degraded_sum(tmp_path: Path) -> None
         prepare_pch_sidecars()
         digest = sum_path.read_text().strip()
         failed.write_text(digest + "\n")
-        sum_path.write_text("degraded:earlier failure latched\n")
+        sum_path.write_text(degraded_sum_text("earlier failure latched"))
         prepare_pch_sidecars()
         assert sum_path.read_text().startswith("degraded:")
         failed.unlink()
@@ -944,15 +938,10 @@ def test_prepare_pch_command_change_invalidates_sum(tmp_path: Path) -> None:
 
     dev = _make_pch_device(tmp_path, "dev_c")
     CORE.build_path = dev
-    gch = dev / "build" / "esphome_pch.h.gch"
-
-    def fake_compile(cmd, **kwargs):
-        gch.write_bytes(b"gch")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
 
     with (
         patch.object(CORE, "name", "test"),
-        patch("esphome.build_helpers.pch.subprocess.run", side_effect=fake_compile),
+        patch("esphome.build_helpers.pch.subprocess.run", side_effect=AssertionError),
     ):
         prepare_pch_sidecars()
         first = (dev / "build" / "esphome_pch.h.gch.sum").read_text()
@@ -983,7 +972,9 @@ def test_prepare_pch_keeps_user_force_includes(tmp_path: Path) -> None:
             ]
         )
     )
-    cmd, _ = pch_compile_command(build, build / "esphome_pch.h", build / "x.gch")
+    cmd, _ = pch_compile_command(
+        build, build / "esphome_pch.h", build / "x.gch", dev / "src"
+    )
     assert "user.h" in cmd
     assert "esphome_pch.h" not in " ".join(cmd[:-3])
 

--- a/tests/unit_tests/build_helpers/test_pch.py
+++ b/tests/unit_tests/build_helpers/test_pch.py
@@ -262,10 +262,10 @@ def test_pch_cmake_consumer_object_depends_override(
     assert 'file(TOUCH "${CMAKE_BINARY_DIR}/esphome_pch.h")' in block
 
 
-def test_guarded_prepare_fallback_runs_instead_of_discard(
+def test_guarded_prepare_runs_cleanup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A fallback leaves the sidecars consistent; strict still raises."""
+    """The cleanup leaves the sidecars consistent; strict still raises."""
     monkeypatch.delenv("ESPHOME_PCH_STRICT", raising=False)
     marker = tmp_path / "marker"
     gch = tmp_path / "esphome_pch.h.gch"
@@ -274,14 +274,17 @@ def test_guarded_prepare_fallback_runs_instead_of_discard(
     def boom() -> None:
         raise RuntimeError("boom")
 
-    pch.guarded_prepare(tmp_path, boom, fallback=lambda: marker.write_text("x"))
+    pch.guarded_prepare(boom, lambda: marker.write_text("x"))
     assert marker.is_file()
-    # The fallback path must not discard: the .gch is a graph input/output
+    # A degrade-style cleanup must not discard: the .gch is a graph output
     assert gch.is_file()
 
     monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
+    marker.unlink()
     with pytest.raises(RuntimeError):
-        pch.guarded_prepare(tmp_path, boom, fallback=lambda: marker.write_text("x"))
+        pch.guarded_prepare(boom, lambda: marker.write_text("x"))
+    # Strict aborts, but only after the cleanup restored consistency
+    assert marker.is_file()
 
 
 def test_pch_cmake_consumer_strict_escalates(
@@ -309,7 +312,7 @@ def test_guarded_prepare_logs_placeholder_failure(
         raise RuntimeError("boom")
 
     # Missing build dir: the touch raises and only warns
-    pch.guarded_prepare(tmp_path / "missing", boom)
+    pch.guarded_prepare(boom, lambda: pch.discard_pch_cleanup(tmp_path / "missing"))
     assert "Could not create the pch placeholder" in caplog.text
 
 

--- a/tests/unit_tests/build_helpers/test_pch.py
+++ b/tests/unit_tests/build_helpers/test_pch.py
@@ -248,6 +248,42 @@ def test_pch_cmake_consumer_substitutes_target_and_sources(
     assert 'file(TOUCH "${CMAKE_BINARY_DIR}/esphome_pch.h")' in block
 
 
+def test_pch_cmake_consumer_object_depends_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend building the .gch in its graph orders TUs after the edge."""
+    monkeypatch.delenv("ESPHOME_PCH_ENABLE", raising=False)
+    block = pch.pch_cmake_consumer(
+        "app", "${APP_SOURCES}", object_depends="esphome_pch.h.gch"
+    )
+    assert 'OBJECT_DEPENDS "${CMAKE_BINARY_DIR}/esphome_pch.h.gch"' in block
+    # The -include and its placeholder guard still target the header
+    assert '"$<$<COMPILE_LANGUAGE:CXX>:esphome_pch.h>"' in block
+    assert 'file(TOUCH "${CMAKE_BINARY_DIR}/esphome_pch.h")' in block
+
+
+def test_guarded_prepare_fallback_runs_instead_of_discard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fallback leaves the sidecars consistent; strict still raises."""
+    monkeypatch.delenv("ESPHOME_PCH_STRICT", raising=False)
+    marker = tmp_path / "marker"
+    gch = tmp_path / "esphome_pch.h.gch"
+    gch.write_bytes(b"stale")
+
+    def boom() -> None:
+        raise RuntimeError("boom")
+
+    pch.guarded_prepare(tmp_path, boom, fallback=lambda: marker.write_text("x"))
+    assert marker.is_file()
+    # The fallback path must not discard: the .gch is a graph input/output
+    assert gch.is_file()
+
+    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
+    with pytest.raises(RuntimeError):
+        pch.guarded_prepare(tmp_path, boom, fallback=lambda: marker.write_text("x"))
+
+
 def test_pch_cmake_consumer_strict_escalates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/build_helpers/test_pch_compile.py
+++ b/tests/unit_tests/build_helpers/test_pch_compile.py
@@ -15,6 +15,13 @@ from esphome.build_helpers import pch_compile
 DIGEST = "a" * 64
 
 
+def _fail_run(returncode: int = 1, stderr: str = "boom"):
+    def run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, returncode, "", stderr)
+
+    return run
+
+
 def _make_build(tmp_path: Path) -> SimpleNamespace:
     """A build dir with the header, a stub compile DB, and a digest sum."""
     build = tmp_path / "build"
@@ -98,10 +105,7 @@ def test_success_compiles_probes_and_clears_latch(tmp_path: Path) -> None:
 def test_deterministic_failure_latches_and_degrades(tmp_path: Path) -> None:
     env = _make_build(tmp_path)
 
-    def failing(cmd, **kwargs):
-        return subprocess.CompletedProcess(cmd, 1, "", "boom")
-
-    with patch.object(pch_compile.subprocess, "run", side_effect=failing):
+    with patch.object(pch_compile.subprocess, "run", side_effect=_fail_run()):
         assert _run_main(env) == 0
     assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
     assert env.sum.read_text().startswith("degraded:")
@@ -119,10 +123,9 @@ def test_transient_failures_do_not_latch(
 ) -> None:
     env = _make_build(tmp_path)
 
-    def failing(cmd, **kwargs):
-        return subprocess.CompletedProcess(cmd, code, "", stderr)
-
-    with patch.object(pch_compile.subprocess, "run", side_effect=failing):
+    with patch.object(
+        pch_compile.subprocess, "run", side_effect=_fail_run(code, stderr)
+    ):
         assert _run_main(env) == 0
     assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
     assert not env.failed.exists()
@@ -144,10 +147,7 @@ def test_strict_failure_exits_nonzero(
     monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
     env = _make_build(tmp_path)
 
-    def failing(cmd, **kwargs):
-        return subprocess.CompletedProcess(cmd, 1, "", "boom")
-
-    with patch.object(pch_compile.subprocess, "run", side_effect=failing):
+    with patch.object(pch_compile.subprocess, "run", side_effect=_fail_run()):
         assert _run_main(env) != 0
 
 

--- a/tests/unit_tests/build_helpers/test_pch_compile.py
+++ b/tests/unit_tests/build_helpers/test_pch_compile.py
@@ -1,0 +1,210 @@
+"""Tests for the pch ninja edge shim (esphome.build_helpers.pch_compile)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from esphome.build_helpers import pch_compile
+
+DIGEST = "a" * 64
+
+
+def _make_build(tmp_path: Path) -> SimpleNamespace:
+    """A build dir with the header, a stub compile DB, and a digest sum."""
+    build = tmp_path / "build"
+    build.mkdir()
+    src = tmp_path / "src" / "esphome"
+    src.mkdir(parents=True)
+    src_file = str(src / "a.cpp")
+    (build / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(build),
+                    "command": (
+                        f'g++ -DX=1 -include esphome_pch.h -o a.cpp.obj -c "{src_file}"'
+                    ),
+                    "file": src_file,
+                }
+            ]
+        )
+    )
+    header = build / "esphome_pch.h"
+    header.write_text('#include "esphome/core/defines.h"\n', encoding="utf-8")
+    gch = build / "esphome_pch.h.gch"
+    (build / "esphome_pch.h.gch.sum").write_text(DIGEST + "\n", encoding="utf-8")
+    return SimpleNamespace(
+        build=build,
+        header=header,
+        gch=gch,
+        sum=build / "esphome_pch.h.gch.sum",
+        failed=build / "esphome_pch.h.gch.failed",
+        depfile=build / "esphome_pch.h.gch.d",
+        src_dir=tmp_path / "src",
+    )
+
+
+def _run_main(env: SimpleNamespace) -> int:
+    argv = [
+        "pch_compile",
+        "--build-dir",
+        str(env.build),
+        "--src-dir",
+        str(env.src_dir),
+        "--header",
+        str(env.header),
+        "--gch",
+        str(env.gch),
+    ]
+    with patch("sys.argv", argv):
+        return pch_compile.main()
+
+
+@pytest.fixture(autouse=True)
+def _no_strict(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ESPHOME_PCH_STRICT", raising=False)
+
+
+def test_success_compiles_probes_and_clears_latch(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+    env.failed.write_text("old\n", encoding="utf-8")
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append(cmd)
+        if "-fsyntax-only" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        env.gch.write_bytes(b"gch")
+        mf = cmd[cmd.index("-MF") + 1]
+        Path(mf).write_text(f"{env.gch.name}: {env.header}\n", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    with patch.object(pch_compile.subprocess, "run", side_effect=fake_run):
+        assert _run_main(env) == 0
+    compile_cmd = seen[0]
+    assert compile_cmd[compile_cmd.index("-MT") + 1] == "esphome_pch.h.gch"
+    assert env.gch.read_bytes() == b"gch"
+    assert env.depfile.is_file()
+    assert not env.failed.exists()
+    assert env.sum.read_text().strip() == DIGEST
+
+
+def test_deterministic_failure_latches_and_degrades(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+
+    def failing(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+    with patch.object(pch_compile.subprocess, "run", side_effect=failing):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+    assert env.sum.read_text().startswith("degraded:")
+    assert env.failed.read_text().strip() == DIGEST
+    assert env.depfile.is_file()
+
+
+@pytest.mark.parametrize(
+    ("stderr", "code"),
+    [("fatal: No space left on device", 1), ("", -9)],
+    ids=("enospc", "signal-kill"),
+)
+def test_transient_failures_do_not_latch(
+    tmp_path: Path, stderr: str, code: int
+) -> None:
+    env = _make_build(tmp_path)
+
+    def failing(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, code, "", stderr)
+
+    with patch.object(pch_compile.subprocess, "run", side_effect=failing):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+    assert not env.failed.exists()
+
+
+def test_spawn_oserror_is_transient(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+    with patch.object(
+        pch_compile.subprocess, "run", side_effect=OSError("no such compiler")
+    ):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+    assert not env.failed.exists()
+
+
+def test_strict_failure_exits_nonzero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ESPHOME_PCH_STRICT", "1")
+    env = _make_build(tmp_path)
+
+    def failing(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+    with patch.object(pch_compile.subprocess, "run", side_effect=failing):
+        assert _run_main(env) != 0
+
+
+def test_degraded_sum_skips_compile(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+    env.sum.write_text("degraded:earlier failure latched\n", encoding="utf-8")
+    with patch.object(pch_compile.subprocess, "run", side_effect=AssertionError):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+    assert env.depfile.is_file()
+
+
+def test_empty_sum_skips_compile(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+    env.sum.write_text("", encoding="utf-8")
+    with patch.object(pch_compile.subprocess, "run", side_effect=AssertionError):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+
+
+def test_missing_compile_db_degrades(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+    (env.build / "compile_commands.json").unlink()
+    with patch.object(pch_compile.subprocess, "run", side_effect=AssertionError):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+    assert env.sum.read_text().startswith("degraded:")
+
+
+def test_probe_rejection_latches(tmp_path: Path) -> None:
+    """The gch builds but will not load: latch, blame the pch when the
+    baseline compile passes."""
+    env = _make_build(tmp_path)
+
+    def run(cmd, **kwargs):
+        if "-include" in cmd and "-fsyntax-only" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "invalid pch")
+        if "-fsyntax-only" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        env.gch.write_bytes(b"gch")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    with patch.object(pch_compile.subprocess, "run", side_effect=run):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER
+    assert env.failed.read_text().strip() == DIGEST
+
+
+def test_unexpected_command_shape_degrades(tmp_path: Path) -> None:
+    env = _make_build(tmp_path)
+    with (
+        patch.object(
+            pch_compile,
+            "pch_compile_command",
+            return_value=(["g++", "-weird"], env.build),
+        ),
+        patch.object(pch_compile.subprocess, "run", side_effect=AssertionError),
+    ):
+        assert _run_main(env) == 0
+    assert env.gch.read_bytes() == pch_compile.PLACEHOLDER

--- a/tests/unit_tests/build_helpers/test_pch_compile.py
+++ b/tests/unit_tests/build_helpers/test_pch_compile.py
@@ -82,13 +82,13 @@ def test_success_compiles_probes_and_clears_latch(tmp_path: Path) -> None:
             return subprocess.CompletedProcess(cmd, 0, "", "")
         env.gch.write_bytes(b"gch")
         mf = cmd[cmd.index("-MF") + 1]
-        Path(mf).write_text(f"{env.gch.name}: {env.header}\n", encoding="utf-8")
+        Path(mf).write_text(f"{env.gch}: {env.header}\n", encoding="utf-8")
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     with patch.object(pch_compile.subprocess, "run", side_effect=fake_run):
         assert _run_main(env) == 0
     compile_cmd = seen[0]
-    assert compile_cmd[compile_cmd.index("-MT") + 1] == "esphome_pch.h.gch"
+    assert compile_cmd[compile_cmd.index("-MT") + 1] == str(env.gch)
     assert env.gch.read_bytes() == b"gch"
     assert env.depfile.is_file()
     assert not env.failed.exists()

--- a/tests/unit_tests/test_espidf_toolchain.py
+++ b/tests/unit_tests/test_espidf_toolchain.py
@@ -669,27 +669,29 @@ def test_get_core_framework_version_from_core_data():
     assert toolchain._get_core_framework_version() == "5.5.4"
 
 
-def test_run_compile_aborts_when_stale_pch_survives_discard(
+def test_run_compile_pch_setup_failure_writes_degraded_sum(
     setup_core: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An undiscardable stale .gch means silently wrong output: abort."""
-    from esphome.core import EsphomeError
-
+    """A failed sidecar setup leaves a degraded sum for the ninja edge to
+    consume instead of a deleted edge input."""
     monkeypatch.setenv("ESPHOME_PCH_ENABLE", "1")
     _setup_build(setup_core)
+    build = setup_core / "build" / "test" / "build"
+    build.mkdir(parents=True, exist_ok=True)
 
     with (
         patch.object(toolchain, "need_reconfigure", return_value=False),
         patch.object(toolchain, "run_idf_py", return_value=0),
         patch.object(toolchain, "print_summary"),
-        patch("esphome.build_gen.espidf.prepare_pch", side_effect=RuntimeError("boom")),
         patch(
-            "esphome.build_helpers.pch.discard_pch",
-            side_effect=EsphomeError("Could not discard the stale precompiled header"),
-        ),
-        pytest.raises(EsphomeError, match="Could not discard"),
+            "esphome.build_gen.espidf.prepare_pch_sidecars",
+            side_effect=RuntimeError("boom"),
+        ) as prepare,
     ):
-        toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
+        assert toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False) == 0
+    prepare.assert_called_once()
+    sum_text = (build / "esphome_pch.h.gch.sum").read_text()
+    assert sum_text.startswith("degraded:")
 
 
 def test_run_compile_strict_reraises_pch_failure(
@@ -707,7 +709,7 @@ def test_run_compile_strict_reraises_pch_failure(
         patch.object(toolchain, "run_idf_py", return_value=0),
         patch.object(toolchain, "print_summary"),
         patch(
-            "esphome.build_gen.espidf.prepare_pch",
+            "esphome.build_gen.espidf.prepare_pch_sidecars",
             side_effect=EsphomeError("ESPHOME_PCH_STRICT: no usable compile command"),
         ),
         pytest.raises(EsphomeError, match="no usable compile command"),
@@ -715,27 +717,21 @@ def test_run_compile_strict_reraises_pch_failure(
         toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False)
 
 
-def test_run_compile_invokes_prepare_pch_and_survives_failure(
+def test_run_compile_invokes_pch_sidecars_and_survives_failure(
     setup_core: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The pch hook runs before the build and a failure never aborts it."""
+    """The sidecar hook runs before the build and a failure never aborts it."""
     monkeypatch.setenv("ESPHOME_PCH_ENABLE", "1")
     _setup_build(setup_core)
-    # A stale .gch must be discarded on the failure path, never consumed
-    build = setup_core / "build" / "test" / "build"
-    build.mkdir(parents=True, exist_ok=True)
-    (build / "esphome_pch.h").write_text("")
-    stale_gch = build / "esphome_pch.h.gch"
-    stale_gch.write_bytes(b"stale")
 
     with (
         patch.object(toolchain, "need_reconfigure", return_value=False),
         patch.object(toolchain, "run_idf_py", return_value=0),
         patch.object(toolchain, "print_summary"),
         patch(
-            "esphome.build_gen.espidf.prepare_pch", side_effect=RuntimeError("boom")
+            "esphome.build_gen.espidf.prepare_pch_sidecars",
+            side_effect=RuntimeError("boom"),
         ) as prepare,
     ):
         assert toolchain.run_compile({CONF_ESPHOME: {}}, verbose=False) == 0
     prepare.assert_called_once()
-    assert not stale_gch.exists()


### PR DESCRIPTION
# What does this implement/fix?

Stacked on #18841.

The espidf backend currently compiles the precompiled header serially between configure and ninja, about 2 seconds where nothing else runs. This moves the .gch compile into the ninja graph so it overlaps the ESP-IDF C compiles that never consume it.

How it works: the pre ninja step (`prepare_pch_sidecars`) now only computes the identity digest and writes the `.sum` sidecar, which ccache keys every consuming TU on. The compile itself is a custom command in the src component CMakeLists that runs `python -m esphome.build_helpers.pch_compile`; the shim derives TU identical flags from `compile_commands.json` at edge execution time, compiles with a depfile, and load probes the result. On any failure it degrades exactly like the old flow: placeholder .gch (consumers warn via `-Winvalid-pch` and parse the header textually), `degraded:` marker in the `.sum` so ccache never keys on a broken pch, and the `.failed` latch for deterministic errors. `ESPHOME_PCH_STRICT` turns every degrade into a build failure.

Two graph details matter: the edge is owned by a bare `add_custom_target` declared before `idf_component_register`, otherwise the command inherits the component lib's inter component dependencies as order only inputs and serializes after every archive; and the depfile `-MT` must be the absolute output path or the CMP0116 transform resolves it against the component binary dir and the edge stays forever dirty.

The win is version update builds, where a core header change misses ccache for the pch and all src TUs while the IDF C objects still hit. Measured on `apollo-r-pro-1-eth-5938e0.yaml` (ESP32-S3, 146 src TUs), M5 Max with fast NVMe; a slower machine like an HA Green spends longer in the compile so the overlap saves more there:

| scenario (dedicated ccache dir per scenario) | before (s) | after (s) |
|---|---|---|
| version update: seeded cache, core header changed (2 runs) | 21.4 / 22.1 | 19.5 / 20.5 |
| cold build, empty cache (median of 3) | 26.6 | 26.9 |
| core header edit, warm cache | 15.2 | 15.0 |
| no-op rebuild | ~2 | ~2 |

The empty cache cold build is a wash: there the pch sits on the critical path into the src TU pool and core contention gives back what the overlap gains. The version update case is the one that matters for fleets, roughly 2 seconds per device per update.

Also verified end to end: injected compiler failure degrades with a warning and latches, deleting the `.failed` retries, strict mode fails the build on the same injection and passes healthy, `ESPHOME_PCH_ENABLE=0` builds plain and self cleans, two clean build dirs share ccache entries (relative `-include`, basedir stripping, `CCACHE_PCH_EXTSUM` on the `.sum`), and a C3 config spot check.

The identity digest, the `degraded:` wire format, and the tool spawn settings are shared helpers in `build_helpers/pch.py` now, used by the espidf, esp8266, and nrf52 paths, so the ccache key recipe cannot drift between backends. The digests are byte identical to what the previous code produced, so no fleet wide cache miss on upgrade.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: test

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
