### PR TITLE
[noise] Bump noise-c to 0.1.24 and libsodium to 1.10021.6

### DIFF
--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -72,12 +72,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.21")
+    cg.add_library("esphome/noise-c", "0.1.22")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.4")
+    cg.add_library("esphome/libsodium", "1.10021.5")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -72,12 +72,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.22")
+    cg.add_library("esphome/noise-c", "0.1.23")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.5")
+    cg.add_library("esphome/libsodium", "1.10021.6")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -72,7 +72,7 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.23")
+    cg.add_library("esphome/noise-c", "0.1.24")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.21                 ; noise (api, ota)
+    esphome/noise-c@0.1.22                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.21                ; noise (api, ota)
+    esphome/noise-c@0.1.22                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.21  ; used by noise (api, ota)
+    esphome/noise-c@0.1.22  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.22                 ; noise (api, ota)
+    esphome/noise-c@0.1.23                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.22                ; noise (api, ota)
+    esphome/noise-c@0.1.23                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.22  ; used by noise (api, ota)
+    esphome/noise-c@0.1.23  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.23                 ; noise (api, ota)
+    esphome/noise-c@0.1.24                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.23                ; noise (api, ota)
+    esphome/noise-c@0.1.24                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.23  ; used by noise (api, ota)
+    esphome/noise-c@0.1.24  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.21") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.21") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 0.1.22") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.22") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.21\n"
+        "    esphome/noise-c @ 0.1.22\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.21\n"
+        "    esphome/noise-c @ 0.1.22\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.21"]
+    assert libs == ["esphome/noise-c @ 0.1.22"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.21",
+        "esphome/noise-c @ 0.1.22",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.21",
-            "esphome/noise-c @ 0.1.21",
+            "esphome/noise-c @ 0.1.22",
+            "esphome/noise-c @ 0.1.22",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.21"]
+    assert cls.calls == ["esphome/noise-c @ 0.1.22"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.21": [
+        "esphome/noise-c @ 0.1.22": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.22", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.21"] is None
+    assert compats["esphome/noise-c @ 0.1.22"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.21": [
+        "esphome/noise-c @ 0.1.22": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.22"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.21"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.22"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.21": [
+        "esphome/noise-c @ 0.1.22": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.21"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.22"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.23") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.23") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 0.1.24") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.24") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.23\n"
+        "    esphome/noise-c @ 0.1.24\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.23\n"
+        "    esphome/noise-c @ 0.1.24\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.23"]
+    assert libs == ["esphome/noise-c @ 0.1.24"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.23",
+        "esphome/noise-c @ 0.1.24",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.23",
-            "esphome/noise-c @ 0.1.23",
+            "esphome/noise-c @ 0.1.24",
+            "esphome/noise-c @ 0.1.24",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.23"]
+    assert cls.calls == ["esphome/noise-c @ 0.1.24"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.23": [
+        "esphome/noise-c @ 0.1.24": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.23", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.24", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.23"] is None
+    assert compats["esphome/noise-c @ 0.1.24"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.23": [
+        "esphome/noise-c @ 0.1.24": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.23"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.24"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.23"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.24"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.23": [
+        "esphome/noise-c @ 0.1.24": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.23"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.24"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.22") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.22") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 0.1.23") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.23") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.22\n"
+        "    esphome/noise-c @ 0.1.23\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.22\n"
+        "    esphome/noise-c @ 0.1.23\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.22"]
+    assert libs == ["esphome/noise-c @ 0.1.23"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.22",
+        "esphome/noise-c @ 0.1.23",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.22",
-            "esphome/noise-c @ 0.1.22",
+            "esphome/noise-c @ 0.1.23",
+            "esphome/noise-c @ 0.1.23",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.22"]
+    assert cls.calls == ["esphome/noise-c @ 0.1.23"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.22": [
+        "esphome/noise-c @ 0.1.23": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.22", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.23", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.22"] is None
+    assert compats["esphome/noise-c @ 0.1.23"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.22": [
+        "esphome/noise-c @ 0.1.23": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.22"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.23"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.22"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.23"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.22": [
+        "esphome/noise-c @ 0.1.23": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.22"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.23"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1576,7 +1576,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.21", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.22", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1596,7 +1596,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.21", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.22", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1576,7 +1576,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.23", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.24", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1596,7 +1596,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.23", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.24", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1576,7 +1576,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.22", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.23", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1596,7 +1596,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.22", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.23", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Bumps noise-c from 0.1.21 to 0.1.24 and libsodium from 1.10021.4 to 1.10021.6; noise-c 0.1.23 pins libsodium 1.10021.6 (esphome-libs/noise-c#29 and #31) and 0.1.24 adds noise_handshakestate_set_local_ephemeral() (esphome-libs/noise-c#30), which esphome/esphome#19000 builds on; nothing in esphome calls it yet. Two library changes affect existing builds, both ESP8266 only: esphome-libs/libsodium#34 keeps the SHA-256 round constant table in flash, which frees 256 bytes of DRAM, and esphome-libs/libsodium#36 makes X25519 about twice as fast (BearSSL m15 ladder for the DH, cheaper fe25519 products for the base point multiply), which also drops the ref10 ladder and its small order blacklist from the image.

Image sizes of one d1_mini build (logger, wifi, api with encryption, ota) from this branch at each pin, fresh registry packages each time. Saved columns are relative to dev. RAM is the static image (.data, .rodata and .bss), DRAM the linker reserves before the heap exists, so every byte saved there is a byte more free heap at runtime; .rodata is part of that RAM column since it lives in DRAM on ESP8266:

| noise-c / libsodium | flash | flash saved | RAM | RAM saved | .rodata | .rodata saved |
| --- | --- | --- | --- | --- | --- | --- |
| 0.1.21 / 1.10021.4 (dev) | 410951 B | | 30656 B | | 2372 B | |
| 0.1.22 / 1.10021.5 | 410951 B | 0 B | 30400 B | 256 B | 2116 B | 256 B |
| 0.1.23 / 1.10021.6 | 403923 B | 7028 B | 30164 B | 492 B | 1888 B | 484 B |
| 0.1.24 / 1.10021.6 (this PR) | 403939 B | 7012 B | 30164 B | 492 B | 1888 B | 484 B |

.data (1932 B) and .bss (26352 B, 26344 B from 1.10021.6 on) are otherwise unchanged. 1.10021.5 moves the 256 byte SHA-256 table from DRAM to flash with the image size unchanged; 1.10021.6 drops the ref10 ladder and its 224 byte small order blacklist; noise-c 0.1.24 only adds noise_handshakestate_set_local_ephemeral(), which nothing calls yet, and pins the same libsodium as 0.1.23.

X25519 and handshake timing on the same d1 mini at 80 MHz, best of 5 (the handshake rows are one Noise_NNpsk0 loopback in RAM):

| noise-c / libsodium | base point multiply | X25519 DH | responder write step | full loopback |
| --- | --- | --- | --- | --- |
| 0.1.21 / 1.10021.4 (dev) | 76.4 ms | 199.7 ms | 288.4 ms | 581.2 ms |
| 0.1.22 / 1.10021.5 | 76.8 ms | 201.6 ms | 288.3 ms | 582.9 ms |
| 0.1.23 and 0.1.24 / 1.10021.6 (this PR) | 55.9 ms | 93.5 ms | 154.6 ms | 317.1 ms |

The 1.10021.6 ladder uses 256 bytes more main loop stack only while a handshake runs (1760 bytes free of the 4096 byte CONT stack at the deepest point), no heap change. 20 encrypted API connects from aioesphomeapi by IP went from a 377 ms median to 139 ms and a 315 ms best to 128 ms.

The same plain build for an ESP32 AtomU (IDF) at each pin:

| noise-c / libsodium | flash | RAM |
| --- | --- | --- |
| 0.1.21 / 1.10021.4 (dev) | 759355 B | 44496 B |
| 0.1.22 / 1.10021.5 | 759355 B | 44496 B |
| 0.1.23 / 1.10021.6 | 759355 B | 44496 B |
| 0.1.24 / 1.10021.6 (this PR) | 759375 B | 44496 B |

The m15 ladder is compiled on ESP32 but unreferenced and dropped by the linker; the remaining 20 byte flash difference was not chased. Both library changes are ESP8266 only, so the ESP32 crypto is the same at every pin: 12.2 ms base point multiply, 14.4 ms DH, 29.3 ms responder write step, 63 ms full loopback, measured on the AtomU at dev and at this PR.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- keeps the noise-c dependency current after esphome-libs/noise-c#30, esphome-libs/noise-c#31, esphome-libs/libsodium#34 and esphome-libs/libsodium#36

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


