### PR TITLE
[ci] Cache clang-tidy idedata and key ESP-IDF cache on Python version

### DIFF
--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -3,8 +3,8 @@ description: >
   Cache the clang-tidy idedata and the headers it references under .temp
   (headers only, about 30MB per env). Run after restore-python and cache-esp-idf.
 inputs:
-  key:
-    description: 'Short environment id used in the cache key (e.g. esp32-idf).'
+  environment:
+    description: 'clang-tidy environment (e.g. esp32-idf-tidy).'
     required: true
 runs:
   using: composite
@@ -14,8 +14,8 @@ runs:
       shell: bash
       run: |
         . venv/bin/activate
-        [ -n "${{ inputs.key }}" ] || { echo "::error::cache-clang-tidy-idedata: 'key' input is empty"; exit 1; }
-        hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import calculate_idedata_cache_hash; print(calculate_idedata_cache_hash())')
+        [ -n "${{ inputs.environment }}" ] || { echo "::error::cache-clang-tidy-idedata: 'environment' input is empty"; exit 1; }
+        hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import idedata_cache_hash; print(idedata_cache_hash("${{ inputs.environment }}"))')
         pyver=$(python -c 'import platform; print(platform.python_version())')
         # Generating idedata is what installs ESP-IDF; never skip it over a missing install.
         if [ -d ~/.esphome-idf/frameworks ]; then
@@ -24,7 +24,7 @@ runs:
           echo "::warning::ESP-IDF install missing, not using the clang-tidy idedata cache"
           echo "skip=true" >> "$GITHUB_OUTPUT"
         fi
-        echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.key }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"
+        echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.environment }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"
     # Mirror cache-esp-idf: write on dev, restore-only on PRs. The post-step
     # save only runs when the job succeeded, so a failed generation is never saved.
     # Extend the extension list if a component ships extensionless headers.

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -1,0 +1,45 @@
+name: Cache clang-tidy idedata
+description: >
+  Cache the clang-tidy idedata work tree (.temp) so a job whose inputs did not
+  change skips regenerating it. For the native ESP-IDF tidy environments that
+  generation is a PlatformIO library download, an ESP-IDF python environment
+  check and two idf.py reconfigure runs, about 90-110 seconds per job.
+  script/helpers.py:load_idedata validates the restored idedata-<env>.hash
+  against calculate_clang_tidy_hash(), so a stale restore is rebuilt, never
+  used. The whole .temp tree is cached because the idedata holds absolute
+  include paths into the generated project (managed_components, build/config,
+  converted pio_components) that must come back with it.
+  Callers must have the Python venv already restored.
+inputs:
+  key:
+    description: 'Short environment id used in the cache key (e.g. esp32-idf).'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Compute clang-tidy input hash
+      # Same hash load_idedata stores next to the idedata, so the cache key and
+      # the in-script validity check can never disagree on what counts as an
+      # input change.
+      id: hash
+      shell: bash
+      run: |
+        . venv/bin/activate
+        hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import calculate_clang_tidy_hash; print(calculate_clang_tidy_hash())')
+        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+    # Mirror cache-esp-idf: only dev-branch runs write the shared cache so it
+    # lives in the default-branch scope readable by all PRs; PRs are
+    # restore-only. The hashFiles part covers the Python that generates the
+    # tidy project, which the clang-tidy hash does not.
+    - name: Cache clang-tidy idedata (write on dev)
+      if: github.ref == 'refs/heads/dev'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .temp
+        key: ${{ runner.os }}-tidy-idedata-${{ inputs.key }}-${{ steps.hash.outputs.hash }}-${{ hashFiles('esphome/espidf/**', 'esphome/build_gen/**', 'esphome/build_helpers/**') }}
+    - name: Cache clang-tidy idedata (restore-only off dev)
+      if: github.ref != 'refs/heads/dev'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .temp
+        key: ${{ runner.os }}-tidy-idedata-${{ inputs.key }}-${{ steps.hash.outputs.hash }}-${{ hashFiles('esphome/espidf/**', 'esphome/build_gen/**', 'esphome/build_helpers/**') }}

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -1,14 +1,8 @@
 name: Cache clang-tidy idedata
 description: >
-  Cache the clang-tidy idedata work tree (.temp) so a job whose inputs did not
-  change skips regenerating it. For the native ESP-IDF tidy environments that
-  generation is a PlatformIO library download, an ESP-IDF python environment
-  check and two idf.py reconfigure runs, about 90-110 seconds per job.
-  script/helpers.py:load_idedata validates the restored idedata-<env>.hash
-  against calculate_clang_tidy_hash(), so a stale restore is rebuilt, never
-  used. The whole .temp tree is cached because the idedata holds absolute
-  include paths into the generated project (managed_components, build/config,
-  converted pio_components) that must come back with it.
+  Cache the clang-tidy idedata work tree (.temp). Generating it for the native
+  ESP-IDF tidy environments takes 90-110s per job. load_idedata validates the
+  restored idedata-<env>.hash, so a stale restore is rebuilt, not used.
   Callers must have the Python venv already restored.
 inputs:
   key:
@@ -18,19 +12,13 @@ runs:
   using: composite
   steps:
     - name: Compute clang-tidy input hash
-      # Same hash load_idedata stores next to the idedata, so the cache key and
-      # the in-script validity check can never disagree on what counts as an
-      # input change.
       id: hash
       shell: bash
       run: |
         . venv/bin/activate
         hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import calculate_clang_tidy_hash; print(calculate_clang_tidy_hash())')
         echo "hash=$hash" >> "$GITHUB_OUTPUT"
