### PR TITLE
[esp32] Fix ESP32-S31 GPIO validation

### DIFF
--- a/esphome/components/esp32/gpio_esp32_s31.py
+++ b/esphome/components/esp32/gpio_esp32_s31.py
@@ -5,11 +5,14 @@ import esphome.config_validation as cv
 from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER, CONF_SCL, CONF_SDA
 from esphome.pins import check_strapping_pin
 
-# Per the ESP32-S31 datasheet (page 96):
-# https://documentation.espressif.com/esp32-s31_datasheet_en.pdf
-_ESP32S31_SPI_FLASH_PINS: set[int] = {27, 28, 29, 31, 32, 33}
-# GPIO60/GPIO61 set the boot mode; GPIO37 selects the JTAG signal source.
-_ESP32S31_STRAPPING_PINS: set[int] = {37, 60, 61}
+# Per the ESP32-S31 datasheet, the SPI flash interface uses dedicated package
+# pins (SPICS/SPIQ/SPIWP/SPIHD/SPICLK/SPID) outside the GPIO matrix, so no
+# GPIOs are reserved for flash. GPIO29 and GPIO41 do not exist on this chip
+# (SOC_GPIO_VALID_GPIO_MASK excludes them).
+_ESP32S31_INVALID_PINS: set[int] = {29, 41}
+# GPIO60/GPIO61 set the boot mode; GPIO37 selects the JTAG signal source;
+# GPIO36 sets the VDD_SPI voltage.
+_ESP32S31_STRAPPING_PINS: set[int] = {36, 37, 60, 61}
 # LP I2C is fixed to GPIO6 (SCL) / GPIO7 (SDA) per the datasheet IO MUX table.
 _ESP32S31_I2C_LP_PINS = {"SDA": 7, "SCL": 6}
 
@@ -19,10 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 def esp32_s31_validate_gpio_pin(value: int) -> int:
     if value < 0 or value > 61:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-61)")
-    if value in _ESP32S31_SPI_FLASH_PINS:
-        raise cv.Invalid(
-            f"GPIO{value} is reserved for the SPI flash interface on ESP32-S31 and cannot be used."
-        )
+    if value in _ESP32S31_INVALID_PINS:
+        raise cv.Invalid(f"GPIO{value} does not exist on ESP32-S31.")
     return value
 
 
@@ -33,6 +34,8 @@ def esp32_s31_validate_supports(value: dict[str, Any]) -> dict[str, Any]:
 
     if num < 0 or num > 61:
         raise cv.Invalid(f"Invalid pin number: {num} (must be 0-61)")
+    if num in _ESP32S31_INVALID_PINS:
+        raise cv.Invalid(f"GPIO{num} does not exist on ESP32-S31.")
     if is_input:
         # All ESP32 pins support input mode
         pass

--- a/esphome/components/esp32/gpio_esp32_s31.py
+++ b/esphome/components/esp32/gpio_esp32_s31.py
@@ -5,10 +5,11 @@ import esphome.config_validation as cv
 from esphome.const import CONF_INPUT, CONF_MODE, CONF_NUMBER, CONF_SCL, CONF_SDA
 from esphome.pins import check_strapping_pin
 
-# Per the ESP32-S31 datasheet, the SPI flash interface uses dedicated package
-# pins (SPICS/SPIQ/SPIWP/SPIHD/SPICLK/SPID) outside the GPIO matrix, so no
-# GPIOs are reserved for flash. GPIO29 and GPIO41 do not exist on this chip
-# (SOC_GPIO_VALID_GPIO_MASK excludes them).
+# Per the ESP32-S31 datasheet, the SPI flash and PSRAM interfaces use
+# dedicated package pins (SPICS/SPIQ/SPIWP/SPIHD/SPICLK/SPID) outside the
+# GPIO matrix, so no GPIOs are reserved for them. GPIO29 and GPIO41 do not
+# exist on this chip (SOC_GPIO_VALID_GPIO_MASK excludes them).
+# https://documentation.espressif.com/esp32-s31_datasheet_en.html
 _ESP32S31_INVALID_PINS: set[int] = {29, 41}
 # GPIO60/GPIO61 set the boot mode; GPIO37 selects the JTAG signal source;
 # GPIO36 sets the VDD_SPI voltage.
@@ -34,6 +35,8 @@ def esp32_s31_validate_supports(value: dict[str, Any]) -> dict[str, Any]:
 
     if num < 0 or num > 61:
         raise cv.Invalid(f"Invalid pin number: {num} (must be 0-61)")
+    # Checked here as well so ignore_pin_validation_error cannot bypass it;
+    # these pins are not bonded and can never work
     if num in _ESP32S31_INVALID_PINS:
         raise cv.Invalid(f"GPIO{num} does not exist on ESP32-S31.")
     if is_input:

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -1268,3 +1268,35 @@ def test_parse_pio_platform_version(value: str, expected: str) -> None:
     from esphome.components.esp32 import _parse_pio_platform_version
 
     assert _parse_pio_platform_version(value) == expected
