### PR TITLE
[core] Deduplicate the pch identity digest across backends

### DIFF
--- a/esphome/build_gen/arduino8266.py
+++ b/esphome/build_gen/arduino8266.py
@@ -27,7 +27,6 @@ import sys
 from typing import TYPE_CHECKING, NamedTuple
 
 from esphome.arduino8266.framework import toolchain_tool
-from esphome.build_helpers.ccache import effective_ccache_basedir
 from esphome.build_helpers.idedata import is_joined_include
 from esphome.build_helpers.ninja import (
     escape as _e,
@@ -37,13 +36,14 @@ from esphome.build_helpers.ninja import (
 from esphome.build_helpers.pch import (
     PCH_CORE_HEADER,
     PCH_HEADER_NAME,
+    log_pch_in_use,
     mark_pch_emitted,
-    pch_checksum,
     pch_consumer_escalation,
     pch_degraded,
     pch_disabled_degraded,
     pch_enabled,
     pch_header_text,
+    pch_identity,
     pch_probe_args,
     pch_strict,
 )
@@ -1243,39 +1243,21 @@ def write_project(paths: InstalledPaths, ccache: str | None) -> bool:
         pch_header = build_dir / PCH_HEADER_NAME
         pch_includes = (*src_includes, PCH_CORE_HEADER)
         pch_text = pch_header_text(pch_includes)
-        checksum = None
-        try:
-            if ccache:
-                # The .sum exists only for CCACHE_PCH_EXTSUM; ninja's depfile
-                # handles staleness. Strip resolved and raw build paths
-                # (symlinks) so identical configs share cache entries
-                flags_id = (
-                    " ".join(cxxflags)
-                    .replace(effective_ccache_basedir(), "")
-                    .replace(str(CORE.build_path), "")
-                )
-                # The header text covers include order
-                checksum = pch_checksum(
-                    src_dir,
-                    pch_includes,
-                    (
-                        pch_text,
-                        str(paths.framework),
-                        str(paths.toolchain),
-                        flags_id,
-                    ),
-                )
-        except (OSError, UnicodeError) as err:
-            # Identity unknown: a stale cache entry must never be served
-            _LOGGER.warning(
-                "Could not establish the pch identity; compiling without it: %s", err
+        # The .sum exists only for CCACHE_PCH_EXTSUM; ninja's depfile
+        # handles staleness
+        checksum = (
+            pch_identity(
+                cxxflags,
+                src_dir,
+                pch_includes,
+                (str(paths.framework), str(paths.toolchain)),
             )
-            pch_degraded(f"identity unknown: {err}")
-        else:
-            _LOGGER.info(
-                "Compiling with a precompiled header "
-                "(set ESPHOME_PCH_ENABLE=0 to disable)"
-            )
+            if ccache
+            else None
+        )
+        # Identity unknown under ccache: pch_identity warned and degraded
+        if not ccache or checksum is not None:
+            log_pch_in_use()
             write_file_if_changed(pch_header, pch_text)
             sum_path = build_dir / f"{PCH_HEADER_NAME}.gch.sum"
             if checksum is not None:

--- a/esphome/build_gen/arduino8266.py
+++ b/esphome/build_gen/arduino8266.py
@@ -1245,18 +1245,18 @@ def write_project(paths: InstalledPaths, ccache: str | None) -> bool:
         pch_text = pch_header_text(pch_includes)
         # The .sum exists only for CCACHE_PCH_EXTSUM; ninja's depfile
         # handles staleness
-        checksum = (
-            pch_identity(
+        identity_ok = True
+        checksum = None
+        if ccache:
+            checksum = pch_identity(
                 cxxflags,
                 src_dir,
                 pch_includes,
                 (str(paths.framework), str(paths.toolchain)),
             )
-            if ccache
-            else None
-        )
-        # Identity unknown under ccache: pch_identity warned and degraded
-        if not ccache or checksum is not None:
+            # Identity unknown: pch_identity warned and degraded
+            identity_ok = checksum is not None
+        if identity_ok:
             log_pch_in_use()
             write_file_if_changed(pch_header, pch_text)
             sum_path = build_dir / f"{PCH_HEADER_NAME}.gch.sum"

--- a/esphome/build_helpers/pch.py
+++ b/esphome/build_helpers/pch.py
@@ -389,7 +389,7 @@ def pch_compile_command(
     return [*args, "-x", "c++-header", "-c", str(header), "-o", str(gch)], cmd_dir
 
 
-def flags_identity(tokens: Iterable[str]) -> str:
+def _flags_identity(tokens: Iterable[str]) -> str:
     """Flag string normalized for digest use: strip like ccache's rewriting
     (user CCACHE_BASEDIR wins); the raw build path covers unresolved
     (symlinked) spellings."""
@@ -420,7 +420,7 @@ def pch_identity(
                 # The closure is sorted, so root order only enters via the text
                 pch_header_text(include_headers),
                 *extra,
-                flags_identity(tokens),
+                _flags_identity(tokens),
             ),
         )
     except (OSError, UnicodeError) as err:

--- a/esphome/build_helpers/pch.py
+++ b/esphome/build_helpers/pch.py
@@ -389,7 +389,50 @@ def pch_compile_command(
     return [*args, "-x", "c++-header", "-c", str(header), "-o", str(gch)], cmd_dir
 
 
-def _log_pch_in_use() -> None:
+def flags_identity(tokens: Iterable[str]) -> str:
+    """Flag string normalized for digest use: strip like ccache's rewriting
+    (user CCACHE_BASEDIR wins); the raw build path covers unresolved
+    (symlinked) spellings."""
+    from esphome.core import CORE
+
+    return (
+        " ".join(tokens)
+        .replace(effective_ccache_basedir(), "")
+        .replace(str(CORE.build_path), "")
+    )
+
+
+def pch_identity(
+    tokens: Iterable[str],
+    src_dir: Path,
+    include_headers: tuple[str, ...],
+    extra: Iterable[str],
+) -> str | None:
+    """The .sum digest naming this exact pch build: include closure, header
+    text, backend identity strings, and the normalized compile command or
+    flags (``tokens``). None (warned and degraded) when the identity
+    cannot be established."""
+    try:
+        return pch_checksum(
+            src_dir,
+            include_headers,
+            (
+                # The closure is sorted, so root order only enters via the text
+                pch_header_text(include_headers),
+                *extra,
+                flags_identity(tokens),
+            ),
+        )
+    except (OSError, UnicodeError) as err:
+        # Identity unknown: a stale cache entry must never be served
+        _LOGGER.warning(
+            "Could not establish the pch identity; compiling without it: %s", err
+        )
+        pch_degraded(f"identity unknown: {err}")
+        return None
+
+
+def log_pch_in_use() -> None:
     # The only place a user can discover the knob; emitted only once a
     # .gch is actually fresh or being built
     _LOGGER.info(
@@ -459,31 +502,9 @@ def prepare_pch(
         pch_degraded("no usable compile command")
         return
     cmd, cmd_dir = cmd_and_dir
-    # Strip like ccache's rewriting (user CCACHE_BASEDIR wins); the raw
-    # build path covers unresolved (symlinked) spellings
-    cmd_id = (
-        " ".join(cmd)
-        .replace(effective_ccache_basedir(), "")
-        .replace(str(CORE.build_path), "")
-    )
-    try:
-        checksum = pch_checksum(
-            CORE.relative_src_path(),
-            include_headers,
-            (
-                # The closure is sorted, so root order only enters via the text
-                pch_header_text(include_headers),
-                *extra,
-                cmd_id,
-            ),
-        )
-    except (OSError, UnicodeError) as err:
-        # Identity unknown: a stale cache entry must never be served
-        _LOGGER.warning(
-            "Could not establish the pch identity; compiling without it: %s", err
-        )
+    checksum = pch_identity(cmd, CORE.relative_src_path(), include_headers, extra)
+    if checksum is None:
         discard_pch(build_dir)
-        pch_degraded(f"identity unknown: {err}")
         return
     failed_marker = Path(f"{gch}.failed")
 
@@ -566,7 +587,7 @@ def prepare_pch(
                 _fail(error, "probe cannot run at all", latch=latch)
 
     if gch.is_file() and _read_stamp(sum_path) == checksum:
-        _log_pch_in_use()
+        log_pch_in_use()
         if pch_strict():
             # Rejection is per-process, so a cached .gch must re-prove
             # loadability for the strict gate (CI-only cost); no latch,
@@ -580,7 +601,7 @@ def prepare_pch(
         )
         pch_degraded("earlier failure latched")
         return
-    _log_pch_in_use()
+    log_pch_in_use()
     result = _run(cmd, "compile")
     if result is None:
         return

--- a/tests/unit_tests/build_gen/test_arduino8266.py
+++ b/tests/unit_tests/build_gen/test_arduino8266.py
@@ -410,7 +410,7 @@ def test_write_project_pch_identity_unknown_skips_pch(
     paths = _make_framework(tmp_path)
     _set_flags("-DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH")
     with patch(
-        "esphome.build_gen.arduino8266.pch_checksum",
+        "esphome.build_helpers.pch.pch_checksum",
         side_effect=OSError("stat failed"),
     ):
         content = _write_ninja(paths, ccache="/usr/bin/ccache")


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18841.

The pch identity digest recipe was written twice: `prepare_pch` in `build_helpers/pch.py` and the esp8266 native generator each carried the same ccache basedir and build path stripping, the same `pch_checksum(src_dir, includes, (header_text, *extras, flags))` call, and the same identity unknown warning and degrade. The stripping is what makes identical configs on different devices share ccache entries, and only one of the two copies was covered by the path poison regression test, so a change landing in one copy would silently break cache sharing on the other backend.

This extracts `flags_identity()` and `pch_identity()` into `build_helpers/pch.py` and points both backends at them. The user facing "Compiling with a precompiled header" hint was also duplicated; `log_pch_in_use()` is now public and both call it.

No behavior change. The digest is byte identical to what both paths produced before, verified on a real ESP32-S3 build where the existing `.sum` came out unchanged, so nobody eats a cache miss from this. The only test change is a patch target that moved with the code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: test

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
