### PR TITLE
[esp32] Skip full rebuild on sdkconfig change with the esp-idf toolchain

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -3249,12 +3249,12 @@ def _write_sdkconfig():
     if write_file_if_changed(internal_path, contents):
         # internal changed, update real one
         write_file_if_changed(sdk_path, contents)
-        if CORE.using_toolchain_platformio:
+        if not CORE.using_toolchain_esp_idf:
             # PIO's dependency tracking under-declares sdkconfig inputs
             # (ldgen, linker scripts); without a clean the image can be
             # unbootable (esphome#15336). The esp-idf toolchain tracks
             # sdkconfig via IDF's cmake and has_outdated_files(), so a
-            # reconfigure suffices.
+            # reconfigure suffices there; everything else fails safe.
             clean_build(clear_pio_cache=False)
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -3249,7 +3249,13 @@ def _write_sdkconfig():
     if write_file_if_changed(internal_path, contents):
         # internal changed, update real one
         write_file_if_changed(sdk_path, contents)
-        clean_build(clear_pio_cache=False)
+        if CORE.using_toolchain_platformio:
+            # PIO's dependency tracking under-declares sdkconfig inputs
+            # (ldgen, linker scripts); without a clean the image can be
+            # unbootable (esphome#15336). The esp-idf toolchain tracks
+            # sdkconfig via IDF's cmake and has_outdated_files(), so a
+            # reconfigure suffices.
+            clean_build(clear_pio_cache=False)
 
 
 def _write_idf_component_yml():

--- a/tests/unit_tests/components/esp32/test_sdkconfig.py
+++ b/tests/unit_tests/components/esp32/test_sdkconfig.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import time
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,24 @@ from esphome.components.esp32 import _write_sdkconfig
 from esphome.components.esp32.const import KEY_SDKCONFIG_OPTIONS
 from esphome.const import KEY_CORE, KEY_ESP32, KEY_FRAMEWORK_VERSION, Toolchain
 from esphome.core import CORE
