### PR TITLE
[mdns] Guard LEAmDNS main loop calls against lwIP re-entrancy on ESP8266

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -192,7 +192,7 @@ async def to_code(config: ConfigType) -> None:
     if CORE.using_arduino:
         if CORE.is_esp8266:
             cg.add_library("ESP8266mDNS", None)
-            # mdns_esp8266.cpp owns a guarded MDNSResponder instead of the library global
+            # No MDNS global in the build; mdns_esp8266.cpp owns a guarded MDNSResponder
             cg.add_build_flag("-DNO_GLOBAL_MDNS")
         elif CORE.is_rp2:
             cg.add_library("LEAmDNS", None)

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -192,6 +192,8 @@ async def to_code(config: ConfigType) -> None:
     if CORE.using_arduino:
         if CORE.is_esp8266:
             cg.add_library("ESP8266mDNS", None)
+            # mdns_esp8266.cpp owns a guarded MDNSResponder instead of the library global
+            cg.add_build_flag("-DNO_GLOBAL_MDNS")
         elif CORE.is_rp2:
             cg.add_library("LEAmDNS", None)
 

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -13,8 +13,56 @@
 
 namespace esphome::mdns {
 
+// Main-loop calls into LEAmDNS (update(), close()) can yield inside UdpContext::sendTimeout();
+// a packet arriving then re-enters LEAmDNS from lwIP on the same UdpContext and both sides free
+// the same tx pbufs (#18760). Received packets are only counted during such a call and drained
+// from the main loop afterwards.
+class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder {
+ public:
+  void update_guarded() {
+    this->run_guarded_([this]() { this->update(); });
+  }
+  void close_guarded() {
+    this->run_guarded_([this]() { this->close(); });
+  }
+
+ private:
+  template<typename F> void run_guarded_(F &&fn) {
+    UdpContext *ctx = this->m_pUDPContext;
+    if (ctx == nullptr) {
+      fn();
+      return;
+    }
+    // Set every time: a restart replaces the context together with its stock handler
+    ctx->onRx([this]() { this->on_rx_(); });
+    this->pending_rx_ = 0;
+    this->in_loop_call_ = true;
+    fn();
+    // Still counting here, so packets arriving during a yield in the drain queue behind it
+    while (this->pending_rx_ > 0) {
+      this->pending_rx_--;
+      this->_process(false);
+    }
+    this->in_loop_call_ = false;
+  }
+
+  // lwIP receive callback (SYS context)
+  void on_rx_() {
+    if (this->in_loop_call_) {
+      this->pending_rx_++;
+    } else {
+      this->_callProcess();
+    }
+  }
+
+  volatile bool in_loop_call_{false};
+  volatile uint8_t pending_rx_{0};
+};
+
+static GuardedMDNSResponder mdns_responder;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 static void register_esp8266(MDNSComponent *, StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services) {
-  MDNS.begin(App.get_name().c_str());
+  mdns_responder.begin(App.get_name().c_str());
 
   for (const auto &service : services) {
     // Strip the leading underscore from the proto and service_type. While it is
@@ -30,10 +78,10 @@ static void register_esp8266(MDNSComponent *, StaticVector<MDNSService, MDNS_SER
       service_type++;
     }
     uint16_t port = service.port.value();
-    MDNS.addService(FPSTR(service_type), FPSTR(proto), port);
+    mdns_responder.addService(FPSTR(service_type), FPSTR(proto), port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(FPSTR(service_type), FPSTR(proto), FPSTR(MDNS_STR_ARG(record.key)),
-                         FPSTR(MDNS_STR_ARG(record.value)));
+      mdns_responder.addServiceTxt(FPSTR(service_type), FPSTR(proto), FPSTR(MDNS_STR_ARG(record.key)),
+                                   FPSTR(MDNS_STR_ARG(record.value)));
     }
   }
 }
@@ -41,19 +89,7 @@ static void register_esp8266(MDNSComponent *, StaticVector<MDNSService, MDNS_SER
 #ifdef USE_MDNS_EVENT_DRIVEN_POLLING
 void MDNSComponent::start_polling_window_() {
   // uint32_t-ID set_interval/set_timeout already does atomic cancel-and-add.
-  this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() {
-#ifdef USE_MDNS_WIFI_LISTENER
-    // MDNS.update() can suspend the loop in UdpContext::sendTimeout() while a send is
-    // failing (radio off-channel during a roam scan, or mid reconnect); an incoming
-    // packet then re-enters LEAmDNS from lwIP and corrupts shared UdpContext state.
-    // Skip the tick while the radio cannot transmit (#18760), but keep polling while
-    // the AP is serving clients (AP-only or fallback AP with the STA down).
-    auto *wifi = wifi::global_wifi_component;
-    if (wifi->is_roaming() || (!wifi->is_connected() && !wifi->is_ap_active()))
-      return;
-#endif
-    MDNS.update();
-  });
+  this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() { mdns_responder.update_guarded(); });
   this->set_timeout(MDNS_POLL_STOP_ID, MDNS_POLL_WINDOW_MS, [this]() { this->cancel_interval(MDNS_POLL_ID); });
 }
 #endif
