### PR TITLE
[remote_transmitter] Fix BK7231N build by limiting the PWM path to BK7238

### DIFF
--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -45,6 +45,8 @@ DigitalWriteAction = remote_transmitter_ns.class_(
 )
 
 
+# Keep in sync with the USE_LIBRETINY_VARIANT_RTL8720C / REMOTE_TRANSMITTER_BK_PWM gates in
+# remote_transmitter.h, which decide where set_non_blocking() is declared
 _NON_BLOCKING_LIBRETINY_FAMILIES = (FAMILY_RTL8720C, FAMILY_BK7238)
 
 

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -4,11 +4,7 @@ from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import esp32, esp32_rmt, remote_base
 from esphome.components.libretiny import get_libretiny_family
-from esphome.components.libretiny.const import (
-    FAMILY_BK7231N,
-    FAMILY_BK7238,
-    FAMILY_RTL8720C,
-)
+from esphome.components.libretiny.const import FAMILY_BK7238, FAMILY_RTL8720C
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -49,7 +45,7 @@ DigitalWriteAction = remote_transmitter_ns.class_(
 )
 
 
-_NON_BLOCKING_LIBRETINY_FAMILIES = (FAMILY_RTL8720C, FAMILY_BK7231N, FAMILY_BK7238)
+_NON_BLOCKING_LIBRETINY_FAMILIES = (FAMILY_RTL8720C, FAMILY_BK7238)
 
 
 def _validate_non_blocking_platform(value: bool) -> bool:
@@ -59,9 +55,7 @@ def _validate_non_blocking_platform(value: bool) -> bool:
         return cv.boolean(value)
     if CORE.is_libretiny and get_libretiny_family() in _NON_BLOCKING_LIBRETINY_FAMILIES:
         return cv.boolean(value)
-    raise cv.Invalid(
-        "non_blocking is only supported on ESP32, RTL8720C, BK7231N and BK7238"
-    )
+    raise cv.Invalid("non_blocking is only supported on ESP32, RTL8720C and BK7238")
 
 
 MULTI_CONF = True

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -15,6 +15,7 @@
 // Enables the ISR-driven transmitter on Beken. Gated on BK7238 alone: the shadow-load PWM
 // block is shared with BK7231N, but LibreTiny builds that family against an older BDK whose
 // PWM driver has no pwm_init_param()/pwm_start(). See remote_transmitter_bk72xx.cpp.
+// Keep in sync with _NON_BLOCKING_LIBRETINY_FAMILIES in __init__.py.
 #ifdef USE_LIBRETINY_VARIANT_BK7238
 #define REMOTE_TRANSMITTER_BK_PWM
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -12,10 +12,10 @@
 #endif  // SOC_RMT_SUPPORTED
 #endif  // USE_ESP32
 
-// The BK7231N-style PWM block (hardware shadow-load duty updates) enables the ISR-driven
-// transmitter on these families; family-level proxy for the SDK's CFG_SOC_NAME gate.
-// See remote_transmitter_bk72xx.cpp.
-#if defined(USE_LIBRETINY_VARIANT_BK7231N) || defined(USE_LIBRETINY_VARIANT_BK7238)
+// Enables the ISR-driven transmitter on Beken. Gated on BK7238 alone: the shadow-load PWM
+// block is shared with BK7231N, but LibreTiny builds that family against an older BDK whose
+// PWM driver has no pwm_init_param()/pwm_start(). See remote_transmitter_bk72xx.cpp.
+#ifdef USE_LIBRETINY_VARIANT_BK7238
 #define REMOTE_TRANSMITTER_BK_PWM
 #endif
 

--- a/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_bk72xx.cpp
@@ -9,10 +9,13 @@
 // with the core's fixes for type-name collisions between the two
 #include <ArduinoPrivate.h>
 
