### PR TITLE
[core] Warn when the .esphome build tree is tracked by git

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -788,7 +788,7 @@ def write_cpp(config: ConfigType) -> int:
 
     if not get_bool_env(ENV_NOGITIGNORE):
         writer.write_gitignore()
-        writer.check_build_tree_not_tracked()
+    writer.check_build_tree_not_tracked()
 
     generate_cpp_contents(config)
     return write_cpp_file()

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -788,6 +788,7 @@ def write_cpp(config: ConfigType) -> int:
 
     if not get_bool_env(ENV_NOGITIGNORE):
         writer.write_gitignore()
+        writer.check_build_tree_not_tracked()
 
     generate_cpp_contents(config)
     return write_cpp_file()

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -4,6 +4,7 @@ import logging
 import os
 from pathlib import Path
 import re
+import subprocess
 import time
 
 from esphome import loader
@@ -739,3 +740,53 @@ def write_gitignore():
     path = CORE.relative_config_path(".gitignore")
     if not path.is_file():
         path.write_text(GITIGNORE_CONTENT, encoding="utf-8")
+
+
+def check_build_tree_not_tracked() -> None:
+    """Warn if the build tree is tracked by git.
+
+    ``write_gitignore`` never touches an existing ``.gitignore``, so a build
+    tree that was committed before it was excluded (or on a config predating
+    ESPHome's auto-generated ``.gitignore``) stays tracked forever: adding a
+    pattern to ``.gitignore`` does not untrack files already in the index.
+    Every subsequent build would then keep changing the regenerated files
+    under version control.
+    """
+    data_dir = CORE.data_dir
+    if (data_dir / ".gitkeep").is_file():
+        # The user deliberately placed a .gitkeep file, opting the build
+        # directory into version control on purpose.
+        return
+
+    try:
+        relative_data_dir = data_dir.relative_to(CORE.config_dir)
+    except ValueError:
+        # Outside the config directory (e.g. the Home Assistant add-on's
+        # /data, or ESPHOME_DATA_DIR pointing elsewhere) -- can't be part of
+        # this repository.
+        return
+
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--", str(relative_data_dir)],
+            cwd=CORE.config_dir,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        # git is not installed.
+        return
+    if result.returncode != 0 or not result.stdout:
+        return
+
+    tracked_count = len([name for name in result.stdout.split(b"\0") if name])
+    _LOGGER.warning(
+        "%s is tracked by git (%d file%s). This is the ESPHome build "
+        "directory; it holds generated files and should not be committed. "
+        "Add it to your .gitignore, then remove it from version control "
+        "with: git rm -r --cached %s",
+        relative_data_dir,
+        tracked_count,
+        "" if tracked_count == 1 else "s",
+        relative_data_dir,
+    )

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -757,6 +757,11 @@ def check_build_tree_not_tracked() -> None:
     Every subsequent build would then keep changing the regenerated files
     under version control.
     """
+    if os.environ.get("CI"):
+        # CI checkouts build fixture configs, not a user's own repository, so
+        # there is nothing meaningful to warn about -- skip the extra process
+        # spawn on every single build.
+        return
     data_dir = CORE.data_dir
     if (data_dir / ".gitkeep").is_file():
         # The user deliberately placed a .gitkeep file, opting the build

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -779,7 +779,7 @@ def check_build_tree_not_tracked() -> None:
     if result.returncode != 0 or not result.stdout:
         return
 
-    tracked_count = len([name for name in result.stdout.split(b"\0") if name])
+    tracked_count = sum(1 for name in result.stdout.split(b"\0") if name)
     _LOGGER.warning(
         "%s is tracked by git (%d file%s). This is the ESPHome build "
         "directory; it holds generated files that may contain your secrets "

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -17,6 +17,7 @@ from esphome.const import (
     __version__,
 )
 from esphome.core import CORE, EsphomeError
+from esphome.git import _GIT_REPO_SCOPING_ENV
 from esphome.helpers import (
     copy_file_if_changed,
     cpp_string_escape,
@@ -698,7 +699,11 @@ def clean_all(configuration: list[str]):
             _LOGGER.info("Cleaning %s", dir)
             # Don't remove storage or .json files which are needed by the dashboard
             for item in dir.iterdir():
-                if item.is_file() and not item.name.endswith(".json"):
+                if (
+                    item.is_file()
+                    and not item.name.endswith(".json")
+                    and item.name != ".gitkeep"
+                ):
                     item.unlink()
                 elif item.is_dir() and item.name != "storage":
                     rmtree(item)
@@ -766,17 +771,35 @@ def check_build_tree_not_tracked() -> None:
         # this repository.
         return
 
+    # Strip the same repo-scoping variables run_git_command() strips (see
+    # esphome/git.py): a git hook or CI wrapper exporting GIT_DIR/GIT_INDEX_FILE
+    # would otherwise redirect this read-only query to its own repository.
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_REPO_SCOPING_ENV}
     try:
         result = subprocess.run(
             ["git", "ls-files", "-z", "--", str(relative_data_dir)],
             cwd=CORE.config_dir,
             capture_output=True,
             check=False,
+            env=env,
+            timeout=5,
         )
-    except FileNotFoundError:
-        # git is not installed.
+    except (OSError, subprocess.TimeoutExpired) as err:
+        # This is a purely advisory check -- git missing, unreadable, or slow
+        # must never turn into a hard failure of the build itself.
+        _LOGGER.debug(
+            "Could not check whether %s is tracked by git: %s", relative_data_dir, err
+        )
         return
-    if result.returncode != 0 or not result.stdout:
+    if result.returncode != 0:
+        if result.stderr:
+            _LOGGER.debug(
+                "git ls-files failed (%d): %s",
+                result.returncode,
+                result.stderr.decode("utf-8", errors="replace").strip(),
+            )
+        return
+    if not result.stdout:
         return
 
     tracked_count = sum(1 for name in result.stdout.split(b"\0") if name)
@@ -791,5 +814,5 @@ def check_build_tree_not_tracked() -> None:
         relative_data_dir,
         tracked_count,
         "" if tracked_count == 1 else "s",
-        relative_data_dir,
+        data_dir,
     )

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -782,9 +782,12 @@ def check_build_tree_not_tracked() -> None:
     tracked_count = len([name for name in result.stdout.split(b"\0") if name])
     _LOGGER.warning(
         "%s is tracked by git (%d file%s). This is the ESPHome build "
-        "directory; it holds generated files and should not be committed. "
-        "Add it to your .gitignore, then remove it from version control "
-        "with: git rm -r --cached %s",
+        "directory; it holds generated files that may contain your secrets "
+        "(e.g. Wi-Fi credentials or API keys) in plain text, and should not "
+        "be committed. Add it to your .gitignore, then remove it from "
+        "version control with: git rm -r --cached %s "
+        "(if you really want to keep this directory in git, add a file "
+        "named .gitkeep to it to silence this warning)",
         relative_data_dir,
         tracked_count,
         "" if tracked_count == 1 else "s",

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -4275,10 +4275,14 @@ def test_write_cpp_writes_gitignore_and_checks_build_tree(
     mock_write_file.assert_called_once()
 
 
-def test_write_cpp_skips_git_checks_when_nogitignore_env_set(
+def test_write_cpp_skips_gitignore_but_still_checks_build_tree(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ESPHOME_NOGITIGNORE skips both writing .gitignore and the tracked-file check."""
+    """ESPHOME_NOGITIGNORE skips writing .gitignore.
+
+    The (read-only) tracked-file check still runs -- it isn't tied to
+    whether ESPHome is allowed to write files.
+    """
     monkeypatch.setenv(ENV_NOGITIGNORE, "true")
 
     with (
@@ -4291,7 +4295,7 @@ def test_write_cpp_skips_git_checks_when_nogitignore_env_set(
         write_cpp({})
 
     mock_write_gitignore.assert_not_called()
-    mock_check_tracked.assert_not_called()
+    mock_check_tracked.assert_called_once()
 
 
 def test_command_config_hash(

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -68,6 +68,7 @@ from esphome.__main__ import (
     upload_using_esptool,
     upload_using_picotool,
     upload_using_platformio,
+    write_cpp,
 )
 from esphome.address_cache import AddressCache
 from esphome.bundle import BUNDLE_EXTENSION, BundleFile, BundleResult
@@ -108,6 +109,7 @@ from esphome.const import (
     CONF_VERSION,
     CONF_WEB_SERVER,
     CONF_WIFI,
+    ENV_NOGITIGNORE,
     KEY_CORE,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
@@ -4248,6 +4250,48 @@ def test_run_esphome_dashboard_redirects_to_device_builder(
 
     assert result == 1
     assert "esphome-device-builder" in caplog.text
+
+
+def test_write_cpp_writes_gitignore_and_checks_build_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """write_cpp writes the .gitignore and checks the build tree isn't tracked."""
+    monkeypatch.delenv(ENV_NOGITIGNORE, raising=False)
+
+    with (
+        patch("esphome.writer.update_storage_json") as mock_update_storage,
+        patch("esphome.writer.write_gitignore") as mock_write_gitignore,
+        patch("esphome.writer.check_build_tree_not_tracked") as mock_check_tracked,
+        patch("esphome.__main__.generate_cpp_contents") as mock_generate,
+        patch("esphome.__main__.write_cpp_file", return_value=0) as mock_write_file,
+    ):
+        result = write_cpp({})
+
+    assert result == 0
+    mock_update_storage.assert_called_once()
+    mock_write_gitignore.assert_called_once()
+    mock_check_tracked.assert_called_once()
+    mock_generate.assert_called_once_with({})
+    mock_write_file.assert_called_once()
+
+
+def test_write_cpp_skips_git_checks_when_nogitignore_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ESPHOME_NOGITIGNORE skips both writing .gitignore and the tracked-file check."""
+    monkeypatch.setenv(ENV_NOGITIGNORE, "true")
+
+    with (
+        patch("esphome.writer.update_storage_json"),
+        patch("esphome.writer.write_gitignore") as mock_write_gitignore,
+        patch("esphome.writer.check_build_tree_not_tracked") as mock_check_tracked,
+        patch("esphome.__main__.generate_cpp_contents"),
+        patch("esphome.__main__.write_cpp_file", return_value=0),
+    ):
+        write_cpp({})
+
+    mock_write_gitignore.assert_not_called()
+    mock_check_tracked.assert_not_called()
 
 
 def test_command_config_hash(

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -842,14 +842,29 @@ def test_write_gitignore_skips_existing_file(
 
 
 @patch("esphome.writer.subprocess.run")
+def test_check_build_tree_not_tracked_silent_in_ci(
+    mock_run: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CI builds fixture configs, not a user's repo -- skip the git spawn entirely."""
+    monkeypatch.setenv("CI", "true")
+
+    check_build_tree_not_tracked()
+
+    mock_run.assert_not_called()
+
+
+@patch("esphome.writer.subprocess.run")
 @patch("esphome.writer.CORE")
 def test_check_build_tree_not_tracked_warns_when_tracked(
     mock_core: MagicMock,
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_build_tree_not_tracked warns when the build dir is tracked by git."""
+    monkeypatch.delenv("CI", raising=False)
     data_dir = tmp_path / ".esphome"
     mock_core.config_dir = tmp_path
     mock_core.data_dir = data_dir
@@ -892,8 +907,10 @@ def test_check_build_tree_not_tracked_silent_when_gitkeep_present(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_build_tree_not_tracked is skipped when .gitkeep opts in."""
+    monkeypatch.delenv("CI", raising=False)
     data_dir = tmp_path / ".esphome"
     data_dir.mkdir()
     (data_dir / ".gitkeep").touch()
@@ -914,8 +931,10 @@ def test_check_build_tree_not_tracked_silent_when_untracked(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_build_tree_not_tracked stays silent when nothing is tracked."""
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
@@ -933,8 +952,10 @@ def test_check_build_tree_not_tracked_silent_outside_git_repo(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_build_tree_not_tracked stays silent when not inside a git repo."""
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.return_value = MagicMock(
@@ -954,8 +975,10 @@ def test_check_build_tree_not_tracked_silent_on_failure_without_stderr(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A non-zero exit with no stderr must not raise trying to log the reason."""
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.return_value = MagicMock(returncode=1, stdout=b"", stderr=b"")
@@ -973,8 +996,10 @@ def test_check_build_tree_not_tracked_silent_when_git_missing(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_build_tree_not_tracked stays silent when git isn't installed."""
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.side_effect = FileNotFoundError()
@@ -992,8 +1017,10 @@ def test_check_build_tree_not_tracked_silent_on_other_os_error(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A non-executable git on PATH (PermissionError) must not abort the build."""
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.side_effect = PermissionError("git is not executable")
@@ -1011,8 +1038,10 @@ def test_check_build_tree_not_tracked_silent_on_timeout(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A hung git process must not block the build indefinitely."""
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=5)
@@ -1030,12 +1059,14 @@ def test_check_build_tree_not_tracked_silent_when_data_dir_outside_config_dir(
     mock_run: MagicMock,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_build_tree_not_tracked skips the check for an external data dir.
 
     Covers the Home Assistant add-on (/data) and ESPHOME_DATA_DIR cases, where
     the build directory can't be part of the config's git repository.
     """
+    monkeypatch.delenv("CI", raising=False)
     mock_core.config_dir = tmp_path / "config"
     mock_core.data_dir = tmp_path / "data"
 

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import re
 import stat
+import subprocess
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -849,25 +850,39 @@ def test_check_build_tree_not_tracked_warns_when_tracked(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test check_build_tree_not_tracked warns when the build dir is tracked by git."""
+    data_dir = tmp_path / ".esphome"
     mock_core.config_dir = tmp_path
-    mock_core.data_dir = tmp_path / ".esphome"
+    mock_core.data_dir = data_dir
     mock_run.return_value = MagicMock(
-        returncode=0, stdout=b".esphome/build/node/main.cpp\0.esphome/node.json\0"
+        returncode=0,
+        stdout=b".esphome/build/node/main.cpp\0.esphome/node.json\0",
+        stderr=b"",
     )
 
-    with caplog.at_level("WARNING"):
+    with (
+        patch.dict(os.environ, {"GIT_DIR": "/somewhere/else/.git"}),
+        caplog.at_level("WARNING"),
+    ):
         check_build_tree_not_tracked()
 
     assert "is tracked by git" in caplog.text
     assert "2 files" in caplog.text
     assert "secrets" in caplog.text
     assert ".gitkeep" in caplog.text
-    mock_run.assert_called_once_with(
-        ["git", "ls-files", "-z", "--", ".esphome"],
-        cwd=tmp_path,
-        capture_output=True,
-        check=False,
-    )
+    # The remediation command must use the absolute path so it also works
+    # when pasted from the repository root of a nested config layout.
+    assert f"git rm -r --cached {data_dir}" in caplog.text
+
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["git", "ls-files", "-z", "--", ".esphome"]
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs["capture_output"] is True
+    assert kwargs["check"] is False
+    assert kwargs["timeout"] == 5
+    # Repo-scoping env vars must be stripped so a hook/CI wrapper can't
+    # redirect this read-only query to a different repository.
+    assert "GIT_DIR" not in kwargs["env"]
 
 
 @patch("esphome.writer.subprocess.run")
@@ -903,7 +918,7 @@ def test_check_build_tree_not_tracked_silent_when_untracked(
     """Test check_build_tree_not_tracked stays silent when nothing is tracked."""
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
-    mock_run.return_value = MagicMock(returncode=0, stdout=b"")
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
 
     with caplog.at_level("WARNING"):
         check_build_tree_not_tracked()
@@ -922,7 +937,9 @@ def test_check_build_tree_not_tracked_silent_outside_git_repo(
     """Test check_build_tree_not_tracked stays silent when not inside a git repo."""
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
-    mock_run.return_value = MagicMock(returncode=128, stdout=b"")
+    mock_run.return_value = MagicMock(
+        returncode=128, stdout=b"", stderr=b"fatal: not a git repository\n"
+    )
 
     with caplog.at_level("WARNING"):
         check_build_tree_not_tracked()
@@ -942,6 +959,44 @@ def test_check_build_tree_not_tracked_silent_when_git_missing(
     mock_core.config_dir = tmp_path
     mock_core.data_dir = tmp_path / ".esphome"
     mock_run.side_effect = FileNotFoundError()
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_on_other_os_error(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-executable git on PATH (PermissionError) must not abort the build."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.side_effect = PermissionError("git is not executable")
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_on_timeout(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hung git process must not block the build indefinitely."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=5)
 
     with caplog.at_level("WARNING"):
         check_build_tree_not_tracked()
@@ -1423,6 +1478,7 @@ def test_clean_all(
     build_dir2.mkdir()
     (build_dir1 / "dummy.txt").write_text("x")
     (build_dir2 / "dummy.txt").write_text("x")
+    (build_dir1 / ".gitkeep").touch()
 
     # Create PlatformIO directories
     pio_cache = tmp_path / "pio_cache"
@@ -1465,6 +1521,10 @@ def test_clean_all(
     # Verify that files in .esphome were removed
     assert not (build_dir1 / "dummy.txt").exists()
     assert not (build_dir2 / "dummy.txt").exists()
+
+    # .gitkeep is the opt-out check_build_tree_not_tracked() advertises; it
+    # must survive clean-all or the warning comes right back on next compile.
+    assert (build_dir1 / ".gitkeep").exists()
     assert not pio_cache.exists()
     assert not pio_packages.exists()
     assert not pio_platforms.exists()

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -860,6 +860,8 @@ def test_check_build_tree_not_tracked_warns_when_tracked(
 
     assert "is tracked by git" in caplog.text
     assert "2 files" in caplog.text
+    assert "secrets" in caplog.text
+    assert ".gitkeep" in caplog.text
     mock_run.assert_called_once_with(
         ["git", "ls-files", "-z", "--", ".esphome"],
         cwd=tmp_path,

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -30,6 +30,7 @@ from esphome.writer import (
     CPP_INCLUDE_BEGIN,
     CPP_INCLUDE_END,
     GITIGNORE_CONTENT,
+    check_build_tree_not_tracked,
     clean_all,
     clean_build,
     clean_cmake_cache,
@@ -837,6 +838,136 @@ def test_write_gitignore_skips_existing_file(
     # Verify file was not modified
     assert gitignore_path.exists()
     assert gitignore_path.read_text() == existing_content
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_warns_when_tracked(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test check_build_tree_not_tracked warns when the build dir is tracked by git."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=b".esphome/build/node/main.cpp\0.esphome/node.json\0"
+    )
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "is tracked by git" in caplog.text
+    assert "2 files" in caplog.text
+    mock_run.assert_called_once_with(
+        ["git", "ls-files", "-z", "--", ".esphome"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+    )
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_when_gitkeep_present(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test check_build_tree_not_tracked is skipped when .gitkeep opts in."""
+    data_dir = tmp_path / ".esphome"
+    data_dir.mkdir()
+    (data_dir / ".gitkeep").touch()
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = data_dir
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    mock_run.assert_not_called()
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_when_untracked(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test check_build_tree_not_tracked stays silent when nothing is tracked."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"")
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_outside_git_repo(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test check_build_tree_not_tracked stays silent when not inside a git repo."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.return_value = MagicMock(returncode=128, stdout=b"")
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_when_git_missing(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test check_build_tree_not_tracked stays silent when git isn't installed."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.side_effect = FileNotFoundError()
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_when_data_dir_outside_config_dir(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test check_build_tree_not_tracked skips the check for an external data dir.
+
+    Covers the Home Assistant add-on (/data) and ESPHOME_DATA_DIR cases, where
+    the build directory can't be part of the config's git repository.
+    """
+    mock_core.config_dir = tmp_path / "config"
+    mock_core.data_dir = tmp_path / "data"
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    mock_run.assert_not_called()
+    assert "tracked by git" not in caplog.text
 
 
 @patch("esphome.writer.write_file_if_changed")  # Mock to capture output

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -949,6 +949,25 @@ def test_check_build_tree_not_tracked_silent_outside_git_repo(
 
 @patch("esphome.writer.subprocess.run")
 @patch("esphome.writer.CORE")
+def test_check_build_tree_not_tracked_silent_on_failure_without_stderr(
+    mock_core: MagicMock,
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-zero exit with no stderr must not raise trying to log the reason."""
+    mock_core.config_dir = tmp_path
+    mock_core.data_dir = tmp_path / ".esphome"
+    mock_run.return_value = MagicMock(returncode=1, stdout=b"", stderr=b"")
+
+    with caplog.at_level("WARNING"):
+        check_build_tree_not_tracked()
+
+    assert "tracked by git" not in caplog.text
+
+
+@patch("esphome.writer.subprocess.run")
+@patch("esphome.writer.CORE")
 def test_check_build_tree_not_tracked_silent_when_git_missing(
     mock_core: MagicMock,
     mock_run: MagicMock,


### PR DESCRIPTION
## What does this implement/fix?

Some users end up with the whole `.esphome` build folder committed to their git repository. This happens because ESPHome only writes a `.gitignore` file if one doesn't already exist — if a user commits `.esphome` before that `.gitignore` is created (or on an older ESPHome version), the folder stays tracked by git forever. Adding a rule to `.gitignore` later does not untrack files that are already committed.

This PR adds a check that runs on every compile: it looks at whether any files under the `.esphome` folder are tracked by git, and if so, prints a warning explaining the problem and how to fix it (`git rm -r --cached .esphome`).

The check stays quiet if:
- the project isn't in a git repository
- git isn't installed
- nothing under `.esphome` is actually tracked
- the build folder is outside the config directory (e.g. the Home Assistant add-on)
- the user has placed a `.gitkeep` file in `.esphome`, which is treated as an explicit choice to keep the folder in git

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Inspired by: #18967 

## Test Environment

This is a Python-only change to the CLI, not tied to a specific device platform.

## Example entry for `config.yaml`:

```yaml
# No configuration change — this is a CLI warning, not a config option.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ9Lx4igvKPPpkb423qVgh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ9Lx4igvKPPpkb423qVgh)_