@@ -81,7 +117,7 @@ void MDNSComponent::on_ip_state(const network::IPAddresses &ips, const network::
 #endif
 
 void MDNSComponent::on_shutdown() {
-  MDNS.close();
+  mdns_responder.close_guarded();
   delay(10);
 }
 

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -87,10 +87,13 @@ void MDNSComponent::start_polling_window_() {
   // uint32_t-ID set_interval/set_timeout already does atomic cancel-and-add.
   this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() {
 #ifdef USE_MDNS_WIFI_LISTENER
-    // Every send fails while the radio is off channel or no interface is up, and each one
-    // spins sendTimeout() for 50 ms; skip the tick rather than stall the loop for nothing.
+    // MDNS.update() can suspend the loop in UdpContext::sendTimeout() while a send is
+    // failing (radio off-channel during a roam scan, or mid reconnect); an incoming
+    // packet then re-enters LEAmDNS from lwIP and corrupts shared UdpContext state.
+    // Skip the tick while the radio cannot transmit (#18760), but keep polling while
+    // the AP is serving clients (AP-only or fallback AP with the STA down).
     auto *wifi = wifi::global_wifi_component;
-    if (wifi->is_roaming_scan_active() || (!wifi->is_connected() && !wifi->is_ap_active()))
+    if (wifi->is_roaming() || (!wifi->is_connected() && !wifi->is_ap_active()))
       return;
 #endif
     mdns_responder.update_guarded();

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -89,7 +89,16 @@ static void register_esp8266(MDNSComponent *, StaticVector<MDNSService, MDNS_SER
 #ifdef USE_MDNS_EVENT_DRIVEN_POLLING
 void MDNSComponent::start_polling_window_() {
   // uint32_t-ID set_interval/set_timeout already does atomic cancel-and-add.
-  this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() { mdns_responder.update_guarded(); });
+  this->set_interval(MDNS_POLL_ID, MDNS_UPDATE_INTERVAL_MS, []() {
+#ifdef USE_MDNS_WIFI_LISTENER
+    // Every send fails while the radio is off channel or no interface is up, and each one
+    // spins sendTimeout() for 50 ms; skip the tick rather than stall the loop for nothing.
+    auto *wifi = wifi::global_wifi_component;
+    if (wifi->is_roaming_scan_active() || (!wifi->is_connected() && !wifi->is_ap_active()))
+      return;
+#endif
+    mdns_responder.update_guarded();
+  });
   this->set_timeout(MDNS_POLL_STOP_ID, MDNS_POLL_WINDOW_MS, [this]() { this->cancel_interval(MDNS_POLL_ID); });
 }
 #endif

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -19,25 +19,21 @@ namespace esphome::mdns {
 // from the main loop afterwards.
 class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder {
  public:
-  void update_guarded() {
-    this->run_guarded_([this]() { this->update(); });
-  }
-  void close_guarded() {
-    this->run_guarded_([this]() { this->close(); });
-  }
+  void update_guarded() { this->run_guarded_(&GuardedMDNSResponder::update); }
+  void close_guarded() { this->run_guarded_(&GuardedMDNSResponder::close); }
 
  private:
-  template<typename F> void run_guarded_(F &&fn) {
+  void run_guarded_(bool (GuardedMDNSResponder::*fn)()) {
     UdpContext *ctx = this->m_pUDPContext;
     if (ctx == nullptr) {
-      fn();
+      (this->*fn)();
       return;
     }
     // Set every time: a restart replaces the context together with its stock handler
     ctx->onRx([this]() { this->on_rx_(); });
     this->pending_rx_ = 0;
     this->in_loop_call_ = true;
-    fn();
+    (this->*fn)();
     // Still counting here, so packets arriving during a yield in the drain queue behind it
     while (this->pending_rx_ > 0) {
       this->pending_rx_--;

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -30,7 +30,9 @@ class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder
       (this->*fn)();
       return;
     }
-    // Set every time: a restart replaces the context together with its stock handler
+    // Set every time: a restart replaces the context together with its stock handler. Only
+    // begin() and the scheduled netif callback restart, never update() or close(), so the
+    // context cannot change underneath this call.
     ctx->onRx([this]() {
       if (!this->in_loop_call_) {
         this->_callProcess();

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -29,8 +29,15 @@ class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder
       (this->*fn)();
       return;
     }
-    // Set every time: a restart replaces the context together with its stock handler
-    ctx->onRx([this]() { this->on_rx_(); });
+    // Set every time: a restart replaces the context together with its stock handler.
+    // Runs from lwIP in the SYS context.
+    ctx->onRx([this]() {
+      if (this->in_loop_call_) {
+        this->pending_rx_++;
+      } else {
+        this->_callProcess();
+      }
+    });
     this->pending_rx_ = 0;
     this->in_loop_call_ = true;
     (this->*fn)();
@@ -40,15 +47,6 @@ class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder
       this->_process(false);
     }
     this->in_loop_call_ = false;
-  }
-
-  // lwIP receive callback (SYS context)
-  void on_rx_() {
-    if (this->in_loop_call_) {
-      this->pending_rx_++;
-    } else {
-      this->_callProcess();
-    }
   }
 
   volatile bool in_loop_call_{false};

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -13,10 +13,11 @@
 
 namespace esphome::mdns {
 
-// Main-loop calls into LEAmDNS (update(), close()) can yield inside UdpContext::sendTimeout();
-// a packet arriving then re-enters LEAmDNS from lwIP on the same UdpContext and both sides free
-// the same tx pbufs (#18760). Received packets are only counted during such a call and drained
-// from the main loop afterwards.
+// Main-loop calls into LEAmDNS that send (update() and close(); begin(), addService() and
+// the scheduled restart never reach a send) can yield inside UdpContext::sendTimeout(); a
+// packet arriving then re-enters LEAmDNS from lwIP on the same UdpContext and both sides
+// free the same tx pbufs (#18760). Received packets stay queued during such a call and are
+// processed from the main loop afterwards.
 class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder {
  public:
   void update_guarded() { this->run_guarded_(&GuardedMDNSResponder::update); }
@@ -29,28 +30,22 @@ class GuardedMDNSResponder : public ::esp8266::MDNSImplementation::MDNSResponder
       (this->*fn)();
       return;
     }
-    // Set every time: a restart replaces the context together with its stock handler.
-    // Runs from lwIP in the SYS context.
+    // Set every time: a restart replaces the context together with its stock handler
     ctx->onRx([this]() {
-      if (this->in_loop_call_) {
-        this->pending_rx_++;
-      } else {
+      if (!this->in_loop_call_) {
         this->_callProcess();
       }
     });
-    this->pending_rx_ = 0;
     this->in_loop_call_ = true;
     (this->*fn)();
-    // Still counting here, so packets arriving during a yield in the drain queue behind it
-    while (this->pending_rx_ > 0) {
-      this->pending_rx_--;
-      this->_process(false);
+    // close() releases the context; a yield in here queues further packets for this loop too
+    while (this->m_pUDPContext != nullptr && this->m_pUDPContext->next()) {
+      this->_parseMessage();
     }
     this->in_loop_call_ = false;
   }
 
   volatile bool in_loop_call_{false};
-  volatile uint8_t pending_rx_{0};
 };
 
 static GuardedMDNSResponder mdns_responder;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -476,6 +476,10 @@ class WiFiComponent final : public Component {
   /// True while a post-connect roaming scan holds the radio off-channel.
   bool is_roaming_scan_active() const { return this->roaming_state_ == RoamingState::SCANNING; }
 
+  /// True while a post-connect roam is in progress (scanning off-channel, reassociating,
+  /// or recovering from a failed roam).
+  bool is_roaming() const { return this->roaming_state_ != RoamingState::IDLE; }
+
 #ifdef USE_ESP32
   /// esp_netif handle of the station interface, used by network for default-route
   /// arbitration. nullptr until wifi_lazy_init_() has run.

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -476,10 +476,6 @@ class WiFiComponent final : public Component {
   /// True while a post-connect roaming scan holds the radio off-channel.
   bool is_roaming_scan_active() const { return this->roaming_state_ == RoamingState::SCANNING; }
 
-  /// True while a post-connect roam is in progress (scanning off-channel, reassociating,
-  /// or recovering from a failed roam).
-  bool is_roaming() const { return this->roaming_state_ != RoamingState::IDLE; }
-
 #ifdef USE_ESP32
   /// esp_netif handle of the station interface, used by network for default-route
   /// arbitration. nullptr until wifi_lazy_init_() has run.


### PR DESCRIPTION
# What does this implement/fix?

Reported on Discord: a Sonoff S31 on 2026.8.2 with an encrypted API crashed with LoadProhibit in `noise_handshakestate_new`, EXCVADDR 0x5C, right after the server hello. Disassembly shows the handshake state pointer was stored, then read back as NULL after `noise_curve25519_new()` called calloc, so calloc handed out a block that still overlapped the live frame helper; that only happens once umm's free list is corrupted by a double free.

The known double free on ESP8266 is LEAmDNS: `MDNS.update()` (and `close()`) yield inside `UdpContext::sendTimeout()` while a send fails, an incoming mDNS packet then re-enters LEAmDNS from lwIP on the same UdpContext and both sides free the same tx pbufs (#18760). The #18785 mitigation only skipped update() while roaming or disconnected; sends also fail transiently with the radio up, and the 15 s announce window after getting an IP is exactly when Home Assistant discovers the device, connects and starts the noise handshake (#18798 shows the same frame). The Arduino core ships no releases, so the guard lives in ESPHome: mdns_esp8266.cpp now owns a `MDNSResponder` subclass (built with `NO_GLOBAL_MDNS`), its receive handler only counts packets while a main loop call into LEAmDNS is running and drains them afterwards from the main loop; LEAmDNS therefore never runs in two contexts at once. The Arduino core's `MDNS` global no longer exists in ESP8266 builds; nothing in ESPHome referenced it. The #18785 tick skip stays unchanged, since each failing send still spins sendTimeout() for 50 ms while the radio is off channel.

Tested on a d1 mini with an encrypted API: 87 reboot and reconnect cycles under an mDNS query flood and ping load with no crash, host and service records still resolve, static RAM is unchanged (the subclass instance is the same 96 bytes as the library global it replaces); a temporary build that forced a yield inside the guarded call saw 57 polling ticks with packets arriving mid call, all were left queued and processed afterwards without a crash. The original corruption did not reproduce on either build on a healthy network since it needs a failing send inside update().

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to #18760
- related to #18798

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp8266:
  board: d1_mini

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