-    # Mirror cache-esp-idf: only dev-branch runs write the shared cache so it
-    # lives in the default-branch scope readable by all PRs; PRs are
-    # restore-only. The hashFiles part covers the Python that generates the
-    # tidy project, which the clang-tidy hash does not.
+    # Mirror cache-esp-idf: write on dev, restore-only on PRs.
     - name: Cache clang-tidy idedata (write on dev)
       if: github.ref == 'refs/heads/dev'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -1,8 +1,9 @@
 name: Cache clang-tidy idedata
 description: >
-  Cache the clang-tidy idedata work tree (.temp). Generating it for the native
-  ESP-IDF tidy environments takes 90-110s per job. load_idedata validates the
-  restored idedata-<env>.hash, so a stale restore is rebuilt, not used.
+  Cache the clang-tidy idedata and the headers it references under .temp.
+  Generating it for the native ESP-IDF tidy environments takes 90-110s per
+  job. Only headers are kept (about 30MB per env instead of 130MB); a key hit
+  implies the clang-tidy hash matches, so the pruned tree is never rebuilt.
   Callers must have the Python venv already restored.
 inputs:
   key:
@@ -23,11 +24,31 @@ runs:
       if: github.ref == 'refs/heads/dev'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: .temp
+        path: |
+          .temp/idedata-*.json
+          .temp/idedata-*.hash
+          .temp/**/*.h
+          .temp/**/*.hpp
+          .temp/**/*.hh
+          .temp/**/*.hxx
+          .temp/**/*.inc
+          .temp/**/*.inl
+          .temp/**/*.ipp
+          .temp/**/*.tpp
         key: ${{ runner.os }}-tidy-idedata-${{ inputs.key }}-${{ steps.hash.outputs.hash }}-${{ hashFiles('esphome/espidf/**', 'esphome/build_gen/**', 'esphome/build_helpers/**') }}
     - name: Cache clang-tidy idedata (restore-only off dev)
       if: github.ref != 'refs/heads/dev'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: .temp
+        path: |
+          .temp/idedata-*.json
+          .temp/idedata-*.hash
+          .temp/**/*.h
+          .temp/**/*.hpp
+          .temp/**/*.hh
+          .temp/**/*.hxx
+          .temp/**/*.inc
+          .temp/**/*.inl
+          .temp/**/*.ipp
+          .temp/**/*.tpp
         key: ${{ runner.os }}-tidy-idedata-${{ inputs.key }}-${{ steps.hash.outputs.hash }}-${{ hashFiles('esphome/espidf/**', 'esphome/build_gen/**', 'esphome/build_helpers/**') }}

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -25,7 +25,9 @@ runs:
           echo "skip=true" >> "$GITHUB_OUTPUT"
         fi
         echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.key }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"
-    # Mirror cache-esp-idf: write on dev, restore-only on PRs.
+    # Mirror cache-esp-idf: write on dev, restore-only on PRs. The post-step
+    # save only runs when the job succeeded, so a failed generation is never saved.
+    # Extend the extension list if a component ships extensionless headers.
     - name: Cache clang-tidy idedata (write on dev)
       if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && steps.key.outputs.skip != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -25,6 +25,12 @@ runs:
           echo "skip=true" >> "$GITHUB_OUTPUT"
         fi
         echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.environment }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"
+        {
+          echo "path<<EOF"
+          printf '%s\n' '.temp/idedata-*.json' '.temp/idedata-*.hash'
+          printf '.temp/**/*.%s\n' h hpp hh hxx inc inl ipp tpp
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
     # Mirror cache-esp-idf: write on dev, restore-only on PRs. The post-step
     # save only runs when the job succeeded, so a failed generation is never saved.
     # Extend the extension list if a component ships extensionless headers.
@@ -32,31 +38,11 @@ runs:
       if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && steps.key.outputs.skip != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: |
-          .temp/idedata-*.json
-          .temp/idedata-*.hash
-          .temp/**/*.h
-          .temp/**/*.hpp
-          .temp/**/*.hh
-          .temp/**/*.hxx
-          .temp/**/*.inc
-          .temp/**/*.inl
-          .temp/**/*.ipp
-          .temp/**/*.tpp
+        path: ${{ steps.key.outputs.path }}
         key: ${{ steps.key.outputs.key }}
     - name: Cache clang-tidy idedata (restore-only off dev)
       if: github.ref != 'refs/heads/dev' && !contains(github.event.pull_request.labels.*.name, 'ci-cache-write') && steps.key.outputs.skip != 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: |
-          .temp/idedata-*.json
-          .temp/idedata-*.hash
-          .temp/**/*.h
-          .temp/**/*.hpp
-          .temp/**/*.hh
-          .temp/**/*.hxx
-          .temp/**/*.inc
-          .temp/**/*.inl
-          .temp/**/*.ipp
-          .temp/**/*.tpp
+        path: ${{ steps.key.outputs.path }}
         key: ${{ steps.key.outputs.key }}

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -3,8 +3,8 @@ description: >
   Cache the clang-tidy idedata and the headers it references under .temp.
   Generating it for the native ESP-IDF tidy environments takes 90-110s per
   job. Only headers are kept (about 30MB per env instead of 130MB); a key hit
-  implies the clang-tidy hash matches, so the pruned tree is never rebuilt.
-  Callers must have the Python venv already restored.
+  implies the idedata hash matches, so the pruned tree is never rebuilt.
+  Callers must have the Python venv restored and cache-esp-idf run first.
 inputs:
   key:
     description: 'Short environment id used in the cache key (e.g. esp32-idf).'
@@ -12,16 +12,27 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Compute clang-tidy input hash
-      id: hash
+    - name: Compute cache key
+      id: key
       shell: bash
       run: |
         . venv/bin/activate
-        hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import calculate_clang_tidy_hash; print(calculate_clang_tidy_hash())')
-        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+        [ -n "${{ inputs.key }}" ] || { echo "::error::cache-clang-tidy-idedata: 'key' input is empty"; exit 1; }
+        hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import calculate_idedata_cache_hash; print(calculate_idedata_cache_hash())')
+        pyver=$(python -c 'import platform; print(platform.python_version())')
+        # The ESP-IDF install only happens as part of generating idedata, so
+        # never restore idedata over a missing install (cache-esp-idf miss or
+        # eviction); the key also carries the Python version to bust with it.
+        if [ -d ~/.esphome-idf/frameworks ]; then
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::ESP-IDF install missing, not using the clang-tidy idedata cache"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        fi
+        echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.key }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"
     # Mirror cache-esp-idf: write on dev, restore-only on PRs.
     - name: Cache clang-tidy idedata (write on dev)
