### PR TITLE
[modbus] Yield the whole-millisecond part of the interframe wait

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -777,9 +777,10 @@ void ModbusServerHub::process_modbus_client_frame_(uint8_t address, uint8_t func
 bool Modbus::send_frame_(const ModbusFrame &frame) {
   int32_t tx_delay_remaining = this->tx_delay_remaining();
   if (tx_delay_remaining > 0) {
-    // delay() only lands on tick boundaries, so yield with it to get close, then busy-wait the rest.
-    if (tx_delay_remaining > (int32_t) (2 * US_PER_MS)) {
-      delay((tx_delay_remaining - US_PER_MS) / US_PER_MS);
+    // Yield the whole-ms part: delay() never blocks past the request on FreeRTOS, and only slightly
+    // over elsewhere, which just lengthens the gap. The recompute below makes the remainder exact.
+    if (tx_delay_remaining >= (int32_t) US_PER_MS) {
+      delay(tx_delay_remaining / US_PER_MS);
       tx_delay_remaining = this->tx_delay_remaining();
     }
     if (tx_delay_remaining > 0)
@@ -814,6 +815,9 @@ bool Modbus::send_frame_(const ModbusFrame &frame) {
 }
 
 void ModbusClientHub::send_next_frame_() {
+  if (this->tx_buffer_.empty())
+    return;
+
   if (this->tx_blocked())
     return;
 


### PR DESCRIPTION
This PR is part of a series of fixes for modbus and related components.

Core modbus architecture:
- #8032 -- in [2026.3.0](https://esphome.io/changelog/2026.3.0/)
- #15291 in [2026.4.0](https://esphome.io/changelog/2026.4.0/)
- #14172 in [2026.4.0](https://esphome.io/changelog/2026.4.0/)
- #15509 in [2026.5.0](https://esphome.io/changelog/2026.5.0/)
- #11969 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #11987 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #12376 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17378 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17282 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17434 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17377 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17844 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17846 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17854 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17848 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17859 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17435 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17888 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17886 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17922 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #18196 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #18844 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18847 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18863 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18873 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18874 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #12421 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18898 (merge ready)

Overhaul of modbus_controller
- #17677 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #11781 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #18652 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18080 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18082 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18787 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18788 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18071 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)
- #18085 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)

New features for server mode
- #17205 in [2026.7.0](https://esphome.io/changelog/2026.7.0/)
- #17387 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17357 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17264 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17464 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)

New features for client mode
- #17467 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #17676 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #18078 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #18215 in [2026.8.0](https://esphome.io/changelog/2026.8.0/)
- #18542 in [2026.9.0](https://esphome.io/changelog/2026.9.0/)

There are associated tests
- #14395 (tests 8032 above)
- #14845 (tests 11969 above)
- #17345 (tests 11781 above)
- #18741 (tests 18082 above)

Original prototype:
- #12614

---
# What does this implement/fix?

`Modbus::send_frame_()` waits out the interframe gap before transmitting.
`delay()` blocks for between one tick less and the full request, so it can return early but never late, which is why the wait is finished with a busy-wait after recomputing from the clock.
The threshold for reaching for `delay()` at all was one millisecond more conservative than that contract requires, so the 1750us gap the spec mandates above 19200 baud fell below it and was spun in full.

Asking `delay()` for the whole-millisecond part still cannot overshoot, and leaves only the sub-tick remainder to spin.

Measured on a client polling three servers at 115200 with `turnaround_time: 0`, accumulating the two halves of the wait separately in `send_frame_()`:

| | spun | yielded | total wait |
| --- | --- | --- | --- |
| before | 1304us | 0us | 1304us |
| after | 405us | 927us | 1332us |

The totals match, which is the point: the wait is the same length, so the gap is still met exactly and throughput is unchanged.
What differs is that 899us per send is no longer spent spinning, which at ~200 transactions/sec is roughly 180ms per second of CPU returned for other tasks.
The 28us the total grew is the cost of yielding and being rescheduled.

This does not show up in `runtime_stats` or in `debug`'s loop time, because both record wall time between loop start and yield, and a blocked `vTaskDelay` counts the same as a busy-wait of equal length.
Bus utilisation measured 95.6-96.3% across six runs with and without the change, with no trend.

`send_next_frame_()` also now returns early when the transmit queue is empty.
That is strictly a subset of the existing `select_next_ready_() == nullptr` path, and skips a UART read and a clock read that cannot change the outcome.

Follows #12421.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; existing modbus configs are unaffected.
modbus:
  uart_id: uart_bus
  id: modbus_hub
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
