### PR TITLE
[mitsubishi] Add fahrenheit_compatibility mode

### DIFF
--- a/esphome/components/mitsubishi/climate.py
+++ b/esphome/components/mitsubishi/climate.py
@@ -20,6 +20,7 @@ SETFANMODE = {
 
 CONF_SUPPORTS_DRY = "supports_dry"
 CONF_SUPPORTS_FAN_ONLY = "supports_fan_only"
+CONF_FAHRENHEIT_COMPATIBILITY = "fahrenheit_compatibility"
 
 CONF_HORIZONTAL_DEFAULT = "horizontal_default"
 HorizontalDirections = mitsubishi_ns.enum("HorizontalDirections")
@@ -49,6 +50,7 @@ CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).ex
         cv.Optional(CONF_SET_FAN_MODE, default="3levels"): cv.enum(SETFANMODE),
         cv.Optional(CONF_SUPPORTS_DRY, default=False): cv.boolean,
         cv.Optional(CONF_SUPPORTS_FAN_ONLY, default=False): cv.boolean,
+        cv.Optional(CONF_FAHRENHEIT_COMPATIBILITY, default=False): cv.boolean,
         cv.Optional(CONF_HORIZONTAL_DEFAULT, default="middle"): cv.enum(
             HORIZONTAL_DIRECTIONS
         ),
@@ -65,5 +67,6 @@ async def to_code(config: ConfigType) -> None:
     cg.add(var.set_fan_mode(config[CONF_SET_FAN_MODE]))
     cg.add(var.set_supports_dry(config[CONF_SUPPORTS_DRY]))
     cg.add(var.set_supports_fan_only(config[CONF_SUPPORTS_FAN_ONLY]))
+    cg.add(var.set_fahrenheit_compatibility(config[CONF_FAHRENHEIT_COMPATIBILITY]))
     cg.add(var.set_horizontal_default(config[CONF_HORIZONTAL_DEFAULT]))
     cg.add(var.set_vertical_default(config[CONF_VERTICAL_DEFAULT]))

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -154,8 +154,12 @@ void MitsubishiClimate::transmit_state() {
   if (this->mode == climate::CLIMATE_MODE_DRY) {
     remote_state[7] = 24 - MITSUBISHI_TEMP_MIN;  // Remote sends always 24°C if "Dry" mode is selected
   } else {
-    remote_state[7] = (uint8_t) roundf(
-        clamp<float>(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) - MITSUBISHI_TEMP_MIN);
+    if (!this->fahrenheit_compatibility_) {
+      remote_state[7] = (uint8_t) roundf(
+          clamp<float>(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) - MITSUBISHI_TEMP_MIN);
+    } else {
+      remote_state[7] = reconvert_from_fahrenheit_(this->target_temperature);
+    }
   }
 
   // Wide Vane
@@ -286,6 +290,32 @@ void MitsubishiClimate::transmit_state() {
 
 bool MitsubishiClimate::parse_state_frame_(const uint8_t frame[]) { return false; }
 
+static const uint8_t FAHRENHEIT_CODES[] = {0x00, 0x10, 0x01, 0x11, 0x02, 0x12, 0x03, 0x04, 0x05, 0x15,
+                                           0x06, 0x16, 0x07, 0x17, 0x08, 0x18, 0x09, 0x19, 0x0a, 0x1a,
+                                           0x0b, 0x1b, 0x0c, 0x1c, 0x0d, 0x1d, 0x0e, 0x0f};
+
+uint8_t MitsubishiClimate::reconvert_from_fahrenheit_(float c_temp) {
+  if (c_temp < 16.0f) {
+    return 0x00;
+  }
+  if (c_temp > 31.2f) {
+    return 0x0f;
+  }
+
+  // Every temperature from 61F..88F sends a unique code to the unit.
+  uint8_t f_index = (uint8_t) roundf(c_temp * 1.8f + 32) - 61;
+  return FAHRENHEIT_CODES[f_index];
+}
+
+float MitsubishiClimate::temp_code_to_celsius_(uint8_t code) {
+  for (size_t i = 0; i < sizeof(FAHRENHEIT_CODES) / sizeof(FAHRENHEIT_CODES[0]); i++) {
+    if (code == FAHRENHEIT_CODES[i]) {
+      return (61.0f + i - 32) / 1.8;
+    }
+  }
+  return -1.0f;
+}
+
 bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t state_frame[18] = {};
 
@@ -340,7 +370,18 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Temp
-  this->target_temperature = state_frame[7] + MITSUBISHI_TEMP_MIN;
+  if (!this->fahrenheit_compatibility_) {
+    this->target_temperature = state_frame[7] + MITSUBISHI_TEMP_MIN;
+    if (state_frame[7] & 0x10) {
+      ESP_LOGV(TAG, "Transmitter is in Fahrenheit mode; enable `fahrenheit_compatibility` for proper decoding");
+    }
+  } else {
+    this->target_temperature = temp_code_to_celsius_(state_frame[7]);
+    if (this->target_temperature < 0) {
+      ESP_LOGV(TAG, "Invalid temperature code %02x", state_frame[7]);
+      return false;
+    }
+  }
 
   // Fan
   uint8_t fan = state_frame[9] & 0x07;  //(Bit 0,1,2 = Speed)

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -8,7 +8,7 @@ namespace esphome::mitsubishi {
 
 // Temperature
 const uint8_t MITSUBISHI_TEMP_MIN = 16;  // Celsius
-const uint8_t MITSUBISHI_TEMP_MAX = 31;  // Celsius
+const uint8_t MITSUBISHI_TEMP_MAX = 32;  // 88F gets sent to us as 31.11C
 
 // Fan mode
 enum SetFanMode {
@@ -53,6 +53,9 @@ class MitsubishiClimate final : public climate_ir::ClimateIR {
   void set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }
   void set_supports_fan_only(bool supports_fan_only) { this->supports_fan_only_ = supports_fan_only; }
   void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
+  void set_fahrenheit_compatibility(bool fahrenheit_compatibility) {
+    this->fahrenheit_compatibility_ = fahrenheit_compatibility;
+  }
 
   void set_fan_mode(SetFanMode fan_mode) { this->fan_mode_ = fan_mode; }
 
@@ -69,8 +72,11 @@ class MitsubishiClimate final : public climate_ir::ClimateIR {
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_state_frame_(const uint8_t frame[]);
+  uint8_t reconvert_from_fahrenheit_(float c_temp);
+  float temp_code_to_celsius_(uint8_t code);
 
   SetFanMode fan_mode_;
+  bool fahrenheit_compatibility_;
 
   HorizontalDirection default_horizontal_direction_;
   VerticalDirection default_vertical_direction_;

--- a/tests/components/mitsubishi/common.yaml
+++ b/tests/components/mitsubishi/common.yaml
@@ -2,3 +2,4 @@ climate:
   - platform: mitsubishi
     name: Mitsubishi
     transmitter_id: xmitr
+    fahrenheit_compatibility: "false"


### PR DESCRIPTION
Same PR as https://github.com/esphome/esphome/pull/12611

I have been running this feature locally for almost a year now with no issues.  It would be awesome to get it into mainline since others have indicated that it would be useful to them too.