### PR TITLE
[audio] Do not treat MP3_STREAM_INFO_CHANGED as a fatal decoder error

### DIFF
--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -313,9 +313,10 @@ FileDecoderState AudioDecoder::decode_mp3_() {
       this->output_transfer_buffer_->increase_buffer_length(
           this->audio_stream_info_.value().frames_to_bytes(samples_decoded));
     }
-  } else if (result == micro_mp3::MP3_STREAM_INFO_READY) {
-    // First successful header parse: capture stream info and resize the output buffer to fit one full frame.
-    // microMP3 always outputs 16-bit PCM.
+  } else if (result == micro_mp3::MP3_STREAM_INFO_READY || result == micro_mp3::MP3_STREAM_INFO_CHANGED) {
+    // Header parsed: capture stream info and resize the output buffer to fit one full frame.
+    // microMP3 always outputs 16-bit PCM. MP3_STREAM_INFO_CHANGED is handled identically: despite its
+    // negative value it is documented as recoverable, so it must not reach the catch-all below.
     this->audio_stream_info_ =
         audio::AudioStreamInfo(16, this->mp3_decoder_->get_channels(), this->mp3_decoder_->get_sample_rate());
     this->free_buffer_required_ =


### PR DESCRIPTION
# What does this implement/fix?

`AudioDecoder::decode_mp3_()` treats `MP3_STREAM_INFO_CHANGED` as a fatal error. micro-mp3 documents it as the opposite — the [component registry](https://components.espressif.com/components/esphome/micro-mp3) describes it as:

> **MP3_STREAM_INFO_CHANGED (value: -5):** Sample rate, channels, or MPEG version changed mid-stream (recoverable; no PCM). Re-read the accessors, reconfigure, and call again.

Only its negative value makes it look like a failure. It is not matched by any of the branches in `decode_mp3_()`, so it falls through to the catch-all, which logs `MP3 decoder failed: -5` and returns `FileDecoderState::FAILED`, ending playback of the file.

This is not an exotic case: the result is returned in ordinary use whenever decoding starts partway into a stream, because the decoder first reports the format of the partial frame it locks onto and then reports the real format from the first complete frame.

The fix handles it exactly like `MP3_STREAM_INFO_READY` — re-read the accessors and resize the output buffer — which is what the library asks the caller to do.

**Known limitation, deliberately left out of scope.** A format change is still not propagated to the sink once playback has begun: `AudioPipeline` sends the stream info to the speaker only on the first parse. So after this change a genuine mid-stream format change plays on at the previously configured rate instead of aborting the file. Propagating it means re-sending the stream info from `AudioPipeline`, which restarts the speaker task, and I would rather do that as its own change than enlarge a one-line fix. Happy to follow up with it if you'd prefer them together.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change.
# Reproduce by starting MP3 decoding partway into a stream, e.g. a seek, or an HTTP source that begins mid-file.

media_player:
  - platform: speaker
    name: Speaker Media Player
    media_pipeline:
      speaker: my_speaker
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