-      if: github.ref == 'refs/heads/dev'
+      if: github.ref == 'refs/heads/dev' && steps.key.outputs.skip != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
@@ -35,9 +46,9 @@ runs:
           .temp/**/*.inl
           .temp/**/*.ipp
           .temp/**/*.tpp
-        key: ${{ runner.os }}-tidy-idedata-${{ inputs.key }}-${{ steps.hash.outputs.hash }}-${{ hashFiles('esphome/espidf/**', 'esphome/build_gen/**', 'esphome/build_helpers/**') }}
+        key: ${{ steps.key.outputs.key }}
     - name: Cache clang-tidy idedata (restore-only off dev)
-      if: github.ref != 'refs/heads/dev'
+      if: github.ref != 'refs/heads/dev' && steps.key.outputs.skip != 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
@@ -51,4 +62,4 @@ runs:
           .temp/**/*.inl
           .temp/**/*.ipp
           .temp/**/*.tpp
-        key: ${{ runner.os }}-tidy-idedata-${{ inputs.key }}-${{ steps.hash.outputs.hash }}-${{ hashFiles('esphome/espidf/**', 'esphome/build_gen/**', 'esphome/build_helpers/**') }}
+        key: ${{ steps.key.outputs.key }}

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -1,10 +1,7 @@
 name: Cache clang-tidy idedata
 description: >
-  Cache the clang-tidy idedata and the headers it references under .temp.
-  Generating it for the native ESP-IDF tidy environments takes 90-110s per
-  job. Only headers are kept (about 30MB per env instead of 130MB); a key hit
-  implies the idedata hash matches, so the pruned tree is never rebuilt.
-  Callers must have the Python venv restored and cache-esp-idf run first.
+  Cache the clang-tidy idedata and the headers it references under .temp
+  (headers only, about 30MB per env). Run after restore-python and cache-esp-idf.
 inputs:
   key:
     description: 'Short environment id used in the cache key (e.g. esp32-idf).'
@@ -20,9 +17,7 @@ runs:
         [ -n "${{ inputs.key }}" ] || { echo "::error::cache-clang-tidy-idedata: 'key' input is empty"; exit 1; }
         hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import calculate_idedata_cache_hash; print(calculate_idedata_cache_hash())')
         pyver=$(python -c 'import platform; print(platform.python_version())')
-        # The ESP-IDF install only happens as part of generating idedata, so
-        # never restore idedata over a missing install (cache-esp-idf miss or
-        # eviction); the key also carries the Python version to bust with it.
+        # Generating idedata is what installs ESP-IDF; never skip it over a missing install.
         if [ -d ~/.esphome-idf/frameworks ]; then
           echo "skip=false" >> "$GITHUB_OUTPUT"
         else

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -17,11 +17,13 @@ runs:
         [ -n "${{ inputs.environment }}" ] || { echo "::error::cache-clang-tidy-idedata: 'environment' input is empty"; exit 1; }
         hash=$(python -c 'import sys; sys.path.insert(0, "script"); from clang_tidy_hash import idedata_cache_hash; print(idedata_cache_hash("${{ inputs.environment }}"))')
         pyver=$(python -c 'import platform; print(platform.python_version())')
-        # Generating idedata is what installs ESP-IDF; never skip it over a missing install.
+        # Generating idedata is what installs ESP-IDF; never skip it over a missing
+        # install. This also skips the save, so a dev run that installs ESP-IDF
+        # warms the idedata cache on the next run.
         if [ -d ~/.esphome-idf/frameworks ]; then
           echo "skip=false" >> "$GITHUB_OUTPUT"
         else
-          echo "::warning::ESP-IDF install missing, not using the clang-tidy idedata cache"
+          echo "ESP-IDF install missing, not using the clang-tidy idedata cache"
           echo "skip=true" >> "$GITHUB_OUTPUT"
         fi
         echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.environment }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -43,7 +43,7 @@ runs:
           .temp/**/*.tpp
         key: ${{ steps.key.outputs.key }}
     - name: Cache clang-tidy idedata (restore-only off dev)
