### PR TITLE
[core] Keep scheduler dump cancelled marker string in flash on ESP8266

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -193,7 +193,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     }
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    this->debug_log_timer_(item, name_type, static_name, hash_or_id, type, delay, now_64);
+    this->debug_log_timer_(item, name_type, static_name, hash_or_id, delay, now_64);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
   }
 
@@ -795,7 +795,7 @@ void Scheduler::trim_freelist() {
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
 void Scheduler::debug_log_timer_(const SchedulerItem *item, NameType name_type, const char *static_name,
-                                 uint32_t hash_or_id, SchedulerItem::Type type, uint32_t delay, uint64_t now) {
+                                 uint32_t hash_or_id, uint32_t delay, uint64_t now) {
   // Validate static strings in debug mode
   if (name_type == NameType::STATIC_STRING && static_name != nullptr) {
     validate_static_string(static_name);
@@ -804,7 +804,7 @@ void Scheduler::debug_log_timer_(const SchedulerItem *item, NameType name_type, 
   // Debug logging
   SchedulerNameLog name_log;
   const char *type_str = LOG_STR_ARG(item->get_type_str());
-  if (type == SchedulerItem::TIMEOUT) {
+  if (item->type == SchedulerItem::TIMEOUT) {
     ESP_LOGD(TAG, "set_%s(name='%s/%s', %s=%" PRIu32 ")", type_str, LOG_STR_ARG(item->get_source()),
              name_log.format(name_type, static_name, hash_or_id), type_str, delay);
   } else {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -438,7 +438,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
       SchedulerNameLog name_log;
       bool is_cancelled = is_item_removed_(item);
       ESP_LOGD(TAG, "  %s '%s/%s' interval=%" PRIu32 " next_execution in %" PRIu64 "ms at %" PRIu64 "%s",
-               item->get_type_str(), LOG_STR_ARG(item->get_source()),
+               LOG_STR_ARG(item->get_type_str()), LOG_STR_ARG(item->get_source()),
                name_log.format(item->get_name_type(), item->get_name(), item->get_name_hash_or_id()), item->interval,
                item->get_next_execution() - now_64, item->get_next_execution(),
                is_cancelled ? LOG_STR_LITERAL(" [CANCELLED]") : LOG_STR_LITERAL(""));
@@ -513,7 +513,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
     {
       SchedulerNameLog name_log;
       ESP_LOGV(TAG, "Running %s '%s/%s' with interval=%" PRIu32 " next_execution=%" PRIu64 " (now=%" PRIu64 ")",
-               item->get_type_str(), LOG_STR_ARG(item->get_source()),
+               LOG_STR_ARG(item->get_type_str()), LOG_STR_ARG(item->get_source()),
                name_log.format(item->get_name_type(), item->get_name(), item->get_name_hash_or_id()), item->interval,
                item->get_next_execution(), now_64);
     }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -440,7 +440,8 @@ uint32_t HOT Scheduler::call(uint32_t now) {
       ESP_LOGD(TAG, "  %s '%s/%s' interval=%" PRIu32 " next_execution in %" PRIu64 "ms at %" PRIu64 "%s",
                item->get_type_str(), LOG_STR_ARG(item->get_source()),
                name_log.format(item->get_name_type(), item->get_name(), item->get_name_hash_or_id()), item->interval,
-               item->get_next_execution() - now_64, item->get_next_execution(), is_cancelled ? " [CANCELLED]" : "");
+               item->get_next_execution() - now_64, item->get_next_execution(),
+               is_cancelled ? LOG_STR_LITERAL(" [CANCELLED]") : LOG_STR_LITERAL(""));
 
       old_items.push_back(item);
     }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -803,7 +803,7 @@ void Scheduler::debug_log_timer_(const SchedulerItem *item, NameType name_type, 
 
   // Debug logging
   SchedulerNameLog name_log;
-  const char *type_str = (type == SchedulerItem::TIMEOUT) ? "timeout" : "interval";
+  const char *type_str = LOG_STR_ARG(item->get_type_str());
   if (type == SchedulerItem::TIMEOUT) {
     ESP_LOGD(TAG, "set_%s(name='%s/%s', %s=%" PRIu32 ")", type_str, LOG_STR_ARG(item->get_source()),
              name_log.format(name_type, static_name, hash_or_id), type_str, delay);

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -404,7 +404,7 @@ class Scheduler {
 #ifdef ESPHOME_DEBUG_SCHEDULER
   // Helper for debug logging in set_timer_common_ - extracted to reduce code size
   void debug_log_timer_(const SchedulerItem *item, NameType name_type, const char *static_name, uint32_t hash_or_id,
-                        SchedulerItem::Type type, uint32_t delay, uint64_t now);
+                        uint32_t delay, uint64_t now);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
 #ifndef ESPHOME_THREAD_SINGLE

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -254,7 +254,7 @@ class Scheduler {
       // This is correct because millis_major_ that creates these values is also 16 bits.
       next_execution_high_ = static_cast<uint16_t>(value >> 32);
     }
-    constexpr const char *get_type_str() const { return (type == TIMEOUT) ? "timeout" : "interval"; }
+    const LogString *get_type_str() const { return (type == TIMEOUT) ? LOG_STR("timeout") : LOG_STR("interval"); }
     // The owning component, or nullptr for SELF_POINTER items (whose slot holds source_name instead).
     // All component access goes through this so SELF_POINTER items read as component-less.
     Component *get_component() const { return name_type_ == NameType::SELF_POINTER ? nullptr : component; }


### PR DESCRIPTION
# What does this implement/fix?

The scheduler debug dump passes `is_cancelled ? " [CANCELLED]" : ""` as a `%s` argument, so on ESP8266 the literal sits in RAM while the rest of the message is in flash. Wrapping both branches in `LOG_STR_LITERAL` keeps it in flash; on other platforms the macro is a no op. `get_type_str()` on the same line returned bare `"timeout"` and `"interval"` literals, so it now returns a `LogString` like `get_source()` next to it and both dump sites read it through `LOG_STR_ARG`. `debug_log_timer_` built the same two literals through its own ternary, so it now reads the item type the same way.

Measured on a d1_mini with `debug_scheduler: true` against dev: RAM 29240 to 29208 bytes (`.rodata` 1064 to 1040), flash 320955 to 320983; none of the three strings remain in RAM. Also compiled on host and ESP32 IDF.

Same pattern as #18905, split out from the component sweep in #18907 because this is core code. The CI check added in #18908 reports this line on current dev:

```
### File esphome/core/scheduler.cpp

esphome/core/scheduler.cpp:443:96: lint: String literal used as a ternary branch in a log call. On ESP8266 the log macro moves the format string to flash, but bare literal arguments stay in RAM. Wrap each branch in LOG_STR_LITERAL(...):
  Before: " [CANCELLED]"
  After:  LOG_STR_LITERAL(" [CANCELLED]")
(If strictly necessary, add `// NOLINT` to the end of the line)

esphome/core/scheduler.cpp:443:113: lint: String literal used as a ternary branch in a log call. On ESP8266 the log macro moves the format string to flash, but bare literal arguments stay in RAM. Wrap each branch in LOG_STR_LITERAL(...):
  Before: ""
  After:  LOG_STR_LITERAL("")
(If strictly necessary, add `// NOLINT` to the end of the line)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  debug_scheduler: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
