### PR TITLE
[noise] Bump noise-c to 0.1.26 and libsodium to 1.10021.8

### DIFF
--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -88,12 +88,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.24")
+    cg.add_library("esphome/noise-c", "0.1.25")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.6")
+    cg.add_library("esphome/libsodium", "1.10021.7")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -88,12 +88,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.25")
+    cg.add_library("esphome/noise-c", "0.1.26")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.7")
+    cg.add_library("esphome/libsodium", "1.10021.8")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.24                 ; noise (api, ota)
+    esphome/noise-c@0.1.25                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.24                ; noise (api, ota)
+    esphome/noise-c@0.1.25                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.24  ; used by noise (api, ota)
+    esphome/noise-c@0.1.25  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.25                 ; noise (api, ota)
+    esphome/noise-c@0.1.26                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.25                ; noise (api, ota)
+    esphome/noise-c@0.1.26                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.25  ; used by noise (api, ota)
+    esphome/noise-c@0.1.26  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.24") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.24") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 0.1.25") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.25") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.24\n"
+        "    esphome/noise-c @ 0.1.25\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.24\n"
+        "    esphome/noise-c @ 0.1.25\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.24"]
+    assert libs == ["esphome/noise-c @ 0.1.25"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.24",
+        "esphome/noise-c @ 0.1.25",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.24",
-            "esphome/noise-c @ 0.1.24",
+            "esphome/noise-c @ 0.1.25",
+            "esphome/noise-c @ 0.1.25",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.24"]
+    assert cls.calls == ["esphome/noise-c @ 0.1.25"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.24": [
+        "esphome/noise-c @ 0.1.25": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.24", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.25", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.24"] is None
+    assert compats["esphome/noise-c @ 0.1.25"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.24": [
+        "esphome/noise-c @ 0.1.25": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.24"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.25"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.24"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.25"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.24": [
+        "esphome/noise-c @ 0.1.25": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.24"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.25"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.25") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.25") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 0.1.26") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.26") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.25\n"
+        "    esphome/noise-c @ 0.1.26\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.25\n"
+        "    esphome/noise-c @ 0.1.26\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.25"]
+    assert libs == ["esphome/noise-c @ 0.1.26"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.25",
+        "esphome/noise-c @ 0.1.26",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.25",
-            "esphome/noise-c @ 0.1.25",
+            "esphome/noise-c @ 0.1.26",
+            "esphome/noise-c @ 0.1.26",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.25"]
+    assert cls.calls == ["esphome/noise-c @ 0.1.26"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.25": [
+        "esphome/noise-c @ 0.1.26": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.25", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.26", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.25"] is None
+    assert compats["esphome/noise-c @ 0.1.26"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.25": [
+        "esphome/noise-c @ 0.1.26": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.25"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.26"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.25"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.26"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.25": [
+        "esphome/noise-c @ 0.1.26": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.25"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.26"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1649,7 +1649,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.24", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.25", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1669,7 +1669,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.24", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.25", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1649,7 +1649,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.25", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.26", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1669,7 +1669,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.25", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.26", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Bumps noise-c from 0.1.24 to 0.1.26 and libsodium from 1.10021.6 to 1.10021.8. noise-c 0.1.25 and 0.1.26 only move the libsodium pin (esphome-libs/noise-c#32, #33). The library changes: esphome-libs/libsodium#38 shrinks the Ed25519 base point table used for key generation from 30 KB to 12 KB on every target, which saves flash everywhere and stops the table thrashing the flash cache (largest on ESP32, where key generation was mostly waiting on flash); esphome-libs/libsodium#39 gives the RP2040 the BearSSL m15 X25519 ladder, since its Cortex-M0+ has no 32x32 to 64 multiply, the same situation the ESP8266 was in; esphome-libs/libsodium#40 makes the per packet ChaCha20-Poly1305 on the ESP8266 a quarter cheaper by keeping the Poly1305 products and the block loads inline. ESP32 handshake DH and all ESP32 and RP2040 transport code are unchanged.

Everything below is measured on the same boards with fresh registry packages at each pin, dev against this branch; best of 5 over two boots for the crypto rows, 20 encrypted API connects from aioesphomeapi by IP, three encrypted OTA uploads of the same firmware each.

Image sizes of one build (logger, wifi, api with encryption, ota); RAM is the static image, the base point table lives in flash on all three so RAM does not move:

| board | dev flash | this PR flash | saved | dev RAM | this PR RAM |
| --- | --- | --- | --- | --- | --- |
| ESP8266 d1 mini, 80 MHz | 405219 B | 387699 B | 17520 B | 30104 B | 30104 B |
| ESP32 AtomU (IDF) | 760071 B | 740007 B | 20064 B | 44472 B | 44472 B |
| Pico W (RP2040) | 501496 B | 482680 B | 18816 B | 78780 B | 78780 B |

X25519 and handshake timing (the loopback rows are one Noise_NNpsk0 handshake in RAM):

| board | pin | base point multiply | X25519 DH | responder write step | full loopback |
| --- | --- | --- | --- | --- | --- |
| ESP8266 d1 mini, 80 MHz | dev | 55.4 ms | 98.4 ms | 160.6 ms | 331.6 ms |
| ESP8266 d1 mini, 80 MHz | this PR | 52.6 ms | 92.5 ms | 153.0 ms | 315.6 ms |
| ESP32 AtomU (IDF) | dev | 12.3 ms | 14.4 ms | 29.2 ms | 63.2 ms |
| ESP32 AtomU (IDF) | this PR | 5.8 ms | 14.0 ms | 23.4 ms | 51.5 ms |
| Pico W (RP2040) | dev | 36.6 ms | 85.4 ms | 126.3 ms | 262.8 ms |
| Pico W (RP2040) | this PR | 36.5 ms | 67.7 ms | 108.1 ms | 224.5 ms |

API connects from aioesphomeapi by IP, 20 per column, median with the fastest in brackets; the first column is dev with `api:` and no encryption key, the floor a connect has without any crypto (a connect is one handshake plus a few small packets, so WiFi dominates the spread):

| board | dev, no encryption | dev, encrypted | this PR, encrypted |
| --- | --- | --- | --- |
| ESP8266 d1 mini, 80 MHz | 27 ms (22 ms) | 209 ms (198 ms) | 206 ms (195 ms) |
| ESP32 AtomU (IDF) | 119 ms (68 ms) | 124 ms (109 ms) | 130 ms (99 ms) |
| Pico W (RP2040) | 30 ms (18 ms) | 194 ms (169 ms) | 179 ms (155 ms) |

The unencrypted column shows what the handshake costs on top of the network: on the ESP8266 and the Pico the encrypted connect is almost entirely the handshake, while on the ESP32 the crypto is a few milliseconds and the connect is dominated by WiFi latency either way.

For reference, the same build without the encryption key at dev is 328483 B, 691547 B, 433516 B of flash on the three boards in that order, so the noise transport costs 76736 B, 68524 B, 67980 B at dev and 59216 B, 48460 B, 49164 B at this PR.

Transport phase, one packet encrypted and decrypted through the same noise-c cipher states the api frame helper uses (best of 5 rounds of 50), with the two primitives alone at 1024 B:

| board | pin | 64 B packet | 256 B packet | 1024 B packet | ChaCha20 1024 B | Poly1305 1024 B |
| --- | --- | --- | --- | --- | --- | --- |
| ESP8266 d1 mini, 80 MHz | dev | 337 us | 1006 us | 3680 us | 469 us | 1324 us |
| ESP8266 d1 mini, 80 MHz | this PR | 269 us | 766 us | 2754 us | 409 us | 916 us |
| ESP32 AtomU (IDF) | dev | 63 us | 168 us | 591 us | 169 us | 117 us |
| ESP32 AtomU (IDF) | this PR | 63 us | 168 us | 591 us | 169 us | 117 us |
| Pico W (RP2040) | dev | 217 us | 587 us | 2075 us | 400 us | 586 us |
| Pico W (RP2040) | this PR | 216 us | 585 us | 2078 us | 399 us | 587 us |

Encrypted OTA uploads of the full bench firmware from the esphome CLI (noise session, 1024 byte frames), transfer time per upload; the image itself is smaller at this PR, so the compressed payload differs:

| board | dev | this PR |
| --- | --- | --- |
| ESP8266 d1 mini, 80 MHz | ok 7.1 s, ok 8.1 s, ok 7.9 s (303037 B compressed) | ok 6.2 s, ok 4.8 s, ok 5.9 s (288627 B compressed) |
| ESP32 AtomU (IDF) | ok 10.4 s, ok 10.6 s, ok 13.4 s (765056 B, not compressed on this platform) | ok 9.6 s, ok 9.7 s, ok 9.4 s (745104 B, not compressed on this platform) |
| Pico W (RP2040) | ok 13.8 s, ok 10.1 s, ok 13.5 s (518452 B, not compressed on this platform) | ok 11.4 s, ok 8.7 s, ok 14.3 s (499620 B, not compressed on this platform) |

The ESP8266 DH column moves with code placement from build to build (that ladder is unchanged); its base point multiply and its transport rows are the measured changes. The OTA rows are a functional check that hundreds of encrypted frames decrypt correctly under real load, not a cipher measurement: by the transport numbers the ESP8266 spends about 0.5 s decrypting the 289 KB payload before and 0.4 s after, so the cipher accounts for roughly 0.1 s of an upload, the smaller image for about 5%, and the rest of the spread between samples is WiFi and flash erase timing (the ESP32 rows, where the cipher is unchanged, show the same spread). The RP2040 DH row is the m15 ladder; the ESP32 rows for DH and transport are unchanged code.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- keeps the noise-c dependency current after esphome-libs/noise-c#32, esphome-libs/noise-c#33, esphome-libs/libsodium#38 (esphome-libs/libsodium#37), esphome-libs/libsodium#39 and esphome-libs/libsodium#40

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
