### PR TITLE
[ci] Drop picolibc from the cached ESP-IDF toolchains

### DIFF
--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -51,10 +51,12 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf
-        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}
+        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}-slim
     - name: Cache ESP-IDF install (restore-only off dev)
       if: github.ref != 'refs/heads/dev' && !contains(github.event.pull_request.labels.*.name, 'ci-cache-write') || inputs.restore-only == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.esphome-idf
-        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}
+        key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}-slim
+    - name: Prune ESP-IDF install
+      uses: ./.github/actions/prune-esp-idf

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -46,6 +46,7 @@ runs:
     # their own scope / the repo quota (e.g. on a version-bump PR). The
     # ci-cache-write label lets a PR write into its own scope to test the hit path;
     # that costs about 1GB of the repo cache quota per run, so remove it when done.
+    # -slim: bump when prune-esp-idf changes what it removes; a key is never overwritten.
     - name: Cache ESP-IDF install (write on dev)
       if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && inputs.restore-only != 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/actions/cache-esp-idf/action.yml
+++ b/.github/actions/cache-esp-idf/action.yml
@@ -58,5 +58,12 @@ runs:
       with:
         path: ~/.esphome-idf
         key: ${{ runner.os }}-esphome-idf-${{ steps.version.outputs.version }}-py${{ steps.version.outputs.python-version }}-slim
+    # Install explicitly so the prune below sees the toolchains on a cache miss
+    # too, instead of the install happening inside the first build step.
+    - name: Install ESP-IDF
+      shell: bash
+      run: |
+        . venv/bin/activate
+        python -c 'from esphome.espidf.framework import check_esp_idf_install; check_esp_idf_install("${{ steps.version.outputs.version }}")'
     - name: Prune ESP-IDF install
       uses: ./.github/actions/prune-esp-idf

--- a/.github/actions/prune-esp-idf/action.yml
+++ b/.github/actions/prune-esp-idf/action.yml
@@ -23,7 +23,10 @@ runs:
           rm -rf "$dir"
           n=$((n + 1))
         done
-        if [ "$n" -eq 0 ] && [ -d "$prefix/tools" ]; then
+        # The marker rides along in the cache entry so a restored slim tree stays quiet.
+        if [ "$n" -gt 0 ]; then
+          touch "$prefix/.picolibc-pruned"
+        elif [ -d "$prefix/tools" ] && [ ! -f "$prefix/.picolibc-pruned" ]; then
           echo "::warning::no picolibc sysroots matched under $prefix/tools"
         fi
         if [ -d "$prefix" ]; then

--- a/.github/actions/prune-esp-idf/action.yml
+++ b/.github/actions/prune-esp-idf/action.yml
@@ -1,9 +1,7 @@
 name: Prune ESP-IDF install
 description: >
-  Remove the picolibc sysroots from the native ESP-IDF toolchains. IDF 5.x
-  links newlib, so they are never used, and they are 1.1GB of the 3.9GB
-  install. Run after the cache restore so every job builds against the pruned
-  tree, and again before the dev cache save.
+  Remove the picolibc sysroots (1.1GB of the 3.9GB install) from the native
+  ESP-IDF toolchains; IDF 5.x links newlib.
 runs:
   using: composite
   steps:

--- a/.github/actions/prune-esp-idf/action.yml
+++ b/.github/actions/prune-esp-idf/action.yml
@@ -1,0 +1,17 @@
+name: Prune ESP-IDF install
+description: >
+  Remove the picolibc sysroots from the native ESP-IDF toolchains. IDF 5.x
+  links newlib, so they are never used, and they are 1.1GB of the 3.9GB
+  install. Run after the cache restore so every job builds against the pruned
+  tree, and again before the dev cache save.
+runs:
+  using: composite
+  steps:
+    - name: Prune picolibc
+      shell: bash
+      run: |
+        shopt -s nullglob
+        for dir in ~/.esphome-idf/tools/*-esp-elf/*/*-esp-elf/picolibc; do
+          echo "Removing $dir ($(du -sh "$dir" | cut -f1))"
+          rm -rf "$dir"
+        done

