### PR TITLE
[deep_sleep] disable loop

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_bk72xx.cpp
@@ -44,7 +44,7 @@ bool DeepSleepComponent::prepare_to_sleep_() {
           this->status_set_warning();
           ESP_LOGV(TAG, "Waiting for pin to switch state to enter deep sleep...");
         }
-        this->next_enter_deep_sleep_ = true;
+        this->defer_sleep_();
         return false;
       }
     }

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -13,6 +13,7 @@ bool global_has_deep_sleep = false;  // NOLINT(cppcoreguidelines-avoid-non-const
 void DeepSleepComponent::setup() {
   global_has_deep_sleep = true;
   this->schedule_sleep_();
+  this->disable_loop();
 }
 
 void DeepSleepComponent::schedule_sleep_() {
@@ -46,12 +47,15 @@ void DeepSleepComponent::loop() {
 void DeepSleepComponent::begin_sleep(bool manual) {
   if (this->prevent_ && !manual) {
     this->next_enter_deep_sleep_ = true;
+    this->enable_loop();
     return;
   }
 
   if (!this->prepare_to_sleep_()) {
+    this->enable_loop();
     return;
   }
+  this->disable_loop();
 
   ESP_LOGI(TAG, "Beginning sleep");
   if (this->sleep_duration_.has_value()) {

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -13,11 +13,11 @@ bool global_has_deep_sleep = false;  // NOLINT(cppcoreguidelines-avoid-non-const
 void DeepSleepComponent::setup() {
   global_has_deep_sleep = true;
   this->schedule_sleep_();
-  this->disable_loop();
 }
 
 void DeepSleepComponent::schedule_sleep_() {
   this->next_enter_deep_sleep_ = false;
+  this->disable_loop();
   const optional<uint32_t> run_duration = get_run_duration_();
   if (run_duration.has_value()) {
     ESP_LOGI(TAG, "Scheduling in %" PRIu32 " ms", *run_duration);
@@ -46,16 +46,13 @@ void DeepSleepComponent::loop() {
 
 void DeepSleepComponent::begin_sleep(bool manual) {
   if (this->prevent_ && !manual) {
-    this->next_enter_deep_sleep_ = true;
-    this->enable_loop();
+    this->defer_sleep_();
     return;
   }
 
   if (!this->prepare_to_sleep_()) {
-    this->enable_loop();
     return;
   }
-  this->disable_loop();
 
   ESP_LOGI(TAG, "Beginning sleep");
   if (this->sleep_duration_.has_value()) {

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -190,6 +190,11 @@ class DeepSleepComponent final : public Component {
   void schedule_sleep_();
   bool should_teardown_();
 
+  void defer_sleep_() {
+    this->next_enter_deep_sleep_ = true;
+    this->enable_loop();
+  }
+
 #ifdef USE_BK72XX
   bool pin_prevents_sleep_(WakeUpPinItem &pin_item) const;
   bool get_real_pin_state_(InternalGPIOPin &pin) const { return (pin.digital_read() ^ pin.is_inverted()); }

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -100,7 +100,7 @@ bool DeepSleepComponent::prepare_to_sleep_() {
       this->status_set_warning();
       ESP_LOGW(TAG, "Waiting for wakeup pin state change");
     }
-    this->next_enter_deep_sleep_ = true;
+    this->defer_sleep_();
     return false;
   }
   return true;


### PR DESCRIPTION
# What does this implement/fix?

Only enable loop while waiting for pin or prevent flag.

There have been already a few attempts to remove the loop completely. This is the low effort approach and enables the loop whenever `next_enter_deep_sleep_` is set. So only the idle loop is disabled and there is no behavior/logic change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
