### PR TITLE
[core] Deduplicate the host program path lookup

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1670,18 +1670,24 @@ def command_compile(args: ArgsProtocol, config: ConfigType) -> int | None:
     if exit_code != 0:
         return exit_code
     if CORE.is_host:
-        if CORE.using_toolchain_esp_idf:
-            from esphome.espidf import toolchain
-
-            program_path = str(toolchain.get_elf_path())
-        else:
-            from esphome.platformio.toolchain import get_idedata
-
-            program_path = str(get_idedata(config).firmware_elf_path)
-        _LOGGER.info("Successfully compiled program to path '%s'", program_path)
+        _LOGGER.info(
+            "Successfully compiled program to path '%s'", _host_program_path(config)
+        )
     else:
         _LOGGER.info("Successfully compiled program.")
     return 0
+
+
+def _host_program_path(config: ConfigType) -> str:
+    """Return the compiled host ELF path."""
+    if CORE.using_toolchain_esp_idf:
+        from esphome.espidf import toolchain
+
+        return str(toolchain.get_elf_path())
+    from esphome.platformio.toolchain import get_idedata
+
+    # Memoized by compile_program's own call; this is a dict lookup
+    return str(get_idedata(config).firmware_elf_path)
 
 
 def command_upload(args: ArgsProtocol, config: ConfigType) -> int | None:
@@ -1728,14 +1734,7 @@ def command_run(args: ArgsProtocol, config: ConfigType) -> int | None:
         return exit_code
     _LOGGER.info("Successfully compiled program.")
     if CORE.is_host:
-        if CORE.using_toolchain_esp_idf:
-            from esphome.espidf import toolchain
-
-            program_path = str(toolchain.get_elf_path())
-        else:
-            from esphome.platformio.toolchain import get_idedata
-
-            program_path = str(get_idedata(config).firmware_elf_path)
+        program_path = _host_program_path(config)
         _LOGGER.info("Running program from path '%s'", program_path)
         return run_external_process(program_path)
 

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -7254,3 +7254,76 @@ async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
     assert first == second
     assert second.index("alpha") < second.index("beta")
     assert second.index("a: 2") < second.index("z: 1")