--- a/.github/actions/prune-esp-idf/action.yml
+++ b/.github/actions/prune-esp-idf/action.yml
@@ -10,18 +10,22 @@ runs:
       shell: bash
       run: |
         shopt -s nullglob
-        for fw in ~/.esphome-idf/frameworks/*/; do
+        prefix="${ESPHOME_ESP_IDF_PREFIX:-$HOME/.esphome-idf}"
+        prefix="${prefix/#\~/$HOME}"
+        for fw in "$prefix"/frameworks/*/; do
           case "$(basename "$fw")" in
             [6-9].*) echo "IDF $(basename "$fw") installed, keeping picolibc"; exit 0 ;;
           esac
         done
         n=0
-        for dir in ~/.esphome-idf/tools/*-esp-elf/*/*-esp-elf/picolibc; do
+        for dir in "$prefix"/tools/*-esp-elf/*/*-esp-elf/picolibc; do
           echo "Removing $dir ($(du -sh "$dir" | cut -f1))"
           rm -rf "$dir"
           n=$((n + 1))
         done
-        if [ "$n" -eq 0 ] && [ -d ~/.esphome-idf/tools ]; then
-          echo "::warning::no picolibc sysroots matched under ~/.esphome-idf/tools"
+        if [ "$n" -eq 0 ] && [ -d "$prefix/tools" ]; then
+          echo "::warning::no picolibc sysroots matched under $prefix/tools"
         fi
-        [ -d ~/.esphome-idf ] && du -sh ~/.esphome-idf
+        if [ -d "$prefix" ]; then
+          du -sh "$prefix"
+        fi

--- a/.github/actions/prune-esp-idf/action.yml
+++ b/.github/actions/prune-esp-idf/action.yml
@@ -1,7 +1,8 @@
 name: Prune ESP-IDF install
 description: >
   Remove the picolibc sysroots (1.1GB of the 3.9GB install) from the native
-  ESP-IDF toolchains; IDF 5.x links newlib.
+  ESP-IDF toolchains; IDF 5.x links newlib. Skipped when an IDF 6 install is
+  present, which links picolibc (see esp32/__init__.py).
 runs:
   using: composite
   steps:
@@ -9,7 +10,18 @@ runs:
       shell: bash
       run: |
         shopt -s nullglob
+        for fw in ~/.esphome-idf/frameworks/*/; do
+          case "$(basename "$fw")" in
+            [6-9].*) echo "IDF $(basename "$fw") installed, keeping picolibc"; exit 0 ;;
+          esac
+        done
+        n=0
         for dir in ~/.esphome-idf/tools/*-esp-elf/*/*-esp-elf/picolibc; do
           echo "Removing $dir ($(du -sh "$dir" | cut -f1))"
           rm -rf "$dir"
+          n=$((n + 1))
         done
+        if [ "$n" -eq 0 ] && [ -d ~/.esphome-idf/tools ]; then
+          echo "::warning::no picolibc sysroots matched under ~/.esphome-idf/tools"
+        fi
+        [ -d ~/.esphome-idf ] && du -sh ~/.esphome-idf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,6 +704,10 @@ jobs:
           # Also cache libdeps, store them in a ~/.platformio subfolder
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
+      - name: Prune ESP-IDF install before cache save
+        if: github.ref == 'refs/heads/dev'
+        uses: ./.github/actions/prune-esp-idf
+
       - name: Suggested changes
         run: script/ci-suggest-changes ${{ matrix.ignore_errors && '|| true' || '' }}
         # yamllint disable-line rule:line-length
@@ -774,6 +778,10 @@ jobs:
         env:
           # Also cache libdeps, store them in a ~/.platformio subfolder
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+
+      - name: Prune ESP-IDF install before cache save
+        if: github.ref == 'refs/heads/dev'
+        uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes
         run: script/ci-suggest-changes
@@ -858,6 +866,10 @@ jobs:
         env:
           # Also cache libdeps, store them in a ~/.platformio subfolder
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+
+      - name: Prune ESP-IDF install before cache save
+        if: github.ref == 'refs/heads/dev'
+        uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes
         run: script/ci-suggest-changes
