### PR TITLE
[docker] Fix generate_tags.py formatting

### DIFF
--- a/docker/generate_tags.py
+++ b/docker/generate_tags.py
@@ -65,7 +65,9 @@ def main():
 
     suffix = f"-{args.suffix}" if args.suffix else ""
 
-    repository = (os.environ.get("GITHUB_REPOSITORY") or "esphome/esphome").strip().lower()
+    repository = (
+        (os.environ.get("GITHUB_REPOSITORY") or "esphome/esphome").strip().lower()
+    )
     image_name = f"{repository}{suffix}"
 
     print(f"channel={channel}")


### PR DESCRIPTION
# What does this implement/fix?

#18916 landed with a line that `ruff format` wants wrapped, so the `prek run --all-files` lint job now fails on dev and on every open PR (for example the dependabot prek bump in #18921). This applies the reformat.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - formatting only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).