-      if: !(github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && steps.key.outputs.skip != 'true'
+      if: github.ref != 'refs/heads/dev' && !contains(github.event.pull_request.labels.*.name, 'ci-cache-write') && steps.key.outputs.skip != 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |

--- a/.github/actions/cache-clang-tidy-idedata/action.yml
+++ b/.github/actions/cache-clang-tidy-idedata/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "key=${{ runner.os }}-tidy-idedata-${{ inputs.key }}-$hash-py$pyver" >> "$GITHUB_OUTPUT"
     # Mirror cache-esp-idf: write on dev, restore-only on PRs.
     - name: Cache clang-tidy idedata (write on dev)
-      if: github.ref == 'refs/heads/dev' && steps.key.outputs.skip != 'true'
+      if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && steps.key.outputs.skip != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
@@ -43,7 +43,7 @@ runs:
           .temp/**/*.tpp
         key: ${{ steps.key.outputs.key }}
     - name: Cache clang-tidy idedata (restore-only off dev)
-      if: github.ref != 'refs/heads/dev' && steps.key.outputs.skip != 'true'
+      if: !(github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && steps.key.outputs.skip != 'true'
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -26,10 +26,9 @@ runs:
       # The native-IDF version is pinned in code, not in any file that feeds the
       # other cache keys, so resolve it explicitly. Keying on it means the cache
       # invalidates on a version bump (actions/cache never overwrites a key).
-      # Key on the exact Python version as well: the ESP-IDF python venv under
-      # ~/.esphome-idf/penvs links to the runner's hosted toolcache interpreter,
-      # so once a new runner image ships a newer patch release the cached venv
-      # fails its stamp check and is reinstalled on every run.
+      # Also key on the Python version: the cached IDF venv links to the
+      # runner's toolcache interpreter and is reinstalled every run after a
+      # runner image bump.
       id: version
       shell: bash
       run: |

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -26,6 +26,10 @@ runs:
       # The native-IDF version is pinned in code, not in any file that feeds the
       # other cache keys, so resolve it explicitly. Keying on it means the cache
       # invalidates on a version bump (actions/cache never overwrites a key).
+      # Key on the exact Python version as well: the ESP-IDF python venv under
+      # ~/.esphome-idf/penvs links to the runner's hosted toolcache interpreter,
+      # so once a new runner image ships a newer patch release the cached venv
+      # fails its stamp check and is reinstalled on every run.
       id: version
       shell: bash
       run: |
@@ -36,6 +40,7 @@ runs:
           version=$(python -c 'from esphome.components.esp32 import ESP_IDF_FRAMEWORK_VERSION_LOOKUP as L; print(L["recommended"])')
         fi
         echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "python-version=$(python -c 'import platform; print(platform.python_version())')" >> "$GITHUB_OUTPUT"
     # Mirror the adjacent PlatformIO cache: only dev-branch runs write the
     # shared cache (so it lives in the default-branch scope readable by all
     # PRs), and PRs are restore-only -- they never push multi-GB artifacts into
@@ -45,10 +50,10 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf
-        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}
+        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}
     - name: Cache ESP-IDF install (restore-only off dev)
       if: github.ref != 'refs/heads/dev' || inputs.restore-only == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf
-        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}
+        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -44,7 +44,8 @@ runs:
     # shared cache (so it lives in the default-branch scope readable by all
     # PRs), and PRs are restore-only -- they never push multi-GB artifacts into
     # their own scope / the repo quota (e.g. on a version-bump PR). The
-    # ci-cache-write label lets a PR write into its own scope to test the hit path.
+    # ci-cache-write label lets a PR write into its own scope to test the hit path;
+    # that costs about 1GB of the repo cache quota per run, so remove it when done.
     - name: Cache ESP-IDF install (write on dev)
       if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && inputs.restore-only != 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -43,15 +43,16 @@ runs:
     # Mirror the adjacent PlatformIO cache: only dev-branch runs write the
     # shared cache (so it lives in the default-branch scope readable by all
     # PRs), and PRs are restore-only -- they never push multi-GB artifacts into
-    # their own scope / the repo quota (e.g. on a version-bump PR).
+    # their own scope / the repo quota (e.g. on a version-bump PR). The
+    # ci-cache-write label lets a PR write into its own scope to test the hit path.
     - name: Cache ESP-IDF install (write on dev)
-      if: github.ref == 'refs/heads/dev' && inputs.restore-only != 'true'
+      if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && inputs.restore-only != 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf
         key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}
     - name: Cache ESP-IDF install (restore-only off dev)
-      if: github.ref != 'refs/heads/dev' || inputs.restore-only == 'true'
+      if: !(github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) || inputs.restore-only == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -52,7 +52,7 @@ runs:
         path: ~/.esphome-idf
         key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}
     - name: Cache ESP-IDF install (restore-only off dev)
-      if: !(github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) || inputs.restore-only == 'true'
+      if: github.ref != 'refs/heads/dev' && !contains(github.event.pull_request.labels.*.name, 'ci-cache-write') || inputs.restore-only == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,12 @@ jobs:
         with:
           framework: arduino
 
+      - name: Cache clang-tidy idedata
+        if: matrix.cache_idf
+        uses: ./.github/actions/cache-clang-tidy-idedata
+        with:
+          key: esp32-arduino
+
       - name: Cache nRF Connect SDK install
         if: matrix.cache_sdk_nrf
         uses: ./.github/actions/cache-sdk-nrf
@@ -730,6 +736,11 @@ jobs:
       - name: Cache ESP-IDF install
         uses: ./.github/actions/cache-esp-idf
 
+      - name: Cache clang-tidy idedata
+        uses: ./.github/actions/cache-clang-tidy-idedata
+        with:
+          key: esp32-idf
+
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
@@ -809,6 +820,11 @@ jobs:
       - name: Cache ESP-IDF install
         uses: ./.github/actions/cache-esp-idf
 
+      - name: Cache clang-tidy idedata
+        uses: ./.github/actions/cache-clang-tidy-idedata
+        with:
+          key: esp32-idf
+
       - name: Register problem matchers
         run: |
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
@@ -866,16 +882,19 @@ jobs:
             name: Run script/clang-tidy for ESP32 S3
             # yamllint disable-line rule:line-length
             options: --environment esp32s3-idf-tidy --grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_ESP32_VARIANT_ESP32S3 --grep USE_LOGGER_USB_CDC
+            tidy_cache_key: esp32s3-idf
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 P4
             # P4 has no native Wi-Fi/BLE; those run over the hosted co-processor,
             # so their code paths differ -- lint them under the P4 build too.
             # yamllint disable-line rule:line-length
             options: --environment esp32p4-idf-tidy --grep USE_ESP32_VARIANT_ESP32P4 --grep USE_ESP32_HOSTED --grep USE_WIFI --grep USE_BLE
