### PR TITLE
[github] Update dismissed bot reviews in place so PRs are not re-drafted on every push

### DIFF
--- a/.github/scripts/auto-label-pr/reviews.js
+++ b/.github/scripts/auto-label-pr/reviews.js
@@ -122,12 +122,13 @@ async function handleReviews(github, context, finalLabels, originalLabelCount, d
     const reviewBody = `${BOT_COMMENT_MARKER}\n\n${reviewMessages.join('\n\n---\n\n')}`;
 
     if (botReviews.length > 0) {
-      // Update existing review
+      // Update the newest review; PRs hit by the old create-on-every-push
+      // behavior can carry several, and the newest is the one users see
       await github.rest.pulls.updateReview({
         owner,
         repo,
         pull_number: pr_number,
-        review_id: botReviews[0].id,
+        review_id: botReviews[botReviews.length - 1].id,
         body: reviewBody
       });
       console.log('Updated existing bot review');

--- a/.github/scripts/auto-label-pr/reviews.js
+++ b/.github/scripts/auto-label-pr/reviews.js
@@ -108,9 +108,13 @@ async function handleReviews(github, context, finalLabels, originalLabelCount, d
     pull_number: pr_number
   });
 
+  // DISMISSED reviews are included so a review dismissed by the bot when the
+  // author marked the PR ready for review is updated in place on later pushes.
+  // Creating a new review instead would emit a fresh changes-requested event,
+  // which makes the bot convert the PR back to draft again.
   const botReviews = reviews.filter(review =>
     review.user.type === 'Bot' &&
-    review.state === 'CHANGES_REQUESTED' &&
+    ['CHANGES_REQUESTED', 'DISMISSED'].includes(review.state) &&
     review.body && review.body.includes(BOT_COMMENT_MARKER)
   );
 
@@ -141,6 +145,9 @@ async function handleReviews(github, context, finalLabels, originalLabelCount, d
   } else if (botReviews.length > 0) {
     // Dismiss existing reviews
     for (const review of botReviews) {
+      if (review.state !== 'CHANGES_REQUESTED') {
+        continue;
+      }
       try {
         await github.rest.pulls.dismissReview({
           owner,

--- a/.github/scripts/auto-label-pr/tests/reviews.test.js
+++ b/.github/scripts/auto-label-pr/tests/reviews.test.js
@@ -1,0 +1,93 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { handleReviews } = require('../reviews');
+const { BOT_COMMENT_MARKER } = require('../constants');
+
+const CONTEXT = {
+  repo: { owner: 'esphome', repo: 'esphome' },
+  issue: { number: 123 },
+  payload: { pull_request: { user: { login: 'author' } } }
+};
+
+// GitHub API mock recording review calls; `reviews` is what listReviews returns.
+function makeGithub(reviews) {
+  const calls = { create: [], update: [], dismiss: [] };
+  return {
+    calls,
+    rest: {
+      pulls: {
+        listReviews: async () => ({ data: reviews }),
+        createReview: async (args) => { calls.create.push(args); },
+        updateReview: async (args) => { calls.update.push(args); },
+        dismissReview: async (args) => { calls.dismiss.push(args); }
+      }
+    }
+  };
+}
+
+function botReview(state) {
+  return {
+    id: 42,
+    state,
+    user: { type: 'Bot', login: 'esphome[bot]' },
+    body: `${BOT_COMMENT_MARKER}\nreview body`
+  };
+}
+
+function run(github, labels) {
+  return handleReviews(github, CONTEXT, labels, labels.length, [], [], 0, 0, 15, 1000);
+}
+
+describe('handleReviews', () => {
+  it('creates a review when there is none and a reviewable label is set', async () => {
+    const github = makeGithub([]);
+    await run(github, ['too-big']);
+    assert.equal(github.calls.create.length, 1);
+    assert.equal(github.calls.create[0].event, 'REQUEST_CHANGES');
+    assert.equal(github.calls.update.length, 0);
+  });
+
+  it('updates an active bot review instead of creating a new one', async () => {
+    const github = makeGithub([botReview('CHANGES_REQUESTED')]);
+    await run(github, ['too-big']);
+    assert.equal(github.calls.create.length, 0);
+    assert.equal(github.calls.update.length, 1);
+    assert.equal(github.calls.update[0].review_id, 42);
+  });
+
+  it('updates a dismissed bot review instead of creating a new one', async () => {
+    // Re-creating the review would emit a new changes-requested event and the
+    // bot would convert the PR back to draft after the author marked it ready.
+    const github = makeGithub([botReview('DISMISSED')]);
+    await run(github, ['too-big']);
+    assert.equal(github.calls.create.length, 0);
+    assert.equal(github.calls.update.length, 1);
+    assert.equal(github.calls.update[0].review_id, 42);
+  });
+
+  it('dismisses an active bot review when no reviewable labels remain', async () => {
+    const github = makeGithub([botReview('CHANGES_REQUESTED')]);
+    await run(github, ['small-pr']);
+    assert.equal(github.calls.dismiss.length, 1);
+    assert.equal(github.calls.dismiss[0].review_id, 42);
+  });
+
+  it('does not dismiss an already dismissed review', async () => {
+    const github = makeGithub([botReview('DISMISSED')]);
+    await run(github, ['small-pr']);
+    assert.equal(github.calls.dismiss.length, 0);
+  });
+
+  it('ignores reviews from humans', async () => {
+    const review = {
+      id: 7,
+      state: 'CHANGES_REQUESTED',
+      user: { type: 'User', login: 'maintainer' },
+      body: 'please fix'
+    };
+    const github = makeGithub([review]);
+    await run(github, ['too-big']);
+    assert.equal(github.calls.create.length, 1);
+    assert.equal(github.calls.update.length, 0);
+  });
+});

--- a/.github/scripts/auto-label-pr/tests/reviews.test.js
+++ b/.github/scripts/auto-label-pr/tests/reviews.test.js
@@ -78,6 +78,16 @@ describe('handleReviews', () => {
     assert.equal(github.calls.dismiss.length, 0);
   });
 
+  it('updates the newest bot review when several exist', async () => {
+    const old = { ...botReview('DISMISSED'), id: 1 };
+    const active = { ...botReview('CHANGES_REQUESTED'), id: 2 };
+    const github = makeGithub([old, active]);
+    await run(github, ['too-big']);
+    assert.equal(github.calls.create.length, 0);
+    assert.equal(github.calls.update.length, 1);
+    assert.equal(github.calls.update[0].review_id, 2);
+  });
+
   it('ignores reviews from humans', async () => {
     const review = {
       id: 7,


### PR DESCRIPTION
# What does this implement/fix?

The auto-label bot converts oversized PRs (or ones touching deprecated components) to draft. That is intended to happen once, but currently it repeats after every push once the author has marked the PR ready for review:

1. The bot posts a `REQUEST_CHANGES` review and the PR is converted to draft.
2. The author marks the PR ready for review; the stale bot review is dismissed.
3. On the next push, `handleReviews` only looks for `CHANGES_REQUESTED` bot reviews, so the dismissed one is invisible to it and it submits a brand-new review. The new `pull_request_review.submitted` event converts the PR back to draft.
4. Repeat for every push.

Example: on #18858 the author was converted back to draft 14 seconds after clicking ready-for-review.

This PR makes `handleReviews` recognize its own dismissed review and update it in place instead of creating a new one. Updating a review body emits no `submitted` event and the review stays dismissed, so the PR stays ready. The first conversion to draft is unchanged, and a human maintainer requesting changes still drafts the PR as before. The dismiss branch now skips already-dismissed reviews so it does not fail on them.

Adds `tests/reviews.test.js` covering `handleReviews` (previously untested): update-instead-of-create for both active and dismissed reviews, no double dismissal, and the existing create/dismiss paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - GitHub workflow scripts only, no firmware changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).