### PR TITLE
[template] Stop water heater republishing when a temperature is unknown

### DIFF
--- a/esphome/components/template/water_heater/template_water_heater.cpp
+++ b/esphome/components/template/water_heater/template_water_heater.cpp
@@ -1,6 +1,8 @@
 #include "template_water_heater.h"
 #include "esphome/core/log.h"
 
+#include <cmath>
+
 namespace esphome::template_ {
 
 static const char *const TAG = "template.water_heater";
@@ -45,9 +47,12 @@ water_heater::WaterHeaterTraits TemplateWaterHeater::traits() {
 void TemplateWaterHeater::loop() {
   bool changed = false;
 
+  // NAN is passed through so a source that has no value yet shows as unknown, but NAN never
+  // equals NAN, so an already-NAN value must not count as a change or it would republish forever.
   auto curr_temp = this->current_temperature_f_.call();
   if (curr_temp.has_value()) {
-    if (*curr_temp != this->current_temperature_) {
+    if (*curr_temp != this->current_temperature_ &&
+        !(std::isnan(*curr_temp) && std::isnan(this->current_temperature_))) {
       this->current_temperature_ = *curr_temp;
       changed = true;
     }
@@ -55,7 +60,8 @@ void TemplateWaterHeater::loop() {
 
   auto target_temp = this->target_temperature_f_.call();
   if (target_temp.has_value()) {
-    if (*target_temp != this->target_temperature_) {
+    if (*target_temp != this->target_temperature_ &&
+        !(std::isnan(*target_temp) && std::isnan(this->target_temperature_))) {
       this->target_temperature_ = *target_temp;
       changed = true;
     }

--- a/tests/integration/fixtures/water_heater_template_unknown_temperature.yaml
+++ b/tests/integration/fixtures/water_heater_template_unknown_temperature.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: wh-template-unknown-test
+host:
+api:
+logger:
+
+water_heater:
+  - platform: template
+    id: unknown_boiler
+    name: Unknown Boiler
+    # Both temperatures stay unknown, as they do before an upstream component reports a value.
+    current_temperature: !lambda "return NAN;"
+    target_temperature: !lambda "return NAN;"
+    supported_modes:
+      - "off"
+      - eco

--- a/tests/integration/test_water_heater_template.py
+++ b/tests/integration/test_water_heater_template.py
@@ -155,3 +155,36 @@ async def test_water_heater_template(
         client.water_heater_command(test_water_heater.key, mode=WaterHeaterMode.ECO)
         eco_state = await wait_for_state()
         assert eco_state.mode == WaterHeaterMode.ECO
+
+
+@pytest.mark.asyncio
+async def test_water_heater_template_unknown_temperature(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test a template water heater whose temperature lambdas stay unknown.
+
+    NAN never compares equal to itself, so a lambda that keeps returning NAN must not be
+    mistaken for a changed value and republish the state on every loop iteration.
+    """
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        state_count = 0
+
+        def on_state(state: aioesphomeapi.EntityState) -> None:
+            nonlocal state_count
+            if isinstance(state, WaterHeaterState):
+                state_count += 1
+
+        entities, _ = await client.list_entities_services()
+        water_heater_infos = [e for e in entities if isinstance(e, WaterHeaterInfo)]
+        assert len(water_heater_infos) == 1
+
+        client.subscribe_states(on_state)
+
+        # Let the device run for a while; only the single initial state may arrive.
+        await asyncio.sleep(1.0)
+        assert state_count <= 1, (
+            f"Expected at most 1 state publish, got {state_count} - "
+            "an unknown (NAN) temperature is republishing every loop"
+        )


### PR DESCRIPTION
# What does this implement/fix?

`TemplateWaterHeater::loop()` decides whether to publish by comparing each lambda's result
against the stored value. `NAN` never compares equal to itself, so a `current_temperature` or
`target_temperature` lambda that keeps returning `NAN` counted as a change on *every* loop
iteration and republished the state forever.

That is not a contrived case: it is what a lambda naturally returns while the component it reads
from has no value yet. I hit it with a template water heater backed by a climate entity whose
temperatures stay `NAN` until the appliance's MCU answers over UART — the API and the logs were
flooded with state updates for the whole startup window:

```
[00:02:53.150][S][water_heater]: '' >>
[00:02:53.150][S][water_heater]:   Mode: OFF
```

`template_climate` already guards against this for its sensors:

```cpp
if (state != this->current_temperature && !(std::isnan(state) && std::isnan(this->current_temperature))) {
```

This applies the same guard to both temperature lambdas: `NAN` is still passed through so a source
that has no value shows as unknown, but an already-`NAN` value no longer counts as a change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Originally observed on an ESP8266. The fix itself is covered by a new host-platform integration
test, `test_water_heater_template_unknown_temperature`, which asserts that a water heater whose
temperature lambdas return `NAN` publishes at most one state; it fails on `dev` and passes here.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
water_heater:
  - platform: template
    name: Unknown Boiler
    # Unknown until something upstream reports a value
    current_temperature: !lambda "return NAN;"
    target_temperature: !lambda "return NAN;"
    supported_modes:
      - "off"
      - eco
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