@@ -949,6 +961,10 @@ jobs:
             echo "Running clang-tidy on changed files only"
             script/clang-tidy --fix --changed ${{ matrix.options }}
           fi
+
+      - name: Prune ESP-IDF install before cache save
+        if: github.ref == 'refs/heads/dev'
+        uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes
         run: script/ci-suggest-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,7 +705,7 @@ jobs:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
       - name: Prune ESP-IDF install before cache save
-        if: github.ref == 'refs/heads/dev'
+        if: matrix.cache_idf && (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write'))
         uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes
@@ -780,7 +780,7 @@ jobs:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
       - name: Prune ESP-IDF install before cache save
-        if: github.ref == 'refs/heads/dev'
+        if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write'))
         uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes
@@ -868,7 +868,7 @@ jobs:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
       - name: Prune ESP-IDF install before cache save
-        if: github.ref == 'refs/heads/dev'
+        if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write'))
         uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes
@@ -963,7 +963,7 @@ jobs:
           fi
 
       - name: Prune ESP-IDF install before cache save
-        if: github.ref == 'refs/heads/dev'
+        if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write'))
         uses: ./.github/actions/prune-esp-idf
 
       - name: Suggested changes


### PR DESCRIPTION
# What does this implement/fix?

Chained on #18868. The native ESP-IDF toolchains ship a picolibc sysroot next to newlib, 759MB for riscv32 and 387MB for xtensa out of a 3.9GB install; IDF 5.x links newlib so nothing in CI uses it. The cache action now installs ESP-IDF in an explicit step (a stamp check on a cache hit) and removes those directories right after, so every job builds against the pruned tree even on a cache miss, which is what this PR's own run exercises; the dev tidy jobs prune again before the cache save so the saved entry never carries them. The cache key gets a `-slim` suffix so the pruned install is written fresh instead of being shadowed by the existing entry.

Whole job times, ESP32 clang-tidy jobs, run 33215834295 with empty caches against run 33217269868 with the caches populated (both with the `ci-cache-write` label on this PR):

| Job | Cache miss | Cache hit | Saved |
|---|---|---|---|
| ESP32 C6 | 3m03s | 0m50s | 2m13s |
| ESP32 S3 | 3m24s | 1m02s | 2m22s |
| ESP32 P4 | 4m35s | 2m15s | 2m20s |
| ESP32 Arduino | 4m36s | 1m50s | 2m46s |
| ESP32 IDF 1/3 | 14m25s | 9m14s | 5m11s |
| ESP32 IDF 2/3 | 8m08s | 6m42s | 1m26s |
| ESP32 IDF 3/3 | 19m22s | 15m14s | 4m08s |

The IDF 1/3 to 3/3 jobs are full scans dominated by clang-tidy itself over about 150 files each, so their totals move by minutes between runs; the setup part of every ESP32 tidy job drops from about 2 to 3 minutes to about 20 seconds on a hit.

Cache entries touched, sizes as compressed GitHub cache entries, on disk sizes measured on a local IDF 5.5.5 install:

| Entry | Before (with #18868) | After |
|---|---|---|
| `Linux-esphome-idf-5.5.5-py3.12.14` | 910MB, 3.9GB on disk | ages out under LRU |
| `Linux-esphome-idf-5.5.5-py3.12.14-slim` | none | 634MB measured, 2.8GB on disk: riscv32 picolibc 759MB and xtensa picolibc 387MB removed |

What stays in the install and why:

| Part | On disk | Needed by |
|---|---|---|
| riscv32 newlib multilibs, 5 variants | 815MB | c2/c3/c6/h2 link `rv32imc`, p4 links `rv32imafc`; the other variants are left alone here |
| xtensa newlib multilibs (esp32, s2, s3) | 434MB | esp32, s2, s3 links |
| compiler binaries, libexec, `lib/gcc`, both arches | about 700MB | every compile and the tidy multilib query |
| IDF source | 521MB | headers for tidy, everything for the compile batches |
| venv | 99MB | `idf.py` |

Both PRs carry the `ci-run-all` label since a `.github` only diff does not schedule clang-tidy or the esp32 component batches on its own.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
