### PR TITLE
[udp] Use cv.invalid for relocated packet_transport options

### DIFF
--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -1,5 +1,4 @@
-from collections.abc import Callable
-from typing import Any, NoReturn
+from typing import Any
 
 from esphome import automation
 from esphome.automation import Trigger
@@ -48,17 +47,10 @@ UDP_SCHEMA = cv.Schema(
 )
 
 
-def is_relocated(option: str) -> Callable[[Any], NoReturn]:
-    def validator(value: Any) -> NoReturn:
-        raise cv.Invalid(
-            f"The '{option}' option should now be configured in the 'packet_transport' component"
-        )
-
-    return validator
-
-
 RELOCATED = {
-    cv.Optional(x): is_relocated(x)
+    cv.Optional(x): cv.invalid(
+        f"The '{x}' option should now be configured in the 'packet_transport' component"
+    )
     for x in (
         CONF_PROVIDERS,
         CONF_ENCRYPTION,

--- a/tests/unit_tests/components/udp/test_init.py
+++ b/tests/unit_tests/components/udp/test_init.py
@@ -1,0 +1,37 @@
+"""Tests for the udp component configuration schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome.components import udp
+from esphome.components.packet_transport import (
+    CONF_BINARY_SENSORS,
+    CONF_ENCRYPTION,
+    CONF_PING_PONG_ENABLE,
+    CONF_PROVIDERS,
+    CONF_ROLLING_CODE_ENABLE,
+    CONF_SENSORS,
+)
+import esphome.config_validation as cv
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        CONF_PROVIDERS,
+        CONF_ENCRYPTION,
+        CONF_PING_PONG_ENABLE,
+        CONF_ROLLING_CODE_ENABLE,
+        CONF_SENSORS,
+        CONF_BINARY_SENSORS,
+    ],
+)
+def test_relocated_option_rejected(option: str) -> None:
+    """Options that moved to packet_transport raise a pointing error."""
+    with pytest.raises(cv.Invalid) as exc_info:
+        udp.CONFIG_SCHEMA({option: True})
+    assert (
+        f"The '{option}' option should now be configured in the 'packet_transport' component"
+        in str(exc_info.value)
+    )


### PR DESCRIPTION
# What does this implement/fix?

The `udp` component rejects the options that moved to `packet_transport` (`providers`, `encryption`, `ping_pong_enable`, `rolling_code_enable`, `sensors`, `binary_sensors`) with a hand-rolled `is_relocated` validator. The language schema generator only recognises `cv.invalid` when deciding which keys to skip, so these removed options were still being exported in the generated schema.

This replaces the custom validator with `cv.invalid`. The error message is unchanged, and the generated schema for `udp` now contains only the live options. A unit test drives each relocated key through the real `CONFIG_SCHEMA` and checks the error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
udp:
  providers: []  # now fails validation with a pointer to packet_transport, and is no longer in the generated schema
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).