### PR TITLE
[internal_temperature] Re-include esp_phy on the original ESP32 so the PHY blob links

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -246,7 +246,7 @@ DEFAULT_EXCLUDED_IDF_COMPONENTS = (
     "esp_https_server",  # HTTPS server - ESPHome has its own web server
     "esp_lcd",  # LCD controller drivers - only needed by display component
     "esp_local_ctrl",  # Local control over HTTPS/BLE - ESPHome has native API
-    "esp_phy",  # RF PHY - esp_wifi/bt/ieee802154 pull it back when they are in the build
+    "esp_phy",  # RF PHY - re-included by internal_temperature on the original ESP32; esp_wifi/bt/ieee802154 pull it back
     "esp_wifi",  # WiFi stack - re-included by request_wifi(), espnow; bt pulls it back for BLE builds
     "espcoredump",  # Core dump support - ESPHome has its own debug component
     "fatfs",  # FAT filesystem - ESPHome doesn't use filesystem storage

--- a/esphome/components/internal_temperature/sensor.py
+++ b/esphome/components/internal_temperature/sensor.py
@@ -1,5 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import sensor
+from esphome.components.esp32 import get_esp32_variant, include_builtin_idf_component
+from esphome.components.esp32.const import VARIANT_ESP32
 from esphome.components.zephyr import zephyr_add_prj_conf
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
@@ -47,6 +49,10 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config: ConfigType) -> None:
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
+
+    if CORE.is_esp32 and get_esp32_variant() == VARIANT_ESP32:
+        # temprature_sens_read() lives in the esp_phy blob, which is excluded by default
+        include_builtin_idf_component("esp_phy")
 
     if CORE.using_zephyr and CORE.is_nrf52:
         zephyr_add_prj_conf("SENSOR", True)

--- a/tests/component_tests/esp32/config/exclusion_reincludes_internal_temperature.yaml
+++ b/tests/component_tests/esp32/config/exclusion_reincludes_internal_temperature.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+sensor:
+  - platform: internal_temperature
+    name: Internal Temperature

--- a/tests/component_tests/esp32/config/exclusion_stays_internal_temperature_s3.yaml
+++ b/tests/component_tests/esp32/config/exclusion_stays_internal_temperature_s3.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: esp-idf
+
+sensor:
+  - platform: internal_temperature
+    name: Internal Temperature

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -313,6 +313,12 @@ def test_esp32_configuration_errors(
             ("esp_wifi",),
             id="espnow",
         ),
+        pytest.param(
+            # temprature_sens_read() on the original ESP32 lives in the esp_phy blob.
+            "exclusion_reincludes_internal_temperature.yaml",
+            ("esp_phy",),
+            id="internal_temperature",
+        ),
     ],
 )
 def test_default_exclusions_reincluded_by_owning_components(
@@ -335,6 +341,15 @@ def test_default_exclusions_reincluded_by_owning_components(
     assert "fatfs" in excluded
     # The HTTP server only comes back for configs that run one.
     assert ("esp_http_server" in excluded) == ("esp_http_server" not in reincluded)
+
+
+def test_esp_phy_stays_excluded_for_internal_temperature_on_newer_variants(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Only the original ESP32 reads the PHY blob; other variants use esp_driver_tsens."""
+    generate_main(component_config_path("exclusion_stays_internal_temperature_s3.yaml"))
+    assert "esp_phy" in CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
 
 
 def test_nvs_sec_provider_stays_excluded_when_encryption_is_off(


### PR DESCRIPTION
# What does this implement/fix?

On the original ESP32 the internal temperature sensor reads `temprature_sens_read()`, which lives in the `libphy.a` blob that ESP-IDF's `esp_phy` component links. Since #18599 `esp_phy` is excluded by default and only comes back when `esp_wifi` or `bt` are in the build, so a config with `internal_temperature` and no WiFi or Bluetooth fails to link with `undefined reference to temprature_sens_read`; this showed up in the CI batch for #17909.

This re-includes `esp_phy` from `internal_temperature` when the target is the original ESP32, matching how `adc` re-includes `esp_adc`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf

sensor:
  - platform: internal_temperature
    name: Internal Temperature

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