+
+
+def test_host_program_path_platformio_toolchain() -> None:
+    """Host + PlatformIO toolchain reads the memoized idedata path."""
+    from unittest.mock import PropertyMock
+
+    idedata = SimpleNamespace(firmware_elf_path="/build/x/.pioenvs/x/program")
+    with (
+        patch.object(
+            type(CORE),
+            "using_toolchain_esp_idf",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        patch(
+            "esphome.platformio.toolchain.get_idedata", return_value=idedata
+        ) as mock_get,
+    ):
+        assert main._host_program_path({}) == "/build/x/.pioenvs/x/program"
+    mock_get.assert_called_once_with({})
+
+
+def test_host_program_path_esp_idf_toolchain() -> None:
+    """Host + native ESP-IDF toolchain asks the espidf toolchain for the ELF."""
+    from unittest.mock import PropertyMock
+
+    with (
+        patch.object(
+            type(CORE),
+            "using_toolchain_esp_idf",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch("esphome.espidf.toolchain.get_elf_path", return_value=Path("/b/app.elf")),
+    ):
+        assert main._host_program_path({}) == str(Path("/b/app.elf"))
+
+
+def test_command_compile_host_logs_program_path() -> None:
+    """command_compile on host resolves and logs the compiled program path."""
+    from unittest.mock import PropertyMock
+
+    setup_core(config={})
+    with (
+        patch.object(main, "write_cpp", return_value=0),
+        patch.object(main, "compile_program", return_value=0),
+        patch.object(
+            type(CORE), "is_host", new_callable=PropertyMock, return_value=True
+        ),
+        patch.object(
+            main, "_host_program_path", return_value="/b/program"
+        ) as mock_path,
+    ):
+        assert main.command_compile(SimpleNamespace(only_generate=False), {}) == 0
+    mock_path.assert_called_once_with({})
+
+
+def test_command_run_host_executes_program() -> None:
+    """command_run on host executes the compiled program directly."""
+    from unittest.mock import PropertyMock
+
+    setup_core(config={})
+    with (
+        patch.object(main, "write_cpp", return_value=0),
+        patch.object(main, "compile_program", return_value=0),
+        patch.object(
+            type(CORE), "is_host", new_callable=PropertyMock, return_value=True
+        ),
+        patch.object(main, "_host_program_path", return_value="/b/program"),
+        patch.object(main, "run_external_process", return_value=0) as mock_run,
+    ):
+        assert main.command_run(SimpleNamespace(), {}) == 0
+    mock_run.assert_called_with("/b/program")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -112,6 +112,7 @@ from esphome.const import (
     PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
+    PLATFORM_HOST,
     PLATFORM_NRF52,
     PLATFORM_RP2,
     Toolchain,
@@ -7258,72 +7259,50 @@ async def test_wrap_to_code_comment_is_insertion_order_independent() -> None:
 
 def test_host_program_path_platformio_toolchain() -> None:
     """Host + PlatformIO toolchain reads the memoized idedata path."""
-    from unittest.mock import PropertyMock
-
+    setup_core(platform=PLATFORM_HOST)
     idedata = SimpleNamespace(firmware_elf_path="/build/x/.pioenvs/x/program")
-    with (
-        patch.object(
-            type(CORE),
-            "using_toolchain_esp_idf",
-            new_callable=PropertyMock,
-            return_value=False,
-        ),
-        patch(
-            "esphome.platformio.toolchain.get_idedata", return_value=idedata
-        ) as mock_get,
-    ):
+    with patch(
+        "esphome.platformio.toolchain.get_idedata", return_value=idedata
+    ) as mock_get:
         assert main._host_program_path({}) == "/build/x/.pioenvs/x/program"
     mock_get.assert_called_once_with({})
 
 
 def test_host_program_path_esp_idf_toolchain() -> None:
     """Host + native ESP-IDF toolchain asks the espidf toolchain for the ELF."""
-    from unittest.mock import PropertyMock
-
-    with (
-        patch.object(
-            type(CORE),
-            "using_toolchain_esp_idf",
-            new_callable=PropertyMock,
-            return_value=True,
-        ),
-        patch("esphome.espidf.toolchain.get_elf_path", return_value=Path("/b/app.elf")),
+    setup_core(platform=PLATFORM_HOST)
+    CORE.toolchain = Toolchain.ESP_IDF
+    with patch(
+        "esphome.espidf.toolchain.get_elf_path", return_value=Path("/b/app.elf")
     ):
         assert main._host_program_path({}) == str(Path("/b/app.elf"))
 
 
-def test_command_compile_host_logs_program_path() -> None:
-    """command_compile on host resolves and logs the compiled program path."""
-    from unittest.mock import PropertyMock
-
-    setup_core(config={})
+def test_command_compile_host_logs_program_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """command_compile on host logs the compiled program path."""
+    setup_core(platform=PLATFORM_HOST)
     with (
         patch.object(main, "write_cpp", return_value=0),
         patch.object(main, "compile_program", return_value=0),
-        patch.object(
-            type(CORE), "is_host", new_callable=PropertyMock, return_value=True
-        ),
-        patch.object(
-            main, "_host_program_path", return_value="/b/program"
-        ) as mock_path,
+        patch.object(main, "_host_program_path", return_value="/b/program"),
+        caplog.at_level(logging.INFO),
     ):
         assert main.command_compile(SimpleNamespace(only_generate=False), {}) == 0
-    mock_path.assert_called_once_with({})
+    assert "Successfully compiled program to path '/b/program'" in caplog.text
 
 
-def test_command_run_host_executes_program() -> None:
-    """command_run on host executes the compiled program directly."""
-    from unittest.mock import PropertyMock
-
-    setup_core(config={})
+def test_command_run_host_executes_program(caplog: pytest.LogCaptureFixture) -> None:
+    """command_run on host logs and executes the compiled program directly."""
+    setup_core(platform=PLATFORM_HOST)
     with (
         patch.object(main, "write_cpp", return_value=0),
         patch.object(main, "compile_program", return_value=0),
-        patch.object(
-            type(CORE), "is_host", new_callable=PropertyMock, return_value=True
-        ),
         patch.object(main, "_host_program_path", return_value="/b/program"),
         patch.object(main, "run_external_process", return_value=0) as mock_run,
+        caplog.at_level(logging.INFO),
     ):
         assert main.command_run(SimpleNamespace(), {}) == 0
     mock_run.assert_called_with("/b/program")
+    assert "Running program from path '/b/program'" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

command_compile and command_run carried identical blocks resolving the compiled host program path; they now share a `_host_program_path()` helper. No behavior change, the idedata result it reads is already memoized by compile_program and the log line format is unchanged. Unit tests cover both toolchain branches and both call sites.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
