### PR TITLE
[core] Show the other downloader's progress while a prefetch job waits on its lock

### DIFF
--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -23,6 +23,7 @@ from esphome.net_retry import (
 )
 
 if TYPE_CHECKING:
+    from filelock import FileLock
     import requests
 
 PathType = str | os.PathLike
@@ -909,15 +910,46 @@ def _part_path(dest: Path) -> Path:
     return dest.with_name(dest.name + ".part")
 
 
-def downloaded_bytes(dest: Path, size: int) -> int:
-    """Bytes of ``dest`` on disk: ``size`` once it landed, else what its
-    ``.part`` holds so far (capped at ``size``), else 0."""
-    if dest.is_file():
-        return size
+def downloaded_bytes(dest: Path, size: int | None = None) -> int:
+    """Bytes of ``dest`` on disk: its ``.part`` so far (capped at ``size``),
+    else the landed file, else 0."""
     try:
-        return min(_part_path(dest).stat().st_size, size)
+        done = _part_path(dest).stat().st_size
     except OSError:
-        return 0
+        if not dest.is_file():
+            return 0
+        done = dest.stat().st_size if size is None else size
+    return done if size is None else min(done, size)
+
+
+# Short lock-acquire slices so a waiting worker still observes Ctrl-C
+_DOWNLOAD_LOCK_POLL = 1
+
+
+def wait_for_download_lock(
+    lock: "FileLock",
+    tracker: Callable[[int], None],
+    on_disk: Callable[[], int],
+    name: str,
+    timeout: float | None = None,
+) -> bool:
+    """Acquire ``lock``, reporting ``on_disk()`` to ``tracker`` each poll so the
+    bar follows the holder's download. False once ``timeout`` seconds pass."""
+    from filelock import Timeout
+
+    deadline = None if timeout is None else time.monotonic() + timeout
+    waiting = False
+    while True:
+        try:
+            lock.acquire(timeout=_DOWNLOAD_LOCK_POLL)
+            return True
+        except Timeout:
+            if not waiting:
+                waiting = True
+                _LOGGER.info("Waiting for another process downloading %s", name)
+            tracker(on_disk())  # raises when the batch is cancelled
+            if deadline is not None and time.monotonic() >= deadline:
+                return False
 
 
 def discard_partial_download(dest: Path) -> None:
@@ -1330,10 +1362,7 @@ def download_from_mirrors(
             )
             # Tick with the bytes already on disk so a combined bar holds
             # steady during the backoff instead of rewinding to zero
-            done = 0
-            if progress is not None:
-                part = _part_path(path_target)
-                done = part.stat().st_size if part.is_file() else 0
+            done = downloaded_bytes(path_target) if progress is not None else 0
             _cancellable_sleep(delay, progress, done)
 
     # 3. Report every attempted URL if all mirrors failed. failures spans

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -909,6 +909,17 @@ def _part_path(dest: Path) -> Path:
     return dest.with_name(dest.name + ".part")
 
 
+def downloaded_bytes(dest: Path, size: int) -> int:
+    """Bytes of ``dest`` on disk: ``size`` once it landed, else what its
+    ``.part`` holds so far (capped at ``size``), else 0."""
+    if dest.is_file():
+        return size
+    try:
+        return min(_part_path(dest).stat().st_size, size)
+    except OSError:
+        return 0
+
+
 def discard_partial_download(dest: Path) -> None:
     """Remove ``dest`` and the resume sidecars of an abandoned download."""
     part = _part_path(dest)

--- a/esphome/framework_helpers.py
+++ b/esphome/framework_helpers.py
@@ -911,19 +911,27 @@ def _part_path(dest: Path) -> Path:
 
 
 def downloaded_bytes(dest: Path, size: int | None = None) -> int:
-    """Bytes of ``dest`` on disk: its ``.part`` so far (capped at ``size``),
-    else the landed file, else 0."""
-    try:
-        done = _part_path(dest).stat().st_size
-    except OSError:
-        if not dest.is_file():
-            return 0
-        done = dest.stat().st_size if size is None else size
+    """Bytes of ``dest`` on disk (its ``.part`` while streaming), capped at ``size``."""
+    done = 0
+    for candidate in (_part_path(dest), dest):
+        try:
+            done = candidate.stat().st_size
+            break
+        except FileNotFoundError:
+            continue
     return done if size is None else min(done, size)
 
 
 # Short lock-acquire slices so a waiting worker still observes Ctrl-C
 _DOWNLOAD_LOCK_POLL = 1
