### PR TITLE
[ld2460] Add support for HLK-LD2460 radar sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -291,6 +291,7 @@ esphome/components/ld2410/* @regevbr @sebcaps
 esphome/components/ld2412/* @Rihan9
 esphome/components/ld2420/* @descipher
 esphome/components/ld2450/* @hareeshmu
+esphome/components/ld2460/* @jesusvallejo
 esphome/components/ld24xx/* @kbx81
 esphome/components/ld6002b/* @hepter
 esphome/components/ledc/* @OttoWinter

--- a/esphome/components/ld2460/__init__.py
+++ b/esphome/components/ld2460/__init__.py
@@ -1,0 +1,52 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_ON_DATA
+from esphome.types import ConfigType
+
+AUTO_LOAD = ["ld24xx"]
+DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@jesusvallejo"]
+MULTI_CONF = True
+
+ld2460_ns = cg.esphome_ns.namespace("ld2460")
+LD2460Component = ld2460_ns.class_("LD2460Component", cg.Component, uart.UARTDevice)
+
+CONF_LD2460_ID = "ld2460_id"
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(LD2460Component),
+            cv.Optional(CONF_ON_DATA): automation.validate_automation({}),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+LD2460BaseSchema = cv.Schema(
+    {
+        cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+    },
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "ld2460",
+    require_tx=True,
+    require_rx=True,
+    parity="NONE",
+    stop_bits=1,
+)
+
+_CALLBACK_AUTOMATIONS = (
+    automation.CallbackAutomation(CONF_ON_DATA, "add_on_data_callback"),
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+    await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)

--- a/esphome/components/ld2460/binary_sensor.py
+++ b/esphome/components/ld2460/binary_sensor.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_HAS_TARGET, CONF_ID, DEVICE_CLASS_OCCUPANCY
+from esphome.types import ConfigType
+
+from . import CONF_LD2460_ID, LD2460Component
+
+DEPENDENCIES = ["ld2460"]
+
+ICON_SHIELD_ACCOUNT = "mdi:shield-account"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+    cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+    cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_OCCUPANCY,
+        icon=ICON_SHIELD_ACCOUNT,
+    ),
+}
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+    if has_target_config := config.get(CONF_HAS_TARGET):
+        sens = await binary_sensor.new_binary_sensor(has_target_config)
+        cg.add(ld2460_component.set_target_binary_sensor(sens))

--- a/esphome/components/ld2460/button/__init__.py
+++ b/esphome/components/ld2460/button/__init__.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+from esphome.components import button
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_FACTORY_RESET,
+    CONF_ID,
+    CONF_RESTART,
+    DEVICE_CLASS_RESTART,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    ICON_RESTART,
+    ICON_RESTART_ALERT,
+)
+from esphome.types import ConfigType
+
+from .. import CONF_LD2460_ID, LD2460Component, ld2460_ns
+
+FactoryResetButton = ld2460_ns.class_("FactoryResetButton", button.Button)
+RestartButton = ld2460_ns.class_("RestartButton", button.Button)
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+    cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+    cv.Optional(CONF_FACTORY_RESET): button.button_schema(
+        FactoryResetButton,
+        device_class=DEVICE_CLASS_RESTART,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_RESTART_ALERT,
+    ),
+    cv.Optional(CONF_RESTART): button.button_schema(
+        RestartButton,
+        device_class=DEVICE_CLASS_RESTART,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        icon=ICON_RESTART,
+    ),
+}
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+    if factory_reset_config := config.get(CONF_FACTORY_RESET):
+        b = await button.new_button(factory_reset_config)
+        await cg.register_parented(b, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_factory_reset_button(b))
+    if restart_config := config.get(CONF_RESTART):
+        b = await button.new_button(restart_config)
+        await cg.register_parented(b, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_restart_button(b))

--- a/esphome/components/ld2460/button/factory_reset_button.cpp
+++ b/esphome/components/ld2460/button/factory_reset_button.cpp
@@ -1,0 +1,7 @@
+#include "factory_reset_button.h"
+
+namespace esphome::ld2460 {
+
+void FactoryResetButton::press_action() { this->parent_->factory_reset(); }
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/button/factory_reset_button.h
+++ b/esphome/components/ld2460/button/factory_reset_button.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class FactoryResetButton : public button::Button, public Parented<LD2460Component> {
+ public:
+  FactoryResetButton() = default;
+
+ protected:
+  void press_action() override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/button/restart_button.cpp
+++ b/esphome/components/ld2460/button/restart_button.cpp
@@ -1,0 +1,7 @@
+#include "restart_button.h"
+
+namespace esphome::ld2460 {
+
+void RestartButton::press_action() { this->parent_->restart_and_read_all_info(); }
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/button/restart_button.h
+++ b/esphome/components/ld2460/button/restart_button.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class RestartButton : public button::Button, public Parented<LD2460Component> {
+ public:
+  RestartButton() = default;
+
+ protected:
+  void press_action() override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/ld2460.cpp
+++ b/esphome/components/ld2460/ld2460.cpp
@@ -1,0 +1,606 @@
+#include "ld2460.h"
+
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#include "esphome/core/application.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstring>
+#include <numbers>
+
+namespace esphome::ld2460 {
+
+static const char *const TAG = "ld2460";
+
+enum BaudRate : uint8_t {
+  BAUD_RATE_9600 = 0,
+  BAUD_RATE_19200 = 1,
+  BAUD_RATE_38400 = 2,
+  BAUD_RATE_57600 = 3,
+  BAUD_RATE_115200 = 4,
+  BAUD_RATE_230400 = 5,
+  BAUD_RATE_256000 = 6,
+  BAUD_RATE_460800 = 7,
+};
+
+// Memory-efficient lookup tables
+struct StringToUint8 {
+  const char *str;
+  const uint8_t value;
+};
+
+struct Uint8ToString {
+  const uint8_t value;
+  const char *str;
+};
+
+constexpr StringToUint8 BAUD_RATES_BY_STR[] = {
+    {"9600", BAUD_RATE_9600},     {"19200", BAUD_RATE_19200},   {"38400", BAUD_RATE_38400},
+    {"57600", BAUD_RATE_57600},   {"115200", BAUD_RATE_115200}, {"230400", BAUD_RATE_230400},
+    {"256000", BAUD_RATE_256000}, {"460800", BAUD_RATE_460800},
+};
+
+constexpr uint32_t BAUD_RATES[] = {9600, 19200, 38400, 57600, 115200, 230400, 256000, 460800};
+
+constexpr Uint8ToString INSTALLATION_MODE_BY_UINT[] = {
+    {MODE_SIDE, "Side"},
+    {MODE_TOP, "Top"},
+};
+
+constexpr StringToUint8 INSTALLATION_MODE_BY_STR[] = {
+    {"Side", MODE_SIDE},
+    {"Top", MODE_TOP},
+};
+
+constexpr Uint8ToString SENSITIVITY_BY_UINT[] = {
+    {SENSITIVITY_HIGH, "High"},
+    {SENSITIVITY_MEDIUM, "Medium"},
+    {SENSITIVITY_LOW, "Low"},
+};
+
+constexpr StringToUint8 SENSITIVITY_BY_STR[] = {
+    {"High", SENSITIVITY_HIGH},
+    {"Medium", SENSITIVITY_MEDIUM},
+    {"Low", SENSITIVITY_LOW},
+};
+
+// Helper functions for lookups
+template<size_t N> uint8_t find_uint8(const StringToUint8 (&arr)[N], const std::string &str) {
+  for (const auto &entry : arr) {
+    if (str == entry.str)
+      return entry.value;
+  }
+  return 0xFF;
+}
+
+template<size_t N> const char *find_str(const Uint8ToString (&arr)[N], uint8_t value) {
+  for (const auto &entry : arr) {
+    if (value == entry.value)
+      return entry.str;
+  }
+  return "";
+}
+
+// LD2460 Frame Headers & Footers
+static constexpr uint8_t HEADER_FOOTER_SIZE = 4;
+static constexpr uint8_t CMD_FRAME_HEADER[HEADER_FOOTER_SIZE] = {0xFD, 0xFC, 0xFB, 0xFA};
+static constexpr uint8_t CMD_FRAME_FOOTER[HEADER_FOOTER_SIZE] = {0x04, 0x03, 0x02, 0x01};
+static constexpr uint8_t DATA_FRAME_HEADER[HEADER_FOOTER_SIZE] = {0xF4, 0xF3, 0xF2, 0xF1};
+static constexpr uint8_t DATA_FRAME_FOOTER[HEADER_FOOTER_SIZE] = {0xF8, 0xF7, 0xF6, 0xF5};
+
+// LD2460 Command Codes
+static constexpr uint8_t CMD_REPORT_DATA = 0x04;
+static constexpr uint8_t CMD_SET_REPORTING = 0x06;
+static constexpr uint8_t CMD_SET_INSTALLATION_PARAMS = 0x07;
+static constexpr uint8_t CMD_QUERY_INSTALLATION_PARAMS = 0x08;
+static constexpr uint8_t CMD_SET_INSTALLATION_MODE = 0x09;
+static constexpr uint8_t CMD_QUERY_INSTALLATION_MODE = 0x0A;
+static constexpr uint8_t CMD_QUERY_VERSION = 0x0B;
+static constexpr uint8_t CMD_RESTART = 0x0D;
+static constexpr uint8_t CMD_SET_BAUD_RATE = 0x0E;
+static constexpr uint8_t CMD_FACTORY_RESET = 0x10;
+static constexpr uint8_t CMD_SET_DETECTION_RANGE = 0x11;
+static constexpr uint8_t CMD_QUERY_DETECTION_RANGE = 0x12;
+static constexpr uint8_t CMD_SET_SENSITIVITY = 0x13;
+static constexpr uint8_t CMD_QUERY_SENSITIVITY = 0x14;
+
+static inline bool validate_header_footer(const uint8_t *expected, const uint8_t *buffer) {
+  return std::memcmp(expected, buffer, HEADER_FOOTER_SIZE) == 0;
+}
+
+
+void LD2460Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up LD2460...");
+  this->read_all_info();
+}
+
+void LD2460Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "LD2460:");
+#ifdef USE_BINARY_SENSOR
+  ESP_LOGCONFIG(TAG, "  Binary Sensors:");
+  LOG_BINARY_SENSOR("    ", "Target", this->target_binary_sensor_);
+#endif
+#ifdef USE_SENSOR
+  ESP_LOGCONFIG(TAG, "  Sensors:");
+  LOG_SENSOR_WITH_DEDUP_SAFE("    ", "TargetCount", this->target_count_sensor_);
+  for (size_t i = 0; i < MAX_TARGETS; i++) {
+    LOG_SENSOR_WITH_DEDUP_SAFE("    ", "TargetX", this->target_x_sensors_[i]);
+    LOG_SENSOR_WITH_DEDUP_SAFE("    ", "TargetY", this->target_y_sensors_[i]);
+    LOG_SENSOR_WITH_DEDUP_SAFE("    ", "TargetDistance", this->target_distance_sensors_[i]);
+    LOG_SENSOR_WITH_DEDUP_SAFE("    ", "TargetAngle", this->target_angle_sensors_[i]);
+  }
+#endif
+#ifdef USE_TEXT_SENSOR
+  ESP_LOGCONFIG(TAG, "  Text Sensors:");
+  LOG_TEXT_SENSOR("    ", "Version", this->version_text_sensor_);
+#endif
+#ifdef USE_NUMBER
+  ESP_LOGCONFIG(TAG, "  Numbers:");
+  LOG_NUMBER("    ", "InstallationHeight", this->installation_height_number_);
+  LOG_NUMBER("    ", "InstallationAngle", this->installation_angle_number_);
+  LOG_NUMBER("    ", "DetectionDistance", this->detection_distance_number_);
+  LOG_NUMBER("    ", "DetectionAngleMin", this->detection_angle_min_number_);
+  LOG_NUMBER("    ", "DetectionAngleMax", this->detection_angle_max_number_);
+#endif
+#ifdef USE_SELECT
+  ESP_LOGCONFIG(TAG, "  Selects:");
+  LOG_SELECT("    ", "BaudRate", this->baud_rate_select_);
+  LOG_SELECT("    ", "InstallationMode", this->installation_mode_select_);
+  LOG_SELECT("    ", "Sensitivity", this->sensitivity_select_);
+#endif
+#ifdef USE_SWITCH
+  ESP_LOGCONFIG(TAG, "  Switches:");
+  LOG_SWITCH("    ", "Reporting", this->reporting_switch_);
+#endif
+#ifdef USE_BUTTON
+  ESP_LOGCONFIG(TAG, "  Buttons:");
+  LOG_BUTTON("    ", "FactoryReset", this->factory_reset_button_);
+  LOG_BUTTON("    ", "Restart", this->restart_button_);
+#endif
+}
+
+void LD2460Component::loop() {
+  size_t avail = this->available();
+  uint8_t buf[MAX_LINE_LENGTH];
+  while (avail > 0) {
+    size_t to_read = std::min(avail, sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
+
+    for (size_t i = 0; i < to_read; i++) {
+      this->readline_(buf[i]);
+    }
+  }
+}
+
+void LD2460Component::read_all_info() {
+  this->query_version_();
+  this->query_installation_mode_();
+  this->query_installation_params_();
+  this->query_detection_range_();
+  this->query_sensitivity_();
+#ifdef USE_SELECT
+  if (this->baud_rate_select_ != nullptr) {
+    if (auto index = ld24xx::find_index(BAUD_RATES, this->parent_->get_baud_rate())) {
+      this->baud_rate_select_->publish_state(*index);
+    }
+  }
+#endif
+}
+
+void LD2460Component::restart_and_read_all_info() {
+  this->restart();
+  this->set_timeout(1500, [this]() { this->read_all_info(); });
+}
+
+void LD2460Component::send_command_(uint8_t command, const uint8_t *data, uint8_t data_len) {
+  ESP_LOGV(TAG, "Sending COMMAND %02X", command);
+  this->write_array(CMD_FRAME_HEADER, HEADER_FOOTER_SIZE);
+  this->write_byte(command);
+  uint16_t total_len = 11 + data_len;
+  uint8_t len_bytes[2] = {static_cast<uint8_t>(total_len & 0xFF), static_cast<uint8_t>((total_len >> 8) & 0xFF)};
+  this->write_array(len_bytes, sizeof(len_bytes));
+  if (data != nullptr && data_len > 0) {
+    this->write_array(data, data_len);
+  }
+  this->write_array(CMD_FRAME_FOOTER, HEADER_FOOTER_SIZE);
+  delay(50);  // NOLINT
+}
+
+void LD2460Component::handle_periodic_data_() {
+  if (this->buffer_pos_ < 11) {
+    ESP_LOGE(TAG, "Invalid periodic data length: %u", this->buffer_pos_);
+    return;
+  }
+  if (!validate_header_footer(DATA_FRAME_HEADER, this->buffer_data_) ||
+      !validate_header_footer(DATA_FRAME_FOOTER, &this->buffer_data_[this->buffer_pos_ - 4])) {
+    ESP_LOGE(TAG, "Invalid periodic header or footer");
+    return;
+  }
+  if (this->buffer_data_[4] != CMD_REPORT_DATA) {
+    ESP_LOGE(TAG, "Invalid function code for periodic data: %02X", this->buffer_data_[4]);
+    return;
+  }
+
+  uint16_t packet_len = this->buffer_data_[5] | (this->buffer_data_[6] << 8);
+  if (packet_len != this->buffer_pos_) {
+    ESP_LOGW(TAG, "Periodic packet length mismatch: %u != %u", packet_len, this->buffer_pos_);
+    return;
+  }
+
+  uint8_t num_targets = (packet_len >= 11) ? ((packet_len - 11) / 4) : 0;
+  if (num_targets > MAX_TARGETS) {
+    num_targets = MAX_TARGETS;
+  }
+
+  for (uint8_t i = 0; i < MAX_TARGETS; i++) {
+    if (i < num_targets) {
+      uint8_t offset = 7 + i * 4;
+      int16_t raw_x = static_cast<int16_t>(this->buffer_data_[offset] | (this->buffer_data_[offset + 1] << 8));
+      int16_t raw_y = static_cast<int16_t>(this->buffer_data_[offset + 2] | (this->buffer_data_[offset + 3] << 8));
+
+      // Accuracy 0.1m -> meters
+      float x = raw_x * 0.1f;
+      float y = raw_y * 0.1f;
+      float distance = std::sqrt(x * x + y * y);
+
+      float angle;
+      if (this->installation_mode_ == MODE_TOP) {
+        angle = std::atan2(y, x) * (180.0f / std::numbers::pi_v<float>);
+        if (angle < 0.0f) {
+          angle += 360.0f;
+        }
+      } else {
+        angle = std::atan2(x, y) * (180.0f / std::numbers::pi_v<float>);
+      }
+
+      this->target_info_[i].x = x;
+      this->target_info_[i].y = y;
+      this->target_info_[i].distance = distance;
+      this->target_info_[i].angle = angle;
+
+#ifdef USE_SENSOR
+      SAFE_PUBLISH_SENSOR(this->target_x_sensors_[i], x);
+      SAFE_PUBLISH_SENSOR(this->target_y_sensors_[i], y);
+      SAFE_PUBLISH_SENSOR(this->target_distance_sensors_[i], distance);
+      SAFE_PUBLISH_SENSOR(this->target_angle_sensors_[i], angle);
+#endif
+    } else {
+      this->target_info_[i].x = 0.0f;
+      this->target_info_[i].y = 0.0f;
+      this->target_info_[i].distance = 0.0f;
+      this->target_info_[i].angle = 0.0f;
+
+#ifdef USE_SENSOR
+      SAFE_PUBLISH_SENSOR_UNKNOWN(this->target_x_sensors_[i]);
+      SAFE_PUBLISH_SENSOR_UNKNOWN(this->target_y_sensors_[i]);
+      SAFE_PUBLISH_SENSOR_UNKNOWN(this->target_distance_sensors_[i]);
+      SAFE_PUBLISH_SENSOR_UNKNOWN(this->target_angle_sensors_[i]);
+#endif
+    }
+  }
+
+#ifdef USE_SENSOR
+  SAFE_PUBLISH_SENSOR(this->target_count_sensor_, num_targets);
+#endif
+
+#ifdef USE_BINARY_SENSOR
+  if (this->target_binary_sensor_ != nullptr) {
+    this->target_binary_sensor_->publish_state(num_targets > 0);
+  }
+#endif
+
+  this->data_callback_.call();
+}
+
+bool LD2460Component::handle_ack_data_() {
+  if (this->buffer_pos_ < 11) {
+    ESP_LOGE(TAG, "Invalid ACK length: %u", this->buffer_pos_);
+    return true;
+  }
+  if (!validate_header_footer(CMD_FRAME_HEADER, this->buffer_data_)) {
+    char hex_buf[format_hex_pretty_size(HEADER_FOOTER_SIZE)];
+    ESP_LOGW(TAG, "Invalid ACK header: %s", format_hex_pretty_to(hex_buf, this->buffer_data_, HEADER_FOOTER_SIZE));
+    return true;
+  }
+
+  uint8_t cmd = this->buffer_data_[4];
+  uint16_t packet_len = this->buffer_data_[5] | (this->buffer_data_[6] << 8);
+  if (packet_len != this->buffer_pos_) {
+    ESP_LOGW(TAG, "ACK packet length mismatch: %u != %u", packet_len, this->buffer_pos_);
+    return true;
+  }
+
+  ESP_LOGV(TAG, "Handling ACK DATA for COMMAND %02X", cmd);
+
+  switch (cmd) {
+    case CMD_SET_REPORTING: {
+      uint8_t val = this->buffer_data_[7];
+      bool success = (val >> 4) == 1;
+      bool enabled = (val & 0x0F) == 1;
+      ESP_LOGV(TAG, "Set reporting ACK: success=%s, enabled=%s", YESNO(success), YESNO(enabled));
+#ifdef USE_SWITCH
+      if (this->reporting_switch_ != nullptr && success) {
+        this->reporting_switch_->publish_state(enabled);
+      }
+#endif
+      break;
+    }
+
+    case CMD_SET_INSTALLATION_PARAMS: {
+      bool success = this->buffer_data_[7] == 0x01;
+      ESP_LOGV(TAG, "Set installation params ACK: %s", success ? "Success" : "Failed");
+      break;
+    }
+
+    case CMD_QUERY_INSTALLATION_PARAMS: {
+      uint16_t height_cm = this->buffer_data_[7] | (this->buffer_data_[8] << 8);
+      uint16_t angle_x100 = this->buffer_data_[9] | (this->buffer_data_[10] << 8);
+      this->installation_height_ = height_cm / 100.0f;
+      this->installation_angle_ = angle_x100 / 100.0f;
+      ESP_LOGV(TAG, "Installation height: %.2fm, angle: %.2f deg", this->installation_height_, this->installation_angle_);
+#ifdef USE_NUMBER
+      if (this->installation_height_number_ != nullptr) {
+        this->installation_height_number_->publish_state(this->installation_height_);
+      }
+      if (this->installation_angle_number_ != nullptr) {
+        this->installation_angle_number_->publish_state(this->installation_angle_);
+      }
+#endif
+      break;
+    }
+
+    case CMD_SET_INSTALLATION_MODE: {
+      uint8_t val = this->buffer_data_[7];
+      bool success = (val >> 4) == 1;
+      uint8_t mode = val & 0x0F;
+      ESP_LOGV(TAG, "Set installation mode ACK: success=%s, mode=%u", YESNO(success), mode);
+#ifdef USE_SELECT
+      if (this->installation_mode_select_ != nullptr && success) {
+        this->installation_mode_select_->publish_state(find_str(INSTALLATION_MODE_BY_UINT, mode));
+      }
+#endif
+      break;
+    }
+
+    case CMD_QUERY_INSTALLATION_MODE: {
+      uint8_t mode = this->buffer_data_[7];
+      this->installation_mode_ = mode;
+      ESP_LOGV(TAG, "Installation mode: %s", find_str(INSTALLATION_MODE_BY_UINT, mode));
+#ifdef USE_SELECT
+      if (this->installation_mode_select_ != nullptr) {
+        this->installation_mode_select_->publish_state(find_str(INSTALLATION_MODE_BY_UINT, mode));
+      }
+#endif
+      break;
+    }
+
+    case CMD_QUERY_VERSION: {
+      uint8_t year = this->buffer_data_[8];
+      uint8_t month = this->buffer_data_[9];
+      uint8_t major = this->buffer_data_[10];
+      uint8_t minor = this->buffer_data_[11];
+      char version_s[32];
+      snprintf(version_s, sizeof(version_s), "V%u.%u (20%02X-%02X)", major, minor, year, month);
+      ESP_LOGV(TAG, "Firmware version: %s", version_s);
+#ifdef USE_TEXT_SENSOR
+      if (this->version_text_sensor_ != nullptr) {
+        this->version_text_sensor_->publish_state(version_s);
+      }
+#endif
+      break;
+    }
+
+    case CMD_SET_BAUD_RATE: {
+      bool success = this->buffer_data_[7] == 0x01;
+      ESP_LOGV(TAG, "Baud rate change ACK: %s", success ? "Success" : "Failed");
+#ifdef USE_SELECT
+      if (this->baud_rate_select_ != nullptr && success) {
+        auto baud = this->baud_rate_select_->current_option();
+        ESP_LOGI(TAG, "Baud rate changed to %.*s; restart module to apply", static_cast<int>(baud.size()), baud.c_str());
+      }
+#endif
+      break;
+    }
+
+    case CMD_FACTORY_RESET: {
+      bool success = this->buffer_data_[7] == 0x01;
+      ESP_LOGV(TAG, "Factory reset ACK: %s", success ? "Success" : "Failed");
+      if (success) {
+        this->set_timeout(500, [this]() { this->read_all_info(); });
+      }
+      break;
+    }
+
+    case CMD_SET_DETECTION_RANGE: {
+      bool success = this->buffer_data_[7] == 0x01;
+      ESP_LOGV(TAG, "Set detection range ACK: %s", success ? "Success" : "Failed");
+      break;
+    }
+
+    case CMD_QUERY_DETECTION_RANGE: {
+      uint8_t dist_01 = this->buffer_data_[7];
+      int16_t min_angle_01 = static_cast<int16_t>(this->buffer_data_[8] | (this->buffer_data_[9] << 8));
+      int16_t max_angle_01 = static_cast<int16_t>(this->buffer_data_[10] | (this->buffer_data_[11] << 8));
+      this->detection_distance_ = dist_01 / 10.0f;
+      this->detection_angle_min_ = min_angle_01 / 10.0f;
+      this->detection_angle_max_ = max_angle_01 / 10.0f;
+      ESP_LOGV(TAG, "Detection range: dist=%.1fm, min_angle=%.1f deg, max_angle=%.1f deg",
+               this->detection_distance_, this->detection_angle_min_, this->detection_angle_max_);
+#ifdef USE_NUMBER
+      if (this->detection_distance_number_ != nullptr) {
+        this->detection_distance_number_->publish_state(this->detection_distance_);
+      }
+      if (this->detection_angle_min_number_ != nullptr) {
+        this->detection_angle_min_number_->publish_state(this->detection_angle_min_);
+      }
+      if (this->detection_angle_max_number_ != nullptr) {
+        this->detection_angle_max_number_->publish_state(this->detection_angle_max_);
+      }
+#endif
+      break;
+    }
+
+    case CMD_SET_SENSITIVITY: {
+      bool success = this->buffer_data_[7] == 0x01;
+      ESP_LOGV(TAG, "Set sensitivity ACK: %s", success ? "Success" : "Failed");
+      break;
+    }
+
+    case CMD_QUERY_SENSITIVITY: {
+      uint8_t sens = this->buffer_data_[7];
+      this->sensitivity_ = sens;
+      ESP_LOGV(TAG, "Sensitivity: %s", find_str(SENSITIVITY_BY_UINT, sens));
+#ifdef USE_SELECT
+      if (this->sensitivity_select_ != nullptr) {
+        this->sensitivity_select_->publish_state(find_str(SENSITIVITY_BY_UINT, sens));
+      }
+#endif
+      break;
+    }
+
+    default:
+      ESP_LOGW(TAG, "Unhandled ACK for command: %02X", cmd);
+      break;
+  }
+  return true;
+}
+
+void LD2460Component::readline_(int readch) {
+  if (readch < 0) {
+    return;
+  }
+
+  if (this->buffer_pos_ < MAX_LINE_LENGTH - 1) {
+    this->buffer_data_[this->buffer_pos_++] = readch;
+    this->buffer_data_[this->buffer_pos_] = 0;
+  } else {
+    ESP_LOGW(TAG, "Max command length exceeded; ignoring");
+    this->buffer_pos_ = 0;
+    return;
+  }
+
+  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
+    return;
+  }
+
+  if (validate_header_footer(DATA_FRAME_FOOTER, &this->buffer_data_[this->buffer_pos_ - 4])) {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+    char hex_buf[format_hex_pretty_size(MAX_LINE_LENGTH)];
+    ESP_LOGV(TAG, "Handling Periodic Data: %s", format_hex_pretty_to(hex_buf, this->buffer_data_, this->buffer_pos_));
+#endif
+    this->handle_periodic_data_();
+    this->buffer_pos_ = 0;
+  } else if (validate_header_footer(CMD_FRAME_FOOTER, &this->buffer_data_[this->buffer_pos_ - 4])) {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+    char hex_buf[format_hex_pretty_size(MAX_LINE_LENGTH)];
+    ESP_LOGV(TAG, "Handling Ack Data: %s", format_hex_pretty_to(hex_buf, this->buffer_data_, this->buffer_pos_));
+#endif
+    if (this->handle_ack_data_()) {
+      this->buffer_pos_ = 0;
+    }
+  }
+}
+
+void LD2460Component::query_version_() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_QUERY_VERSION, &payload, 1);
+}
+
+void LD2460Component::query_installation_params_() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_QUERY_INSTALLATION_PARAMS, &payload, 1);
+}
+
+void LD2460Component::query_installation_mode_() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_QUERY_INSTALLATION_MODE, &payload, 1);
+}
+
+void LD2460Component::query_detection_range_() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_QUERY_DETECTION_RANGE, &payload, 1);
+}
+
+void LD2460Component::query_sensitivity_() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_QUERY_SENSITIVITY, &payload, 1);
+}
+
+void LD2460Component::restart() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_RESTART, &payload, 1);
+}
+
+void LD2460Component::factory_reset() {
+  uint8_t payload = 0x01;
+  this->send_command_(CMD_FACTORY_RESET, &payload, 1);
+}
+
+void LD2460Component::set_reporting(bool enable) {
+  uint8_t payload = enable ? 0x01 : 0x00;
+  this->send_command_(CMD_SET_REPORTING, &payload, 1);
+}
+
+void LD2460Component::set_baud_rate(const char *state) {
+  uint8_t baud_val = find_uint8(BAUD_RATES_BY_STR, state);
+  if (baud_val != 0xFF) {
+    this->send_command_(CMD_SET_BAUD_RATE, &baud_val, 1);
+  }
+}
+
+void LD2460Component::set_installation_mode(const char *state) {
+  uint8_t mode = find_uint8(INSTALLATION_MODE_BY_STR, state);
+  if (mode != 0xFF) {
+    this->send_command_(CMD_SET_INSTALLATION_MODE, &mode, 1);
+  }
+}
+
+void LD2460Component::set_sensitivity(const char *state) {
+  uint8_t sens = find_uint8(SENSITIVITY_BY_STR, state);
+  if (sens != 0xFF) {
+    this->send_command_(CMD_SET_SENSITIVITY, &sens, 1);
+  }
+}
+
+void LD2460Component::set_installation_params(float height, float angle) {
+  this->installation_height_ = height;
+  this->installation_angle_ = angle;
+  uint16_t height_cm = static_cast<uint16_t>(roundf(height * 100.0f));
+  uint16_t angle_x100 = static_cast<uint16_t>(roundf(angle * 100.0f));
+  uint8_t payload[4] = {
+      static_cast<uint8_t>(height_cm & 0xFF),
+      static_cast<uint8_t>((height_cm >> 8) & 0xFF),
+      static_cast<uint8_t>(angle_x100 & 0xFF),
+      static_cast<uint8_t>((angle_x100 >> 8) & 0xFF),
+  };
+  this->send_command_(CMD_SET_INSTALLATION_PARAMS, payload, sizeof(payload));
+}
+
+void LD2460Component::set_detection_range(float distance, float min_angle, float max_angle) {
+  this->detection_distance_ = distance;
+  this->detection_angle_min_ = min_angle;
+  this->detection_angle_max_ = max_angle;
+  uint8_t dist_01 = static_cast<uint8_t>(roundf(distance * 10.0f));
+  int16_t min_a01 = static_cast<int16_t>(roundf(min_angle * 10.0f));
+  int16_t max_a01 = static_cast<int16_t>(roundf(max_angle * 10.0f));
+  uint8_t payload[5] = {
+      dist_01,
+      static_cast<uint8_t>(min_a01 & 0xFF),
+      static_cast<uint8_t>((min_a01 >> 8) & 0xFF),
+      static_cast<uint8_t>(max_a01 & 0xFF),
+      static_cast<uint8_t>((max_a01 >> 8) & 0xFF),
+  };
+  this->send_command_(CMD_SET_DETECTION_RANGE, payload, sizeof(payload));
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/ld2460.h
+++ b/esphome/components/ld2460/ld2460.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+#include "esphome/core/component.h"
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+#ifdef USE_BUTTON
+#include "esphome/components/button/button.h"
+#endif
+#ifdef USE_SELECT
+#include "esphome/components/select/select.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
+#include "esphome/components/ld24xx/ld24xx.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/helpers.h"
+
+#include <array>
+
+namespace esphome::ld2460 {
+
+using namespace ld24xx;
+
+static constexpr uint8_t MAX_LINE_LENGTH = 64;  // Max frame length (data: 31, ack: 16) + margins
+static constexpr uint8_t MAX_TARGETS = 5;       // LD2460 supports up to 5 targets
+
+enum InstallationMode : uint8_t {
+  MODE_SIDE = 1,
+  MODE_TOP = 2,
+};
+
+enum Sensitivity : uint8_t {
+  SENSITIVITY_HIGH = 1,
+  SENSITIVITY_MEDIUM = 2,
+  SENSITIVITY_LOW = 3,
+};
+
+// Target coordinate struct
+struct Target {
+  float x{0.0f};
+  float y{0.0f};
+  float distance{0.0f};
+  float angle{0.0f};
+};
+
+class LD2460Component : public Component, public uart::UARTDevice {
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(target)
+#endif
+#ifdef USE_SENSOR
+  SUB_SENSOR_WITH_DEDUP(target_count, uint8_t)
+#endif
+#ifdef USE_TEXT_SENSOR
+  SUB_TEXT_SENSOR(version)
+#endif
+#ifdef USE_NUMBER
+  SUB_NUMBER(installation_height)
+  SUB_NUMBER(installation_angle)
+  SUB_NUMBER(detection_distance)
+  SUB_NUMBER(detection_angle_min)
+  SUB_NUMBER(detection_angle_max)
+#endif
+#ifdef USE_SELECT
+  SUB_SELECT(baud_rate)
+  SUB_SELECT(installation_mode)
+  SUB_SELECT(sensitivity)
+#endif
+#ifdef USE_SWITCH
+  SUB_SWITCH(reporting)
+#endif
+#ifdef USE_BUTTON
+  SUB_BUTTON(factory_reset)
+  SUB_BUTTON(restart)
+#endif
+
+ public:
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+
+  void read_all_info();
+  void restart_and_read_all_info();
+  void factory_reset();
+  void restart();
+
+  void set_reporting(bool enable);
+  void set_baud_rate(const char *state);
+  void set_installation_mode(const char *state);
+  void set_sensitivity(const char *state);
+  void set_installation_params(float height, float angle);
+  void set_detection_range(float distance, float min_angle, float max_angle);
+  float get_installation_height() const { return this->installation_height_; }
+  float get_installation_angle() const { return this->installation_angle_; }
+  float get_detection_distance() const { return this->detection_distance_; }
+  float get_detection_angle_min() const { return this->detection_angle_min_; }
+  float get_detection_angle_max() const { return this->detection_angle_max_; }
+
+#ifdef USE_SENSOR
+  void set_target_x_sensor(uint8_t target, sensor::Sensor *s) { this->target_x_sensors_[target].set_sensor(s); }
+  void set_target_y_sensor(uint8_t target, sensor::Sensor *s) { this->target_y_sensors_[target].set_sensor(s); }
+  void set_target_distance_sensor(uint8_t target, sensor::Sensor *s) {
+    this->target_distance_sensors_[target].set_sensor(s);
+  }
+  void set_target_angle_sensor(uint8_t target, sensor::Sensor *s) { this->target_angle_sensors_[target].set_sensor(s); }
+#endif
+
+  /// Add a callback that will be called after each successfully processed periodic data frame.
+  template<typename F> void add_on_data_callback(F &&callback) { this->data_callback_.add(std::forward<F>(callback)); }
+
+ protected:
+  void send_command_(uint8_t command, const uint8_t *data = nullptr, uint8_t data_len = 0);
+  void handle_periodic_data_();
+  bool handle_ack_data_();
+  void readline_(int readch);
+
+  void query_version_();
+  void query_installation_params_();
+  void query_installation_mode_();
+  void query_detection_range_();
+  void query_sensitivity_();
+
+  uint8_t buffer_data_[MAX_LINE_LENGTH];
+  uint8_t buffer_pos_{0};
+
+  uint8_t installation_mode_{MODE_SIDE};
+  uint8_t sensitivity_{SENSITIVITY_MEDIUM};
+  float installation_height_{2.6f};
+  float installation_angle_{30.0f};
+  float detection_distance_{6.0f};
+  float detection_angle_min_{-60.0f};
+  float detection_angle_max_{60.0f};
+
+  Target target_info_[MAX_TARGETS];
+
+#ifdef USE_SENSOR
+  std::array<SensorWithDedup<float>, MAX_TARGETS> target_x_sensors_{};
+  std::array<SensorWithDedup<float>, MAX_TARGETS> target_y_sensors_{};
+  std::array<SensorWithDedup<float>, MAX_TARGETS> target_distance_sensors_{};
+  std::array<SensorWithDedup<float>, MAX_TARGETS> target_angle_sensors_{};
+#endif
+
+  LazyCallbackManager<void()> data_callback_;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/__init__.py
+++ b/esphome/components/ld2460/number/__init__.py
@@ -1,0 +1,116 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_DISTANCE,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_RULER,
+    UNIT_DEGREES,
+    UNIT_METER,
+)
+from esphome.types import ConfigType
+
+from .. import CONF_LD2460_ID, LD2460Component, ld2460_ns
+
+CONF_INSTALLATION_HEIGHT = "installation_height"
+CONF_INSTALLATION_ANGLE = "installation_angle"
+CONF_DETECTION_DISTANCE = "detection_distance"
+CONF_DETECTION_ANGLE_MIN = "detection_angle_min"
+CONF_DETECTION_ANGLE_MAX = "detection_angle_max"
+
+InstallationHeightNumber = ld2460_ns.class_("InstallationHeightNumber", number.Number)
+InstallationAngleNumber = ld2460_ns.class_("InstallationAngleNumber", number.Number)
+DetectionDistanceNumber = ld2460_ns.class_("DetectionDistanceNumber", number.Number)
+DetectionAngleMinNumber = ld2460_ns.class_("DetectionAngleMinNumber", number.Number)
+DetectionAngleMaxNumber = ld2460_ns.class_("DetectionAngleMaxNumber", number.Number)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+        cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+        cv.Optional(CONF_INSTALLATION_HEIGHT): number.number_schema(
+            InstallationHeightNumber,
+            device_class=DEVICE_CLASS_DISTANCE,
+            unit_of_measurement=UNIT_METER,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon=ICON_RULER,
+        ),
+        cv.Optional(CONF_INSTALLATION_ANGLE): number.number_schema(
+            InstallationAngleNumber,
+            unit_of_measurement=UNIT_DEGREES,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DETECTION_DISTANCE): number.number_schema(
+            DetectionDistanceNumber,
+            device_class=DEVICE_CLASS_DISTANCE,
+            unit_of_measurement=UNIT_METER,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon=ICON_RULER,
+        ),
+        cv.Optional(CONF_DETECTION_ANGLE_MIN): number.number_schema(
+            DetectionAngleMinNumber,
+            unit_of_measurement=UNIT_DEGREES,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DETECTION_ANGLE_MAX): number.number_schema(
+            DetectionAngleMaxNumber,
+            unit_of_measurement=UNIT_DEGREES,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+    }
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+
+    if inst_height_config := config.get(CONF_INSTALLATION_HEIGHT):
+        n = await number.new_number(
+            inst_height_config,
+            min_value=0.0,
+            max_value=10.0,
+            step=0.01,
+        )
+        await cg.register_parented(n, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_installation_height_number(n))
+
+    if inst_angle_config := config.get(CONF_INSTALLATION_ANGLE):
+        n = await number.new_number(
+            inst_angle_config,
+            min_value=0,
+            max_value=90,
+            step=1,
+        )
+        await cg.register_parented(n, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_installation_angle_number(n))
+
+    if det_dist_config := config.get(CONF_DETECTION_DISTANCE):
+        n = await number.new_number(
+            det_dist_config,
+            min_value=0.1,
+            max_value=6.0,
+            step=0.1,
+        )
+        await cg.register_parented(n, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_detection_distance_number(n))
+
+    if det_angle_min_config := config.get(CONF_DETECTION_ANGLE_MIN):
+        n = await number.new_number(
+            det_angle_min_config,
+            min_value=-60,
+            max_value=360,
+            step=1,
+        )
+        await cg.register_parented(n, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_detection_angle_min_number(n))
+
+    if det_angle_max_config := config.get(CONF_DETECTION_ANGLE_MAX):
+        n = await number.new_number(
+            det_angle_max_config,
+            min_value=-60,
+            max_value=360,
+            step=1,
+        )
+        await cg.register_parented(n, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_detection_angle_max_number(n))

--- a/esphome/components/ld2460/number/detection_angle_number.cpp
+++ b/esphome/components/ld2460/number/detection_angle_number.cpp
@@ -1,0 +1,15 @@
+#include "detection_angle_number.h"
+
+namespace esphome::ld2460 {
+
+void DetectionAngleMinNumber::control(float value) {
+  this->publish_state(value);
+  this->parent_->set_detection_range(this->parent_->get_detection_distance(), value, this->parent_->get_detection_angle_max());
+}
+
+void DetectionAngleMaxNumber::control(float value) {
+  this->publish_state(value);
+  this->parent_->set_detection_range(this->parent_->get_detection_distance(), this->parent_->get_detection_angle_min(), value);
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/detection_angle_number.h
+++ b/esphome/components/ld2460/number/detection_angle_number.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class DetectionAngleMinNumber : public number::Number, public Parented<LD2460Component> {
+ public:
+  DetectionAngleMinNumber() = default;
+
+ protected:
+  void control(float value) override;
+};
+
+class DetectionAngleMaxNumber : public number::Number, public Parented<LD2460Component> {
+ public:
+  DetectionAngleMaxNumber() = default;
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/detection_distance_number.cpp
+++ b/esphome/components/ld2460/number/detection_distance_number.cpp
@@ -1,0 +1,10 @@
+#include "detection_distance_number.h"
+
+namespace esphome::ld2460 {
+
+void DetectionDistanceNumber::control(float value) {
+  this->publish_state(value);
+  this->parent_->set_detection_range(value, this->parent_->get_detection_angle_min(), this->parent_->get_detection_angle_max());
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/detection_distance_number.h
+++ b/esphome/components/ld2460/number/detection_distance_number.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class DetectionDistanceNumber : public number::Number, public Parented<LD2460Component> {
+ public:
+  DetectionDistanceNumber() = default;
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/installation_angle_number.cpp
+++ b/esphome/components/ld2460/number/installation_angle_number.cpp
@@ -1,0 +1,10 @@
+#include "installation_angle_number.h"
+
+namespace esphome::ld2460 {
+
+void InstallationAngleNumber::control(float value) {
+  this->publish_state(value);
+  this->parent_->set_installation_params(this->parent_->get_installation_height(), value);
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/installation_angle_number.h
+++ b/esphome/components/ld2460/number/installation_angle_number.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class InstallationAngleNumber : public number::Number, public Parented<LD2460Component> {
+ public:
+  InstallationAngleNumber() = default;
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/installation_height_number.cpp
+++ b/esphome/components/ld2460/number/installation_height_number.cpp
@@ -1,0 +1,10 @@
+#include "installation_height_number.h"
+
+namespace esphome::ld2460 {
+
+void InstallationHeightNumber::control(float value) {
+  this->publish_state(value);
+  this->parent_->set_installation_params(value, this->parent_->get_installation_angle());
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/number/installation_height_number.h
+++ b/esphome/components/ld2460/number/installation_height_number.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class InstallationHeightNumber : public number::Number, public Parented<LD2460Component> {
+ public:
+  InstallationHeightNumber() = default;
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/select/__init__.py
+++ b/esphome/components/ld2460/select/__init__.py
@@ -1,0 +1,81 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_BAUD_RATE,
+    CONF_ID,
+    CONF_SENSITIVITY,
+    ENTITY_CATEGORY_CONFIG,
+)
+from esphome.types import ConfigType
+
+from .. import CONF_LD2460_ID, LD2460Component, ld2460_ns
+
+CONF_INSTALLATION_MODE = "installation_mode"
+
+ICON_ROTATE_LEFT = "mdi:rotate-left"
+ICON_TUNE = "mdi:tune"
+
+BaudRateSelect = ld2460_ns.class_("BaudRateSelect", select.Select)
+InstallationModeSelect = ld2460_ns.class_("InstallationModeSelect", select.Select)
+SensitivitySelect = ld2460_ns.class_("SensitivitySelect", select.Select)
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+    cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+    cv.Optional(CONF_BAUD_RATE): select.select_schema(
+        BaudRateSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+    ),
+    cv.Optional(CONF_INSTALLATION_MODE): select.select_schema(
+        InstallationModeSelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_ROTATE_LEFT,
+    ),
+    cv.Optional(CONF_SENSITIVITY): select.select_schema(
+        SensitivitySelect,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_TUNE,
+    ),
+}
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+    if baud_rate_config := config.get(CONF_BAUD_RATE):
+        s = await select.new_select(
+            baud_rate_config,
+            options=[
+                "9600",
+                "19200",
+                "38400",
+                "57600",
+                "115200",
+                "230400",
+                "256000",
+                "460800",
+            ],
+        )
+        await cg.register_parented(s, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_baud_rate_select(s))
+    if installation_mode_config := config.get(CONF_INSTALLATION_MODE):
+        s = await select.new_select(
+            installation_mode_config,
+            options=[
+                "Side",
+                "Top",
+            ],
+        )
+        await cg.register_parented(s, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_installation_mode_select(s))
+    if sensitivity_config := config.get(CONF_SENSITIVITY):
+        s = await select.new_select(
+            sensitivity_config,
+            options=[
+                "High",
+                "Medium",
+                "Low",
+            ],
+        )
+        await cg.register_parented(s, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_sensitivity_select(s))

--- a/esphome/components/ld2460/select/baud_rate_select.cpp
+++ b/esphome/components/ld2460/select/baud_rate_select.cpp
@@ -1,0 +1,10 @@
+#include "baud_rate_select.h"
+
+namespace esphome::ld2460 {
+
+void BaudRateSelect::control(size_t index) {
+  this->publish_state(index);
+  this->parent_->set_baud_rate(this->at(index)->c_str());
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/select/baud_rate_select.h
+++ b/esphome/components/ld2460/select/baud_rate_select.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class BaudRateSelect : public select::Select, public Parented<LD2460Component> {
+ public:
+  BaudRateSelect() = default;
+
+ protected:
+  void control(size_t index) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/select/installation_mode_select.cpp
+++ b/esphome/components/ld2460/select/installation_mode_select.cpp
@@ -1,0 +1,10 @@
+#include "installation_mode_select.h"
+
+namespace esphome::ld2460 {
+
+void InstallationModeSelect::control(size_t index) {
+  this->publish_state(index);
+  this->parent_->set_installation_mode(this->at(index)->c_str());
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/select/installation_mode_select.h
+++ b/esphome/components/ld2460/select/installation_mode_select.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class InstallationModeSelect : public select::Select, public Parented<LD2460Component> {
+ public:
+  InstallationModeSelect() = default;
+
+ protected:
+  void control(size_t index) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/select/sensitivity_select.cpp
+++ b/esphome/components/ld2460/select/sensitivity_select.cpp
@@ -1,0 +1,10 @@
+#include "sensitivity_select.h"
+
+namespace esphome::ld2460 {
+
+void SensitivitySelect::control(size_t index) {
+  this->publish_state(index);
+  this->parent_->set_sensitivity(this->at(index)->c_str());
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/select/sensitivity_select.h
+++ b/esphome/components/ld2460/select/sensitivity_select.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class SensitivitySelect : public select::Select, public Parented<LD2460Component> {
+ public:
+  SensitivitySelect() = default;
+
+ protected:
+  void control(size_t index) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/sensor.py
+++ b/esphome/components/ld2460/sensor.py
@@ -1,0 +1,94 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+from esphome.components.const import CONF_TARGET_COUNT
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ANGLE,
+    CONF_DISTANCE,
+    CONF_ID,
+    CONF_X,
+    CONF_Y,
+    DEVICE_CLASS_DISTANCE,
+    UNIT_DEGREES,
+    UNIT_METER,
+)
+from esphome.types import ConfigType
+
+from . import CONF_LD2460_ID, LD2460Component
+
+DEPENDENCIES = ["ld2460"]
+
+ICON_ACCOUNT_GROUP = "mdi:account-group"
+ICON_ALPHA_X_BOX_OUTLINE = "mdi:alpha-x-box-outline"
+ICON_ALPHA_Y_BOX_OUTLINE = "mdi:alpha-y-box-outline"
+ICON_FORMAT_TEXT_ROTATION_ANGLE_UP = "mdi:format-text-rotation-angle-up"
+ICON_MAP_MARKER_DISTANCE = "mdi:map-marker-distance"
+
+MAX_TARGETS = 5
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+        cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+        cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
+            accuracy_decimals=0,
+            icon=ICON_ACCOUNT_GROUP,
+        ),
+    }
+)
+
+CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
+    {
+        cv.Optional(f"target_{n + 1}"): cv.Schema(
+            {
+                cv.Optional(CONF_X): sensor.sensor_schema(
+                    device_class=DEVICE_CLASS_DISTANCE,
+                    icon=ICON_ALPHA_X_BOX_OUTLINE,
+                    unit_of_measurement=UNIT_METER,
+                    accuracy_decimals=1,
+                ),
+                cv.Optional(CONF_Y): sensor.sensor_schema(
+                    device_class=DEVICE_CLASS_DISTANCE,
+                    icon=ICON_ALPHA_Y_BOX_OUTLINE,
+                    unit_of_measurement=UNIT_METER,
+                    accuracy_decimals=1,
+                ),
+                cv.Optional(CONF_DISTANCE): sensor.sensor_schema(
+                    device_class=DEVICE_CLASS_DISTANCE,
+                    icon=ICON_MAP_MARKER_DISTANCE,
+                    unit_of_measurement=UNIT_METER,
+                    accuracy_decimals=2,
+                ),
+                cv.Optional(CONF_ANGLE): sensor.sensor_schema(
+                    icon=ICON_FORMAT_TEXT_ROTATION_ANGLE_UP,
+                    unit_of_measurement=UNIT_DEGREES,
+                    accuracy_decimals=1,
+                ),
+            }
+        )
+        for n in range(MAX_TARGETS)
+    }
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+
+    if target_count_config := config.get(CONF_TARGET_COUNT):
+        sens = await sensor.new_sensor(target_count_config)
+        cg.add(ld2460_component.set_target_count_sensor(sens))
+
+    for n in range(MAX_TARGETS):
+        if target_conf := config.get(f"target_{n + 1}"):
+            if x_config := target_conf.get(CONF_X):
+                sens = await sensor.new_sensor(x_config)
+                cg.add(ld2460_component.set_target_x_sensor(n, sens))
+            if y_config := target_conf.get(CONF_Y):
+                sens = await sensor.new_sensor(y_config)
+                cg.add(ld2460_component.set_target_y_sensor(n, sens))
+            if distance_config := target_conf.get(CONF_DISTANCE):
+                sens = await sensor.new_sensor(distance_config)
+                cg.add(ld2460_component.set_target_distance_sensor(n, sens))
+            if angle_config := target_conf.get(CONF_ANGLE):
+                sens = await sensor.new_sensor(angle_config)
+                cg.add(ld2460_component.set_target_angle_sensor(n, sens))

--- a/esphome/components/ld2460/switch/__init__.py
+++ b/esphome/components/ld2460/switch/__init__.py
@@ -1,0 +1,35 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_SWITCH,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_PULSE,
+)
+from esphome.types import ConfigType
+
+from .. import CONF_LD2460_ID, LD2460Component, ld2460_ns
+
+ReportingSwitch = ld2460_ns.class_("ReportingSwitch", switch.Switch)
+
+CONF_REPORTING = "reporting"
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+    cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+    cv.Optional(CONF_REPORTING): switch.switch_schema(
+        ReportingSwitch,
+        device_class=DEVICE_CLASS_SWITCH,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        icon=ICON_PULSE,
+    ),
+}
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+    if reporting_config := config.get(CONF_REPORTING):
+        s = await switch.new_switch(reporting_config)
+        await cg.register_parented(s, config[CONF_LD2460_ID])
+        cg.add(ld2460_component.set_reporting_switch(s))

--- a/esphome/components/ld2460/switch/reporting_switch.cpp
+++ b/esphome/components/ld2460/switch/reporting_switch.cpp
@@ -1,0 +1,10 @@
+#include "reporting_switch.h"
+
+namespace esphome::ld2460 {
+
+void ReportingSwitch::write_state(bool state) {
+  this->publish_state(state);
+  this->parent_->set_reporting(state);
+}
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/switch/reporting_switch.h
+++ b/esphome/components/ld2460/switch/reporting_switch.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "../ld2460.h"
+
+namespace esphome::ld2460 {
+
+class ReportingSwitch : public switch_::Switch, public Parented<LD2460Component> {
+ public:
+  ReportingSwitch() = default;
+
+ protected:
+  void write_state(bool state) override;
+};
+
+}  // namespace esphome::ld2460

--- a/esphome/components/ld2460/text_sensor.py
+++ b/esphome/components/ld2460/text_sensor.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_VERSION, ENTITY_CATEGORY_DIAGNOSTIC, ICON_CHIP
+from esphome.types import ConfigType
+
+from . import CONF_LD2460_ID, LD2460Component
+
+DEPENDENCIES = ["ld2460"]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+        cv.GenerateID(CONF_LD2460_ID): cv.use_id(LD2460Component),
+        cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            icon=ICON_CHIP,
+        ),
+    }
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    ld2460_component = await cg.get_variable(config[CONF_LD2460_ID])
+    if version_config := config.get(CONF_VERSION):
+        sens = await text_sensor.new_text_sensor(version_config)
+        cg.add(ld2460_component.set_version_text_sensor(sens))

--- a/tests/components/ld2460/common.h
+++ b/tests/components/ld2460/common.h
@@ -1,0 +1,78 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "esphome/components/ld2460/ld2460.h"
+#include "esphome/components/uart/uart_component.h"
+
+namespace esphome::ld2460::testing {
+
+// Mock UART component to satisfy UARTDevice parent requirement.
+class MockUARTComponent : public uart::UARTComponent {
+ public:
+  void write_array(const uint8_t *data, size_t len) override {}
+  MOCK_METHOD(bool, read_array, (uint8_t * data, size_t len), (override));
+  MOCK_METHOD(bool, peek_byte, (uint8_t * data), (override));
+  MOCK_METHOD(size_t, available, (), (override));
+  MOCK_METHOD(uart::UARTFlushResult, flush, (), (override));
+  MOCK_METHOD(void, check_logger_conflict, (), (override));
+#if defined(USE_ESP8266) || defined(USE_ESP32)
+  void load_settings(bool dump_config) override {}
+#endif
+};
+
+// Expose protected members for testing.
+class TestableLD2460 : public LD2460Component {
+ public:
+  using LD2460Component::buffer_data_;
+  using LD2460Component::buffer_pos_;
+  using LD2460Component::readline_;
+  using LD2460Component::target_info_;
+  using LD2460Component::installation_mode_;
+  using LD2460Component::detection_distance_;
+
+  void feed(const std::vector<uint8_t> &data) {
+    for (uint8_t byte : data) {
+      this->readline_(byte);
+    }
+  }
+};
+
+// LD2460 periodic data frame:
+// Header (4) + Func (1) + Len (2) + Targets * 4 + Footer (4)
+inline std::vector<uint8_t> make_periodic_frame(uint8_t num_targets = 1) {
+  uint16_t len = 11 + num_targets * 4;
+  std::vector<uint8_t> frame = {
+      0xF4, 0xF3, 0xF2, 0xF1,
+      0x04,
+      static_cast<uint8_t>(len & 0xFF),
+      static_cast<uint8_t>((len >> 8) & 0xFF),
+  };
+  for (int i = 0; i < num_targets; i++) {
+    // Target X = 15 (1.5m), Target Y = 23 (2.3m)
+    frame.push_back(0x0F);
+    frame.push_back(0x00);
+    frame.push_back(0x17);
+    frame.push_back(0x00);
+  }
+  frame.push_back(0xF8);
+  frame.push_back(0xF7);
+  frame.push_back(0xF6);
+  frame.push_back(0xF5);
+  return frame;
+}
+
+// LD2460 command ACK frame for CMD_SET_REPORTING (0x06), successful.
+inline std::vector<uint8_t> make_ack_frame() {
+  return {
+      0xFD, 0xFC, 0xFB, 0xFA,  // CMD_FRAME_HEADER
+      0x06,                    // command = reporting
+      0x0C, 0x00,              // length = 12
+      0x11,                    // result = ok, enabled
+      0x04, 0x03, 0x02, 0x01   // CMD_FRAME_FOOTER
+  };
+}
+
+}  // namespace esphome::ld2460::testing

--- a/tests/components/ld2460/common.yaml
+++ b/tests/components/ld2460/common.yaml
@@ -1,0 +1,113 @@
+ld2460:
+  - id: ld2460_radar
+    on_data:
+      then:
+        - logger.log: "LD2460 Radar Data Received"
+
+button:
+  - platform: ld2460
+    id: ld2460_button
+    ld2460_id: ld2460_radar
+    factory_reset:
+      name: LD2460 Factory Reset
+    restart:
+      name: LD2460 Restart
+
+sensor:
+  - platform: ld2460
+    id: ld2460_sensor
+    ld2460_id: ld2460_radar
+    target_count:
+      name: Target Count
+    target_1:
+      x:
+        name: Target-1 X
+      y:
+        name: Target-1 Y
+      angle:
+        name: Target-1 Angle
+      distance:
+        name: Target-1 Distance
+    target_2:
+      x:
+        name: Target-2 X
+      y:
+        name: Target-2 Y
+      angle:
+        name: Target-2 Angle
+      distance:
+        name: Target-2 Distance
+    target_3:
+      x:
+        name: Target-3 X
+      y:
+        name: Target-3 Y
+      angle:
+        name: Target-3 Angle
+      distance:
+        name: Target-3 Distance
+    target_4:
+      x:
+        name: Target-4 X
+      y:
+        name: Target-4 Y
+      angle:
+        name: Target-4 Angle
+      distance:
+        name: Target-4 Distance
+    target_5:
+      x:
+        name: Target-5 X
+      y:
+        name: Target-5 Y
+      angle:
+        name: Target-5 Angle
+      distance:
+        name: Target-5 Distance
+
+binary_sensor:
+  - platform: ld2460
+    id: ld2460_binary
+    ld2460_id: ld2460_radar
+    has_target:
+      name: Presence
+
+switch:
+  - platform: ld2460
+    id: ld2460_switch
+    ld2460_id: ld2460_radar
+    reporting:
+      name: Radar Reporting
+
+text_sensor:
+  - platform: ld2460
+    id: ld2460_textsensor
+    ld2460_id: ld2460_radar
+    version:
+      name: LD2460 Firmware
+
+number:
+  - platform: ld2460
+    id: ld2460_number
+    ld2460_id: ld2460_radar
+    installation_height:
+      name: Installation Height
+    installation_angle:
+      name: Installation Angle
+    detection_distance:
+      name: Detection Distance
+    detection_angle_min:
+      name: Detection Angle Min
+    detection_angle_max:
+      name: Detection Angle Max
+
+select:
+  - platform: ld2460
+    id: ld2460_select
+    ld2460_id: ld2460_radar
+    baud_rate:
+      name: Baud Rate
+    installation_mode:
+      name: Installation Mode
+    sensitivity:
+      name: Sensitivity

--- a/tests/components/ld2460/ld2460_readline.cpp
+++ b/tests/components/ld2460/ld2460_readline.cpp
@@ -1,0 +1,148 @@
+#include "common.h"
+
+namespace esphome::ld2460::testing {
+
+class LD2460ReadlineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    this->ld2460_.set_uart_parent(&this->mock_uart_);
+    ASSERT_EQ(this->ld2460_.buffer_pos_, 0);
+  }
+
+  MockUARTComponent mock_uart_;
+  TestableLD2460 ld2460_;
+};
+
+TEST_F(LD2460ReadlineTest, ValidPeriodicFrame) {
+  auto frame = make_periodic_frame();
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, ValidCommandAckFrame) {
+  auto frame = make_ack_frame();
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, BackToBackPeriodicFrames) {
+  auto frame = make_periodic_frame();
+  for (int i = 0; i < 5; i++) {
+    this->ld2460_.feed(frame);
+    EXPECT_EQ(this->ld2460_.buffer_pos_, 0) << "Frame " << i << " not processed";
+  }
+}
+
+TEST_F(LD2460ReadlineTest, BackToBackMixedFrames) {
+  auto periodic = make_periodic_frame();
+  auto ack = make_ack_frame();
+  this->ld2460_.feed(periodic);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+  this->ld2460_.feed(ack);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+  this->ld2460_.feed(periodic);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, GarbageThenValidFrame) {
+  std::vector<uint8_t> garbage = {0x01, 0x02, 0x03, 0x42, 0x99};
+  this->ld2460_.feed(garbage);
+  EXPECT_GT(this->ld2460_.buffer_pos_, 0);
+
+  auto frame = make_periodic_frame();
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, FooterInGarbageResyncs) {
+  std::vector<uint8_t> garbage_with_footer = {0x01, 0x02, 0x03, 0x04, 0xF8, 0xF7, 0xF6, 0xF5};
+  this->ld2460_.feed(garbage_with_footer);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+
+  auto frame = make_periodic_frame();
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, CmdFooterInGarbageResyncs) {
+  std::vector<uint8_t> garbage_with_footer = {0x10, 0x20, 0x30, 0x40, 0x04, 0x03, 0x02, 0x01};
+  this->ld2460_.feed(garbage_with_footer);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+
+  auto frame = make_periodic_frame();
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, OverflowResetsBuffer) {
+  std::vector<uint8_t> overflow_data(MAX_LINE_LENGTH, 0x11);
+  this->ld2460_.feed(overflow_data);
+  EXPECT_LT(this->ld2460_.buffer_pos_, 4);
+}
+
+TEST_F(LD2460ReadlineTest, OverflowThenValidFrame) {
+  std::vector<uint8_t> overflow_data(MAX_LINE_LENGTH, 0x11);
+  this->ld2460_.feed(overflow_data);
+
+  auto frame = make_periodic_frame();
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, BufferLargeEnoughForDesyncedFooter) {
+  std::vector<uint8_t> mid_frame = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39};
+  auto frame = make_periodic_frame(5);  // 31 bytes
+  mid_frame.insert(mid_frame.end(), frame.begin(), frame.end());
+
+  this->ld2460_.feed(mid_frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, SimulatedRestartThenFrames) {
+  std::vector<uint8_t> restart_noise = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37};
+  auto frame = make_periodic_frame();
+  restart_noise.insert(restart_noise.end(), frame.begin(), frame.end());
+
+  this->ld2460_.feed(restart_noise);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+
+  this->ld2460_.feed(frame);
+  EXPECT_EQ(this->ld2460_.buffer_pos_, 0);
+}
+
+TEST_F(LD2460ReadlineTest, TargetCoordinateDecoding) {
+  // 1 target at (1.5, 2.3)
+  auto frame = make_periodic_frame(1);
+  this->ld2460_.feed(frame);
+
+  EXPECT_NEAR(this->ld2460_.target_info_[0].x, 1.5f, 0.01f);
+  EXPECT_NEAR(this->ld2460_.target_info_[0].y, 2.3f, 0.01f);
+  EXPECT_NEAR(this->ld2460_.target_info_[0].distance, 2.745f, 0.01f);
+  // Unused slots are cleared
+  EXPECT_EQ(this->ld2460_.target_info_[1].x, 0.0f);
+}
+
+TEST_F(LD2460ReadlineTest, ZeroTargetsFrameClearsInfo) {
+  // First feed 1 target
+  auto frame1 = make_periodic_frame(1);
+  this->ld2460_.feed(frame1);
+  EXPECT_NEAR(this->ld2460_.target_info_[0].x, 1.5f, 0.01f);
+
+  // Then feed 0 targets
+  auto frame0 = make_periodic_frame(0);
+  this->ld2460_.feed(frame0);
+  EXPECT_EQ(this->ld2460_.target_info_[0].x, 0.0f);
+  EXPECT_EQ(this->ld2460_.target_info_[0].y, 0.0f);
+  EXPECT_EQ(this->ld2460_.target_info_[0].distance, 0.0f);
+}
+
+TEST_F(LD2460ReadlineTest, AckQueryDetectionRange) {
+  // Receipt for CMD_QUERY_DETECTION_RANGE (0x12): distance=6.0m (60), start=-50.0 deg (-500), end=50.0 deg (500)
+  // FD FC FB FA 12 10 00 3C 0C FE F4 01 04 03 02 01
+  std::vector<uint8_t> ack = {0xFD, 0xFC, 0xFB, 0xFA, 0x12, 0x10, 0x00, 0x3C,
+                              0x0C, 0xFE, 0xF4, 0x01, 0x04, 0x03, 0x02, 0x01};
+  this->ld2460_.feed(ack);
+  EXPECT_NEAR(this->ld2460_.detection_distance_, 6.0f, 0.01f);
+}
+
+}  // namespace esphome::ld2460::testing

--- a/tests/components/ld2460/test.esp32-idf.yaml
+++ b/tests/components/ld2460/test.esp32-idf.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+packages:
+  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/ld2460/test.esp8266-ard.yaml
+++ b/tests/components/ld2460/test.esp8266-ard.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+packages:
+  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/ld2460/test.rp2040-ard.yaml
+++ b/tests/components/ld2460/test.rp2040-ard.yaml
@@ -1,0 +1,8 @@
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+packages:
+  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds full native support for the Hi-Link HLK-LD2460 24GHz 2T4R multi-target trajectory tracking radar sensor.

Supported features according to official documentation:
- Up to 5 target tracking with distance, angle, and coordinates (X, Y)
- Presence / target occupancy binary sensor (`has_target`)
- Sensor configuration via numbers (min/max detection distance, min/max detection angle, installation height, installation angle)
- Mode configuration via selects (Installation mode: Side / Top mount, Sensitivity: High / Medium / Low, Baud rate: 9600 to 256000)
- Target reporting control switch
- Restart and factory reset action buttons
- Native unit tests and multi-platform compilation support

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  id: uart_radar
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

ld2460:
  uart_id: uart_radar
  has_target:
    name: "LD2460 Presence"
  target_1:
    x:
      name: "Target 1 X"
    y:
      name: "Target 1 Y"
    distance:
      name: "Target 1 Distance"
    angle:
      name: "Target 1 Angle"
  installation_mode:
    name: "Installation Mode"
  sensitivity:
    name: "Sensitivity"
  reporting:
    name: "Target Reporting"
  restart:
    name: "Restart Sensor"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
