### PR TITLE
[core] Restore the shared git hooks after post-checkout runs script/setup

### DIFF
--- a/script/git-hooks/post-checkout
+++ b/script/git-hooks/post-checkout
@@ -14,7 +14,31 @@ top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 [ -x "$top/venv/bin/python" ] && exit 0
 [ -x "$top/script/setup" ] || exit 0
 
+# Every worktree shares the hooks directory of the checkout it was created
+# from, and the script/setup run below is the one from whichever branch was just
+# checked out. Older branches install their own pre-commit hook without checking
+# for a worktree: that moves the shared hook aside as pre-commit.legacy and
+# replaces it with one tied to this worktree's virtual environment, so commits
+# break in every checkout. To rule that out, the hooks directory is copied
+# before script/setup runs and put back exactly as it was afterwards, including
+# removing any file script/setup added.
+hooks=$(git rev-parse --path-format=absolute --git-path hooks 2>/dev/null) || exit 0
+snap=$(mktemp -d "$hooks/.post-checkout.XXXXXX") || exit 0
+cp -p "$hooks"/* "$snap"/ 2>/dev/null
+
 # Clear VIRTUAL_ENV so a checkout made from a shell with an environment already
 # activated still gets its own, rather than having the active one repointed at
 # this working tree.
-exec env -u VIRTUAL_ENV "$top/script/setup"
+env -u VIRTUAL_ENV "$top/script/setup"
+status=$?
+
+for f in "$hooks"/*; do
+  [ -e "$snap/${f##*/}" ] || rm -f "$f"
+done
+# Files are moved rather than copied so a hook that is still running, such as
+# this one, is swapped out atomically instead of being rewritten in place.
+for f in "$snap"/*; do
+  cmp -s "$f" "$hooks/${f##*/}" 2>/dev/null || mv -f "$f" "$hooks/${f##*/}"
+done
+rm -rf "$snap"
+exit $status


### PR DESCRIPTION
# What does this implement/fix?

Git worktrees share one hooks directory, and the `post-checkout` hook installed there by `script/setup` runs the `script/setup` of whichever branch was just checked out whenever a new worktree has no virtual environment. Branches from before #18843 have a `script/setup` that runs a plain `pre-commit install` with no worktree guard. Checking such a branch out into a worktree moves the shared prek hook aside as `pre-commit.legacy` and replaces it with a pre-commit shim tied to that worktree's virtual environment. From then on every `git commit` in every checkout runs all hooks and then aborts with "prek's Git shim is installed in migration mode".

The hook now copies the hooks directory before running `script/setup`, runs it as a child process instead of replacing itself, and then puts the directory back exactly as it was: any file the setup script added is removed, and any file it changed is swapped back with an atomic move so the running hook is never rewritten in place. The hook is still plain POSIX sh, still exits early for file checkouts, when a venv exists, or when the branch has no `script/setup`, and the current `script/setup` works unchanged.

Verified by hand against the real shared hooks directory: a throwaway worktree on f158e0539a reproduced the migration-mode install and, after the hook returned, `.git/hooks/pre-commit` was byte-identical to before with no `pre-commit.legacy` left behind. A throwaway worktree on `dev` ran the current `script/setup` through the hook with the same result.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).