+
+# Waiting on another process's download; past this the caller leaves the
+# file to its holder (the later sequential install waits on the same lock)
+DOWNLOAD_LOCK_TIMEOUT = 60
+
+
+class DownloadLockUnavailable(OSError):
+    """The lock file cannot be used at all (a lock-less filesystem)."""
 
 
 def wait_for_download_lock(
@@ -931,25 +939,30 @@ def wait_for_download_lock(
     tracker: Callable[[int], None],
     on_disk: Callable[[], int],
     name: str,
-    timeout: float | None = None,
-) -> bool:
+) -> None:
     """Acquire ``lock``, reporting ``on_disk()`` to ``tracker`` each poll so the
-    bar follows the holder's download. False once ``timeout`` seconds pass."""
+    bar follows the holder's download. Raises filelock's ``Timeout`` once
+    ``DOWNLOAD_LOCK_TIMEOUT`` seconds pass."""
     from filelock import Timeout
 
-    deadline = None if timeout is None else time.monotonic() + timeout
+    deadline = time.monotonic() + DOWNLOAD_LOCK_TIMEOUT
     waiting = False
     while True:
         try:
             lock.acquire(timeout=_DOWNLOAD_LOCK_POLL)
-            return True
+            return
         except Timeout:
-            if not waiting:
-                waiting = True
-                _LOGGER.info("Waiting for another process downloading %s", name)
-            tracker(on_disk())  # raises when the batch is cancelled
-            if deadline is not None and time.monotonic() >= deadline:
-                return False
+            pass
+        except OSError as err:
+            # Distinct from an OSError out of on_disk(), which must not
+            # read as "locks unsupported"
+            raise DownloadLockUnavailable(*err.args) from err
+        if not waiting:
+            waiting = True
+            _LOGGER.info("Waiting for another process downloading %s", name)
+        tracker(on_disk())  # raises when the batch is cancelled
+        if time.monotonic() >= deadline:
+            raise Timeout(lock.lock_file)
 
 
 def discard_partial_download(dest: Path) -> None:

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, suppress
-from functools import partial
 import hashlib
 import json
 import logging
@@ -34,6 +33,7 @@ import time
 from typing import Any, NamedTuple
 
 from esphome.framework_helpers import (
+    DownloadLockUnavailable,
     content_length,
     discard_partial_download,
     downloaded_bytes,
@@ -63,9 +63,6 @@ _RESOLVE_WORKERS = 8
 
 # A hung child must not block the build; downloads resume on the next run
 _PREFETCH_TIMEOUT = 20 * 60
-
-# Waiting on another process's URL download; past this, leave it to pio
-_DOWNLOAD_LOCK_TIMEOUT = 60
 
 # Child exit for a handled, already-warned failure; 1 would collide with
 # the interpreter's own import-failure exit
@@ -474,25 +471,29 @@ def _serialized_fetch_job(
     is a clean skip. On a lock-less filesystem a sha256-verified body runs
     unlocked with one warning; a checksum-less one (``unlocked_ok=False``) fails.
     """
-    # The holder's part file sits beside dl_path, or beside the staging
-    # path a URL job promotes from
-    on_disk = partial(downloaded_bytes, stream_dest or dl_path, size)
+
+    def on_disk() -> int:
+        # A URL job's holder streams beside the staging path until it
+        # promotes; after that only dl_path is left
+        done = downloaded_bytes(dl_path, size)
+        if not done and stream_dest is not None:
+            done = downloaded_bytes(stream_dest, size)
+        return done
 
     def run(tracker: Any) -> None:
-        from filelock import FileLock
+        from filelock import FileLock, Timeout
 
         # fallback_to_soft would leave a stale marker on lock-less
         # filesystems that blocks every later build (see git.py)
         lock = FileLock(lock_path, fallback_to_soft=False)
         try:
