### PR TITLE
[nextion] Keep a queued command when an unrelated response arrives

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -410,6 +410,21 @@ void Nextion::process_pending_in_queue_() {
 }
 #endif  // USE_NEXTION_COMMAND_SPACING
 
+void Nextion::enqueue_sent_(NextionQueue *item) {
+#ifdef USE_NEXTION_COMMAND_SPACING
+  // The command is already on the wire, so it will be answered before anything
+  // still waiting to be sent. Keeping the queue in transmit order is what makes
+  // front() the right entry to match a response against.
+  auto it = this->nextion_queue_.begin();
+  while (it != this->nextion_queue_.end() && (*it == nullptr || (*it)->pending_command.empty())) {
+    ++it;
+  }
+  this->nextion_queue_.insert(it, item);
+#else   // USE_NEXTION_COMMAND_SPACING
+  this->nextion_queue_.push_back(item);
+#endif  // USE_NEXTION_COMMAND_SPACING
+}
+
 bool Nextion::remove_from_q_(bool report_empty) {
   if (this->nextion_queue_.empty()) {
     if (report_empty) {
@@ -1126,7 +1141,7 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
 
   nextion_queue->queue_time = App.get_loop_component_start_time();
 
-  this->nextion_queue_.push_back(nextion_queue);
+  this->enqueue_sent_(nextion_queue);
 
   ESP_LOGN(TAG, "Queue NORESULT: %s", nextion_queue->component->get_variable_name().c_str());
 }
@@ -1331,13 +1346,14 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
   std::string command = "get " + component->get_variable_name_to_send();
 
 #ifdef USE_NEXTION_COMMAND_SPACING
-  // Always enqueue first so the response handler is present when the command
-  // is eventually sent. Store the command for retry if spacing blocked it;
-  // process_pending_in_queue_() will transmit it when the pacer allows.
-  nextion_queue->pending_command = command;
-  this->nextion_queue_.push_back(nextion_queue);
+  // Store the command for retry if spacing blocks it; process_pending_in_queue_()
+  // will transmit it when the pacer allows. A command that goes out right away is
+  // placed ahead of the entries still waiting, so the queue keeps transmit order.
   if (this->send_command_(command)) {
-    nextion_queue->pending_command.clear();
+    this->enqueue_sent_(nextion_queue);
+  } else {
+    nextion_queue->pending_command = command;
+    this->nextion_queue_.push_back(nextion_queue);
   }
 #else   // USE_NEXTION_COMMAND_SPACING
   if (this->send_command_(command)) {

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -426,6 +426,15 @@ bool Nextion::remove_from_q_(bool report_empty) {
   }
   NextionComponentBase *component = nb->component;
 
+#ifdef USE_NEXTION_COMMAND_SPACING
+  if (!nb->pending_command.empty()) {
+    // Not sent yet, so this response cannot belong to it. Dropping the
+    // response leaves the command queued instead of losing it.
+    ESP_LOGW(TAG, "Response for a command not yet sent, ignoring");
+    return false;
+  }
+#endif  // USE_NEXTION_COMMAND_SPACING
+
   ESP_LOGN(TAG, "Removed: %s", component->get_variable_name().c_str());
 
   if (component->get_queue_type() == NextionQueueType::NO_RESULT) {

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1468,6 +1468,12 @@ class Nextion final : public NextionBase, public PollingComponent, public uart::
   uint16_t recv_ret_string_(std::string &response, uint32_t timeout, bool recv_flag);
   void all_components_send_state_(bool force_update = false);
   uint32_t comok_sent_ = 0;
+  /**
+   * Add an entry whose command has already been sent, keeping the queue in
+   * transmit order so that front() is the entry a response belongs to.
+   * @param item Queue entry to insert.
+   */
+  void enqueue_sent_(NextionQueue *item);
   bool remove_from_q_(bool report_empty = true);
 
   /**


### PR DESCRIPTION
# What does this implement/fix?

Two related queue bugs in `nextion`, both only reachable with `command_spacing` enabled.

**1. `remove_from_q_()` drops an unsent command (97dc652)**

`remove_from_q_()` pops the front of the queue for every response from the display, without checking whether that entry has actually been sent. An entry queued by `add_no_result_to_queue_with_pending_command_()` still holds its command in `pending_command` and is waiting for `process_pending_in_queue_()`; if a response arrives first, that entry is deleted and the command is never sent.

A response cannot belong to a command that was never sent, so such a response is spurious and dropping it is safe. The front entry is now kept and a warning is logged instead.

**2. `enqueue_sent_()` keeps the queue in transmit order (4370f36)**

The check above relies on "unsent entries are always at the back", which the queue did not actually guarantee. Commands sent immediately (no spacing delay due) were appended behind entries still waiting in `pending_command`, so queue order and wire order disagreed. `enqueue_sent_()` inserts an already-sent entry ahead of the pending ones, and `add_to_get_queue()` was restructured to go through it, which restores the FIFO invariant that `remove_from_q_()` and `purge_stale_queue_entries_()` both depend on.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/19018

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — no user-facing configuration change.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Sonoff NSPanel (NX4832F035_011C, display firmware 115, 921600 baud, `command_spacing: 1ms`).

**Commit 1 — before:** a page render writing four components of one tile lost `button01bri.picc` (queued, never sent), so that component kept its previous background and the tile was drawn half in one state and half in the other:

```
15:50:39.742  [VV][nextion:047]: cmd: button01pic.picc=47
15:50:39.753  [VV][nextion:1122]: Queue NORESULT: .picc
15:50:39.756  [VV][nextion:042]: Command spacing: delaying 'button01bri.picc=47'
15:50:39.759  [VV][nextion:1183]: Queue with pending command: .picc
15:50:39.763  [VV][nextion:042]: Command spacing: delaying 'button01text.picc=47'
```

`button01pic.picc`, `button01text.picc` and `button01icon.picc` all appear later as `cmd:` lines; `button01bri.picc` never does.

**Commit 1 — after:** the new warning fires five times during the same test, three of them on entering that page, and the render is complete every time.

**Commit 2:** instrumented the queue to count entries sitting behind an unsent one — 3 at boot and 8 to 39 during page changes, i.e. queue order and wire order disagreed for most of a render burst. With the ordering fix that count drops to 0, and the warning added by commit 1 no longer fires at all (3 times before, 0 after).

## Example entry for `config.yaml`:

```yaml
# No configuration change; reproduced with an existing display config.
display:
  - platform: nextion
    command_spacing: 1ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

## Related

#17744 adds the same `pending_command` check to `deliver_queue_response_()` for the `0x70`/`0x71` return paths; this PR covers the error and acknowledgement codes that go through `remove_from_q_()`, which that PR leaves unchanged. The two are independent.
