### PR TITLE
[serial_proxy] Skip no-op reconfigure requests

### DIFF
--- a/esphome/components/serial_proxy/serial_proxy.cpp
+++ b/esphome/components/serial_proxy/serial_proxy.cpp
@@ -130,17 +130,26 @@ SerialProxyResult SerialProxy::configure(api::APIConnection *api_connection, uin
     return SerialProxyResult::SERIAL_PROXY_RESULT_NOT_SUPPORTED;
   }
 
-  // Apply validated parameters
-  uart_comp->set_baud_rate(baudrate);
-  uart_comp->set_stop_bits(stop_bits);
-  uart_comp->set_data_bits(data_size);
-
-  // Map parity value to UARTParityOptions
+  // Skip a no-op reconfigure. Clients routinely re-send identical settings on every
+  // port open, and on a USB UART each apply is a CDC SET_LINE_CODING control transfer.
+  // Some bridges watch line-coding changes as a signalling channel (a magic baud
+  // sequence to enter a bootloader, say), so redundant applies are not harmless.
   static const uart::UARTParityOptions PARITY_MAP[] = {
       uart::UART_CONFIG_PARITY_NONE,
       uart::UART_CONFIG_PARITY_EVEN,
       uart::UART_CONFIG_PARITY_ODD,
   };
+  if (uart_comp->get_baud_rate() == baudrate && uart_comp->get_stop_bits() == stop_bits &&
+      uart_comp->get_data_bits() == data_size && uart_comp->get_parity() == PARITY_MAP[parity]) {
+    ESP_LOGV(TAG, "Settings unchanged, skipping reconfigure [%" PRIu32 "]", this->instance_index_);
+    return SerialProxyResult::SERIAL_PROXY_RESULT_OK;
+  }
+
+  // Apply validated parameters
+  uart_comp->set_baud_rate(baudrate);
+  uart_comp->set_stop_bits(stop_bits);
+  uart_comp->set_data_bits(data_size);
+
   uart_comp->set_parity(PARITY_MAP[parity]);
 
   // load_settings() is available on ESP8266 and ESP32 platforms


### PR DESCRIPTION
# What does this implement/fix?

Clients routinely re-send identical port settings every time they open a `serial_proxy` port. Today each `configure` request is applied unconditionally. On a hardware UART that is wasteful but harmless; on a USB UART every apply becomes a CDC `SET_LINE_CODING` control transfer, and some USB serial bridges watch line-coding changes as a signalling channel (for example, a magic baud-rate sequence that drops the attached module into its bootloader). Redundant applies are therefore not harmless.

This change compares the requested settings against the UART's current settings and returns `SERIAL_PROXY_RESULT_OK` without touching the UART when nothing changed.

Extracted as a standalone change from the Zigbee proxy work on the `20260218-zigbee-proxy` branch, where this was observed with an ESP32-S3 USB-UART bridge carrying an EFR32 radio. Code by @puddly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  id: proxy_uart
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

serial_proxy:
  - uart_id: proxy_uart
    name: Radio
    port_type: TTL
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
