### PR TITLE
[core] Add UnavoidableBlockingScope for blocking that cannot be shortened

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -389,6 +389,7 @@ class Application {
   friend Component;
   friend class Scheduler;
   friend class LoopBlockingGuard;
+  friend class UnavoidableBlockingScope;
 #ifdef USE_RUNTIME_STATS
   friend class runtime_stats::RuntimeStatsCollector;
 #endif
@@ -629,6 +630,35 @@ class LoopBlockingGuard {
  private:
   // Cold path; defined in component.cpp. Reads the current component/source from App to name the culprit.
   static void __attribute__((noinline, cold)) warn_blocking(uint32_t blocking_time);
+};
+
+/// Leaves a stretch of the current loop pass out of the blocking warning.
+///
+/// For work that cannot be made shorter or split across passes, such as
+/// bringing up a radio, the initial connect of a network stack, or a key
+/// generation whose cost is the algorithm itself; the warning then keeps
+/// reporting everything else in the pass, and the component's threshold does
+/// not ratchet up over such an operation. It must never wrap work that could
+/// be made faster or moved off the loop: that is exactly what the warning
+/// exists to find.
+///
+///   {
+///     UnavoidableBlockingScope scope;
+///     bring_up_radio();
+///   }
+class UnavoidableBlockingScope {
+ public:
+  UnavoidableBlockingScope() : started_(millis()) {}
+  ~UnavoidableBlockingScope() {
+    // Move the pass start forward by the time spent here; the guard measures
+    // from that start, and components reading it as "now" get a fresher value
+    App.set_loop_component_start_time_(App.get_loop_component_start_time() + (millis() - this->started_));
+  }
+  UnavoidableBlockingScope(const UnavoidableBlockingScope &) = delete;
+  UnavoidableBlockingScope &operator=(const UnavoidableBlockingScope &) = delete;
+
+ private:
+  uint32_t started_;
 };
 
 // Phase A: drain wake notifications and run the scheduler. Invoked on every

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -651,6 +651,8 @@ class LoopBlockingGuard {
 /// nothing there. Main loop task only. The watchdog is not fed inside the
 /// scope, so the work must still finish within the watchdog timeout. Scopes
 /// may nest; the outermost one decides how much of the pass is left out.
+/// App.get_loop_component_start_time() reads later in the same pass return
+/// the moved start, so elapsed time across the scope needs millis().
 ///
 ///   void MyComponent::loop() {
 ///     if (this->needs_key_) {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -635,8 +635,8 @@ class LoopBlockingGuard {
 /// Leaves a stretch of the current loop pass out of the blocking warning.
 ///
 /// Only for work that cannot be made shorter and cannot be split across
-/// passes: bringing up a radio, the initial connect of a network stack, a
-/// key generation whose cost is the algorithm itself. The warning then keeps
+/// passes: enabling a radio, the initial connect of a network stack, a key
+/// generation whose cost is the algorithm itself. The warning then keeps
 /// reporting everything else in the pass, and the component's threshold does
 /// not ratchet up over the one step nothing can be done about.
 ///
@@ -646,22 +646,27 @@ class LoopBlockingGuard {
 /// the warning exists to find, and wrapping them in this scope hides the
 /// bug instead of fixing it. If in doubt, leave the warning in.
 ///
-/// Main loop task only. The watchdog is not fed inside the scope, so the
-/// work must still finish within the watchdog timeout.
+/// Only work timed by a LoopBlockingGuard is affected, that is a component's
+/// loop() or a scheduler callback; setup() is not timed, so the scope does
+/// nothing there. Main loop task only. The watchdog is not fed inside the
+/// scope, so the work must still finish within the watchdog timeout. Scopes
+/// may nest; the outermost one decides how much of the pass is left out.
 ///
-///   {
-///     UnavoidableBlockingScope scope;
-///     bring_up_radio();
+///   void MyComponent::loop() {
+///     if (this->needs_key_) {
+///       UnavoidableBlockingScope scope;
+///       this->generate_key_();
+///     }
 ///   }
 class UnavoidableBlockingScope {
  public:
-  UnavoidableBlockingScope() : started_(millis()) {}
+  UnavoidableBlockingScope() : started_(millis()), pass_start_(App.get_loop_component_start_time()) {}
   ~UnavoidableBlockingScope() {
-    // Move the pass start forward by the time spent here, but never past now:
-    // nested scopes count the inner stretch twice, and a start in the future
-    // would underflow the guard's subtraction
+    // Move the pass start seen at entry forward by the time spent here, so an
+    // outer scope overrides an inner one instead of adding to it; never past
+    // now, which would underflow the guard's subtraction
     const uint32_t now = millis();
-    const uint32_t moved = App.get_loop_component_start_time() + (now - this->started_);
+    const uint32_t moved = this->pass_start_ + (now - this->started_);
     App.set_loop_component_start_time_(static_cast<int32_t>(now - moved) < 0 ? now : moved);
   }
   UnavoidableBlockingScope(const UnavoidableBlockingScope &) = delete;
@@ -669,6 +674,7 @@ class UnavoidableBlockingScope {
 
  private:
   uint32_t started_;
+  uint32_t pass_start_;
 };
 
 // Phase A: drain wake notifications and run the scheduler. Invoked on every

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -634,11 +634,11 @@ class LoopBlockingGuard {
 
 /// Leaves a stretch of the current loop pass out of the blocking warning.
 ///
-/// Only for work that cannot be made shorter and cannot be split across
-/// passes: enabling a radio, the initial connect of a network stack, a key
-/// generation whose cost is the algorithm itself. The warning then keeps
-/// reporting everything else in the pass, and the component's threshold does
-/// not ratchet up over the one step nothing can be done about.
+/// Only for work done from a loop pass that cannot be made shorter and
+/// cannot be split across passes: turning on a radio, the first Wi-Fi
+/// connect, a key generation whose cost is the algorithm itself. The warning
+/// then keeps reporting everything else in the pass, and the component's
+/// threshold does not ratchet up over the one step nothing can be done about.
 ///
 /// Never use it to paper over a problem that can be solved. A slow driver
 /// call, a loop that could be a state machine, a computation that could be

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -647,8 +647,8 @@ class LoopBlockingGuard {
 /// bug instead of fixing it. If in doubt, leave the warning in.
 ///
 /// Only work timed by a LoopBlockingGuard is affected, that is a component's
-/// loop() or a scheduler callback; setup() is not timed, so the scope does
-/// nothing there. Main loop task only. The watchdog is not fed inside the
+/// loop() or a scheduler callback; setup() is not timed by the guard, so the
+/// scope has no effect on the warning there. Main loop task only. The watchdog is not fed inside the
 /// scope, so the work must finish within the watchdog timeout, or be paired
 /// with a watchdog::WatchdogManager that raises the timeout for the same
 /// stretch. Scopes may nest; the outermost one decides how much of the pass
@@ -664,12 +664,12 @@ class LoopBlockingGuard {
 ///   }
 class UnavoidableBlockingScope {
  public:
-  UnavoidableBlockingScope() : started_(millis()), pass_start_(App.get_loop_component_start_time()) {}
+  UnavoidableBlockingScope() : started_(MillisInternal::get()), pass_start_(App.get_loop_component_start_time()) {}
   ~UnavoidableBlockingScope() {
     // Move the pass start seen at entry forward by the time spent here, so an
     // outer scope overrides an inner one instead of adding to it; never past
     // now, which would underflow the guard's subtraction
-    const uint32_t now = millis();
+    const uint32_t now = MillisInternal::get();
     const uint32_t moved = this->pass_start_ + (now - this->started_);
     App.set_loop_component_start_time_(static_cast<int32_t>(now - moved) < 0 ? now : moved);
   }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -646,6 +646,9 @@ class LoopBlockingGuard {
 /// the warning exists to find, and wrapping them in this scope hides the
 /// bug instead of fixing it. If in doubt, leave the warning in.
 ///
+/// Main loop task only. The watchdog is not fed inside the scope, so the
+/// work must still finish within the watchdog timeout.
+///
 ///   {
 ///     UnavoidableBlockingScope scope;
 ///     bring_up_radio();
@@ -654,9 +657,12 @@ class UnavoidableBlockingScope {
  public:
   UnavoidableBlockingScope() : started_(millis()) {}
   ~UnavoidableBlockingScope() {
-    // Move the pass start forward by the time spent here; the guard measures
-    // from that start, and components reading it as "now" get a fresher value
-    App.set_loop_component_start_time_(App.get_loop_component_start_time() + (millis() - this->started_));
+    // Move the pass start forward by the time spent here, but never past now:
+    // nested scopes count the inner stretch twice, and a start in the future
+    // would underflow the guard's subtraction
+    const uint32_t now = millis();
+    const uint32_t moved = App.get_loop_component_start_time() + (now - this->started_);
+    App.set_loop_component_start_time_(static_cast<int32_t>(now - moved) < 0 ? now : moved);
   }
   UnavoidableBlockingScope(const UnavoidableBlockingScope &) = delete;
   UnavoidableBlockingScope &operator=(const UnavoidableBlockingScope &) = delete;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -649,8 +649,10 @@ class LoopBlockingGuard {
 /// Only work timed by a LoopBlockingGuard is affected, that is a component's
 /// loop() or a scheduler callback; setup() is not timed, so the scope does
 /// nothing there. Main loop task only. The watchdog is not fed inside the
-/// scope, so the work must still finish within the watchdog timeout. Scopes
-/// may nest; the outermost one decides how much of the pass is left out.
+/// scope, so the work must finish within the watchdog timeout, or be paired
+/// with a watchdog::WatchdogManager that raises the timeout for the same
+/// stretch. Scopes may nest; the outermost one decides how much of the pass
+/// is left out.
 /// App.get_loop_component_start_time() reads later in the same pass return
 /// the moved start, so elapsed time across the scope needs millis().
 ///

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -634,13 +634,17 @@ class LoopBlockingGuard {
 
 /// Leaves a stretch of the current loop pass out of the blocking warning.
 ///
-/// For work that cannot be made shorter or split across passes, such as
-/// bringing up a radio, the initial connect of a network stack, or a key
-/// generation whose cost is the algorithm itself; the warning then keeps
+/// Only for work that cannot be made shorter and cannot be split across
+/// passes: bringing up a radio, the initial connect of a network stack, a
+/// key generation whose cost is the algorithm itself. The warning then keeps
 /// reporting everything else in the pass, and the component's threshold does
-/// not ratchet up over such an operation. It must never wrap work that could
-/// be made faster or moved off the loop: that is exactly what the warning
-/// exists to find.
+/// not ratchet up over the one step nothing can be done about.
+///
+/// Never use it to paper over a problem that can be solved. A slow driver
+/// call, a loop that could be a state machine, a computation that could be
+/// cached or deferred, a blocking read that could be polled: those are what
+/// the warning exists to find, and wrapping them in this scope hides the
+/// bug instead of fixing it. If in doubt, leave the warning in.
 ///
 ///   {
 ///     UnavoidableBlockingScope scope;

--- a/esphome/core/millis_internal.h
+++ b/esphome/core/millis_internal.h
@@ -51,6 +51,7 @@ class MillisInternal {
   }
   friend class Application;
   friend class LoopBlockingGuard;
+  friend class UnavoidableBlockingScope;
 };
 
 }  // namespace esphome

--- a/tests/components/core/test_blocking_scope.cpp
+++ b/tests/components/core/test_blocking_scope.cpp
@@ -27,8 +27,46 @@ TEST(UnavoidableBlockingScope, ExcludesItsDurationFromThePass) {
 TEST(UnavoidableBlockingScope, ZeroLengthScopeLeavesTheStartAlone) {
   const uint32_t pass_start = millis();
   LoopBlockingGuard guard(nullptr, nullptr, pass_start);
+  const uint32_t before = millis();
   { UnavoidableBlockingScope scope; }
-  EXPECT_LE(App.get_loop_component_start_time() - pass_start, 1u);
+  EXPECT_LE(App.get_loop_component_start_time() - pass_start, millis() - before);
+}
+
+// Nesting counts the inner stretch twice; the start must still never pass now
+TEST(UnavoidableBlockingScope, NestedScopesNeverMoveTheStartPastNow) {
+  const uint32_t pass_start = millis();
+  LoopBlockingGuard guard(nullptr, nullptr, pass_start);
+  {
+    UnavoidableBlockingScope outer;
+    {
+      UnavoidableBlockingScope inner;
+      delay(30);
+    }
+    delay(5);
+  }
+  const uint32_t now = millis();
+  EXPECT_GE(static_cast<int32_t>(now - App.get_loop_component_start_time()), 0);
+  EXPECT_GE(App.get_loop_component_start_time() - pass_start, 35u);
+}
+
+class DummyComponent : public Component {};
+
+// The excused stretch must neither warn nor ratchet the component's threshold
+TEST(UnavoidableBlockingScope, ExcusedStretchDoesNotRatchetTheThreshold) {
+  DummyComponent component;
+  uint32_t threshold_before = 0;
+  component.should_warn_of_blocking(0, threshold_before);
+  {
+    LoopBlockingGuard guard(&component, nullptr, millis());
+    {
+      UnavoidableBlockingScope scope;
+      delay(WARN_IF_BLOCKING_OVER_CS * 10U + 20);
+    }
+    guard.finish();
+  }
+  uint32_t threshold_after = 0;
+  component.should_warn_of_blocking(0, threshold_after);
+  EXPECT_EQ(threshold_after, threshold_before);
 }
 
 }  // namespace esphome

--- a/tests/components/core/test_blocking_scope.cpp
+++ b/tests/components/core/test_blocking_scope.cpp
@@ -54,17 +54,18 @@ TEST(UnavoidableBlockingScope, NestedScopesExcuseTheOuterSpanOnce) {
 }
 
 namespace {
-// Static: the guard publishes the component to App and nothing clears it
+// Static: the guard publishes the component to App and nothing clears it.
+// One instance per test, since a ratcheted threshold is permanent
 class DummyComponent : public Component {};
-DummyComponent &blocking_test_component() {
-  static DummyComponent component;
-  return component;
+DummyComponent &blocking_test_component(size_t index) {
+  static DummyComponent components[2];
+  return components[index];
 }
 }  // namespace
 
 // The excused stretch must neither warn nor ratchet the component's threshold
 TEST(UnavoidableBlockingScope, ExcusedStretchDoesNotRatchetTheThreshold) {
-  DummyComponent &component = blocking_test_component();
+  DummyComponent &component = blocking_test_component(0);
   uint32_t threshold_before = 0;
   component.should_warn_of_blocking(0, threshold_before);
   {
@@ -78,6 +79,25 @@ TEST(UnavoidableBlockingScope, ExcusedStretchDoesNotRatchetTheThreshold) {
   uint32_t threshold_after = 0;
   component.should_warn_of_blocking(0, threshold_after);
   EXPECT_EQ(threshold_after, threshold_before);
+}
+
+// Work outside the scope is still measured and still ratchets
+TEST(UnavoidableBlockingScope, WorkOutsideTheScopeStillRatchetsTheThreshold) {
+  DummyComponent &component = blocking_test_component(1);
+  uint32_t threshold_before = 0;
+  component.should_warn_of_blocking(0, threshold_before);
+  {
+    LoopBlockingGuard guard(&component, nullptr, millis());
+    {
+      UnavoidableBlockingScope scope;
+      delay(20);
+    }
+    delay(WARN_IF_BLOCKING_OVER_CS * 10U + 20);
+    guard.finish();
+  }
+  uint32_t threshold_after = 0;
+  component.should_warn_of_blocking(0, threshold_after);
+  EXPECT_GT(threshold_after, threshold_before);
 }
 
 }  // namespace esphome

--- a/tests/components/core/test_blocking_scope.cpp
+++ b/tests/components/core/test_blocking_scope.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+
+// The scope must push the pass start forward by the time it covers and by
+// nothing else, so the blocking guard sees only the work outside it
+TEST(UnavoidableBlockingScope, ExcludesItsDurationFromThePass) {
+  const uint32_t pass_start = millis();
+  LoopBlockingGuard guard(nullptr, nullptr, pass_start);
+  ASSERT_EQ(App.get_loop_component_start_time(), pass_start);
+
+  const uint32_t before = millis();
+  {
+    UnavoidableBlockingScope scope;
+    delay(30);
+  }
+  const uint32_t excused = millis() - before;
+
+  const uint32_t moved = App.get_loop_component_start_time() - pass_start;
+  EXPECT_GE(moved, 30u);
+  EXPECT_LE(moved, excused);
+}
+
+TEST(UnavoidableBlockingScope, ZeroLengthScopeLeavesTheStartAlone) {
+  const uint32_t pass_start = millis();
+  LoopBlockingGuard guard(nullptr, nullptr, pass_start);
+  { UnavoidableBlockingScope scope; }
+  EXPECT_LE(App.get_loop_component_start_time() - pass_start, 1u);
+}
+
+}  // namespace esphome

--- a/tests/components/core/test_blocking_scope.cpp
+++ b/tests/components/core/test_blocking_scope.cpp
@@ -32,10 +32,12 @@ TEST(UnavoidableBlockingScope, ZeroLengthScopeLeavesTheStartAlone) {
   EXPECT_LE(App.get_loop_component_start_time() - pass_start, millis() - before);
 }
 
-// Nesting counts the inner stretch twice; the start must still never pass now
-TEST(UnavoidableBlockingScope, NestedScopesNeverMoveTheStartPastNow) {
+// Nested scopes leave out the outer span exactly once, and never move the
+// start past now
+TEST(UnavoidableBlockingScope, NestedScopesExcuseTheOuterSpanOnce) {
   const uint32_t pass_start = millis();
   LoopBlockingGuard guard(nullptr, nullptr, pass_start);
+  const uint32_t before = millis();
   {
     UnavoidableBlockingScope outer;
     {
@@ -44,16 +46,25 @@ TEST(UnavoidableBlockingScope, NestedScopesNeverMoveTheStartPastNow) {
     }
     delay(5);
   }
-  const uint32_t now = millis();
-  EXPECT_GE(static_cast<int32_t>(now - App.get_loop_component_start_time()), 0);
-  EXPECT_GE(App.get_loop_component_start_time() - pass_start, 35u);
+  const uint32_t excused = millis() - before;
+  const uint32_t moved = App.get_loop_component_start_time() - pass_start;
+  EXPECT_GE(moved, 35u);
+  EXPECT_LE(moved, excused);
+  EXPECT_GE(static_cast<int32_t>(millis() - App.get_loop_component_start_time()), 0);
 }
 
+namespace {
+// Static: the guard publishes the component to App and nothing clears it
 class DummyComponent : public Component {};
+DummyComponent &blocking_test_component() {
+  static DummyComponent component;
+  return component;
+}
+}  // namespace
 
 // The excused stretch must neither warn nor ratchet the component's threshold
 TEST(UnavoidableBlockingScope, ExcusedStretchDoesNotRatchetTheThreshold) {
-  DummyComponent component;
+  DummyComponent &component = blocking_test_component();
   uint32_t threshold_before = 0;
   component.should_warn_of_blocking(0, threshold_before);
   {


### PR DESCRIPTION
# What does this implement/fix?

Adds UnavoidableBlockingScope to core. Some work has no shorter form and cannot be split across loop passes: bringing up a radio, the first connect of a network stack, a key generation whose cost is the algorithm itself. Today such a step trips the loop blocking warning and ratchets the component's threshold up for the rest of the boot, which then hides real slowdowns in that component. Wrapping the step in this scope moves the pass start forward by the time it took, so the guard still measures everything else in the pass and the threshold stays where it was; the class comment restricts it to work that genuinely cannot be made faster or moved off the loop. Only work timed by the guard is affected, so loop() and scheduler callbacks; setup() is not timed. Each scope records the pass start at entry, so nested scopes leave out the outer span exactly once, and the moved start is clamped to now. Five host gtests cover the excluded duration, the zero length case, nesting, the unchanged threshold, and that work outside the scope still ratchets. No component uses it yet; esphome/esphome#19000 will use it around its spare ephemeral key generation on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to esphome/esphome#19000

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#173

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

