### PR TITLE
[mipi_dsi] Let IDF pick the DPHY PLL reference clock

### DIFF
--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -35,8 +35,11 @@ void MipiDsi::setup() {
       .bus_id = 0,  // index from 0, specify the DSI host to use
       .num_data_lanes =
           this->lanes_,  // Number of data lanes to use, can't set a value that exceeds the chip's capability
-      .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,  // Clock source for the DPHY
-      .lane_bit_rate_mbps = this->lane_bit_rate_,   // Bit rate of the data lanes, in Mbps
+      // phy_clk_src is deliberately left unset (0). esp_lcd_new_dsi_bus() then picks the
+      // revision-correct DPHY PLL reference clock itself: PLL_F20M below ESP32-P4 rev 3.0,
+      // XTAL at rev 3.0 and above. Naming either macro here aborts in mipi_dsi_ll.h on the
+      // other silicon revision.
+      .lane_bit_rate_mbps = this->lane_bit_rate_,  // Bit rate of the data lanes, in Mbps
   };
   auto err = esp_lcd_new_dsi_bus(&bus_config, &this->bus_handle_);
   if (err != ESP_OK) {

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -35,10 +35,7 @@ void MipiDsi::setup() {
       .bus_id = 0,  // index from 0, specify the DSI host to use
       .num_data_lanes =
           this->lanes_,  // Number of data lanes to use, can't set a value that exceeds the chip's capability
-      // phy_clk_src is deliberately left unset (0). esp_lcd_new_dsi_bus() then picks the
-      // revision-correct DPHY PLL reference clock itself: PLL_F20M below ESP32-P4 rev 3.0,
-      // XTAL at rev 3.0 and above. Naming either macro here aborts in mipi_dsi_ll.h on the
-      // other silicon revision.
+      // phy_clk_src left at 0 to enable runtime auto-select.
       .lane_bit_rate_mbps = this->lane_bit_rate_,  // Bit rate of the data lanes, in Mbps
   };
   auto err = esp_lcd_new_dsi_bus(&bus_config, &this->bus_handle_);


### PR DESCRIPTION
# What does this implement/fix?

On ESP32-P4 rev 3.0+ silicon, `mipi_dsi` aborts inside `esp_lcd_new_dsi_bus()`
and the device boot-loops with a black screen until it lands in safe mode.

There is **no single `phy_clk_src` value that is valid on every P4 revision.**
`hal/esp32p4/include/hal/mipi_dsi_ll.h` defines the setter twice:

```c
#if HAL_CONFIG(CHIP_SUPPORT_MIN_REV) >= 300
    // accepts XTAL / APLL / CPLL / SPLL / MPLL      -> default: abort()
#else
    // accepts PLL_F20M / RC_FAST / PLL_F25M         -> default: abort()
#endif
```

So `MIPI_DSI_PHY_CLK_SRC_DEFAULT` — a backward-compatibility alias that
resolves to `PLL_F20M` — aborts at rev 3.0+, and `MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT`
(XTAL) aborts below it. Naming either literal breaks half the boards.

**The driver already solves this.** `soc_module_clk_t` starts at 1, with the
explicit comment *"enum starts from 1, to save 0 for special purpose"*, and
`esp_lcd_new_dsi_bus()` maps an unset (0) source to the revision-correct
default itself:

```c
// esp_lcd/dsi/esp_lcd_mipi_dsi_bus.c
mipi_dsi_phy_pllref_clock_source_t phy_clk_src = bus_config->phy_clk_src;
if (phy_clk_src == 0) {
#if CONFIG_IDF_TARGET_ESP32P4 && HAL_CONFIG(CHIP_SUPPORT_MIN_REV) < 300
    phy_clk_src = MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT_LEGACY;
#else
    phy_clk_src = MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT;
#endif
}
```

(Identical logic in IDF 5.5.5 and 6.0.2; 6.0.2 only changes the guard to
`SOC_IS(ESP32P4)`.)

So this PR just stops setting the field. That is correct on every revision, and
duplicates no revision logic in ESPHome.

This is not an edge case: `boards.py` already makes **`esp32-p4_r3-evboard`
(rev.301) the default board for `VARIANT_ESP32P4`**, and marks the pre-3.0
boards `engineering_sample: True`. The default P4 configuration selects rev3
silicon and then crashes in display init.

### Diagnosis note, in case it saves someone else the time

Safe mode masks this badly. After 10 failed boots the device sits in safe mode,
where WiFi, mDNS and OTA (3232) all answer but the API (6053) does not — so the
board pings, resolves, and accepts OTA uploads, and looks healthy on the network
while it is actually crash-looping. `safe_mode: disabled: true` is what surfaced
the real panic:

```
riscv32-esp-elf-addr2line -pfiaC -e firmware.elf 0x4002ea3d
-> _mipi_dsi_ll_set_phy_pllref_clock_source at hal/esp32p4/include/hal/mipi_dsi_ll.h:218
   (inlined by) esp_lcd_new_dsi_bus at dsi/esp_lcd_mipi_dsi_bus.c:61
```

I'm not proposing any change to safe mode — noting it only because "board is on
the network but the API never comes up" is not an obvious symptom of a display
driver abort.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- (none open that I could find; searched `mipi_dsi`, `MIPI_DSI_PHY_CLK_SRC_DEFAULT`, and P4 chip revision)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — no user-facing configuration change.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Proven on exactly one board, which is the only P4 hardware I have:

- **Waveshare ESP32-P4-WIFI6-Touch-LCD-10.1**
- ESP32-P4 rev **v3.2** (production silicon), ROM `esp32p4-eco7-20260109`, 400 MHz
- 32 MB GD25Q256 flash; 32 MB in-package hex PSRAM @ 200 MHz (`mode: hex`, 200MHz)
- Panel: **JD9365** 800x1280 portrait, 2 lanes; ESPHome model
  `WAVESHARE-P4-NANO-10.1`, reset on GPIO27, backlight GPIO26
- DSI PHY power: `esp_ldo` channel 3 @ 2.5 V (LDO_VO3 -> VDD_MIPI_DPHY)
- Touch: **GT911** @ I2C `0x5D` (SDA 7 / SCL 8)
- Board selected in YAML: `esp32-p4_r3-evboard`
- ESPHome **2026.8.2**, ESP-IDF **5.5.5**, `framework: type: esp-idf`

Before: continuous reboot loop, black screen, then safe mode.
After: display and touch come up and stay up.

**This exact commit was built and flashed**, not an equivalent of it. Compiled
clean (748224 bytes, 40.8% flash), OTA'd to the board, and confirmed on the
running device — the panel is lit and the component reports itself set up:

```
[C][display.mipi_dsi:391]: MIPI_DSI RGB LCD
[C][display.mipi_dsi:391]:   Model: WAVESHARE-P4-NANO-10.1
[C][display.mipi_dsi:391]:   Width: 800
[C][display.mipi_dsi:391]:   Height: 1280
[C][display.mipi_dsi:391]:   DSI Lanes: 2
[C][display.mipi_dsi:391]:   Lane Bit Rate: 1500Mbps
[C][gt911.touchscreen:153]: GT911 Touchscreen:
[C][gt911.touchscreen:154]:   Address: 0x5D
```

The API stayed up continuously past the 60 s `boot_is_good` threshold, so the
device is not in safe mode.

**I have no pre-3.0 engineering sample**, so the `#else` branch is read from the
IDF sources above rather than executed. That is the one thing here I cannot
test, and it is the branch this PR restores correct behaviour to — a check from
anyone holding an ES part would be welcome. If someone with an ES part
can confirm, that closes the last gap.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32-p4_r3-evboard   # rev3 production silicon
  framework:
    type: esp-idf

psram:
  mode: hex
  speed: 200MHz

logger:
  hardware_uart: UART0   # the P4 default is USB_SERIAL_JTAG; this board's console is a CH343

# LDO_VO3 feeds VDD_MIPI_DPHY on this board
esp_ldo:
  - id: dsi_phy_ldo
    channel: 3
    voltage: 2.5V

i2c:
  sda: GPIO7
  scl: GPIO8
  frequency: 400kHz

output:
  - platform: gpio
    pin: GPIO26          # backlight, active high
    id: backlight_output

light:
  - platform: binary
    name: Backlight
    output: backlight_output
    restore_mode: ALWAYS_ON

display:
  - platform: mipi_dsi
    id: main_display
    model: WAVESHARE-P4-NANO-10.1
    reset_pin: GPIO27
    show_test_card: true

touchscreen:
  - platform: gt911
    id: main_touch
    display: main_display

# Without this fix the board never gets this far: it aborts inside
# esp_lcd_new_dsi_bus(), reboots ten times, and disappears into safe mode.
# Adding `safe_mode: disabled: true` is what makes the real panic visible.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

`tests/components/mipi_dsi/test.esp32-p4-idf.yaml` already covers this component
and still compiles; the failure is a silicon-revision runtime abort, so there is
nothing meaningful to add in CI.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
