### PR TITLE
[gpio][pcf8574] Avoid binary output / PCF857x flash on reboot

### DIFF
--- a/esphome/components/gpio/output/gpio_binary_output.h
+++ b/esphome/components/gpio/output/gpio_binary_output.h
@@ -11,9 +11,12 @@ class GPIOBinaryOutput final : public output::BinaryOutput, public Component {
   void set_pin(GPIOPin *pin) { pin_ = pin; }
 
   void setup() override {
-    this->turn_off();
+    // Only configure the pin mode here. Do not force the pin off: LightState (and
+    // similar consumers) restore the intended level shortly after setup. Forcing
+    // OFF first causes a visible off→on flash when the previous state was ON
+    // (especially with PCF857x expanders that keep latch state across ESP reset).
+    // See https://github.com/esphome/issues/issues/5390
     this->pin_->setup();
-    this->turn_off();
   }
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }

--- a/esphome/components/gpio/output/gpio_binary_output.h
+++ b/esphome/components/gpio/output/gpio_binary_output.h
@@ -10,14 +10,7 @@ class GPIOBinaryOutput final : public output::BinaryOutput, public Component {
  public:
   void set_pin(GPIOPin *pin) { pin_ = pin; }
 
-  void setup() override {
-    // Only configure the pin mode here. Do not force the pin off: LightState (and
-    // similar consumers) restore the intended level shortly after setup. Forcing
-    // OFF first causes a visible off→on flash when the previous state was ON
-    // (especially with PCF857x expanders that keep latch state across ESP reset).
-    // See https://github.com/esphome/issues/issues/5390
-    this->pin_->setup();
-  }
+  void setup() override { this->pin_->setup(); }
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -12,8 +12,13 @@ void PCF8574Component::setup() {
     return;
   }
 
-  this->write_gpio_();
-  this->read_gpio_();
+  // Keep the current latch levels. An immediate write_gpio_() here runs with
+  // mode_mask_ still 0, so ~mode_mask_ forces every pin HIGH and drops
+  // active-low loads for a moment before LightState restore. Copy the read
+  // value into output_mask_ so the first real write (after pin modes are set)
+  // can preserve ON outputs across ESP reboot.
+  // See https://github.com/esphome/issues/issues/4127
+  this->output_mask_ = this->input_mask_;
 
   if (this->interrupt_pin_ != nullptr) {
     this->interrupt_pin_->setup();
@@ -65,10 +70,10 @@ void PCF8574Component::digital_write_hw(uint8_t pin, bool value) {
 }
 void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
-    // Clear mode mask bit
+    // Clear mode mask bit. Do not write yet: an early write_gpio_() while other
+    // pins are still unregistered (mode_mask_ bit 0 → treated as input/HIGH)
+    // can force active-low outputs off before LightState restore.
     this->mode_mask_ &= ~(1 << pin);
-    // Write GPIO to enable input mode
-    this->write_gpio_();
     // Enable polling loop for input pins (not needed for interrupt-driven mode
     // where the ISR handles re-enabling loop)
     if (this->interrupt_pin_ == nullptr) {

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -12,12 +12,6 @@ void PCF8574Component::setup() {
     return;
   }
 
-  // Keep the current latch levels. An immediate write_gpio_() here runs with
-  // mode_mask_ still 0, so ~mode_mask_ forces every pin HIGH and drops
-  // active-low loads for a moment before LightState restore. Copy the read
-  // value into output_mask_ so the first real write (after pin modes are set)
-  // can preserve ON outputs across ESP reboot.
-  // See https://github.com/esphome/issues/issues/4127
   this->output_mask_ = this->input_mask_;
 
   if (this->interrupt_pin_ != nullptr) {
@@ -70,9 +64,6 @@ void PCF8574Component::digital_write_hw(uint8_t pin, bool value) {
 }
 void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
-    // Clear mode mask bit. Do not write yet: an early write_gpio_() while other
-    // pins are still unregistered (mode_mask_ bit 0 → treated as input/HIGH)
-    // can force active-low outputs off before LightState restore.
     this->mode_mask_ &= ~(1 << pin);
     // Enable polling loop for input pins (not needed for interrupt-driven mode
     // where the ISR handles re-enabling loop)


### PR DESCRIPTION
## Summary
- Stop `GPIOBinaryOutput` from forcing OFF during `setup()` so `LightState` restore is not preceded by a visible off→on blink ([esphome/issues#5390](https://github.com/esphome/issues/issues/5390)).
- On `PCF8574`/`PCF8575`, preserve the expander latch across ESP reboot instead of writing all-HIGH while `mode_mask_` is still empty, and defer the early input `pin_mode` bus write that could clear active-low outputs ([esphome/issues#4127](https://github.com/esphome/issues/issues/4127)).

## Test plan
- [x] Kincony B16M (PCF8575, inverted outputs, binary lights): lights left ON, OTA/`esphome run` reboot — no brief flash; ON lights stay ON
- [x] Kincony A16 / other PCF8574 boards with mixed inverted/non-inverted outputs
- [ ] Native ESP32 GPIO binary light with `RESTORE_DEFAULT_OFF` (on and off cases)
- [ ] PCF857x with `interrupt_pin` configured (polling loop still enables for inputs)

Fixes https://github.com/esphome/issues/issues/4127
Fixes https://github.com/esphome/issues/issues/5390

Made with [Cursor](https://cursor.com)