### PR TITLE
[mipi_rgb] Add ESP32S31 support

### DIFF
--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -12,7 +12,12 @@ from esphome.components.const import (
     CONF_DRAW_ROUNDING,
 )
 from esphome.components.display import CONF_SHOW_TEST_CARD
-from esphome.components.esp32 import VARIANT_ESP32P4, VARIANT_ESP32S3, only_on_variant
+from esphome.components.esp32 import (
+    VARIANT_ESP32P4,
+    VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
+    only_on_variant,
+)
 from esphome.components.mipi import (
     COLOR_ORDERS,
     CONF_DE_PIN,
@@ -226,7 +231,7 @@ def _config_schema(config: ConfigType) -> ConfigType:
     config = cv.All(
         schema,
         cv.only_on_esp32,
-        only_on_variant(supported=[VARIANT_ESP32S3, VARIANT_ESP32P4]),
+        only_on_variant(supported=[VARIANT_ESP32S3, VARIANT_ESP32P4, VARIANT_ESP32S31]),
     )(config)
     model = MODELS[config[CONF_MODEL].upper()]
     model.check_requirements()

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -1,4 +1,4 @@
-#if defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4)
+#if defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S31)
 #include "mipi_rgb.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/hal.h"
@@ -400,4 +400,5 @@ void MipiRgb::dump_config() {
 }
 
 }  // namespace esphome::mipi_rgb
-#endif  // defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4)
+#endif  // defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4) ||
+        // defined(USE_ESP32_VARIANT_ESP32S31)

--- a/esphome/components/mipi_rgb/mipi_rgb.h
+++ b/esphome/components/mipi_rgb/mipi_rgb.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4)
+#if defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S31)
 #include "esphome/core/gpio.h"
 #include "esphome/components/display/display.h"
 #include "esp_lcd_panel_ops.h"

--- a/tests/component_tests/mipi_rgb/test_mipi_rgb_config.py
+++ b/tests/component_tests/mipi_rgb/test_mipi_rgb_config.py
@@ -10,7 +10,13 @@ from esphome import config_validation as cv
 # via ch422g) can be validated by the mipi_rgb CONFIG_SCHEMA in this test.
 import esphome.components.ch422g  # noqa: F401
 from esphome.components.display import get_display_metadata
-from esphome.components.esp32 import KEY_BOARD, VARIANT_ESP32S3
+from esphome.components.esp32 import (
+    KEY_BOARD,
+    VARIANT_ESP32C3,
+    VARIANT_ESP32P4,
+    VARIANT_ESP32S3,
+    VARIANT_ESP32S31,
+)
 import esphome.components.pca9554  # noqa: F401
 import esphome.components.xl9535  # noqa: F401
 from esphome.const import (
@@ -135,3 +141,54 @@ def test_metadata_records_rotation(
 
     config = CONFIG_SCHEMA({**base, "id": "unrotated"})
     assert get_display_metadata(config["id"]).rotation == 0
+
+
+@pytest.mark.parametrize(
+    ("variant", "board"),
+    [
+        (VARIANT_ESP32S3, "esp32-s3-devkitc-1"),
+        (VARIANT_ESP32P4, "esp32-p4-evboard"),
+        # No dedicated board is registered for ESP32-S31 yet; an unknown board
+        # name simply skips per-board pin validation.
+        (VARIANT_ESP32S31, "esp32-s31-devkitc"),
+    ],
+)
+def test_configuration_succeeds_on_supported_variants(
+    variant: str, board: str, set_core_config: SetCoreConfigCallable
+) -> None:
+    """mipi_rgb requires a chip with an RGB LCD peripheral: S3, P4 or S31."""
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_BOARD: board, KEY_VARIANT: variant},
+    )
+
+    from esphome.components.mipi_rgb.display import CONFIG_SCHEMA
+
+    CONFIG_SCHEMA({"model": "ESP32-8048S070", "data_pins": DATA_PINS, "pclk_pin": 21})
+
+
+def test_only_on_variant_rejects_unsupported_variant(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """A variant without the RGB LCD peripheral (e.g. ESP32-C3) is rejected.
+
+    Exercises the exact ``only_on_variant`` call used by ``mipi_rgb.display``
+    directly, since building a full model config with GPIO numbers that are
+    also valid on an unsupported variant like ESP32-C3 is unrelated to what
+    this checks.
+    """
+    from esphome.components.esp32 import only_on_variant
+
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_VARIANT: VARIANT_ESP32C3},
+    )
+
+    validator = only_on_variant(
+        supported=[VARIANT_ESP32S3, VARIANT_ESP32P4, VARIANT_ESP32S31]
+    )
+    with pytest.raises(
+        cv.Invalid,
+        match=r"This feature is only available on ESP32S3, ESP32P4, ESP32S31",
+    ):
+        validator({})


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The ESP32S31 also supports RGB display interfaces, so allow that.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/524177279270780928/1543902997254512701

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