-            if not wait_for_download_lock(
-                lock, tracker, on_disk, dl_path.name, _DOWNLOAD_LOCK_TIMEOUT
-            ):
-                # The holder's copy is what the build needs (a large
-                # framework archive can outlast this deadline)
-                _LOGGER.debug("Leaving %s to its current downloader", dl_path.name)
-                return
-        except OSError as err:
+            wait_for_download_lock(lock, tracker, on_disk, dl_path.name)
+        except Timeout:
+            # The holder's copy is what the build needs (a large
+            # framework archive can outlast this deadline)
+            _LOGGER.debug("Leaving %s to its current downloader", dl_path.name)
+            return
+        except DownloadLockUnavailable as err:
             if not unlocked_ok:
                 # A body with no checksum to catch interleaved corruption
                 raise

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -35,6 +35,7 @@ from typing import Any, NamedTuple
 from esphome.framework_helpers import (
     content_length,
     discard_partial_download,
+    downloaded_bytes,
     failure_reason,
     resume_fetch_job,
     run_batch_downloads,
@@ -462,16 +463,22 @@ def _uri_jobs(
 
 
 def _serialized_fetch_job(
-    dl_path: Path, lock_path: str, body: Any, unlocked_ok: bool = True
+    dl_path: Path,
+    lock_path: str,
+    body: Any,
+    size: int,
+    stream_dest: Path,
+    unlocked_ok: bool = True,
 ) -> Any:
     """Wrap ``body`` so the shared destination is single-writer.
 
     Interleaved writers truncate each other's ``.part`` bytes (see
-    registry.py). The bounded poll observes Ctrl-C via the tracker; a
-    blown deadline is a clean skip (the holder's copy is what the build
-    needs). On a lock-less filesystem a sha256-verified body runs
-    unlocked with one warning; a checksum-less one
-    (``unlocked_ok=False``) is a counted failure instead.
+    registry.py). While the lock is held elsewhere the poll reports the
+    holder's bytes (streamed into ``stream_dest``) so the bar moves, and
+    observes Ctrl-C via the tracker; a blown deadline is a clean skip
+    (the holder's copy is what the build needs). On a lock-less
+    filesystem a sha256-verified body runs unlocked with one warning; a
+    checksum-less one (``unlocked_ok=False``) is a counted failure instead.
     """
 
     def run(tracker: Any) -> None:
@@ -481,12 +488,21 @@ def _serialized_fetch_job(
         # filesystems that blocks every later build (see git.py)
         lock = FileLock(lock_path, fallback_to_soft=False)
         deadline = time.monotonic() + _DOWNLOAD_LOCK_TIMEOUT
+        waiting = False
         while True:
             try:
                 lock.acquire(timeout=_URI_LOCK_POLL)
                 break
             except Timeout:
-                tracker(0)  # raises when the batch is cancelled
+                if not waiting:
+                    waiting = True
+                    _LOGGER.info(
+                        "Waiting for another process downloading %s", dl_path.name
+                    )
+                # Raises when the batch is cancelled
+                tracker(
+                    size if dl_path.is_file() else downloaded_bytes(stream_dest, size)
+                )
                 if time.monotonic() >= deadline:
                     # Another process is fetching this same file; its copy
                     # is what the build needs (a large framework archive
@@ -506,7 +522,8 @@ def _serialized_fetch_job(
                 break
         try:
             if dl_path.is_file():
-                return  # another process finished it while we waited
+                tracker(size)  # another process finished it while we waited
+                return
             body(tracker)
         finally:
             if lock is not None:
@@ -540,6 +557,8 @@ def _registry_fetch_job(
         dl_path,
         f"{dl_path}.esphome.lock",
         resume_fetch_job(url, dl_path, sha256=checksum, size=size),
+        size,
+        dl_path,
     )
 
     def run(tracker: Any) -> None:
@@ -571,9 +590,9 @@ def _uri_fetch_job(manager: Any, url: str, dl_path: Path, size: int) -> Any:
         tmp.replace(dl_path)
 
     def run(tracker: Any) -> None:
-        _serialized_fetch_job(dl_path, f"{tmp}.lock", promote, unlocked_ok=False)(
-            tracker
-        )
+        _serialized_fetch_job(
+            dl_path, f"{tmp}.lock", promote, size, tmp, unlocked_ok=False
+        )(tracker)
         if dl_path.is_file():
             # Won or lost, the race is over; staging files left behind
             # are dead weight PlatformIO's cache never prunes

--- a/esphome/platformio/prefetch.py
+++ b/esphome/platformio/prefetch.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, suppress
+from functools import partial
 import hashlib
 import json
 import logging
@@ -39,6 +40,7 @@ from esphome.framework_helpers import (
     failure_reason,
     resume_fetch_job,
     run_batch_downloads,
+    wait_for_download_lock,
     warn_prefetch_failures,
 )
 from esphome.helpers import get_bool_env, get_usable_cpu_count, rmtree
@@ -68,9 +70,6 @@ _DOWNLOAD_LOCK_TIMEOUT = 60
 # Child exit for a handled, already-warned failure; 1 would collide with
 # the interpreter's own import-failure exit
 _EXIT_HANDLED = 3
-
-# Short lock-acquire slices so a waiting worker still observes Ctrl-C
-_URI_LOCK_POLL = 1
 
 # Resolution errored (vs a clean skip); suppresses the warm sentinel
 _RESOLVE_FAILED = object()
@@ -467,59 +466,42 @@ def _serialized_fetch_job(
     lock_path: str,
     body: Any,
     size: int,
-    stream_dest: Path,
+    stream_dest: Path | None = None,
     unlocked_ok: bool = True,
 ) -> Any:
-    """Wrap ``body`` so the shared destination is single-writer.
-
-    Interleaved writers truncate each other's ``.part`` bytes (see
-    registry.py). While the lock is held elsewhere the poll reports the
-    holder's bytes (streamed into ``stream_dest``) so the bar moves, and
-    observes Ctrl-C via the tracker; a blown deadline is a clean skip
-    (the holder's copy is what the build needs). On a lock-less
-    filesystem a sha256-verified body runs unlocked with one warning; a
-    checksum-less one (``unlocked_ok=False``) is a counted failure instead.
+    """Wrap ``body`` so the shared destination is single-writer (interleaved
+    writers truncate each other's ``.part``, see registry.py). A blown deadline
+    is a clean skip. On a lock-less filesystem a sha256-verified body runs
+    unlocked with one warning; a checksum-less one (``unlocked_ok=False``) fails.
     """
+    # The holder's part file sits beside dl_path, or beside the staging
+    # path a URL job promotes from
+    on_disk = partial(downloaded_bytes, stream_dest or dl_path, size)
 
     def run(tracker: Any) -> None:
-        from filelock import FileLock, Timeout
+        from filelock import FileLock
 
         # fallback_to_soft would leave a stale marker on lock-less
         # filesystems that blocks every later build (see git.py)
         lock = FileLock(lock_path, fallback_to_soft=False)
-        deadline = time.monotonic() + _DOWNLOAD_LOCK_TIMEOUT
-        waiting = False
-        while True:
-            try:
-                lock.acquire(timeout=_URI_LOCK_POLL)
-                break
-            except Timeout:
-                if not waiting:
-                    waiting = True
-                    _LOGGER.info(
-                        "Waiting for another process downloading %s", dl_path.name
-                    )
-                # Raises when the batch is cancelled
-                tracker(
-                    size if dl_path.is_file() else downloaded_bytes(stream_dest, size)
-                )
-                if time.monotonic() >= deadline:
-                    # Another process is fetching this same file; its copy
-                    # is what the build needs (a large framework archive
-                    # can hold the lock far longer than this deadline)
-                    _LOGGER.debug("Leaving %s to its current downloader", dl_path.name)
-                    return
-            except OSError as err:
-                if not unlocked_ok:
-                    # A body with no checksum to catch interleaved corruption
-                    raise
-                lock = None
-                _LOGGER.warning(
-                    "Could not lock %s (%s); downloading unlocked",
-                    dl_path.name,
-                    err,
-                )
-                break
+        try:
+            if not wait_for_download_lock(
+                lock, tracker, on_disk, dl_path.name, _DOWNLOAD_LOCK_TIMEOUT
+            ):
+                # The holder's copy is what the build needs (a large
+                # framework archive can outlast this deadline)
+                _LOGGER.debug("Leaving %s to its current downloader", dl_path.name)
+                return
+        except OSError as err:
+            if not unlocked_ok:
+                # A body with no checksum to catch interleaved corruption
+                raise
+            lock = None
+            _LOGGER.warning(
+                "Could not lock %s (%s); downloading unlocked",
+                dl_path.name,
+                err,
+            )
         try:
             if dl_path.is_file():
                 tracker(size)  # another process finished it while we waited
@@ -558,7 +540,6 @@ def _registry_fetch_job(
         f"{dl_path}.esphome.lock",
         resume_fetch_job(url, dl_path, sha256=checksum, size=size),
         size,
-        dl_path,
     )
 
     def run(tracker: Any) -> None:

--- a/esphome/platformio/registry.py
+++ b/esphome/platformio/registry.py
@@ -189,7 +189,7 @@ def prefetch_packages(
     lock as ``install_package``: the archive's ``.part`` file is shared, and
     two concurrent writers would truncate each other's bytes.
     """
-    from filelock import FileLock
+    from filelock import FileLock, Timeout
 
     pending: list[_PendingArchive] = []
     seen: set[str] = set()
@@ -233,7 +233,13 @@ def prefetch_packages(
             return entry.size if _already_installed(entry.dest) else 0
 
         lock = FileLock(f"{entry.dest}.lock", fallback_to_soft=False)
-        wait_for_download_lock(lock, tracker, on_disk, entry.name)
+        try:
+            wait_for_download_lock(lock, tracker, on_disk, entry.name)
+        except Timeout:
+            # install_package waits on this same lock and verifies the
+            # holder's copy
+            _LOGGER.debug("Leaving %s to its current downloader", entry.name)
+            return
         try:
             if _already_installed(entry.dest):
                 # A concurrent build installed it while we waited; a

--- a/esphome/platformio/registry.py
+++ b/esphome/platformio/registry.py
@@ -17,8 +17,10 @@ from esphome.framework_helpers import (
     archive_extract_all,
     download_from_mirrors,
     download_with_resume,
+    downloaded_bytes,
     rmdir,
     run_batch_downloads,
+    wait_for_download_lock,
 )
 from esphome.net_retry import fetch_with_retry, http_request
 
@@ -222,20 +224,31 @@ def prefetch_packages(
 
     def _fetch(entry: _PendingArchive, tracker: Callable[[int], None]) -> None:
         entry.dest.parent.mkdir(parents=True, exist_ok=True)
-        with FileLock(f"{entry.dest}.lock", fallback_to_soft=False):
-            # Marker re-check: a concurrent build may have installed (and
-            # deleted the archive of) this package while we waited;
-            # re-downloading would orphan a fresh copy in downloads_dir
-            # no branch: the thread tracer misses the skip edge; both
-            # arms of _already_installed are pinned directly
-            if not _already_installed(entry.dest):  # pragma: no branch
-                download_with_resume(
-                    entry.url,
-                    downloads_dir / f"{entry.name}-{entry.version}",
-                    sha256=entry.sha256,
-                    size=entry.size,
-                    progress=tracker,
-                )
+        archive = downloads_dir / f"{entry.name}-{entry.version}"
+
+        def on_disk() -> int:
+            if done := downloaded_bytes(archive, entry.size):
+                return done
+            # The holder deletes the archive once it has installed it
+            return entry.size if _already_installed(entry.dest) else 0
+
+        lock = FileLock(f"{entry.dest}.lock", fallback_to_soft=False)
+        wait_for_download_lock(lock, tracker, on_disk, entry.name)
+        try:
+            if _already_installed(entry.dest):
+                # A concurrent build installed it while we waited; a
+                # re-download would orphan a fresh copy in downloads_dir
+                tracker(entry.size)
+                return
+            download_with_resume(
+                entry.url,
+                archive,
+                sha256=entry.sha256,
+                size=entry.size,
+                progress=tracker,
+            )
+        finally:
+            lock.release()
 
     failures = run_batch_downloads(
         "Downloading packages",

--- a/esphome/platformio/registry.py
+++ b/esphome/platformio/registry.py
@@ -166,9 +166,15 @@ class _PendingArchive(NamedTuple):
     name: str
     version: str
     dest: Path
+    archive: Path
     url: str
     sha256: str
     size: int
+
+
+def _archive_path(downloads_dir: Path, name: str, version: str) -> Path:
+    """The one archive path the prefetch and the sequential install share."""
+    return downloads_dir / f"{name}-{version}"
 
 
 def _already_installed(dest: Path) -> bool:
@@ -192,15 +198,15 @@ def prefetch_packages(
     from filelock import FileLock, Timeout
 
     pending: list[_PendingArchive] = []
-    seen: set[str] = set()
+    seen: set[Path] = set()
     for name, version, dest, mirrors in packages:
         if mirrors or (dest / ".esphome_extracted").is_file():
             continue
-        archive_name = f"{name}-{version}"
-        if archive_name in seen:
+        archive = _archive_path(downloads_dir, name, version)
+        if archive in seen:
             # A duplicate entry would race itself between two workers
             continue
-        seen.add(archive_name)
+        seen.add(archive)
         try:
             url, sha256, size = registry_download(name, version)
         except EsphomeError as err:
@@ -209,10 +215,9 @@ def prefetch_packages(
             continue
         if not size:
             continue
-        archive = downloads_dir / archive_name
         if archive.is_file() and archive.stat().st_size == size:
             continue
-        pending.append(_PendingArchive(name, version, dest, url, sha256, size))
+        pending.append(_PendingArchive(name, version, dest, archive, url, sha256, size))
     if len(pending) < 2:
         return
     downloads_dir.mkdir(parents=True, exist_ok=True)
@@ -224,10 +229,9 @@ def prefetch_packages(
 
     def _fetch(entry: _PendingArchive, tracker: Callable[[int], None]) -> None:
         entry.dest.parent.mkdir(parents=True, exist_ok=True)
-        archive = downloads_dir / f"{entry.name}-{entry.version}"
 
         def on_disk() -> int:
-            if done := downloaded_bytes(archive, entry.size):
+            if done := downloaded_bytes(entry.archive, entry.size):
                 return done
             # The holder deletes the archive once it has installed it
             return entry.size if _already_installed(entry.dest) else 0
@@ -248,7 +252,7 @@ def prefetch_packages(
                 return
             download_with_resume(
                 entry.url,
-                archive,
+                entry.archive,
                 sha256=entry.sha256,
                 size=entry.size,
                 progress=tracker,
@@ -307,7 +311,7 @@ def install_package(
         rmdir(dest, msg=f"Clean up incomplete {name} install")
         # Persistent location so an interrupted download resumes across runs.
         downloads_dir.mkdir(parents=True, exist_ok=True)
-        archive = downloads_dir / f"{name}-{version}"
+        archive = _archive_path(downloads_dir, name, version)
         _LOGGER.info("Downloading %s %s ...", name, version)
         if mirrors:
             _LOGGER.warning(

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -143,14 +143,17 @@ def mock_get_component() -> Generator[Mock, None, None]:
 def held_lock() -> Callable[..., Callable[..., None]]:
     """Factory for a ``FileLock.acquire`` fake held by another downloader.
 
-    Each poll writes the next chunk to ``part`` and raises ``Timeout``; when
-    the chunks run out the part is removed, ``land()`` runs, and the acquire
-    succeeds (also for any later job, so ``land`` must be idempotent).
+    Each poll writes the next chunk to ``part`` (or runs it, for a callable)
+    and raises ``Timeout``; when the chunks run out the part is removed,
+    ``land()`` runs, and the acquire succeeds (also for any later job, so
+    ``land`` must be idempotent).
     """
     from filelock import Timeout
 
     def make(
-        part: Path, chunks: list[bytes], land: Callable[[], None]
+        part: Path,
+        chunks: list[bytes | Callable[[], None]],
+        land: Callable[[], None],
     ) -> Callable[..., None]:
         polls = iter(chunks)
 
@@ -161,8 +164,11 @@ def held_lock() -> Callable[..., Callable[..., None]]:
                 part.unlink(missing_ok=True)
                 land()
                 return
-            part.parent.mkdir(parents=True, exist_ok=True)
-            part.write_bytes(chunk)
+            if callable(chunk):
+                chunk()
+            else:
+                part.parent.mkdir(parents=True, exist_ok=True)
+                part.write_bytes(chunk)
             raise Timeout("held")
 
         return acquire

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -9,7 +9,7 @@ not be part of a unit test suite.
 
 """
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 import os
 from pathlib import Path
 import sys
@@ -137,3 +137,34 @@ def mock_get_component() -> Generator[Mock, None, None]:
     """Mock get_component for config module."""
     with patch("esphome.config.get_component") as mock:
         yield mock
+
+
+@pytest.fixture
+def held_lock() -> Callable[..., Callable[..., None]]:
+    """Factory for a ``FileLock.acquire`` fake held by another downloader.
+
+    Each poll writes the next chunk to ``part`` and raises ``Timeout``; when
+    the chunks run out the part is removed, ``land()`` runs, and the acquire
+    succeeds (also for any later job, so ``land`` must be idempotent).
+    """
+    from filelock import Timeout
+
+    def make(
+        part: Path, chunks: list[bytes], land: Callable[[], None]
+    ) -> Callable[..., None]:
+        polls = iter(chunks)
+
+        def acquire(*args, **kwargs) -> None:
+            try:
+                chunk = next(polls)
+            except StopIteration:
+                part.unlink(missing_ok=True)
+                land()
+                return
+            part.parent.mkdir(parents=True, exist_ok=True)
+            part.write_bytes(chunk)
+            raise Timeout("held")
+
+        return acquire
+
+    return make

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -2353,3 +2353,17 @@ def test_discard_partial_download_logs_undeletable(
     ):
         framework_helpers.discard_partial_download(dest)
     assert "Could not remove" in caplog.text
+
+
+def test_downloaded_bytes_reports_what_is_on_disk(tmp_path: Path) -> None:
+    """A landed file counts in full, a part file counts what it holds
+    (never more than the size), and nothing on disk counts zero."""
+    dest = tmp_path / "archive"
+    assert framework_helpers.downloaded_bytes(dest, 4) == 0
+    part = tmp_path / "archive.part"
+    part.write_bytes(b"ab")
+    assert framework_helpers.downloaded_bytes(dest, 4) == 2
+    part.write_bytes(b"abcdef")
+    assert framework_helpers.downloaded_bytes(dest, 4) == 4
+    dest.write_bytes(b"abcd")
+    assert framework_helpers.downloaded_bytes(dest, 4) == 4

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -2356,7 +2356,7 @@ def test_discard_partial_download_logs_undeletable(
 
 
 def test_downloaded_bytes_reports_what_is_on_disk(tmp_path: Path) -> None:
-    """Landed file: size; part file: its bytes, capped at size; nothing: 0."""
+    """Part file first, then the landed file, both capped at size; else 0."""
     dest = tmp_path / "archive"
     assert framework_helpers.downloaded_bytes(dest, 4) == 0
     part = tmp_path / "archive.part"
@@ -2364,7 +2364,9 @@ def test_downloaded_bytes_reports_what_is_on_disk(tmp_path: Path) -> None:
     assert framework_helpers.downloaded_bytes(dest, 4) == 2
     part.write_bytes(b"abcdef")
     assert framework_helpers.downloaded_bytes(dest, 4) == 4
-    dest.write_bytes(b"abcd")
-    assert framework_helpers.downloaded_bytes(dest, 4) == 4
     part.unlink()
-    assert framework_helpers.downloaded_bytes(dest) == 4
+    dest.write_bytes(b"abc")
+    assert framework_helpers.downloaded_bytes(dest, 4) == 3
+    assert framework_helpers.downloaded_bytes(dest) == 3
+    dest.write_bytes(b"abcdef")
+    assert framework_helpers.downloaded_bytes(dest, 4) == 4

--- a/tests/unit_tests/test_framework_helpers.py
+++ b/tests/unit_tests/test_framework_helpers.py
@@ -2356,8 +2356,7 @@ def test_discard_partial_download_logs_undeletable(
 
 
 def test_downloaded_bytes_reports_what_is_on_disk(tmp_path: Path) -> None:
-    """A landed file counts in full, a part file counts what it holds
-    (never more than the size), and nothing on disk counts zero."""
+    """Landed file: size; part file: its bytes, capped at size; nothing: 0."""
     dest = tmp_path / "archive"
     assert framework_helpers.downloaded_bytes(dest, 4) == 0
     part = tmp_path / "archive.part"
@@ -2367,3 +2366,5 @@ def test_downloaded_bytes_reports_what_is_on_disk(tmp_path: Path) -> None:
     assert framework_helpers.downloaded_bytes(dest, 4) == 4
     dest.write_bytes(b"abcd")
     assert framework_helpers.downloaded_bytes(dest, 4) == 4
+    part.unlink()
+    assert framework_helpers.downloaded_bytes(dest) == 4

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -466,7 +466,7 @@ def test_lock_deadline_leaves_download_to_the_holder(
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
         patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
-        patch.object(pf, "_DOWNLOAD_LOCK_TIMEOUT", 0),
+        patch("esphome.framework_helpers.DOWNLOAD_LOCK_TIMEOUT", 0),
     ):
         pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
     mock_download.assert_not_called()
@@ -524,6 +524,26 @@ def test_lock_wait_reports_the_holders_progress(
     assert caplog.text.count("Waiting for another process downloading archive") == 1
 
 
+def test_uri_lock_wait_prefers_the_landed_archive(tmp_path: Path, held_lock) -> None:
+    """Between the holder's promotion rename and its release the staging
+    part is gone; the landed cache file is credited instead of 0."""
+    dl_path = tmp_path / "archive"
+    ticks: list[int] = []
+    acquire = held_lock(
+        tmp_path / "archive.prefetch.part",
+        [b"ab", lambda: dl_path.write_bytes(b"abcd")],
+        lambda: None,
+    )
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch("filelock.FileLock.acquire", side_effect=acquire),
+        patch("filelock.FileLock.release"),
+    ):
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
+    mock_download.assert_not_called()
+    assert ticks == [2, 4, 4]
+
+
 def test_registry_lock_deadline_skips_registration(tmp_path: Path) -> None:
     """A registry job that lost the download race to another process
     must not stamp a nonexistent archive into pio's usage.db."""
@@ -532,7 +552,7 @@ def test_registry_lock_deadline_skips_registration(tmp_path: Path) -> None:
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
         patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
-        patch.object(pf, "_DOWNLOAD_LOCK_TIMEOUT", 0),
+        patch("esphome.framework_helpers.DOWNLOAD_LOCK_TIMEOUT", 0),
     ):
         pf._registry_fetch_job(manager, "https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
             lambda done: None

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -458,13 +458,10 @@ def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
 def test_lock_deadline_leaves_download_to_the_holder(
     tmp_path: Path, staged: bytes
 ) -> None:
-    """A lock held past the deadline means another process is fetching the
-    same file; skipping cleanly beats a misleading failure warning. The
-    tracker is still polled so a parked worker observes cancellation, and
-    it reports what the holder has staged so far."""
+    """A lock held past the deadline is another process's download; skip
+    cleanly, polling the tracker with what the holder has staged so far."""
     dl_path = tmp_path / "archive"
-    if staged:
-        (tmp_path / "archive.prefetch.part").write_bytes(staged)
+    (tmp_path / "archive.prefetch.part").write_bytes(staged)
     ticks: list[int] = []
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
@@ -477,67 +474,54 @@ def test_lock_deadline_leaves_download_to_the_holder(
     assert not dl_path.exists()
 
 
+@pytest.mark.parametrize(
+    ("job", "part_name", "chunks", "expected"),
+    [
+        (
+            lambda dl_path: pf._registry_fetch_job(
+                MagicMock(), "https://x/a.tar.gz", dl_path, "ab" * 32, 4
+            ),
+            "archive.part",
+            [b"a", b"abc"],
+            [1, 3, 4],
+        ),
+        (
+            lambda dl_path: pf._uri_fetch_job(
+                MagicMock(), "https://x/a.zip", dl_path, 4
+            ),
+            "archive.prefetch.part",
+            [b"ab"],
+            [2, 4],
+        ),
+    ],
+    ids=["registry", "uri"],
+)
 def test_lock_wait_reports_the_holders_progress(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    held_lock,
+    job,
+    part_name: str,
+    chunks: list[bytes],
+    expected: list[int],
 ) -> None:
-    """While another process holds the lock the bar follows its part file,
-    and the job credits the full size once that process lands the archive
-    (the 0% bar of a build racing the dashboard for the same toolchain)."""
-    manager = MagicMock()
+    """A waiting job reports the holder's part file (the staging one for a
+    URL job), then the full size once the holder lands the archive."""
     dl_path = tmp_path / "archive"
-    part = tmp_path / "archive.part"
     ticks: list[int] = []
-    polls = iter([b"a", b"abc"])
-
-    def acquire(*args, **kwargs):
-        try:
-            part.write_bytes(next(polls))
-        except StopIteration:
-            part.unlink()
-            dl_path.write_bytes(b"abcd")
-            return
-        raise Timeout("held")
-
+    acquire = held_lock(
+        tmp_path / part_name, chunks, lambda: dl_path.write_bytes(b"abcd")
+    )
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
         patch("filelock.FileLock.acquire", side_effect=acquire),
         patch("filelock.FileLock.release"),
         caplog.at_level(logging.INFO),
     ):
-        pf._registry_fetch_job(manager, "https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
-            ticks.append
-        )
+        job(dl_path)(ticks.append)
     mock_download.assert_not_called()
-    assert ticks == [1, 3, 4]
+    assert ticks == expected
     assert caplog.text.count("Waiting for another process downloading archive") == 1
-    manager.set_download_utime.assert_called_once_with(str(dl_path))
-
-
-def test_uri_lock_wait_reads_the_staging_part(tmp_path: Path) -> None:
-    """A URL job's holder streams into the staging path, so the wait
-    reports that part file, not one beside the cache path."""
-    dl_path = tmp_path / "archive"
-    staging_part = tmp_path / "archive.prefetch.part"
-    ticks: list[int] = []
-    polls = iter([b"ab"])
-
-    def acquire(*args, **kwargs):
-        try:
-            staging_part.write_bytes(next(polls))
-        except StopIteration:
-            staging_part.unlink()
-            dl_path.write_bytes(b"abcd")
-            return
-        raise Timeout("held")
-
-    with (
-        patch("esphome.framework_helpers.download_with_resume") as mock_download,
-        patch("filelock.FileLock.acquire", side_effect=acquire),
-        patch("filelock.FileLock.release"),
-    ):
-        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
-    mock_download.assert_not_called()
-    assert ticks == [2, 4]
 
 
 def test_registry_lock_deadline_skips_registration(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -454,11 +454,17 @@ def test_uri_fetch_job_waits_out_a_briefly_held_lock(tmp_path: Path) -> None:
     assert dl_path.read_bytes() == b"data"
 
 
-def test_lock_deadline_leaves_download_to_the_holder(tmp_path: Path) -> None:
+@pytest.mark.parametrize("staged", [b"", b"ab"])
+def test_lock_deadline_leaves_download_to_the_holder(
+    tmp_path: Path, staged: bytes
+) -> None:
     """A lock held past the deadline means another process is fetching the
     same file; skipping cleanly beats a misleading failure warning. The
-    tracker is still polled so a parked worker observes cancellation."""
+    tracker is still polled so a parked worker observes cancellation, and
+    it reports what the holder has staged so far."""
     dl_path = tmp_path / "archive"
+    if staged:
+        (tmp_path / "archive.prefetch.part").write_bytes(staged)
     ticks: list[int] = []
     with (
         patch("esphome.framework_helpers.download_with_resume") as mock_download,
@@ -467,8 +473,71 @@ def test_lock_deadline_leaves_download_to_the_holder(tmp_path: Path) -> None:
     ):
         pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
     mock_download.assert_not_called()
-    assert ticks == [0]
+    assert ticks == [len(staged)]
     assert not dl_path.exists()
+
+
+def test_lock_wait_reports_the_holders_progress(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """While another process holds the lock the bar follows its part file,
+    and the job credits the full size once that process lands the archive
+    (the 0% bar of a build racing the dashboard for the same toolchain)."""
+    manager = MagicMock()
+    dl_path = tmp_path / "archive"
+    part = tmp_path / "archive.part"
+    ticks: list[int] = []
+    polls = iter([b"a", b"abc"])
+
+    def acquire(*args, **kwargs):
+        try:
+            part.write_bytes(next(polls))
+        except StopIteration:
+            part.unlink()
+            dl_path.write_bytes(b"abcd")
+            return
+        raise Timeout("held")
+
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch("filelock.FileLock.acquire", side_effect=acquire),
+        patch("filelock.FileLock.release"),
+        caplog.at_level(logging.INFO),
+    ):
+        pf._registry_fetch_job(manager, "https://x/a.tar.gz", dl_path, "ab" * 32, 4)(
+            ticks.append
+        )
+    mock_download.assert_not_called()
+    assert ticks == [1, 3, 4]
+    assert caplog.text.count("Waiting for another process downloading archive") == 1
+    manager.set_download_utime.assert_called_once_with(str(dl_path))
+
+
+def test_uri_lock_wait_reads_the_staging_part(tmp_path: Path) -> None:
+    """A URL job's holder streams into the staging path, so the wait
+    reports that part file, not one beside the cache path."""
+    dl_path = tmp_path / "archive"
+    staging_part = tmp_path / "archive.prefetch.part"
+    ticks: list[int] = []
+    polls = iter([b"ab"])
+
+    def acquire(*args, **kwargs):
+        try:
+            staging_part.write_bytes(next(polls))
+        except StopIteration:
+            staging_part.unlink()
+            dl_path.write_bytes(b"abcd")
+            return
+        raise Timeout("held")
+
+    with (
+        patch("esphome.framework_helpers.download_with_resume") as mock_download,
+        patch("filelock.FileLock.acquire", side_effect=acquire),
+        patch("filelock.FileLock.release"),
+    ):
+        pf._uri_fetch_job(MagicMock(), "https://x/a.zip", dl_path, 4)(ticks.append)
+    mock_download.assert_not_called()
+    assert ticks == [2, 4]
 
 
 def test_registry_lock_deadline_skips_registration(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_registry.py
+++ b/tests/unit_tests/test_platformio_registry.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from filelock import Timeout
 import pytest
 
 from esphome.core import EsphomeError
@@ -564,9 +565,16 @@ def test_prefetch_packages_waits_with_the_holders_progress(
     dest = tmp_path / "a"
     dest.mkdir()
     ticks: list[int] = []
+    part = tmp_path / "dl" / "a-1.0.part"
+
+    def installed_and_pruned() -> None:
+        # install_package touches the marker, then unlinks the archive
+        (dest / ".esphome_extracted").touch()
+        part.unlink()
+
     acquire = held_lock(
-        tmp_path / "dl" / "a-1.0.part",
-        [b"abc"],
+        part,
+        [lambda: None, b"abc", installed_and_pruned],
         (dest / ".esphome_extracted").touch,
     )
 
@@ -588,8 +596,28 @@ def test_prefetch_packages_waits_with_the_holders_progress(
             [("a", "1.0", dest, []), ("b", "2.0", tmp_path / "b", [])],
             tmp_path / "dl",
         )
-    assert ticks == [3, 10]
+    assert ticks == [0, 3, 10, 10]
     mock_download.assert_called_once()
+
+
+def test_prefetch_packages_leaves_a_long_held_lock_to_its_holder(
+    tmp_path: Path,
+) -> None:
+    """Past the deadline the worker skips; install_package waits on the same
+    lock later and verifies whatever the holder produced."""
+    with (
+        patch("filelock.FileLock.acquire", side_effect=Timeout("held")),
+        patch("esphome.framework_helpers.DOWNLOAD_LOCK_TIMEOUT", 0),
+        patch.object(registry, "download_with_resume") as mock_download,
+        patch.object(
+            registry, "registry_download", side_effect=_resolve_for({"a": 10, "b": 5})
+        ),
+    ):
+        registry.prefetch_packages(
+            [("a", "1.0", tmp_path / "a", []), ("b", "2.0", tmp_path / "b", [])],
+            tmp_path / "dl",
+        )
+    mock_download.assert_not_called()
 
 
 def test_already_installed_probe(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_platformio_registry.py
+++ b/tests/unit_tests/test_platformio_registry.py
@@ -540,16 +540,13 @@ def test_prefetch_packages_skips_freshly_installed_dest(tmp_path: Path) -> None:
     dest = tmp_path / "a"
     dest.mkdir()
 
-    from contextlib import contextmanager
-
-    @contextmanager
-    def marker_appears_under_lock(path, **kwargs):
+    def marker_appears_under_lock(*args, **kwargs):
         # Simulates the concurrent build finishing while we waited
         (dest / ".esphome_extracted").touch()
-        yield
 
     with (
-        patch("filelock.FileLock", side_effect=marker_appears_under_lock),
+        patch("filelock.FileLock.acquire", side_effect=marker_appears_under_lock),
+        patch("filelock.FileLock.release"),
         patch.object(registry, "download_with_resume") as mock_download,
         patch.object(
             registry, "registry_download", side_effect=_resolve_for({"a": 10})
@@ -557,6 +554,42 @@ def test_prefetch_packages_skips_freshly_installed_dest(tmp_path: Path) -> None:
     ):
         registry.prefetch_packages([("a", "1.0", dest, [])], tmp_path / "dl")
     mock_download.assert_not_called()
+
+
+def test_prefetch_packages_waits_with_the_holders_progress(
+    tmp_path: Path, held_lock
+) -> None:
+    """A worker parked on another build's lock reports that build's part
+    file, then the full size once the marker appears."""
+    dest = tmp_path / "a"
+    dest.mkdir()
+    ticks: list[int] = []
+    acquire = held_lock(
+        tmp_path / "dl" / "a-1.0.part",
+        [b"abc"],
+        (dest / ".esphome_extracted").touch,
+    )
+
+    def fake_batch(header, jobs):
+        for _name, _size, fetch in jobs:
+            fetch(ticks.append)
+        return []
+
+    with (
+        patch("filelock.FileLock.acquire", side_effect=acquire),
+        patch("filelock.FileLock.release"),
+        patch.object(registry, "run_batch_downloads", side_effect=fake_batch),
+        patch.object(registry, "download_with_resume") as mock_download,
+        patch.object(
+            registry, "registry_download", side_effect=_resolve_for({"a": 10, "b": 5})
+        ),
+    ):
+        registry.prefetch_packages(
+            [("a", "1.0", dest, []), ("b", "2.0", tmp_path / "b", [])],
+            tmp_path / "dl",
+        )
+    assert ticks == [3, 10]
+    mock_download.assert_called_once()
 
 
 def test_already_installed_probe(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Regression in 2026.9.0b1, where the combined download bar arrived with the parallel package prefetch (#18769 for PlatformIO, #18662 for the ESP-IDF registry).

When two esphome processes need the same PlatformIO archive at the same time (for example a terminal build and the Device Builder sharing `~/.platformio`), the second one waits on the first one's download lock. That wait loop reported 0 bytes on every poll, and once the holder finished the job returned without crediting anything, so the combined bar sat at 0% for the whole download and then ended its line. The archive was there and the build went on, so nothing looked broken except the bar.

The wait loop now reports the bytes the holder has streamed into its `.part` file, credits the full size once the archive lands, and logs one line saying which archive it is waiting for. A single process downloading on its own is unchanged.

The ESP-IDF package prefetch in `registry.py` had the same blind spot (it blocked on its lock and skipped without crediting the install another build finished), so both wait loops now share one helper.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