+            tidy_cache_key: esp32p4-idf
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 C6
             # yamllint disable-line rule:line-length
             options: --environment esp32c6-idf-tidy --grep SOC_LP_I2C_SUPPORTED --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE
+            tidy_cache_key: esp32c6-idf
 
     steps:
       - name: Check out code from GitHub
@@ -892,6 +911,11 @@ jobs:
 
       - name: Cache ESP-IDF install
         uses: ./.github/actions/cache-esp-idf
+
+      - name: Cache clang-tidy idedata
+        uses: ./.github/actions/cache-clang-tidy-idedata
+        with:
+          key: ${{ matrix.tidy_cache_key }}
 
       - name: Register problem matchers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,7 +653,7 @@ jobs:
         if: matrix.cache_idf
         uses: ./.github/actions/cache-clang-tidy-idedata
         with:
-          key: esp32-arduino
+          environment: esp32-arduino-tidy
 
       - name: Cache nRF Connect SDK install
         if: matrix.cache_sdk_nrf
@@ -739,7 +739,7 @@ jobs:
       - name: Cache clang-tidy idedata
         uses: ./.github/actions/cache-clang-tidy-idedata
         with:
-          key: esp32-idf
+          environment: esp32-idf-tidy
 
       - name: Register problem matchers
         run: |
@@ -823,7 +823,7 @@ jobs:
       - name: Cache clang-tidy idedata
         uses: ./.github/actions/cache-clang-tidy-idedata
         with:
-          key: esp32-idf
+          environment: esp32-idf-tidy
 
       - name: Register problem matchers
         run: |
@@ -882,19 +882,19 @@ jobs:
             name: Run script/clang-tidy for ESP32 S3
             # yamllint disable-line rule:line-length
             options: --environment esp32s3-idf-tidy --grep SOC_TEMP_SENSOR_SUPPORTED --grep USE_ESP32_VARIANT_ESP32S3 --grep USE_LOGGER_USB_CDC
-            tidy_cache_key: esp32s3-idf
+            tidy_environment: esp32s3-idf-tidy
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 P4
             # P4 has no native Wi-Fi/BLE; those run over the hosted co-processor,
             # so their code paths differ -- lint them under the P4 build too.
             # yamllint disable-line rule:line-length
             options: --environment esp32p4-idf-tidy --grep USE_ESP32_VARIANT_ESP32P4 --grep USE_ESP32_HOSTED --grep USE_WIFI --grep USE_BLE
-            tidy_cache_key: esp32p4-idf
+            tidy_environment: esp32p4-idf-tidy
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 C6
             # yamllint disable-line rule:line-length
             options: --environment esp32c6-idf-tidy --grep SOC_LP_I2C_SUPPORTED --grep USE_ESP32_VARIANT_ESP32C6 --grep USE_OPENTHREAD --grep USE_ZIGBEE
-            tidy_cache_key: esp32c6-idf
+            tidy_environment: esp32c6-idf-tidy
 
     steps:
       - name: Check out code from GitHub
@@ -915,7 +915,7 @@ jobs:
       - name: Cache clang-tidy idedata
         uses: ./.github/actions/cache-clang-tidy-idedata
         with:
-          key: ${{ matrix.tidy_cache_key }}
+          environment: ${{ matrix.tidy_environment }}
 
       - name: Register problem matchers
         run: |