+from esphome.espidf.toolchain import has_outdated_files
+
+
+def _setup_core(tmp_path: Path, toolchain: Toolchain) -> None:
+    CORE.config_path = tmp_path / "test.yaml"
+    CORE.build_path = tmp_path
+    CORE.toolchain = toolchain
+    CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_X": "y"}}
+    CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: "5.5.5"}
+
+
+def _seed_configured_build(tmp_path: Path) -> None:
+    """A settled native build: configure outputs predate what comes next."""
+    build = tmp_path / "build"
+    (build / "config").mkdir(parents=True)
+    (build / "config" / "sdkconfig.h").write_text("")
+    (build / "CMakeCache.txt").write_text("")
+    (build / "build.ninja").write_text("")
 
 
 @pytest.mark.parametrize(
@@ -22,11 +42,8 @@ def test_write_sdkconfig_cleans_only_on_platformio(
 ) -> None:
     """A changed sdkconfig forces a full clean only under PlatformIO; the
     esp-idf toolchain reconfigures via has_outdated_files() instead."""
-    CORE.config_path = tmp_path / "test.yaml"
-    CORE.build_path = tmp_path
-    CORE.toolchain = toolchain
-    CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_X": "y"}}
-    CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: "5.5.5"}
+    _setup_core(tmp_path, toolchain)
+    _seed_configured_build(tmp_path)
     with (
         patch.object(CORE, "name", "test"),
         patch("esphome.components.esp32.clean_build") as clean,
@@ -36,7 +53,14 @@ def test_write_sdkconfig_cleans_only_on_platformio(
         assert clean.called is clean_expected
         if clean_expected:
             clean.assert_called_once_with(clear_pio_cache=False)
+        # The change must still trigger a reconfigure: the internal
+        # sdkconfig snapshot is now newer than build/CMakeCache.txt
+        assert has_outdated_files() is True
         clean.reset_mock()
-        # Unchanged contents: never clean, on either toolchain
+        # A settled configure restamps the cache; an unchanged rewrite
+        # must then neither clean nor mark the build stale
+        future = time.time() + 60
+        os.utime(CORE.relative_build_path("build/CMakeCache.txt"), (future, future))
         _write_sdkconfig()
         clean.assert_not_called()
+        assert has_outdated_files() is False

--- a/tests/unit_tests/components/esp32/test_sdkconfig.py
+++ b/tests/unit_tests/components/esp32/test_sdkconfig.py
@@ -1,0 +1,42 @@
+"""Tests for the esp32 sdkconfig write and its toolchain-gated clean."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from esphome.components.esp32 import _write_sdkconfig
+from esphome.components.esp32.const import KEY_SDKCONFIG_OPTIONS
+from esphome.const import KEY_CORE, KEY_ESP32, KEY_FRAMEWORK_VERSION, Toolchain
+from esphome.core import CORE
+
+
+@pytest.mark.parametrize(
+    ("toolchain", "clean_expected"),
+    [(Toolchain.ESP_IDF, False), (Toolchain.PLATFORMIO, True)],
+)
+def test_write_sdkconfig_cleans_only_on_platformio(
+    tmp_path: Path, toolchain: Toolchain, clean_expected: bool
+) -> None:
+    """A changed sdkconfig forces a full clean only under PlatformIO; the
+    esp-idf toolchain reconfigures via has_outdated_files() instead."""
+    CORE.config_path = tmp_path / "test.yaml"
+    CORE.build_path = tmp_path
+    CORE.toolchain = toolchain
+    CORE.data[KEY_ESP32] = {KEY_SDKCONFIG_OPTIONS: {"CONFIG_X": "y"}}
+    CORE.data[KEY_CORE] = {KEY_FRAMEWORK_VERSION: "5.5.5"}
+    with (
+        patch.object(CORE, "name", "test"),
+        patch("esphome.components.esp32.clean_build") as clean,
+    ):
+        _write_sdkconfig()
+        assert "CONFIG_X" in CORE.relative_build_path("sdkconfig.test").read_text()
+        assert clean.called is clean_expected
+        if clean_expected:
+            clean.assert_called_once_with(clear_pio_cache=False)
+        clean.reset_mock()
+        # Unchanged contents: never clean, on either toolchain
+        _write_sdkconfig()
+        clean.assert_not_called()

--- a/tests/unit_tests/components/esp32/test_sdkconfig.py
+++ b/tests/unit_tests/components/esp32/test_sdkconfig.py
@@ -16,7 +16,7 @@ from esphome.core import CORE
 from esphome.espidf.toolchain import has_outdated_files
 
 
-def _setup_core(tmp_path: Path, toolchain: Toolchain) -> None:
+def _setup_core(tmp_path: Path, toolchain: Toolchain | None) -> None:
     CORE.config_path = tmp_path / "test.yaml"
     CORE.build_path = tmp_path
     CORE.toolchain = toolchain
@@ -31,17 +31,23 @@ def _seed_configured_build(tmp_path: Path) -> None:
     (build / "config" / "sdkconfig.h").write_text("")
     (build / "CMakeCache.txt").write_text("")
     (build / "build.ninja").write_text("")
+    # Explicitly older than what the test writes next: has_outdated_files()
+    # compares st_mtime with a strict >, so same-tick writes would pass
+    past = time.time() - 60
+    for f in build.rglob("*"):
+        os.utime(f, (past, past))
 
 
 @pytest.mark.parametrize(
     ("toolchain", "clean_expected"),
-    [(Toolchain.ESP_IDF, False), (Toolchain.PLATFORMIO, True)],
+    [(Toolchain.ESP_IDF, False), (Toolchain.PLATFORMIO, True), (None, True)],
 )
 def test_write_sdkconfig_cleans_only_on_platformio(
-    tmp_path: Path, toolchain: Toolchain, clean_expected: bool
+    tmp_path: Path, toolchain: Toolchain | None, clean_expected: bool
 ) -> None:
     """A changed sdkconfig forces a full clean only under PlatformIO; the
-    esp-idf toolchain reconfigures via has_outdated_files() instead."""
+    esp-idf toolchain reconfigures via has_outdated_files() instead; an
+    unresolved toolchain fails safe onto the clean."""
     _setup_core(tmp_path, toolchain)
     _seed_configured_build(tmp_path)
     with (


### PR DESCRIPTION
# What does this implement/fix?

Changing any sdkconfig option currently wipes the build directory and forces a full rebuild (~16s with warm ccache on a fast machine, far more cold or on slow hardware). That clean came from #15439, which fixed #15336, an ESP32-P4 that would not boot after toggling `execute_from_psram`; the root cause was never pinned down, and at the time every build went through PlatformIO, whose dependency tracking under declares sdkconfig inputs (ldgen, generated linker scripts). The esp-idf toolchain tracks sdkconfig through IDF's own cmake and `has_outdated_files()`, so a reconfigure is enough. This keeps the clean on PlatformIO and skips it on the esp-idf toolchain.

Verified by byte comparing incremental no clean builds against from scratch builds; they are identical apart from the embedded build timestamp and the two hashes derived from it, the same delta any two builds have. Covered five sdkconfig changes: adding `esp32_ble_tracker` (rewrites sections.ld, pulls in the bt component), `CONFIG_SPIRAM_XIP_FROM_PSRAM`, `execute_from_psram` on S3, `execute_from_psram` on P4 (the original #15336 trigger, rewrites memory.ld and sections.ld), and `CONFIG_BOOTLOADER_LOG_LEVEL_NONE` (rebuilds the bootloader, 20784 to 13792 bytes).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: test

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
