### PR TITLE
[ci] Cache the integration test PlatformIO dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,14 @@ jobs:
       fail-fast: false
       matrix:
         bucket: ${{ fromJson(needs.determine-jobs.outputs.integration-test-buckets) }}
+    env:
+      # What the cache steps persist; libdeps is excluded (keyed per xdist
+      # worker and env, it never crosses runs).
+      INTEGRATION_PIO_CACHE_PATH: |
+        ~/.esphome-integration-tests/platformio/platforms
+        ~/.esphome-integration-tests/platformio/packages
+        ~/.esphome-integration-tests/platformio/appstate.json
+        ~/.esphome-integration-tests/platformio/.cache
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -373,6 +381,14 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+      - name: Restore integration PlatformIO cache
+        # Native platform + toolchain installed by shared_platformio_cache in
+        # tests/integration/conftest.py; a miss self-heals, so no restore-keys.
+        id: pio-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.INTEGRATION_PIO_CACHE_PATH }}
+          key: integration-pio-v1-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements.txt', 'tests/integration/fixtures/cache_init.yaml', 'esphome/components/host/__init__.py') }}
       - name: Restore Python virtual environment
         id: cache-venv
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -416,6 +432,13 @@ jobs:
         # esphome stores the PlatformIO ccache under the machine-global cache
         # dir (see _ccache_env() in esphome/platformio/toolchain.py).
         run: CCACHE_DIR="$HOME/.cache/esphome/platformio-ccache" ccache -s
+      - name: Save integration PlatformIO cache
+        # Bucket 0 only; the others would race the same immutable key.
+        if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && strategy.job-index == 0 && steps.pio-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.INTEGRATION_PIO_CACHE_PATH }}
+          key: ${{ steps.pio-cache.outputs.cache-primary-key }}
 
   import-time:
     name: Check import esphome.__main__ time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,7 @@ jobs:
         ~/.esphome-integration-tests/platformio/packages
         ~/.esphome-integration-tests/platformio/appstate.json
         ~/.esphome-integration-tests/platformio/.cache
+        ~/.esphome-integration-tests/platformio/.esphome.pio.stamp.json
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -434,7 +435,7 @@ jobs:
         run: CCACHE_DIR="$HOME/.cache/esphome/platformio-ccache" ccache -s
       - name: Save integration PlatformIO cache
         # Bucket 0 only; the others would race the same immutable key.
-        if: (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && strategy.job-index == 0 && steps.pio-cache.outputs.cache-hit != 'true'
+        if: success() && (github.ref == 'refs/heads/dev' || contains(github.event.pull_request.labels.*.name, 'ci-cache-write')) && strategy.job-index == 0 && steps.pio-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.INTEGRATION_PIO_CACHE_PATH }}

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -101,11 +101,15 @@ COMPONENT_TEST_BATCH_SIZE = 40
 INTEGRATION_TESTS_SPLIT_THRESHOLD = 10
 INTEGRATION_TESTS_SPLIT_BUCKETS = 3
 
-# platformio and aioesphomeapi (requirements.txt) and the pytest stack
-# (requirements_test.txt) are used by every integration test; a change to
-# either runs the full matrix
+# platformio and aioesphomeapi (requirements.txt), the pytest stack
+# (requirements_test.txt) and the fixture every session compiles; a change
+# to any runs the full matrix
 INTEGRATION_TESTS_TRIGGER_FILES = frozenset(
-    {"requirements.txt", "requirements_test.txt"}
+    {
+        "requirements.txt",
+        "requirements_test.txt",
+        "tests/integration/fixtures/cache_init.yaml",
+    }
 )
 
 
