### PR TITLE
[homeassistant] Add integration test for binary sensor initial state triggers

### DIFF
--- a/tests/integration/fixtures/api_homeassistant_binary_sensor_initial_state.yaml
+++ b/tests/integration/fixtures/api_homeassistant_binary_sensor_initial_state.yaml
@@ -1,0 +1,49 @@
+esphome:
+  name: ha-bs-initial
+
+host:
+
+api:
+
+logger:
+  level: DEBUG
+
+binary_sensor:
+  # trigger_on_initial_state: true must fire on_press for the first state from HA
+  - platform: homeassistant
+    name: Initial On
+    entity_id: binary_sensor.initial_on
+    trigger_on_initial_state: true
+    on_press:
+      - logger.log: "initial_on on_press"
+    on_release:
+      - logger.log: "initial_on on_release"
+
+  # Default (false) must not fire on the first state, only on later changes
+  - platform: homeassistant
+    name: Default
+    entity_id: binary_sensor.default
+    on_press:
+      - logger.log: "default on_press"
+    on_release:
+      - logger.log: "default on_release"
+
+  # Real HA startup shape: 'unavailable' arrives before the first real state
+  - platform: homeassistant
+    name: Unavailable First
+    entity_id: binary_sensor.unavailable_first
+    trigger_on_initial_state: true
+    on_press:
+      - logger.log: "unavailable_first on_press"
+    on_release:
+      - logger.log: "unavailable_first on_release"
+
+  # Initial 'off' must fire on_release when trigger_on_initial_state is set
+  - platform: homeassistant
+    name: Initial Off
+    entity_id: binary_sensor.initial_off
+    trigger_on_initial_state: true
+    on_press:
+      - logger.log: "initial_off on_press"
+    on_release:
+      - logger.log: "initial_off on_release"

--- a/tests/integration/fixtures/api_homeassistant_binary_sensor_initial_state.yaml
+++ b/tests/integration/fixtures/api_homeassistant_binary_sensor_initial_state.yaml
@@ -47,3 +47,13 @@ binary_sensor:
       - logger.log: "initial_off on_press"
     on_release:
       - logger.log: "initial_off on_release"
+
+  # Same 'unavailable' first shape without the flag; must stay quiet on the
+  # first real state and only fire on the later change
+  - platform: homeassistant
+    name: Default Unavailable First
+    entity_id: binary_sensor.default_unavail
+    on_press:
+      - logger.log: "default_unavail on_press"
+    on_release:
+      - logger.log: "default_unavail on_release"

--- a/tests/integration/log_utils.py
+++ b/tests/integration/log_utils.py
@@ -28,6 +28,11 @@ class LineWaiter:
             self._future.set_result(line)
             self._future = None
 
+    async def wait_for_each(self, *texts: str, timeout: float = 10.0) -> None:
+        """Await one line per text, in order; each wait uses the full timeout."""
+        for text in texts:
+            await self.wait_for(text, timeout=timeout)
+
     async def wait_for(self, *needles: str, timeout: float = 10.0) -> str:
         """Return the first line, past or future, containing every needle."""
         for line in self.lines:

--- a/tests/integration/log_utils.py
+++ b/tests/integration/log_utils.py
@@ -29,7 +29,7 @@ class LineWaiter:
             self._future = None
 
     async def wait_for_each(self, *texts: str, timeout: float = 10.0) -> None:
-        """Await one line per text, in order; each wait uses the full timeout."""
+        """Await each text in turn; a text may match a line already received."""
         for text in texts:
             await self.wait_for(text, timeout=timeout)
 

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -88,11 +88,11 @@ async def test_api_homeassistant_binary_sensor_initial_state(
         client.send_home_assistant_state("binary_sensor.unavailable_first", "", "off")
         client.send_home_assistant_state("binary_sensor.initial_off", "", "on")
         client.send_home_assistant_state("binary_sensor.default_unavail", "", "off")
-        for text in (
+        await waiter.wait_for_each(
             "initial_on on_release",
             "default on_release",
             "default_unavail on_release",
             "unavailable_first on_release",
             "initial_off on_press",
-        ):
-            await waiter.wait_for(text, timeout=5.0)
+            timeout=5.0,
+        )

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -14,6 +14,7 @@ ENTITIES = (
     "binary_sensor.default",
     "binary_sensor.unavailable_first",
     "binary_sensor.initial_off",
+    "binary_sensor.default_unavail",
 )
 
 
@@ -51,10 +52,18 @@ async def test_api_homeassistant_binary_sensor_initial_state(
             "binary_sensor.unavailable_first", "", "unavailable"
         )
         client.send_home_assistant_state("binary_sensor.unavailable_first", "", "on")
+        client.send_home_assistant_state(
+            "binary_sensor.default_unavail", "", "unavailable"
+        )
+        client.send_home_assistant_state("binary_sensor.default_unavail", "", "on")
         client.send_home_assistant_state("binary_sensor.initial_off", "", "off")
 
         await waiter.wait_for("initial_on on_press", timeout=5.0)
         await waiter.wait_for("unavailable_first on_press", timeout=5.0)
+        # Pin that the 'unavailable' message actually arrived and was rejected
+        await waiter.wait_for(
+            "Can't convert 'unavailable' to binary state", timeout=5.0
+        )
         # initial_off is the last state sent, so this wait also proves the
         # earlier 'default' initial state was already processed
         await waiter.wait_for("initial_off on_release", timeout=5.0)
@@ -64,6 +73,8 @@ async def test_api_homeassistant_binary_sensor_initial_state(
             "initial_on on_release",
             "default on_press",
             "default on_release",
+            "default_unavail on_press",
+            "default_unavail on_release",
             "unavailable_first on_release",
             "initial_off on_press",
         ):
@@ -76,9 +87,11 @@ async def test_api_homeassistant_binary_sensor_initial_state(
         client.send_home_assistant_state("binary_sensor.default", "", "off")
         client.send_home_assistant_state("binary_sensor.unavailable_first", "", "off")
         client.send_home_assistant_state("binary_sensor.initial_off", "", "on")
+        client.send_home_assistant_state("binary_sensor.default_unavail", "", "off")
         for text in (
             "initial_on on_release",
             "default on_release",
+            "default_unavail on_release",
             "unavailable_first on_release",
             "initial_off on_press",
         ):

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -1,0 +1,74 @@
+"""Test on_press/on_release for homeassistant binary sensors on the first HA state."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from .log_utils import LineWaiter
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+ENTITIES = (
+    "binary_sensor.initial_on",
+    "binary_sensor.default",
+    "binary_sensor.unavailable_first",
+    "binary_sensor.initial_off",
+)
+
+
+@pytest.mark.asyncio
+async def test_api_homeassistant_binary_sensor_initial_state(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """The first state from HA fires on_press only with trigger_on_initial_state."""
+    loop = asyncio.get_running_loop()
+    waiter = LineWaiter()
+    subscribed: set[str] = set()
+    all_subscribed = loop.create_future()
+
+    def on_state_sub(entity_id: str, _attribute: str | None) -> None:
+        subscribed.add(entity_id)
+        if not all_subscribed.done() and subscribed.issuperset(ENTITIES):
+            all_subscribed.set_result(None)
+
+    async with (
+        run_compiled(yaml_config, line_callback=waiter.callback),
+        api_client_connected() as client,
+    ):
+        client.subscribe_home_assistant_states(on_state_sub)
+        await asyncio.wait_for(all_subscribed, timeout=5.0)
+
+        # First state from HA
+        client.send_home_assistant_state("binary_sensor.initial_on", "", "on")
+        client.send_home_assistant_state("binary_sensor.default", "", "on")
+        client.send_home_assistant_state(
+            "binary_sensor.unavailable_first", "", "unavailable"
+        )
+        client.send_home_assistant_state("binary_sensor.unavailable_first", "", "on")
+        client.send_home_assistant_state("binary_sensor.initial_off", "", "off")
+
+        await waiter.wait_for("initial_on on_press", timeout=5.0)
+        await waiter.wait_for("unavailable_first on_press", timeout=5.0)
+        # initial_off is the last state sent, so this wait also proves the
+        # earlier 'default' initial state was already processed
+        await waiter.wait_for("initial_off on_release", timeout=5.0)
+        assert not any("default on_press" in line for line in waiter.lines), (
+            "default binary sensor fired on_press for its initial state"
+        )
+        assert not any("initial_off on_press" in line for line in waiter.lines)
+
+        # A later change fires for all of them
+        client.send_home_assistant_state("binary_sensor.initial_on", "", "off")
+        client.send_home_assistant_state("binary_sensor.default", "", "off")
+        client.send_home_assistant_state("binary_sensor.unavailable_first", "", "off")
+        client.send_home_assistant_state("binary_sensor.initial_off", "", "on")
+        for text in (
+            "initial_on on_release",
+            "default on_release",
+            "unavailable_first on_release",
+            "initial_off on_press",
+        ):
+            await waiter.wait_for(text, timeout=5.0)

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -61,20 +61,12 @@ async def test_api_homeassistant_binary_sensor_initial_state(
         await waiter.wait_for("initial_on on_press", timeout=5.0)
         await waiter.wait_for("unavailable_first on_press", timeout=5.0)
         # Pin that the 'unavailable' message actually arrived and was rejected
-        await waiter.wait_for(
-            "Can't convert 'unavailable' to binary state", timeout=5.0
-        )
+        await waiter.wait_for("Can't convert 'unavailable'", timeout=5.0)
         # initial_off is the last state sent, so this wait also proves the
         # earlier 'default' initial state was already processed
         await waiter.wait_for("initial_off on_release", timeout=5.0)
         # Both 'unavailable' senders must have been seen and rejected
-        assert (
-            sum(
-                "Can't convert 'unavailable' to binary state" in line
-                for line in waiter.lines
-            )
-            == 2
-        )
+        assert sum("Can't convert 'unavailable'" in line for line in waiter.lines) == 2
         # Guard every phase 2 needle against being satisfied by a stale
         # phase 1 line, and pin that the initial states fired nothing else
         for absent in (

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -58,13 +58,18 @@ async def test_api_homeassistant_binary_sensor_initial_state(
         # initial_off is the last state sent, so this wait also proves the
         # earlier 'default' initial state was already processed
         await waiter.wait_for("initial_off on_release", timeout=5.0)
-        assert not any("default on_press" in line for line in waiter.lines), (
-            "default binary sensor fired on_press for its initial state"
-        )
-        assert not any("initial_off on_press" in line for line in waiter.lines)
-        assert not any(
-            "unavailable_first on_release" in line for line in waiter.lines
-        ), "'unavailable' fired a trigger instead of being ignored"
+        # Guard every phase 2 needle against being satisfied by a stale
+        # phase 1 line, and pin that the initial states fired nothing else
+        for absent in (
+            "initial_on on_release",
+            "default on_press",
+            "default on_release",
+            "unavailable_first on_release",
+            "initial_off on_press",
+        ):
+            assert not any(absent in line for line in waiter.lines), (
+                f"unexpected trigger before the second state change: {absent}"
+            )
 
         # A later change fires for all of them
         client.send_home_assistant_state("binary_sensor.initial_on", "", "off")

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -39,7 +39,10 @@ async def test_api_homeassistant_binary_sensor_initial_state(
         api_client_connected() as client,
     ):
         client.subscribe_home_assistant_states(on_state_sub)
-        await asyncio.wait_for(all_subscribed, timeout=5.0)
+        try:
+            await asyncio.wait_for(all_subscribed, timeout=5.0)
+        except TimeoutError:
+            pytest.fail(f"never subscribed: {set(ENTITIES) - subscribed}")
 
         # First state from HA
         client.send_home_assistant_state("binary_sensor.initial_on", "", "on")
@@ -59,6 +62,9 @@ async def test_api_homeassistant_binary_sensor_initial_state(
             "default binary sensor fired on_press for its initial state"
         )
         assert not any("initial_off on_press" in line for line in waiter.lines)
+        assert not any(
+            "unavailable_first on_release" in line for line in waiter.lines
+        ), "'unavailable' fired a trigger instead of being ignored"
 
         # A later change fires for all of them
         client.send_home_assistant_state("binary_sensor.initial_on", "", "off")

--- a/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
+++ b/tests/integration/test_api_homeassistant_binary_sensor_initial_state.py
@@ -67,6 +67,14 @@ async def test_api_homeassistant_binary_sensor_initial_state(
         # initial_off is the last state sent, so this wait also proves the
         # earlier 'default' initial state was already processed
         await waiter.wait_for("initial_off on_release", timeout=5.0)
+        # Both 'unavailable' senders must have been seen and rejected
+        assert (
+            sum(
+                "Can't convert 'unavailable' to binary state" in line
+                for line in waiter.lines
+            )
+            == 2
+        )
         # Guard every phase 2 needle against being satisfied by a stale
         # phase 1 line, and pin that the initial states fired nothing else
         for absent in (


### PR DESCRIPTION
# What does this implement/fix?

A user reported that homeassistant binary sensors stopped running on_press and on_release for the first state received from Home Assistant after upgrading from 2026.5.1 to 2026.7.4, with trigger_on_initial_state set to true. This adds an integration test covering the initial state paths: trigger_on_initial_state with an initial on and with an initial off, the default behavior that only fires on later changes, and the startup shape where unavailable arrives before the first real state. The test passes on dev and also on the 2026.7.4 and 2026.5.1 tags, so no regression was found; this locks the behavior in.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
binary_sensor:
  - platform: homeassistant
    entity_id: binary_sensor.motion
    trigger_on_initial_state: true
    on_press:
      - logger.log: pressed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
