### PR TITLE
[mqtt] Restore brightness flag in light discovery

### DIFF
--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -67,6 +67,9 @@ void MQTTJSONLightComponent::send_discovery(JsonObject root, mqtt::SendDiscovery
   if (traits.supports_color_mode(ColorMode::RGB_COLD_WARM_WHITE))
     color_modes.add(ESPHOME_F("rgbww"));
 
+  if (traits.supports_color_capability(ColorCapability::BRIGHTNESS))
+    root[ESPHOME_F("brightness")] = true;
+
   if (traits.supports_color_mode(ColorMode::COLOR_TEMPERATURE) ||
       traits.supports_color_mode(ColorMode::COLD_WARM_WHITE)) {
     root[MQTT_MIN_MIREDS] = traits.get_min_mireds();


### PR DESCRIPTION
# What does this implement/fix?

Restores `"brightness": true` in MQTT JSON light discovery for lights that have the `BRIGHTNESS` color capability.

#13667 (commit 21bd0ff6a) removed the key together with `color_mode`, treating both as deprecated. Only `color_mode` was actually removed from Home Assistant's MQTT JSON light schema. `brightness` is still a live, documented option (default `false`) and HA's `schema_json.py` branches on it in `_scale_rgbxx()`: when it is false, any `light.turn_on` that carries both a color and a brightness gets the brightness multiplied into the rgb/rgbw/rgbww values and the `brightness` key dropped from the command. On an ESPHome `rgbw` light the white channel level is scaled instead of the master brightness, which silently corrupts the light every time a scene or a combined automation call touches it.

Verified on 17 BK7231T rgbw lights: with this change the device publishes `"brightness": true` again, HA sends `{"state":"ON","color":{...,"w":255},"brightness":128}` for a combined call, and the device lands at `brightness: 128`, `w: 255` (previously `w` scaled, `brightness` unchanged). `color_mode` stays removed, as HA does reject that one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18949

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A (no user-facing configuration change)

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
mqtt:
  broker: !secret mqtt_broker

output:
  - platform: libretiny_pwm
    id: output_red
    pin: P7
  - platform: libretiny_pwm
    id: output_green
    pin: P8
  - platform: libretiny_pwm
    id: output_blue
    pin: P9
  - platform: libretiny_pwm
    id: output_white
    pin: P24

light:
  - platform: rgbw
    name: none
    red: output_red
    green: output_green
    blue: output_blue
    white: output_white
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). N/A, just restoring old code and behavior, no tests to update.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io). N/A.
