### PR TITLE
[api] Keep action dropped warning strings in flash on ESP8266

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -433,8 +433,10 @@ void APIServer::send_homeassistant_action(const HomeassistantActionRequest &call
     // Home Assistant subscribes to actions shortly *after* authenticating, so actions
     // fired right at connection time (on_client_connected, on_time_sync, ...) can
     // arrive before the subscription and are lost - warn instead of failing silently.
-    ESP_LOGW(TAG, "Home Assistant %s '%s' dropped; %s", call.is_event ? "event" : "action", call.service.c_str(),
-             this->is_connected() ? "client has not subscribed to actions (yet)" : "no client connected");
+    ESP_LOGW(TAG, "Home Assistant %s '%s' dropped; %s",
+             call.is_event ? LOG_STR_LITERAL("event") : LOG_STR_LITERAL("action"), call.service.c_str(),
+             this->is_connected() ? LOG_STR_LITERAL("client has not subscribed to actions (yet)")
+                                  : LOG_STR_LITERAL("no client connected"));
   }
 }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES


### PR DESCRIPTION
# What does this implement/fix?

The action dropped warning added in #17560 passes two ternary string literals as `%s` arguments. The format string goes to flash on ESP8266, but those argument literals do not, so they take up RAM. This wraps them in `LOG_STR` and `LOG_STR_ARG` like the rest of the api component, which keeps them in flash on ESP8266 and is a no op on other platforms. The CI check added in #18908 reports this line on current dev:

```
### File esphome/components/api/api_server.cpp

esphome/components/api/api_server.cpp:436:73: lint: String literal used as a ternary branch in a log call. On ESP8266 the log macro moves the format string to flash, but bare literal arguments stay in RAM. Wrap each branch in LOG_STR_LITERAL(...):
  Before: "event"
  After:  LOG_STR_LITERAL("event")
(If strictly necessary, add `// NOLINT` to the end of the line)

esphome/components/api/api_server.cpp:436:83: lint: String literal used as a ternary branch in a log call. On ESP8266 the log macro moves the format string to flash, but bare literal arguments stay in RAM. Wrap each branch in LOG_STR_LITERAL(...):
  Before: "action"
  After:  LOG_STR_LITERAL("action")
(If strictly necessary, add `// NOLINT` to the end of the line)

esphome/components/api/api_server.cpp:437:37: lint: String literal used as a ternary branch in a log call. On ESP8266 the log macro moves the format string to flash, but bare literal arguments stay in RAM. Wrap each branch in LOG_STR_LITERAL(...):
  Before: "client has not subscribed to actions (yet)"
  After:  LOG_STR_LITERAL("client has not subscribed to actions (yet)")
(If strictly necessary, add `// NOLINT` to the end of the line)

esphome/components/api/api_server.cpp:437:84: lint: String literal used as a ternary branch in a log call. On ESP8266 the log macro moves the format string to flash, but bare literal arguments stay in RAM. Wrap each branch in LOG_STR_LITERAL(...):
  Before: "no client connected"
  After:  LOG_STR_LITERAL("no client connected")
(If strictly necessary, add `// NOLINT` to the end of the line)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
