### PR TITLE
[usb_uart] Add claim_comm_interface option

### DIFF
--- a/esphome/components/usb_uart/__init__.py
+++ b/esphome/components/usb_uart/__init__.py
@@ -123,17 +123,8 @@ uart_types = (
 
 
 def channel_schema(type_: "Type") -> cv.Schema:
-    return cv.Schema(
+    schema = cv.Schema(
         {
-            # The comm (interrupt) interface pins a host hardware channel per device;
-            # disable to save one on channel-poor hosts (some devices may need it
-            # claimed before enabling data flow). Only offered on types that claim
-            # it in the first place — elsewhere the option would be a silent no-op.
-            **(
-                {cv.Optional(CONF_CLAIM_COMM_INTERFACE, default=True): cv.boolean}
-                if type_.has_comm_interface
-                else {}
-            ),
             cv.Required(CONF_CHANNELS): cv.All(
                 cv.ensure_list(
                     cv.Schema(
@@ -174,6 +165,23 @@ def channel_schema(type_: "Type") -> cv.Schema:
             ),
         }
     )
+    if type_.has_comm_interface:
+        # The comm (interrupt) interface pins a host hardware channel per device;
+        # disable to save one on channel-poor hosts (some devices may need it
+        # claimed before enabling data flow).
+        schema = schema.extend(
+            {cv.Optional(CONF_CLAIM_COMM_INTERFACE, default=True): cv.boolean}
+        )
+    else:
+        schema = schema.extend(
+            {
+                cv.Optional(CONF_CLAIM_COMM_INTERFACE): cv.invalid(
+                    f"'{CONF_CLAIM_COMM_INTERFACE}' is only supported on device types "
+                    f"that claim the CDC comm interface; {type_.name} never claims it"
+                )
+            }
+        )
+    return schema
 
 
 CONFIG_SCHEMA = cv.ensure_list(
@@ -204,8 +212,9 @@ async def to_code(config: list[ConfigType]) -> None:
 
     for device in config:
         var = await register_usb_client(device)
-        if CONF_CLAIM_COMM_INTERFACE in device:
-            cg.add(var.set_claim_comm_interface(device[CONF_CLAIM_COMM_INTERFACE]))
+        # The C++ default is true; only emit the override
+        if not device.get(CONF_CLAIM_COMM_INTERFACE, True):
+            cg.add(var.set_claim_comm_interface(False))
         for index, channel in enumerate(device[CONF_CHANNELS]):
             chvar = cg.new_Pvariable(channel[CONF_ID], index, channel[CONF_BUFFER_SIZE])
             await cg.register_parented(chvar, var)

--- a/esphome/components/usb_uart/__init__.py
+++ b/esphome/components/usb_uart/__init__.py
@@ -57,6 +57,7 @@ class Type:
         max_channels: int = 1,
         baud_rate_required: bool = True,
         max_baud: int = 1_000_000,
+        has_comm_interface: bool = False,
     ) -> None:
         self.name = name
         cls = cls or name
@@ -66,6 +67,9 @@ class Type:
         self._max_channels = max_channels
         self.baud_rate_required = baud_rate_required
         self.max_baud = max_baud
+        # True for types that claim the CDC comm (interrupt) interface; only these
+        # accept the claim_comm_interface option.
+        self.has_comm_interface = has_comm_interface
 
     @property
     def max_channels(self) -> int:
@@ -81,11 +85,21 @@ class Type:
 
 
 uart_types = (
-    Type("CDC_ACM", 0, 0, "CdcAcm", 1, baud_rate_required=False),
+    Type(
+        "CDC_ACM", 0, 0, "CdcAcm", 1, baud_rate_required=False, has_comm_interface=True
+    ),
     Type("CH34X", 0x1A86, 0x55D5, "CH34X", 4, max_baud=2_000_000),
     Type("CH340", 0x1A86, 0x7523, "CH34X", 1, max_baud=2_000_000),
     Type("CP210X", 0x10C4, 0xEA60, "CP210X", 3, max_baud=2_000_000),
-    Type("ESP_JTAG", 0x303A, 0x1001, "CdcAcm", 1, baud_rate_required=False),
+    Type(
+        "ESP_JTAG",
+        0x303A,
+        0x1001,
+        "CdcAcm",
+        1,
+        baud_rate_required=False,
+        has_comm_interface=True,
+    ),
     Type("FT232", 0x0403, 0x6001, "FT23XX", 1, max_baud=3_000_000),
     Type("FT2232", 0x0403, 0x6010, "FT23XX", 2, max_baud=12_000_000),
     Type("FT4232", 0x0403, 0x6011, "FT23XX", 4, max_baud=12_000_000),
@@ -96,7 +110,15 @@ uart_types = (
     Type("PL2303GL", 0x067B, 0x23D3, "PL2303", 1, max_baud=6_000_000),
     Type("PL2303GS", 0x067B, 0x23F3, "PL2303", 1, max_baud=6_000_000),
     Type("PL2303GT", 0x067B, 0x23C3, "PL2303", 1, max_baud=6_000_000),
-    Type("STM32_VCP", 0x0483, 0x5740, "CdcAcm", 1, baud_rate_required=False),
+    Type(
+        "STM32_VCP",
+        0x0483,
+        0x5740,
+        "CdcAcm",
+        1,
+        baud_rate_required=False,
+        has_comm_interface=True,
+    ),
 )
 
 
@@ -105,8 +127,13 @@ def channel_schema(type_: "Type") -> cv.Schema:
         {
             # The comm (interrupt) interface pins a host hardware channel per device;
             # disable to save one on channel-poor hosts (some devices may need it
-            # claimed before enabling data flow).
-            cv.Optional(CONF_CLAIM_COMM_INTERFACE, default=True): cv.boolean,
+            # claimed before enabling data flow). Only offered on types that claim
+            # it in the first place — elsewhere the option would be a silent no-op.
+            **(
+                {cv.Optional(CONF_CLAIM_COMM_INTERFACE, default=True): cv.boolean}
+                if type_.has_comm_interface
+                else {}
+            ),
             cv.Required(CONF_CHANNELS): cv.All(
                 cv.ensure_list(
                     cv.Schema(
@@ -177,7 +204,8 @@ async def to_code(config: list[ConfigType]) -> None:
 
     for device in config:
         var = await register_usb_client(device)
-        cg.add(var.set_claim_comm_interface(device[CONF_CLAIM_COMM_INTERFACE]))
+        if CONF_CLAIM_COMM_INTERFACE in device:
+            cg.add(var.set_claim_comm_interface(device[CONF_CLAIM_COMM_INTERFACE]))
         for index, channel in enumerate(device[CONF_CHANNELS]):
             chvar = cg.new_Pvariable(channel[CONF_ID], index, channel[CONF_BUFFER_SIZE])
             await cg.register_parented(chvar, var)

--- a/esphome/components/usb_uart/__init__.py
+++ b/esphome/components/usb_uart/__init__.py
@@ -44,6 +44,7 @@ UART_STOP_BITS_OPTIONS = {
 }
 
 DEFAULT_BAUD_RATE = 9600
+CONF_CLAIM_COMM_INTERFACE = "claim_comm_interface"
 
 
 class Type:
@@ -102,6 +103,10 @@ uart_types = (
 def channel_schema(type_: "Type") -> cv.Schema:
     return cv.Schema(
         {
+            # The comm (interrupt) interface pins a host hardware channel per device;
+            # disable to save one on channel-poor hosts (some devices may need it
+            # claimed before enabling data flow).
+            cv.Optional(CONF_CLAIM_COMM_INTERFACE, default=True): cv.boolean,
             cv.Required(CONF_CHANNELS): cv.All(
                 cv.ensure_list(
                     cv.Schema(
@@ -139,7 +144,7 @@ def channel_schema(type_: "Type") -> cv.Schema:
                     max=type_.max_channels,
                     msg=f"Device type {type_.name} supports a maximum of {type_.max_channels} channels",
                 ),
-            )
+            ),
         }
     )
 
@@ -172,6 +177,7 @@ async def to_code(config: list[ConfigType]) -> None:
 
     for device in config:
         var = await register_usb_client(device)
+        cg.add(var.set_claim_comm_interface(device[CONF_CLAIM_COMM_INTERFACE]))
         for index, channel in enumerate(device[CONF_CHANNELS]):
             chvar = cg.new_Pvariable(channel[CONF_ID], index, channel[CONF_BUFFER_SIZE])
             await cg.register_parented(chvar, var)

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -466,7 +466,8 @@ void USBUartTypeCdcAcm::on_disconnected() {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.out_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.out_ep->bEndpointAddress);
     }
-    // The notify pipe only exists in the host stack while its interface is claimed
+    // Only tear down the notify pipe when we claimed its interface ourselves;
+    // no transfer is ever submitted on it, so there is nothing else to cancel.
     if (channel->cdc_dev_.notify_ep != nullptr && channel->cdc_dev_.interrupt_interface_claimed) {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -466,7 +466,8 @@ void USBUartTypeCdcAcm::on_disconnected() {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.out_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.out_ep->bEndpointAddress);
     }
-    if (channel->cdc_dev_.notify_ep != nullptr) {
+    // The notify pipe only exists in the host stack while its interface is claimed
+    if (channel->cdc_dev_.notify_ep != nullptr && channel->cdc_dev_.interrupt_interface_claimed) {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
     }

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -434,11 +434,12 @@ void USBUartTypeCdcAcm::on_connected() {
       auto err_comm = usb_host_interface_claim(this->handle_, this->device_handle_,
                                                channel->cdc_dev_.interrupt_interface_number, 0);
       if (err_comm != ESP_OK) {
+        // Continue anyway: the interface number stays valid for CDC request addressing
         ESP_LOGW(TAG, "Could not claim comm interface %d: %s", channel->cdc_dev_.interrupt_interface_number,
                  esp_err_to_name(err_comm));
-        channel->cdc_dev_.interrupt_interface_number = 0xFF;  // Mark as unavailable, but continue anyway
       } else {
         ESP_LOGD(TAG, "Claimed comm interface %d", channel->cdc_dev_.interrupt_interface_number);
+        channel->cdc_dev_.interrupt_interface_claimed = true;
       }
     }
     auto err =
@@ -469,10 +470,9 @@ void USBUartTypeCdcAcm::on_disconnected() {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
     }
-    if (channel->cdc_dev_.interrupt_interface_number != 0xFF &&
-        channel->cdc_dev_.interrupt_interface_number != channel->cdc_dev_.bulk_interface_number) {
+    if (channel->cdc_dev_.interrupt_interface_claimed) {
       usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.interrupt_interface_number);
-      channel->cdc_dev_.interrupt_interface_number = 0xFF;
+      channel->cdc_dev_.interrupt_interface_claimed = false;
     }
     usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.bulk_interface_number);
     // Reset the input and output started flags to their initial state to avoid the possibility of spurious restarts

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -431,15 +431,20 @@ void USBUartTypeCdcAcm::on_connected() {
     // they enable data flow on the bulk endpoints.
     if (channel->cdc_dev_.interrupt_interface_number != 0xFF &&
         channel->cdc_dev_.interrupt_interface_number != channel->cdc_dev_.bulk_interface_number) {
-      auto err_comm = usb_host_interface_claim(this->handle_, this->device_handle_,
-                                               channel->cdc_dev_.interrupt_interface_number, 0);
-      if (err_comm != ESP_OK) {
-        // Continue anyway: the interface number stays valid for CDC request addressing
-        ESP_LOGW(TAG, "Could not claim comm interface %d: %s", channel->cdc_dev_.interrupt_interface_number,
-                 esp_err_to_name(err_comm));
+      if (!this->claim_comm_interface_) {
+        ESP_LOGD(TAG, "Skipping comm interface %d (claim_comm_interface: false)",
+                 channel->cdc_dev_.interrupt_interface_number);
       } else {
-        ESP_LOGD(TAG, "Claimed comm interface %d", channel->cdc_dev_.interrupt_interface_number);
-        channel->cdc_dev_.interrupt_interface_claimed = true;
+        auto err_comm = usb_host_interface_claim(this->handle_, this->device_handle_,
+                                                 channel->cdc_dev_.interrupt_interface_number, 0);
+        if (err_comm != ESP_OK) {
+          // Continue anyway: the interface number stays valid for CDC request addressing
+          ESP_LOGW(TAG, "Could not claim comm interface %d: %s", channel->cdc_dev_.interrupt_interface_number,
+                   esp_err_to_name(err_comm));
+        } else {
+          ESP_LOGD(TAG, "Claimed comm interface %d", channel->cdc_dev_.interrupt_interface_number);
+          channel->cdc_dev_.interrupt_interface_claimed = true;
+        }
       }
     }
     auto err =

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -34,7 +34,10 @@ struct CdcEps {
   const usb_ep_desc_t *in_ep;
   const usb_ep_desc_t *out_ep;
   uint8_t bulk_interface_number;
+  // Also the wIndex target for CDC class requests (SET_LINE_CODING etc.), so it
+  // must remain valid even when the interface itself is not claimed.
   uint8_t interrupt_interface_number;
+  bool interrupt_interface_claimed{false};
 };
 
 enum CH34xChipType : uint8_t {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -271,12 +271,16 @@ class USBUartComponent : public usb_host::USBClient {
 class USBUartTypeCdcAcm : public USBUartComponent {
  public:
   USBUartTypeCdcAcm(uint16_t vid, uint16_t pid) : USBUartComponent(vid, pid) {}
+  void set_claim_comm_interface(bool claim) { this->claim_comm_interface_ = claim; }
 
  protected:
   virtual std::vector<CdcEps> parse_descriptors(usb_device_handle_t dev_hdl);
   void on_connected() override;
   void on_disconnected() override;
   bool config_step(USBUartChannelBase *channel, uint8_t step, bool reload, bool ok, const uint8_t *response) override;
+  // Each claimed interface pins one host hardware channel per endpoint; skipping
+  // the comm (interrupt) interface frees one on channel-poor hosts (ESP32-S3: 8).
+  bool claim_comm_interface_{true};
 };
 
 class USBUartTypeCP210X : public USBUartTypeCdcAcm {

--- a/tests/components/usb_uart/common.yaml
+++ b/tests/components/usb_uart/common.yaml
@@ -6,6 +6,7 @@ usb_uart:
     type: cdc_acm
     vid: 0x1234
     pid: 0x5678
+    claim_comm_interface: false
     channels:
       - id: channel_0_1
   - id: uart_1


### PR DESCRIPTION
# What does this implement/fix?

Adds a per-device `claim_comm_interface` option (default `true`) that skips claiming the CDC comm (interrupt) interface.

Rationale: every claimed interface pins one USB host hardware channel per endpoint, and channel-poor hosts run out quickly — the ESP32-S3 has 8 total, and a hub plus two CDC-ACM devices needs 9 (hub control+status = 2, each CDC device = EP0 + notification + bulk IN/OUT = 4). The comm interface's notification endpoint carries modem-status events this component never consumes, so skipping its claim saves one channel per device with no functional loss; CDC class requests (`SET_LINE_CODING` etc.) still work because they address the comm interface *number*, which needs no claim.

Hardware-verified on an ESP32-S3 host: hub + two CDC-ACM devices (one using `claim_comm_interface: false`) lands at exactly 8/8 channels with both devices enumerated, configured, and passing bidirectional traffic — a topology that previously failed with `No more HCD channels available` and a dead device.

Built on #18968 (now merged into dev — this branch has it merged in), which fixed the comm-interface bookkeeping this option relies on.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7323

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
usb_host:
  enable_hubs: true

usb_uart:
  - type: cdc_acm
    vid: 0x303A
    pid: 0x4001
    claim_comm_interface: false
    channels:
      - id: uch_0
        baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

