### PR TITLE
[tuya] Build without a network component

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -1,9 +1,12 @@
 #include "tuya.h"
-#include "esphome/components/network/util.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
+
+#ifdef USE_NETWORK
+#include "esphome/components/network/util.h"
+#endif
 
 #ifdef USE_WIFI
 #include "esphome/components/wifi/wifi_component.h"
@@ -21,6 +24,14 @@ static const int RECEIVE_TIMEOUT = 300;
 static const int MAX_RETRIES = 5;
 // Max bytes to log for datapoint values (larger values are truncated)
 static constexpr size_t MAX_DATAPOINT_LOG_BYTES = 16;
+
+static bool network_is_connected() {
+#ifdef USE_NETWORK
+  return network::is_connected();
+#else
+  return false;
+#endif
+}
 
 void Tuya::setup() {
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
@@ -554,14 +565,14 @@ void Tuya::send_empty_command_(TuyaCommandType command) {
 }
 
 void Tuya::set_status_pin_() {
-  bool is_network_ready = network::is_connected() && remote_is_connected();
+  bool is_network_ready = network_is_connected() && remote_is_connected();
   this->status_pin_->digital_write(is_network_ready);
 }
 
 uint8_t Tuya::get_wifi_status_code_() {
   uint8_t status = 0x02;
 
-  if (network::is_connected()) {
+  if (network_is_connected()) {
     status = 0x03;
 
     // Protocol version 3 also supports specifying when connected to "the cloud"

--- a/tests/components/tuya/test-no-network.bk72xx-ard.yaml
+++ b/tests/components/tuya/test-no-network.bk72xx-ard.yaml
@@ -1,0 +1,29 @@
+# Tuya without any network component (no wifi/ethernet/api), as used on
+# serial-only or BLE-only Tuya MCU boards. Regression test for
+# https://github.com/esphome/esphome/issues/18942
+substitutions:
+  status_pin: P6
+
+packages:
+  uart: !include ../../test_build_components/common/uart/bk72xx-ard.yaml
+
+tuya:
+  status_pin: ${status_pin}
+
+binary_sensor:
+  - platform: tuya
+    id: tuya_presence
+    sensor_datapoint: 101
+
+sensor:
+  - platform: tuya
+    id: tuya_light_intensity
+    sensor_datapoint: 103
+
+number:
+  - platform: tuya
+    id: tuya_far_detection
+    number_datapoint: 109
+    min_value: 0
+    max_value: 600
+    step: 1


### PR DESCRIPTION
# What does this implement/fix?

`tuya.cpp` included `esphome/components/network/util.h` unconditionally, so any config with no wifi/ethernet/api (for example a serial-only Tuya MCU board) failed to compile with `network/util.h: No such file or directory`. This has been the case since the ESP-IDF support PR in 2021, it is not a regression.

The include and the two `network::is_connected()` call sites are now guarded with `USE_NETWORK`, matching what e131/udp/syslog/prometheus already do. Without a network component the MCU is told "not connected" (`0x02`) and the status pin stays low. With a network component behaviour is unchanged.

A bk72xx variant test with no network component is added. I verified it reproduces the exact error from the issue with the fix reverted, and passes with the fix. Also compiled the existing esp8266 test (with wifi) to confirm the network path still builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18942

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bk72xx:
  board: cb3s

uart:
  tx_pin: 11
  rx_pin: 10
  baud_rate: 9600

tuya:

sensor:
  - platform: tuya
    name: "Light Intensity"
    sensor_datapoint: 103
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).