### PR TITLE
[i2s_audio] Keep a start request that arrives while the speaker task stops

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -91,7 +91,15 @@ void I2SAudioSpeakerBase::loop() {
     this->speaker_task_handle_ = nullptr;
 
     this->stop_i2s_driver_();
-    xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
+    // ALL_BITS includes COMMAND_START. Take the bits from the clear itself, not from the snapshot at
+    // the top of loop(): the audio source's task can raise a start at any point above, including
+    // during stop_i2s_driver_(), and nothing would ever re-issue it.
+    const EventBits_t bits_before_clear =
+        xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
+    if (bits_before_clear & SpeakerEventGroupBits::COMMAND_START) {
+      ESP_LOGD(TAG, "Start requested while stopping; keeping the request");
+      xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
+    }
     this->status_clear_error();
 
     this->on_task_stopped();

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -94,8 +94,7 @@ void I2SAudioSpeakerBase::loop() {
     // ALL_BITS includes COMMAND_START. Take the bits from the clear itself, not from the snapshot at
     // the top of loop(): the audio source's task can raise a start at any point above, including
     // during stop_i2s_driver_(), and nothing would ever re-issue it.
-    const EventBits_t bits_before_clear =
-        xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
+    const EventBits_t bits_before_clear = xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
     if (bits_before_clear & SpeakerEventGroupBits::COMMAND_START) {
       ESP_LOGD(TAG, "Start requested while stopping; keeping the request");
       xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);


### PR DESCRIPTION
# What does this implement/fix?

When the speaker task finishes, `I2SAudioSpeakerBase::loop()` clears every bit in the event group. `ALL_BITS` includes `COMMAND_START`, so a start request raised while the task was winding down is discarded. Nothing re-issues it, and the speaker never starts again.

The window is not narrow, because the speaker reports itself as stopped throughout it:

* `is_running()` tests for `STATE_RUNNING`, and `state_` is only set to `STATE_STOPPED` *after* the `ALL_BITS` clear, so the speaker already answers "not running" for the whole of `STATE_STOPPING` — which lasts at least one further `loop()` iteration.
* `AudioPipeline::process_state()` returns `STOPPED` as soon as `!speaker_->is_running()`, so the media player can hand over the next file while the old task is still being torn down.
* The standard speaker task exits whenever `audio_stream_info_ != current_stream_info_`, so a new file at a different sample rate always goes through this teardown.
* `play()` auto-starts the speaker, which sets `COMMAND_START` — and the next `loop()` iteration wipes it.

So the shape of the failure is: play a file, then a file with a different sample rate (music at 44.1 kHz followed by a TTS announcement at 16 kHz, for example), and the second one can be silent with nothing in the log to say why.

The fix preserves the request instead of dropping it. `xEventGroupClearBits()` returns the bits as they were before the clear, so it is recovered from the same atomic operation rather than from the snapshot taken at the top of `loop()` — no new race between the test and the clear.

Honest scope note: the in-tree path above is described from reading the code. My own measurement of the bug came from an external component driving `speaker::Speaker` through the same public API, where the same sequence (reconfigure, then start, while the previous task was stopping) left the speaker silent for the rest of the track.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change.
# Reproduce with any i2s_audio speaker that is handed two streams of different sample rates back to back:

i2s_audio:
  - id: i2s_out
    i2s_lrclk_pin: GPIO25
    i2s_bclk_pin: GPIO26

speaker:
  - platform: i2s_audio
    id: my_speaker
    i2s_audio_id: i2s_out
    i2s_dout_pin: GPIO27
    dac_type: external

media_player:
  - platform: speaker
    name: Speaker Media Player
    announcement_pipeline:
      speaker: my_speaker
    media_pipeline:
      speaker: my_speaker
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).