@@ -228,9 +232,8 @@ def determine_integration_tests(branch: str | None = None) -> tuple[bool, list[s
     3. Integration test infrastructure files changed
        - conftest.py, types.py, const.py, entity_utils.py, state_utils.py, etc.
 
-    4. requirements.txt or requirements_test.txt changed
-       - platformio and aioesphomeapi (requirements.txt) and the pytest stack
-         (requirements_test.txt) are used by every integration test
+    4. A file in INTEGRATION_TESTS_TRIGGER_FILES changed
+       - The dependency pins and the session init fixture affect every test
 
     Returns (run_all=False, [test_files...]) when:
 

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -101,6 +101,13 @@ COMPONENT_TEST_BATCH_SIZE = 40
 INTEGRATION_TESTS_SPLIT_THRESHOLD = 10
 INTEGRATION_TESTS_SPLIT_BUCKETS = 3
 
+# platformio and aioesphomeapi (requirements.txt) and the pytest stack
+# (requirements_test.txt) are used by every integration test; a change to
+# either runs the full matrix
+INTEGRATION_TESTS_TRIGGER_FILES = frozenset(
+    {"requirements.txt", "requirements_test.txt"}
+)
+
 
 def _split_list(items: list[str], n: int) -> list[list[str]]:
     """Split a list into n roughly-equal contiguous parts (matches script/clang-tidy)."""
@@ -222,7 +229,8 @@ def determine_integration_tests(branch: str | None = None) -> tuple[bool, list[s
        - conftest.py, types.py, const.py, entity_utils.py, state_utils.py, etc.
 
     4. requirements.txt or requirements_test.txt changed
-       - They pin platformio and aioesphomeapi, which every integration test uses
+       - platformio and aioesphomeapi (requirements.txt) and the pytest stack
+         (requirements_test.txt) are used by every integration test
 
     Returns (run_all=False, [test_files...]) when:
 
@@ -247,8 +255,7 @@ def determine_integration_tests(branch: str | None = None) -> tuple[bool, list[s
         # If any core files changed, run all integration tests
         return (True, [])
 
-    # They pin platformio and aioesphomeapi, which every integration test uses
-    if any(f in ("requirements.txt", "requirements_test.txt") for f in files):
+    if any(f in INTEGRATION_TESTS_TRIGGER_FILES for f in files):
         return (True, [])
 
     # If infrastructure Python files changed (conftest, utils, etc.), run all tests

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -221,12 +221,15 @@ def determine_integration_tests(branch: str | None = None) -> tuple[bool, list[s
     3. Integration test infrastructure files changed
        - conftest.py, types.py, const.py, entity_utils.py, state_utils.py, etc.
 
+    4. requirements.txt or requirements_test.txt changed
+       - They pin platformio and aioesphomeapi, which every integration test uses
+
     Returns (run_all=False, [test_files...]) when:
 
-    4. Specific integration test files changed
+    5. Specific integration test files changed
        - Only those specific test files are returned
 
-    5. Components used by integration tests (or their dependencies) changed
+    6. Components used by integration tests (or their dependencies) changed
        - Only test files whose fixtures use the changed components are returned
 
     Args:
@@ -242,6 +245,10 @@ def determine_integration_tests(branch: str | None = None) -> tuple[bool, list[s
 
     if core_changed(files):
         # If any core files changed, run all integration tests
+        return (True, [])
+
+    # They pin platformio and aioesphomeapi, which every integration test uses
+    if any(f in ("requirements.txt", "requirements_test.txt") for f in files):
         return (True, [])
 
     # If infrastructure Python files changed (conftest, utils, etc.), run all tests

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -78,7 +78,8 @@ def _get_platformio_env(cache_dir: Path) -> dict[str, str]:
 @pytest.fixture(scope="session")
 def shared_platformio_cache() -> Generator[Path]:
     """Initialize a shared PlatformIO cache for all integration tests."""
-    # Use a dedicated directory for integration tests to avoid conflicts
+    # Use a dedicated directory for integration tests to avoid conflicts.
+    # CI caches parts of this path; keep in sync with ci.yml integration-tests.
     test_cache_dir = Path.home() / ".esphome-integration-tests"
     cache_dir = test_cache_dir / "platformio"
 

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -552,9 +552,9 @@ def test_determine_integration_tests(
         assert run_all is True
         assert test_files == []
 
-    # Requirements files pin platformio and aioesphomeapi; they trigger run_all
-    for requirements in ("requirements.txt", "requirements_test.txt"):
-        with patch.object(determine_jobs, "changed_files", return_value=[requirements]):
+    # Dependency pins and the session init fixture trigger run_all
+    for trigger in sorted(determine_jobs.INTEGRATION_TESTS_TRIGGER_FILES):
+        with patch.object(determine_jobs, "changed_files", return_value=[trigger]):
             run_all, test_files = determine_jobs.determine_integration_tests()
             assert run_all is True
             assert test_files == []

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -552,6 +552,13 @@ def test_determine_integration_tests(
         assert run_all is True
         assert test_files == []
 
+    # Requirements files pin platformio and aioesphomeapi; they trigger run_all
+    for requirements in ("requirements.txt", "requirements_test.txt"):
+        with patch.object(determine_jobs, "changed_files", return_value=[requirements]):
+            run_all, test_files = determine_jobs.determine_integration_tests()
+            assert run_all is True
+            assert test_files == []
+
     # Python files directly in esphome/ do NOT trigger tests
     with patch.object(
         determine_jobs, "changed_files", return_value=["esphome/config.py"]


### PR DESCRIPTION
# What does this implement/fix?

Every integration test bucket starts with a cold PlatformIO dir, so each job pays about 37 seconds compiling cache_init.yaml just to install the native platform and toolchain. This caches the parts of ~/.esphome-integration-tests that gate that init (platforms, packages, appstate.json and the download cache, about 5 MB; per worker libdeps are excluded since they never cross runs). The key carries the runner Python version, a version salt and the pins that produce the contents; pull requests restore only, dev pushes save from bucket 0 when the key rotated, and the ci-cache-write label lets a PR exercise the save path. A miss self-heals because the test harness rebuilds the directory when the native platform is absent.

It also makes requirements.txt and requirements_test.txt changes schedule the full integration matrix; platformio, aioesphomeapi and the pytest stack live there, yet today a bump runs zero integration tests, which is also what would have orphaned this cache key between dev merges.

Integration test job times on this branch with the ci-cache-write label, cache miss run 33333366043 against cache hit run 33336014678; the hit run logs `Cache restored from key: integration-pio-v1-...` and skips the cache_init compile entirely:

| Bucket | Cache miss | Cache hit | Saved |
|---|---|---|---|
| 1/3 | 11m50s | 9m37s | 2m13s |
| 2/3 | 11m00s | 9m44s | 1m16s |
| 3/3 | 16m02s | 14m35s | 1m27s |

The saving exceeds the ~37s cache_init compile because the restored download cache also short circuits the per env libsodium and noise-c fetches.

Cache entries touched by this PR, sizes as compressed GitHub cache entries:

| Entry | Before | After |
|---|---|---|
| `integration-pio-v1-Linux-py<version>-<pins hash>` | none | 1.8 MB measured |

One entry per key; the key rotates only when the hashed pins or the runner Python change, and old entries age out under LRU.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
