### PR TITLE
[docker] Use GITHUB_REPOSITORY instead of hardcoded esphome/esphome

### DIFF
--- a/docker/generate_tags.py
+++ b/docker/generate_tags.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import os
 import re
 
 CHANNEL_DEV = "dev"
@@ -64,7 +65,8 @@ def main():
 
     suffix = f"-{args.suffix}" if args.suffix else ""
 
-    image_name = f"esphome/esphome{suffix}"
+    repository = os.environ.get("GITHUB_REPOSITORY", "esphome/esphome")
+    image_name = f"{repository}{suffix}"
 
     print(f"channel={channel}")
 

--- a/docker/generate_tags.py
+++ b/docker/generate_tags.py
@@ -65,7 +65,7 @@ def main():
 
     suffix = f"-{args.suffix}" if args.suffix else ""
 
-    repository = os.environ.get("GITHUB_REPOSITORY", "esphome/esphome")
+    repository = (os.environ.get("GITHUB_REPOSITORY") or "esphome/esphome").strip().lower()
     image_name = f"{repository}{suffix}"
 
     print(f"channel={channel}")


### PR DESCRIPTION
# What does this implement/fix?

`docker/generate_tags.py` hardcoded the image name as `esphome/esphome`. This meant the script produced incorrect Docker tags when run in a fork's own CI (e.g. `clydebarrow/esphome`), since it always pointed at the upstream repo's image name regardless of which repository was actually running the build.

This change reads the repository owner/name from the `GITHUB_REPOSITORY` environment variable, which GitHub Actions sets automatically for every workflow run, falling back to `esphome/esphome` when the script is run outside of GitHub Actions (e.g. locally).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# N/A - this change only affects docker/generate_tags.py, a CI helper script.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