--- a/script/clang_tidy_hash.py
+++ b/script/clang_tidy_hash.py
@@ -31,13 +31,8 @@ CLANG_TIDY_GLOBAL_FILES = (
 # this prefix at the repo root.
 SDKCONFIG_DEFAULTS_PREFIX = "sdkconfig.defaults"
 
-# Native-build infra: changes under esphome/espidf/, the shared
-# esphome/build_helpers/ package, or the modules the native ESP-IDF build
-# imports affect every esp32 IDF build (now the default toolchain) but aren't
-# components, so the component matrix wouldn't otherwise force any esp32
-# compile. determine-jobs folds the `esp32` component into the matrix when
-# they change; calculate_idedata_cache_hash() folds them into the idedata
-# cache key since they generate the clang-tidy idedata.
+# Native ESP-IDF build infra: determine-jobs forces an esp32 compile when these
+# change, and they feed the clang-tidy idedata cache key.
 ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES = ("esphome/espidf/", "esphome/build_helpers/")
 ESP_IDF_INFRA_TRIGGER_FILES = frozenset(
     {
@@ -86,11 +81,7 @@ def calculate_clang_tidy_hash(repo_root: Path | None = None) -> str:
 
 
 def calculate_idedata_cache_hash(repo_root: Path | None = None) -> str:
-    """Hash of everything that feeds the generated clang-tidy idedata.
-
-    The clang-tidy hash covers the data inputs (platformio.ini, sdkconfig,
-    idf_component.yml); this adds the Python that turns them into a project.
-    """
+    """Clang-tidy hash plus the Python that generates the idedata."""
     repo_root = _ensure_repo_root(repo_root)
 
     hasher = hashlib.sha256()

--- a/script/clang_tidy_hash.py
+++ b/script/clang_tidy_hash.py
@@ -31,6 +31,23 @@ CLANG_TIDY_GLOBAL_FILES = (
 # this prefix at the repo root.
 SDKCONFIG_DEFAULTS_PREFIX = "sdkconfig.defaults"
 
+# Native-build infra: changes under esphome/espidf/, the shared
+# esphome/build_helpers/ package, or the modules the native ESP-IDF build
+# imports affect every esp32 IDF build (now the default toolchain) but aren't
+# components, so the component matrix wouldn't otherwise force any esp32
+# compile. determine-jobs folds the `esp32` component into the matrix when
+# they change; calculate_idedata_cache_hash() folds them into the idedata
+# cache key since they generate the clang-tidy idedata.
+ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES = ("esphome/espidf/", "esphome/build_helpers/")
+ESP_IDF_INFRA_TRIGGER_FILES = frozenset(
+    {
+        "esphome/build_gen/espidf.py",
+        "esphome/framework_helpers.py",
+        "esphome/platformio/library.py",
+        "esphome/platformio/extra_script.py",
+    }
+)
+
 
 def read_file_bytes(path: Path) -> bytes:
     """Read bytes from a file."""
@@ -64,5 +81,27 @@ def calculate_clang_tidy_hash(repo_root: Path | None = None) -> str:
     for path in sorted(repo_root.glob(f"{SDKCONFIG_DEFAULTS_PREFIX}*")):
         hasher.update(path.name.encode())
         hasher.update(read_file_bytes(path))
+
+    return hasher.hexdigest()
+
+
+def calculate_idedata_cache_hash(repo_root: Path | None = None) -> str:
+    """Hash of everything that feeds the generated clang-tidy idedata.
+
+    The clang-tidy hash covers the data inputs (platformio.ini, sdkconfig,
+    idf_component.yml); this adds the Python that turns them into a project.
+    """
+    repo_root = _ensure_repo_root(repo_root)
+
+    hasher = hashlib.sha256()
+    hasher.update(calculate_clang_tidy_hash(repo_root).encode())
+
+    paths = {repo_root / name for name in ESP_IDF_INFRA_TRIGGER_FILES}
+    for prefix in ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES:
+        paths.update((repo_root / prefix).rglob("*.py"))
+    for path in sorted(paths):
+        if path.is_file():
+            hasher.update(str(path.relative_to(repo_root)).encode())
+            hasher.update(read_file_bytes(path))
 
     return hasher.hexdigest()

--- a/script/clang_tidy_hash.py
+++ b/script/clang_tidy_hash.py
@@ -89,10 +89,21 @@ def calculate_idedata_cache_hash(repo_root: Path | None = None) -> str:
 
     paths = {repo_root / name for name in ESP_IDF_INFRA_TRIGGER_FILES}
     for prefix in ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES:
-        paths.update((repo_root / prefix).rglob("*.py"))
+        paths.update(
+            path
+            for path in (repo_root / prefix).rglob("*")
+            if "__pycache__" not in path.parts
+        )
     for path in sorted(paths):
         if path.is_file():
             hasher.update(str(path.relative_to(repo_root)).encode())
             hasher.update(read_file_bytes(path))
 
     return hasher.hexdigest()
+
+
+def idedata_cache_hash(environment: str, repo_root: Path | None = None) -> str:
+    """Hash gating the cached idedata of one clang-tidy environment."""
+    if "esp32" in environment:
+        return calculate_idedata_cache_hash(repo_root)
+    return calculate_clang_tidy_hash(repo_root)

--- a/script/clang_tidy_hash.py
+++ b/script/clang_tidy_hash.py
@@ -1,13 +1,10 @@
-"""Files that affect clang-tidy results, and a content hash over them.
+"""Files that affect clang-tidy results and the idedata built from them.
 
-``CLANG_TIDY_GLOBAL_FILES`` (plus ``SDKCONFIG_DEFAULTS_PREFIX``) is the single
-source of truth for which files influence clang-tidy output. A change to any of
-them can surface warnings in source files a PR didn't touch, so:
-
-* ``script/determine-jobs.py`` runs a full clang-tidy scan when one changes, and
-* ``calculate_clang_tidy_hash()`` folds them into the idedata cache key used by
-  ``script/helpers.py`` (a content hash, unlike an mtime check, stays correct
-  across git checkouts).
+``CLANG_TIDY_GLOBAL_FILES`` (plus ``SDKCONFIG_DEFAULTS_PREFIX``) lists the files
+that influence clang-tidy output; ``script/determine-jobs.py`` runs a full scan
+when one changes. ``ESP_IDF_INFRA_TRIGGER_*`` lists the native ESP-IDF build
+code. ``idedata_cache_hash()`` folds the right set into the idedata cache key
+used by ``script/helpers.py`` and the CI cache action.
 """
 
 from __future__ import annotations
@@ -89,6 +86,7 @@ def calculate_idedata_cache_hash(repo_root: Path | None = None) -> str:
 
     paths = {repo_root / name for name in ESP_IDF_INFRA_TRIGGER_FILES}
     for prefix in ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES:
+        # .pyc files appear between the CI key computation and load_idedata's.
         paths.update(
             path
             for path in (repo_root / prefix).rglob("*")

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -58,7 +58,12 @@ from pathlib import Path
 import sys
 from typing import Any
 
-from clang_tidy_hash import CLANG_TIDY_GLOBAL_FILES, SDKCONFIG_DEFAULTS_PREFIX
+from clang_tidy_hash import (
+    CLANG_TIDY_GLOBAL_FILES,
+    ESP_IDF_INFRA_TRIGGER_FILES,
+    ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES,
+    SDKCONFIG_DEFAULTS_PREFIX,
+)
 from helpers import (
     CPP_FILE_EXTENSIONS,
     ESPHOME_TESTS_COMPONENTS_PATH,
@@ -522,23 +527,6 @@ def _esp32_platformio_path_or_file_trigger(files: list[str]) -> bool:
         ):
             return True
     return False
-
-
-# Native-build infra: changes under esphome/espidf/, the shared
-# esphome/build_helpers/ package, or the modules the native ESP-IDF build
-# imports affect every esp32 IDF build (now the default toolchain) but aren't
-# components, so the component matrix wouldn't otherwise force any esp32
-# compile. When they change we fold the `esp32` component into the matrix so
-# the default native-IDF build path is still compiled on an infra-only PR.
-ESP_IDF_INFRA_TRIGGER_PATH_PREFIXES = ("esphome/espidf/", "esphome/build_helpers/")
-ESP_IDF_INFRA_TRIGGER_FILES = frozenset(
-    {
-        "esphome/build_gen/espidf.py",
-        "esphome/framework_helpers.py",
-        "esphome/platformio/library.py",
-        "esphome/platformio/extra_script.py",
-    }
-)
 
 
 def _esp_idf_infra_changed(files: list[str]) -> bool:

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -811,17 +811,12 @@ def load_idedata(environment: str) -> dict[str, Any]:
 
     # Content hash of the idedata inputs (data files and the generator code); a
     # content hash, unlike mtimes, stays correct across git checkouts.
-    from clang_tidy_hash import calculate_clang_tidy_hash, calculate_idedata_cache_hash
+    from clang_tidy_hash import idedata_cache_hash
 
     temp_idedata = Path(temp_folder) / f"idedata-{environment}.json"
     temp_hash = Path(temp_folder) / f"idedata-{environment}.hash"
 
-    # Only the native ESP-IDF path depends on the generator code.
-    cache_key = (
-        calculate_idedata_cache_hash()
-        if "esp32" in environment
-        else calculate_clang_tidy_hash()
-    )
+    cache_key = idedata_cache_hash(environment)
     changed = (
         not temp_idedata.is_file()
         or not temp_hash.is_file()

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -811,12 +811,17 @@ def load_idedata(environment: str) -> dict[str, Any]:
 
     # Content hash of the idedata inputs (data files and the generator code); a
     # content hash, unlike mtimes, stays correct across git checkouts.
-    from clang_tidy_hash import calculate_idedata_cache_hash
+    from clang_tidy_hash import calculate_clang_tidy_hash, calculate_idedata_cache_hash
 
     temp_idedata = Path(temp_folder) / f"idedata-{environment}.json"
     temp_hash = Path(temp_folder) / f"idedata-{environment}.hash"
 
-    cache_key = calculate_idedata_cache_hash()
+    # Only the native ESP-IDF path depends on the generator code.
+    cache_key = (
+        calculate_idedata_cache_hash()
+        if "esp32" in environment
+        else calculate_clang_tidy_hash()
+    )
     changed = (
         not temp_idedata.is_file()
         or not temp_hash.is_file()

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -809,17 +809,14 @@ def load_idedata(environment: str) -> dict[str, Any]:
     start_time = time.time()
     print(f"Loading IDE data for environment '{environment}'...")
 
-    # Reuse the clang-tidy input hash as the cache key: it already covers every
-    # file baked into the generated idedata (platformio.ini, sdkconfig.defaults,
-    # esphome/idf_component.yml), so this can't drift from that file list. A
-    # content hash -- unlike an mtime comparison -- stays correct across git
-    # checkouts, which don't preserve mtimes.
-    from clang_tidy_hash import calculate_clang_tidy_hash
+    # Content hash of the idedata inputs (data files and the generator code); a
+    # content hash, unlike mtimes, stays correct across git checkouts.
+    from clang_tidy_hash import calculate_idedata_cache_hash
 
     temp_idedata = Path(temp_folder) / f"idedata-{environment}.json"
     temp_hash = Path(temp_folder) / f"idedata-{environment}.hash"
 
-    cache_key = calculate_clang_tidy_hash()
+    cache_key = calculate_idedata_cache_hash()
     changed = (
         not temp_idedata.is_file()
         or not temp_hash.is_file()

--- a/tests/script/test_clang_tidy_hash.py
+++ b/tests/script/test_clang_tidy_hash.py
@@ -101,3 +101,20 @@ def test_calculate_idedata_cache_hash_includes_listed_files(tmp_path: Path) -> N
     listed.parent.mkdir(parents=True)
     listed.write_text("x")
     assert clang_tidy_hash.calculate_idedata_cache_hash(repo_root=tmp_path) != before
+
+
+def test_idedata_cache_hash_only_widens_for_esp32(tmp_path: Path) -> None:
+    _populate(tmp_path)
+    infra = tmp_path / "esphome" / "espidf" / "clang_tidy.py"
+    infra.parent.mkdir(parents=True)
+    infra.write_text("a")
+    esp32_before = clang_tidy_hash.idedata_cache_hash("esp32-idf-tidy", tmp_path)
+    other_before = clang_tidy_hash.idedata_cache_hash("esp8266-arduino-tidy", tmp_path)
+    infra.write_text("b")
+    assert (
+        clang_tidy_hash.idedata_cache_hash("esp32-idf-tidy", tmp_path) != esp32_before
+    )
+    assert (
+        clang_tidy_hash.idedata_cache_hash("esp8266-arduino-tidy", tmp_path)
+        == other_before
+    )

--- a/tests/script/test_clang_tidy_hash.py
+++ b/tests/script/test_clang_tidy_hash.py
@@ -81,3 +81,23 @@ def test_read_file_bytes(tmp_path: Path) -> None:
     result = clang_tidy_hash.read_file_bytes(test_file)
 
     assert result == test_content
+
+
+def test_calculate_idedata_cache_hash_changes_with_infra_code(tmp_path: Path) -> None:
+    _populate(tmp_path)
+    infra = tmp_path / "esphome" / "espidf" / "clang_tidy.py"
+    infra.parent.mkdir(parents=True)
+    infra.write_text("a")
+    before = clang_tidy_hash.calculate_idedata_cache_hash(repo_root=tmp_path)
+    assert before == clang_tidy_hash.calculate_idedata_cache_hash(repo_root=tmp_path)
+    infra.write_text("b")
+    assert clang_tidy_hash.calculate_idedata_cache_hash(repo_root=tmp_path) != before
+
+
+def test_calculate_idedata_cache_hash_includes_listed_files(tmp_path: Path) -> None:
+    _populate(tmp_path)
+    before = clang_tidy_hash.calculate_idedata_cache_hash(repo_root=tmp_path)
+    listed = tmp_path / "esphome" / "platformio" / "library.py"
+    listed.parent.mkdir(parents=True)
+    listed.write_text("x")
+    assert clang_tidy_hash.calculate_idedata_cache_hash(repo_root=tmp_path) != before


### PR DESCRIPTION
# What does this implement/fix?

The ESP32 clang-tidy jobs regenerate idedata on every run because the `.temp` cache that `load_idedata` uses never survives between CI runs. On the native ESP-IDF path that costs about 90s for esp32-idf-tidy and 110s for esp32-arduino-tidy; roughly 23s of PlatformIO library resolution and downloads, 24s of ESP-IDF install checks, and two `idf.py reconfigure` runs at 25s and 15s.

This adds a `cache-clang-tidy-idedata` action that caches `.temp` for the ESP32 tidy jobs, keyed on the tidy environment name and `idedata_cache_hash(environment)` in `clang_tidy_hash.py`, the same helper `load_idedata` validates against; for the ESP-IDF environments that is the clang-tidy input hash plus the files under `ESP_IDF_INFRA_TRIGGER_*` (moved from determine-jobs into `clang_tidy_hash.py`), and the key also carries the runner Python version so it always busts together with the ESP-IDF cache. Since the ESP-IDF install only happens while generating idedata, the action skips the idedata cache when `~/.esphome-idf` is missing. Like the other shared caches it is written on dev and restore only on PRs, so a PR that does not touch the inputs skips generation entirely.

Whole job times, ESP32 clang-tidy jobs, run 33215835043 with empty caches against run 33218736592, a plain restore-only run with no labels that read the entries an earlier `ci-cache-write` run left in this PR's scope; every job in the hit run logged `IDE data loaded from cache in 0.00 seconds`:

| Job | Cache miss | Cache hit | Saved |
|---|---|---|---|
| ESP32 C6 | 2m59s | 0m59s | 2m00s |
| ESP32 S3 | 2m59s | 1m05s | 1m54s |
| ESP32 P4 | 4m58s | 2m03s | 2m55s |
| ESP32 Arduino | 5m00s | 1m46s | 3m14s |
| ESP32 IDF 1/3 | 14m10s | 12m07s | 2m03s |
| ESP32 IDF 2/3 | 10m24s | 9m06s | 1m18s |
| ESP32 IDF 3/3 | 17m27s | 15m19s | 2m08s |

The IDF 1/3 to 3/3 jobs are full scans dominated by clang-tidy itself over about 150 files each, so their totals move by minutes between runs; the setup part of every ESP32 tidy job drops from about 2 to 3 minutes to about 20 seconds on a hit.

Cache entries touched by this PR, sizes as compressed GitHub cache entries:

| Entry | Before | After |
|---|---|---|
| `Linux-esphome-idf-5.5.5` | 910MB, venv inside unusable, reinstalled every job | ages out under LRU |
| `Linux-esphome-idf-5.5.5-py3.12.14` | none | 910MB, same install re-saved under the new key (3.9GB on disk: riscv32 and xtensa toolchains 3.1GB, IDF source 0.5GB, venv 0.1GB), venv now matches the runner Python |
| `Linux-tidy-idedata-esp32-idf-<hash>-py<ver>` | none | ~28MB, shared by nosplit and split 1/3 to 3/3 |
| `Linux-tidy-idedata-esp32-arduino-<hash>-py<ver>` | none | 28MB measured |
| `Linux-tidy-idedata-esp32s3-idf-<hash>-py<ver>` | none | 25MB measured |
| `Linux-tidy-idedata-esp32p4-idf-<hash>-py<ver>` | none | 26MB measured |
| `Linux-tidy-idedata-esp32c6-idf-<hash>-py<ver>` | none | 25MB measured |

Net change is about 135MB once the old IDF entry is evicted; the chained #18871 drops picolibc from the cached toolchains, which shrinks the ESP-IDF entry from 910MB to 634MB and more than pays for it (sizes measured from a run with the `ci-cache-write` label, which lets a PR write these caches into its own scope so the hit path can be verified before merge); the repo cache is at 9.9GB of 10GB today, with setup-uv at 1.3GB over 12 entries, sdk-nrf at 1.2GB and the PlatformIO tidy caches at 0.3 to 0.6GB each.

Cache size: the full esp32-idf work tree is 394MB (130MB compressed) but the idedata only references headers, so the action caches header files plus the idedata json and hash, which is 106MB on disk and about 28MB compressed per env, roughly 140MB for the five ESP32 tidy envs. A key hit implies the clang-tidy hash matches, so the pruned tree is never fed back into a regenerate. Verified locally that clang-tidy on the pruned tree gives identical diagnostics to the full tree with no missing headers.

It also keys the ESP-IDF install cache on the Python version. The `Linux-esphome-idf-5.5.5` entry was saved on 2026-08-18 by jobs running Python 3.12.13, current runners ship 3.12.14, and the IDF venv inside it links to the 3.12.13 toolcache interpreter and stamps that version, so the venv check fails and it is reinstalled on every run, which is where the 18s pip install in the 24s above comes from. The rebuilt venv is never saved back either, PRs are restore only and dev never overwrites an existing key, so the venv inside the 910MB `Linux-esphome-idf-5.5.5` entry has been dead weight since the runner image bump while every esp32 job reinstalls it. The PlatformIO cache already keys on the Python version for the same reason.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