-// Only the BK7231N-style PWM block (shadow registers with a hardware CFG_UPDATA load bit)
-// supports glitch-free per-edge duty updates; older SoCs compile the generic bit-bang
-// implementation (remote_transmitter.cpp) instead, and this file compiles to nothing.
-// REMOTE_TRANSMITTER_BK_PWM is set per-family in remote_transmitter.h.
+// Needs the BK7231N-style PWM block (shadow registers with a hardware CFG_UPDATA load bit)
+// for glitch-free per-edge duty updates, and an SDK exposing pwm_init_param()/pwm_start().
+// BK7231N has the block but LibreTiny builds it against an older BDK offering only the
+// sddev_control API (CMD_PWM_INIT_PARAM), so it stays on the generic bit-bang path until
+// someone can add and validate that path on real hardware. Every other Beken SoC lacks the
+// block. REMOTE_TRANSMITTER_BK_PWM is set per-family in remote_transmitter.h; when it is
+// unset this file compiles to nothing and remote_transmitter.cpp is used instead.
 
 namespace esphome::remote_transmitter {
 

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny_isr.cpp
@@ -3,11 +3,11 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-// Envelope chain shared by the LibreTiny families that pace transmission from a hardware
-// timer interrupt: RTL8720C (gtimer) and the BK7231N-style PWM block (BKTIMER1). Everything
-// platform-specific sits behind five hooks implemented in the per-family files -- carrier
-// setup, duty writes, one-shot arming and timer stop. Families without a usable timer keep
-// the generic bit-bang implementation and compile none of this.
+// Envelope chain shared by the LibreTiny families that pace transmission from a hardware timer
+// interrupt: RTL8720C (gtimer) and BK7238 (BKTIMER1). Everything platform-specific sits behind
+// five hooks implemented in the per-family files -- carrier setup, duty writes, one-shot arming
+// and timer stop. Families without a usable timer keep the generic bit-bang implementation and
+// compile none of this.
 #if defined(USE_LIBRETINY_VARIANT_RTL8720C) || defined(REMOTE_TRANSMITTER_BK_PWM)
 
 namespace esphome::remote_transmitter {

--- a/tests/component_tests/remote_transmitter/test_non_blocking_gate.py
+++ b/tests/component_tests/remote_transmitter/test_non_blocking_gate.py
@@ -26,7 +26,7 @@ from ..types import SetCoreConfigCallable
         (PlatformFramework.ESP32_IDF, None, True),
         (PlatformFramework.RTL87XX_ARDUINO, FAMILY_RTL8720C, True),
         (PlatformFramework.RTL87XX_ARDUINO, FAMILY_RTL8710B, False),
-        (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7231N, True),
+        (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7231N, False),
         (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7238, True),
         (PlatformFramework.BK72XX_ARDUINO, FAMILY_BK7231T, False),
         (PlatformFramework.ESP8266_ARDUINO, None, False),

--- a/tests/components/remote_transmitter/test.bk72xx-ard.yaml
+++ b/tests/components/remote_transmitter/test.bk72xx-ard.yaml
@@ -2,7 +2,7 @@ remote_transmitter:
   id: xmitr
   pin: GPIO26
   carrier_duty_percent: 50%
-  # non_blocking is bk7231n/bk7238-only; the CI board is a BK7252
+  # non_blocking is bk7238-only; the CI board is a BK7252, so this builds the bit-bang path
 
 packages:
   buttons: !include common-buttons.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes a build regression from #18660 on BK7231N. Any BK7231N config using `remote_transmitter` currently fails to compile:

```
remote_transmitter_bk72xx.cpp:86:3: error: 'pwm_param_st' was not declared in this scope; did you mean 'pwm_param_t'?
remote_transmitter_bk72xx.cpp:91:7: error: 'pwm_init_param' was not declared in this scope
remote_transmitter_bk72xx.cpp:91:38: error: 'pwm_start' was not declared in this scope; did you mean 'pwm_ctrl'?
```

`REMOTE_TRANSMITTER_BK_PWM` was gated on the PWM peripheral: BK7231N and BK7238 share the shadow-register block with the hardware `CFG_UPDATA` load bit that the ISR path needs. That part is correct, but the *driver API* is not shared. LibreTiny builds the two families against different BDK snapshots: BK7238 gets one exposing `pwm_param_st` with `pwm_init_param()`/`pwm_start()`, while BK7231N gets an older one whose PWM driver offers only the `sddev_control` interface (`pwm_param_t`, `CMD_PWM_INIT_PARAM`) and does not declare those functions at all.

This narrows the gate to BK7238, the family the implementation was written and hardware-validated against. BK7231N returns to the generic bit-bang implementation it used before #18660, so it builds and behaves exactly as it did in 2026.8 and earlier — this is a restoration, not a new limitation. Adding BK7231N properly means implementing the `sddev_control` arming path, which needs hardware to validate; the reason it is excluded is now recorded at the top of `remote_transmitter_bk72xx.cpp` for whoever picks that up.

`_NON_BLOCKING_LIBRETINY_FAMILIES` drops BK7231N in the same commit. Leaving it would let `non_blocking: true` pass validation on a family whose header no longer declares `set_non_blocking`, turning a clear config error into a confusing compile error. No working configuration can regress here: on BK7231N the option only ever reached a translation unit that failed to compile.

Verified by compiling the reporter's exact configuration (`board: cb3s`, BK7231N) before and after — failing then succeeding — plus BK7238 hardware firmware, the `bk72xx-ard`, `rtl87xx-ard` and `esp8266-ard` component tests, an RTL8720C build with `non_blocking: true`, and the gate unit tests (BK7231N now asserts rejection). A BK7231N config with `non_blocking: true` now reports `non_blocking is only supported on ESP32, RTL8720C and BK7238` at validation time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7319

**Pull request in [developers.esphome.io](https://github.com/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml -- this failed to compile before, and builds now
bk72xx:
  board: cb3s

remote_transmitter:
  pin: P26
  carrier_duty_percent: 50%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