+
+
+def test_esp32_s31_gpio_validation(
+    set_core_config: SetCoreConfigCallable,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """S31: flash uses dedicated pins so GPIO33 is a normal pin, GPIO29/GPIO41
+    do not exist, and GPIO36 is a strapping pin."""
+    from esphome.components.esp32.const import VARIANT_ESP32S31
+    from esphome.components.esp32.gpio import validate_supports
+    from esphome.const import CONF_INPUT, CONF_MODE, CONF_OPEN_DRAIN, CONF_OUTPUT
+
+    set_core_config(
+        PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32S31}
+    )
+
+    pin = {CONF_NUMBER: 33, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
+    assert validate_gpio_pin(pin)[CONF_NUMBER] == 33
+
+    for num in (29, 41):
+        with pytest.raises(cv.Invalid, match=f"GPIO{num} does not exist"):
+            validate_gpio_pin(
+                {CONF_NUMBER: num, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
+            )
+
+    pin = {
+        CONF_NUMBER: 36,
+        CONF_MODE: {CONF_INPUT: True, CONF_OUTPUT: False, CONF_OPEN_DRAIN: False},
+    }
+    with caplog.at_level("WARNING"):
+        validate_supports(pin)
+    assert "GPIO36 is a strapping PIN" in caplog.text

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -1274,8 +1274,8 @@ def test_esp32_s31_gpio_validation(
     set_core_config: SetCoreConfigCallable,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """S31: flash uses dedicated pins so GPIO33 is a normal pin, GPIO29/GPIO41
-    do not exist, and GPIO36 is a strapping pin."""
+    """S31: flash uses dedicated pins so GPIO27-33 are normal pins, GPIO29 and
+    GPIO41 do not exist, and GPIO36 is a strapping pin."""
     from esphome.components.esp32.const import VARIANT_ESP32S31
     from esphome.components.esp32.gpio import validate_supports
     from esphome.const import CONF_INPUT, CONF_MODE, CONF_OPEN_DRAIN, CONF_OUTPUT
@@ -1284,19 +1284,24 @@ def test_esp32_s31_gpio_validation(
         PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32S31}
     )
 
-    pin = {CONF_NUMBER: 33, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
-    assert validate_gpio_pin(pin)[CONF_NUMBER] == 33
+    input_mode = {CONF_INPUT: True, CONF_OUTPUT: False, CONF_OPEN_DRAIN: False}
+
+    # Previously reserved for the flash interface, which uses dedicated pins
+    for num in (27, 28, 31, 32, 33):
+        pin = {CONF_NUMBER: num, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
+        assert validate_gpio_pin(pin)[CONF_NUMBER] == num
 
     for num in (29, 41):
         with pytest.raises(cv.Invalid, match=f"GPIO{num} does not exist"):
             validate_gpio_pin(
                 {CONF_NUMBER: num, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
             )
+        # Also rejected in validate_supports so ignore_pin_validation_error
+        # cannot bypass it
+        with pytest.raises(cv.Invalid, match=f"GPIO{num} does not exist"):
+            validate_supports({CONF_NUMBER: num, CONF_MODE: input_mode})
 
-    pin = {
-        CONF_NUMBER: 36,
-        CONF_MODE: {CONF_INPUT: True, CONF_OUTPUT: False, CONF_OPEN_DRAIN: False},
-    }
+    pin = {CONF_NUMBER: 36, CONF_MODE: input_mode}
     with caplog.at_level("WARNING"):
         validate_supports(pin)
     assert "GPIO36 is a strapping PIN" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

The ESP32-S31 GPIO validation rejected pins that are actually usable and allowed pins that do not exist:

- `_ESP32S31_SPI_FLASH_PINS = {27, 28, 29, 31, 32, 33}` reserved GPIOs for the flash interface, but on the S31 the SPI flash uses dedicated package pins (SPICS/SPIQ/SPIWP/SPIHD/SPICLK/SPID) routed through a separate `IOMUX_MSPI_PIN` register block, not the GPIO matrix. IDF's own `spi_pins.h` for the S31 says the legacy GPIO defines there "are all wrong ... don't use normal GPIO pins anymore". No GPIOs need to be reserved for flash, so the reservation is removed; GPIO26-33 are ordinary pins. This was reported by a user whose Korvo-1 board uses GPIO33 as a display data pin.
- GPIO29 and GPIO41 do not exist on this chip (`SOC_GPIO_VALID_GPIO_MASK` excludes them; the datasheet lists GPIO0-28, GPIO30-40, GPIO42-61) and were not rejected before. They now fail validation with a clear message.
- GPIO36 is a strapping pin (it sets the VDD_SPI voltage) per the datasheet, alongside 37/60/61; it is now included in the strapping warning list.

Verified with `esphome config`: GPIO33 accepted, GPIO29/GPIO41 rejected with "does not exist", GPIO36 produces the strapping warning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (reported on Discord by a Korvo-1 tester)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  variant: esp32s31
  framework:
    type: esp-idf
    version: 6.1.0

binary_sensor:
  - platform: gpio
    pin: GPIO33
    name: Test pin
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).