### PR TITLE
[modbus][hoermann_hcp] Announce a restart to the bus controller

### DIFF
--- a/esphome/components/hoermann_hcp/__init__.py
+++ b/esphome/components/hoermann_hcp/__init__.py
@@ -1,7 +1,10 @@
+from esphome import automation
 import esphome.codegen as cg
 from esphome.components import modbus
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@zweckj"]
@@ -14,6 +17,9 @@ hoermann_hcp_ns = cg.esphome_ns.namespace("hoermann_hcp")
 HoermannHcp = hoermann_hcp_ns.class_(
     "HoermannHcp", cg.PollingComponent, modbus.ModbusServerDevice
 )
+AnnouncePauseAction = hoermann_hcp_ns.class_(
+    "AnnouncePauseAction", automation.Action, cg.Parented.template(HoermannHcp)
+)
 
 # The Hoermann UAP module answers on Modbus server address 2.
 CONFIG_SCHEMA = (
@@ -25,6 +31,23 @@ CONFIG_SCHEMA = (
 FINAL_VALIDATE_SCHEMA = modbus.final_validate_modbus_device(
     "hoermann_hcp", role="server"
 )
+
+
+@automation.register_action(
+    "hoermann_hcp.announce_pause",
+    AnnouncePauseAction,
+    automation.maybe_simple_id({cv.GenerateID(): cv.use_id(HoermannHcp)}),
+    synchronous=True,
+)
+async def announce_pause_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
 
 
 async def to_code(config: ConfigType) -> None:

--- a/esphome/components/hoermann_hcp/automation.h
+++ b/esphome/components/hoermann_hcp/automation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+
+#include "hoermann_hcp.h"
+
+namespace esphome::hoermann_hcp {
+
+// Tells the bus controller the accessory is about to go quiet. An ordinary restart announces itself during
+// teardown; an update has to say so when the transfer starts, because by the time teardown runs the image
+// has been written and the controller has been unanswered throughout.
+template<typename... Ts> class AnnouncePauseAction final : public Action<Ts...>, public Parented<HoermannHcp> {
+ public:
+  void play(const Ts &...x) override { this->parent_->announce_pause(); }
+};
+
+}  // namespace esphome::hoermann_hcp

--- a/esphome/components/hoermann_hcp/automation.h
+++ b/esphome/components/hoermann_hcp/automation.h
@@ -7,9 +7,8 @@
 
 namespace esphome::hoermann_hcp {
 
-// Tells the bus controller the accessory is about to go quiet. An ordinary restart announces itself during
-// teardown; an update has to say so when the transfer starts, because by the time teardown runs the image
-// has been written and the controller has been unanswered throughout.
+// For the ota on_begin trigger. An ordinary restart announces itself from on_shutdown, but an update is
+// written to flash long before that runs, so it has to say so when the transfer starts.
 template<typename... Ts> class AnnouncePauseAction final : public Action<Ts...>, public Parented<HoermannHcp> {
  public:
   void play(const Ts &...x) override { this->parent_->announce_pause(); }

--- a/esphome/components/hoermann_hcp/hoermann_hcp.cpp
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.cpp
@@ -140,7 +140,6 @@ modbus::ResponseStatus HoermannHcp::on_read_holding_registers(uint16_t start_add
   switch (number_of_registers) {
     case 8:
       if (this->announcing_pause_()) {
-        // Announced in place of the ordinary state, naming the address it applies to.
         registers.push_back(counter);
         registers.push_back(static_cast<uint16_t>(RESPONSE_PAUSE | command));
         registers.push_back(this->get_address());
@@ -329,9 +328,8 @@ bool HoermannHcp::advance_pause_() {
       return false;
 
     case PauseState::PAUSE_STATE_SETTLING:
-      // Wait for a gap in what the controller sends us, so the last exchange is finished rather than cut
-      // short. This measures frames addressed to us, not every byte on the wire, so it is a courtesy and
-      // not a guarantee. Give up rather than let a busy bus hold up the restart.
+      // A gap in what the controller sends us, so the last exchange is finished rather than cut short.
+      // Only frames addressed to us, so it is a courtesy rather than a guarantee, and it gives up.
       if (now - this->last_response_ > this->pause_quiet_ms_ ||
           now - this->pause_started_at_ >= this->pause_settle_ms_) {
         this->end_pause_();

--- a/esphome/components/hoermann_hcp/hoermann_hcp.cpp
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.cpp
@@ -1,5 +1,6 @@
 #include "hoermann_hcp.h"
 
+#include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
@@ -15,6 +16,18 @@ static constexpr float CLOSE_POSITION_THRESHOLD = 0.05f;
 static constexpr float OPEN_POSITION_THRESHOLD = 0.95f;
 // Only the parity of the outstanding toggles says where the lamp is heading, so the count must not run away.
 static constexpr uint8_t MAX_LIGHT_TOGGLES_IN_FLIGHT = 4;
+
+// Replaces the ordinary 0x0001 status while a pause is announced. The protocol calls this a pause, not a
+// departure: the accessory is going quiet, it is not asking to be forgotten.
+static constexpr uint16_t RESPONSE_PAUSE = 0x0029;
+// Payload transfers arrive as this command in the low byte of the command register.
+static constexpr uint8_t TRANSFER_COMMAND = 0x04;
+static constexpr uint8_t TRANSFER_SUB_PAUSE_ACK = 0x19;
+static constexpr uint8_t TRANSFER_ACK = 0xFD;
+static constexpr uint8_t TRANSFER_NAK = 0xFE;
+// Bit 15 of the counter register selects the half of a split payload and is not part of the count. Only
+// transfers carry it, so only the answer to one masks it off; the ordinary echo is left as it was.
+static constexpr uint16_t COUNTER_MASK = 0x7F00;
 
 // Command encoding: the high byte of the first register is the phase (0x02 pressed, 0x01 released) and the
 // rest names the button - the low byte for the door commands, the second register for those that do not fit
@@ -113,6 +126,12 @@ modbus::ResponseStatus HoermannHcp::on_read_holding_registers(uint16_t start_add
 
   this->record_response_();
 
+  // A payload transfer the write half just took is answered here, whatever the controller reads next.
+  if (this->transfer_answer_pending_) {
+    this->push_transfer_answer_(registers, number_of_registers);
+    return {};
+  }
+
   // 0x17 read half: STATE_REG is read back right after COMMAND_REG was written, so echo the stored message
   // counter (high byte) and command (low byte). The read length identifies which internal block is requested.
   const uint16_t counter = this->command_reg_value_ & 0xFF00;
@@ -120,6 +139,14 @@ modbus::ResponseStatus HoermannHcp::on_read_holding_registers(uint16_t start_add
 
   switch (number_of_registers) {
     case 8:
+      if (this->announcing_pause_()) {
+        // Announced in place of the ordinary state, naming the address it applies to.
+        registers.push_back(counter);
+        registers.push_back(static_cast<uint16_t>(RESPONSE_PAUSE | command));
+        registers.push_back(this->get_address());
+        push_zeros(registers, 5);
+        break;
+      }
       // Command request: return the internal state, injecting any pending command.
       registers.push_back(counter);
       registers.push_back(static_cast<uint16_t>(0x0001 | command));
@@ -156,6 +183,8 @@ modbus::ResponseStatus HoermannHcp::on_write_registers(uint16_t start_address,
     // command byte back from STATE_REG. The hub always runs the write before the read within one request.
     this->record_response_();
     this->command_reg_value_ = registers[0];
+    // The same block carries payload transfers, which are answered rather than ignored.
+    this->take_transfer_(registers);
     return {};
   }
 
@@ -217,6 +246,137 @@ void HoermannHcp::push_command_registers_(modbus::RegisterValues &registers) {
   registers.push_back(command->released_value_2);
 }
 
+void HoermannHcp::take_transfer_(const modbus::RegisterValues &registers) {
+  // Only while a pause is out. The command byte alone is too thin a discriminator to start answering
+  // transfers in steady state, and an answer armed there would pre-empt the next read of any length.
+  if (!this->announcing_pause_() || registers.size() < 2)
+    return;
+  // Low byte of the first register is what the controller wants from us, high byte its running counter.
+  if (static_cast<uint8_t>(registers[0] & 0x00FF) != TRANSFER_COMMAND)
+    return;
+
+  const bool is_pause_ack = static_cast<uint8_t>(registers[1] >> 8) == TRANSFER_SUB_PAUSE_ACK;
+  // Answered either way. Leaving a transfer open is worse than refusing one we did not understand, and an
+  // undefined answer code is worse still.
+  this->transfer_answer_counter_ = static_cast<uint8_t>(registers[0] >> 8);
+  this->transfer_answer_code_ = is_pause_ack ? TRANSFER_ACK : TRANSFER_NAK;
+  this->transfer_answer_pending_ = true;
+
+  // The address the controller is pausing sits astride two registers: the low byte of the sub-code register
+  // and the high byte of the next.
+  if (!is_pause_ack || registers.size() < 3)
+    return;
+  const uint16_t named = static_cast<uint16_t>(((registers[1] & 0x00FF) << 8) | (registers[2] >> 8));
+  if (named == this->get_address())
+    this->pause_confirmed_ = true;
+}
+
+void HoermannHcp::push_transfer_answer_(modbus::RegisterValues &registers, uint16_t number_of_registers) {
+  // A read too short to carry the answer leaves it armed for the next one rather than swallowing it.
+  if (number_of_registers < 2) {
+    push_zeros(registers, number_of_registers);
+    return;
+  }
+  this->transfer_answer_pending_ = false;
+  registers.push_back(static_cast<uint16_t>((this->transfer_answer_counter_ << 8) & COUNTER_MASK));
+  registers.push_back(static_cast<uint16_t>((TRANSFER_COMMAND << 8) | this->transfer_answer_code_));
+  push_zeros(registers, number_of_registers - 2);
+}
+
+void HoermannHcp::drop_unsent_command_() {
+  // Cleared first so the settling below no longer counts this command among the toggles still to be sent.
+  const bool was_light_toggle = this->is_light_toggle_pending_();
+  this->next_command_ = nullptr;
+  if (was_light_toggle)
+    this->light_toggle_settled_();
+  this->changed_ = true;
+}
+
+void HoermannHcp::end_pause_() {
+  this->transfer_answer_pending_ = false;
+  this->pause_state_ = PauseState::PAUSE_STATE_DONE;
+}
+
+bool HoermannHcp::advance_pause_() {
+  const uint32_t now = millis();
+  switch (this->pause_state_) {
+    case PauseState::PAUSE_STATE_IDLE:
+      // Nobody to tell: nothing has ever arrived, or nothing recently enough for anyone to still be
+      // listening. A restart must not pay for that.
+      if (this->last_response_ == 0 || now - this->last_response_ > this->connection_timeout_ms_) {
+        this->end_pause_();
+        return true;
+      }
+      // A key press already shown to the controller has to be released first. Dropping it here would leave
+      // the controller holding a key that is never let go.
+      if (this->command_written_at_ != 0)
+        return false;
+      this->drop_unsent_command_();
+      this->pause_started_at_ = now;
+      this->pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK;
+      return false;
+
+    case PauseState::PAUSE_STATE_WAITING_FOR_ACK:
+      if (this->pause_confirmed_) {
+        ESP_LOGI(TAG, "Bus controller confirmed the pause");
+      } else if (now - this->pause_started_at_ < this->pause_ack_timeout_ms_) {
+        return false;
+      } else {
+        ESP_LOGW(TAG, "Bus controller did not confirm the pause, going quiet anyway");
+      }
+      this->pause_started_at_ = now;
+      this->pause_state_ = PauseState::PAUSE_STATE_SETTLING;
+      return false;
+
+    case PauseState::PAUSE_STATE_SETTLING:
+      // Wait for a gap in what the controller sends us, so the last exchange is finished rather than cut
+      // short. This measures frames addressed to us, not every byte on the wire, so it is a courtesy and
+      // not a guarantee. Give up rather than let a busy bus hold up the restart.
+      if (now - this->last_response_ > this->pause_quiet_ms_ ||
+          now - this->pause_started_at_ >= this->pause_settle_ms_) {
+        this->end_pause_();
+        return true;
+      }
+      return false;
+
+    default:
+      return true;
+  }
+}
+
+bool HoermannHcp::announce_pause() {
+  // Re-entering would clear the announcement the outer call is still waiting on, and would turn the hub from
+  // inside its own frame handling.
+  if (this->announcing_)
+    return false;
+  this->announcing_ = true;
+  // Every announcement starts afresh. The guard above means no other one is in flight, and every exit below
+  // ends in PAUSE_STATE_DONE, so there is never anything here worth carrying over.
+  this->pause_confirmed_ = false;
+  this->pause_state_ = PauseState::PAUSE_STATE_IDLE;
+  const uint32_t started = millis();
+  while (!this->advance_pause_() && millis() - started < this->pause_total_timeout_ms_) {
+    App.feed_wdt();
+    // The loop cannot turn the hub from here, so the bus is served by hand for as long as this takes.
+    this->service_bus_();
+    delay(1);
+  }
+  // Out of time with the announcement unfinished. It must not be left standing: the pause replaces the
+  // answer that carries key presses, so the door would stop taking commands until the next restart.
+  if (this->pause_state_ != PauseState::PAUSE_STATE_DONE) {
+    ESP_LOGW(TAG, "Gave up announcing the pause, going quiet without it");
+    this->end_pause_();
+  }
+  // One more pass, so a reply the last one parked still reaches the wire.
+  this->service_bus_();
+  this->announcing_ = false;
+  return this->pause_confirmed_;
+}
+
+// The UART driver is deleted in its own on_shutdown, and components are torn down in reverse setup
+// priority, so this is the last point at which the controller can still be told anything.
+void HoermannHcp::on_shutdown() { this->announce_pause(); }
+
 void HoermannHcp::on_position_reg_(uint16_t value) {
   // Low byte: current position.
   const uint8_t position = static_cast<uint8_t>(value);
@@ -270,6 +430,12 @@ void HoermannHcp::on_light_reg_(uint16_t value) {
 }
 
 bool HoermannHcp::queue_command_(const HoermannHcpCommand &command) {
+  // The pause replaces the answer a key press travels in, so one taken here could only be presented after
+  // the announcement, to a door that has moved on since. Refusing says so at once.
+  if (this->announcing_pause_()) {
+    ESP_LOGW(TAG, "Refused '%s' command: the restart has been announced to the bus controller", command.name);
+    return false;
+  }
   if (!this->valid_) {
     // Queueing now would fire the command whenever the controller comes back, which may be much later.
     ESP_LOGW(TAG, "Not connected to the bus controller, dropping '%s' command", command.name);
@@ -365,6 +531,7 @@ void HoermannHcp::set_valid_(bool valid) {
   }
   ESP_LOGW(TAG, "Bus controller connection lost (no request for %" PRIu32 "ms)", millis() - this->last_response_);
   // Drop what the controller never fetched, so it neither blocks later commands nor fires on reconnect.
+  this->transfer_answer_pending_ = false;
   this->drop_command_();
   // The door cannot be watched while the bus is quiet, so a target left armed would stop it long afterwards.
   this->clear_target_();

--- a/esphome/components/hoermann_hcp/hoermann_hcp.h
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.h
@@ -21,6 +21,14 @@ enum class DoorState : uint8_t {
   STOPPED,
 };
 
+// Steps of announcing that the accessory is about to go quiet.
+enum class PauseState : uint8_t {
+  PAUSE_STATE_IDLE,
+  PAUSE_STATE_WAITING_FOR_ACK,
+  PAUSE_STATE_SETTLING,
+  PAUSE_STATE_DONE,
+};
+
 // A HCP command is a simulated key press: the pressed value is presented to the bus controller, then after a
 // short delay the released value. Each half also carries a second register, which names the buttons that do
 // not fit into the first.
@@ -38,6 +46,15 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
  public:
   void update() override;
   void dump_config() override;
+  void on_shutdown() override;
+
+  /** Tells the bus controller the accessory is about to go quiet and waits for it to agree.
+   *
+   * The controller registered this accessory during its bus scan, so one that simply stops answering is a
+   * fault to it rather than an absence. Blocks, serving the bus itself, because neither caller runs where
+   * the main loop would turn it. Returns whether it was acknowledged; the caller carries on either way.
+   */
+  bool announce_pause();
 
   // Registered by child entities to be notified when the door state changes.
   template<typename F> void add_on_state_callback(F &&callback) {
@@ -96,6 +113,27 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   void on_state_reg_(uint16_t value);
   void on_light_reg_(uint16_t value);
 
+  // Reads a payload transfer and arms the answer the controller expects on the read half of the same request.
+  void take_transfer_(const modbus::RegisterValues &registers);
+  void push_transfer_answer_(modbus::RegisterValues &registers, uint16_t number_of_registers);
+  /** Moves the announcement along one step and reports whether anything is left to say.
+   *
+   * Decides everything from the clock so it can be called repeatedly, which is what lets the restart path
+   * and the ota trigger share the same steps and makes them testable without a bus.
+   */
+  bool advance_pause_();
+  // Drops a command the controller has not been shown yet. Unlike drop_command_ it keeps the travel target:
+  // nothing can be sent until the announcement is over, but if no restart follows, the next position the
+  // door reports still stops it where it was told to stop.
+  void drop_unsent_command_();
+  // Ends the announcement, however it ended, and puts the device back to answering normally.
+  void end_pause_();
+  // The pause replaces the ordinary state answer until the whole announcement is over.
+  bool announcing_pause_() const {
+    return this->pause_state_ == PauseState::PAUSE_STATE_WAITING_FOR_ACK ||
+           this->pause_state_ == PauseState::PAUSE_STATE_SETTLING;
+  }
+
   void set_valid_(bool valid);
   void set_door_state_(DoorState state);
   // Recomputes the reported position from position_raw_ and the current door state.
@@ -121,11 +159,21 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // When the door was last handed a lamp key press. It reports the lamp a moment later, so this bounds the
   // wait. Queueing another toggle deliberately leaves it alone, so the one already sent keeps its deadline.
   uint32_t light_toggle_released_at_{0};
+  // When the current step of the announcement began.
+  uint32_t pause_started_at_{0};
 
   // A command is "pressed" for this long before its end value is sent.
   uint16_t key_press_delay_ms_{100};
   // Drop the "connected" flag if the bus controller has not polled us for this long.
   uint16_t connection_timeout_ms_{2000};
+  // How long the announcement waits to be acknowledged. The controller polls several times a second.
+  uint16_t pause_ack_timeout_ms_{800};
+  // Nothing arriving for this long means no telegram is in flight, so a restart lands between them.
+  uint16_t pause_quiet_ms_{40};
+  // A controller that never falls quiet must not hold up the restart for longer than this.
+  uint16_t pause_settle_ms_{200};
+  // Ceiling on the whole announcement, so a controller that keeps a key press open cannot hold it open.
+  uint16_t pause_total_timeout_ms_{1500};
   // The state starts on a value the bus controller never reports, so the first broadcast is decoded even when
   // it reads 0x0000.
   uint16_t prev_state_reg_{0xFFFF};
@@ -140,6 +188,14 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // Position as reported by the bus controller, 0..200 across the full travel.
   uint8_t position_raw_{0};
   uint8_t light_toggles_in_flight_{0};
+  // Running counter and code of a payload transfer still to be answered on the following read half.
+  uint8_t transfer_answer_counter_{0};
+  uint8_t transfer_answer_code_{0};
+  bool transfer_answer_pending_{false};
+  PauseState pause_state_{PauseState::PAUSE_STATE_IDLE};
+  bool pause_confirmed_{false};
+  // Guards the blocking announcement against being entered from inside itself.
+  bool announcing_{false};
   bool target_started_{false};
   bool valid_{false};
   bool changed_{false};

--- a/esphome/components/hoermann_hcp/hoermann_hcp.h
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.h
@@ -48,11 +48,12 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   void dump_config() override;
   void on_shutdown() override;
 
-  /** Tells the bus controller the accessory is about to go quiet and waits for it to agree.
+  /** Tells the bus controller the accessory is about to go quiet, then waits briefly for it to answer.
    *
    * The controller registered this accessory during its bus scan, so one that simply stops answering is a
    * fault to it rather than an absence. Blocks, serving the bus itself, because neither caller runs where
-   * the main loop would turn it. Returns whether it was acknowledged; the caller carries on either way.
+   * the main loop would turn it. Goes quiet either way; the return value only says whether it was
+   * acknowledged.
    */
   bool announce_pause();
 
@@ -159,7 +160,6 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // When the door was last handed a lamp key press. It reports the lamp a moment later, so this bounds the
   // wait. Queueing another toggle deliberately leaves it alone, so the one already sent keeps its deadline.
   uint32_t light_toggle_released_at_{0};
-  // When the current step of the announcement began.
   uint32_t pause_started_at_{0};
 
   // A command is "pressed" for this long before its end value is sent.

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -319,12 +319,16 @@ bool ModbusServerHub::parse_modbus_client_frame_() {
   std::span<const uint8_t> data(data_buffer, data_len);
   this->clear_rx_buffer_(LOG_STR("parse succeeded"), false, frame_length);
 
+  // Restored rather than cleared: loop() is public, so a nested pass must not free the outer dispatch.
+  const bool was_dispatching = this->in_dispatch_;
+  this->in_dispatch_ = true;
   if (address == BROADCAST_ADDRESS) {
     // Keep the unicast response buffers out of the broadcast call chain.
     this->process_broadcast_frame_(function_code, data);
   } else {
     this->process_modbus_client_frame_(address, function_code, data);
   }
+  this->in_dispatch_ = was_dispatching;
 
   return true;
 }
@@ -397,6 +401,30 @@ void ModbusServerHub::process_modbus_server_frame(uint8_t address, std::span<con
   // This always resets, even if the address doesn't match.
   // If an unexpected response is received, we can't trust that a correct response will follow (it shouldn't).
   this->expecting_peer_response_ = 0;
+}
+
+// Out of line: ModbusServerDevice is not yet defined at this point in the header.
+void ModbusServerHub::register_device(ModbusServerDevice *device) {
+  device->hub_ = this;
+  this->devices_.push_back(device);
+}
+
+bool ModbusServerDevice::service_bus_() {
+  if (this->hub_ == nullptr)
+    return false;
+  return this->hub_->service();
+}
+
+bool ModbusServerHub::service() {
+  // Re-entering from a handler would answer a later frame before the one being handled, and would overwrite
+  // the single reply this hub can hold back.
+  if (this->in_dispatch_)
+    return false;
+  // Owed first, so a reply held back earlier cannot end up on the wire behind one this pass produces. The
+  // scheduler that would otherwise send it does not run during the waits this method exists for.
+  this->send_deferred_(false);
+  this->loop();
+  return true;
 }
 
 ModbusServerDevice *ModbusServerHub::find_device_(uint8_t address) {
@@ -1196,19 +1224,32 @@ void ModbusServerHub::send_raw_(const uint8_t *payload, uint16_t len) {
     std::memcpy(this->deferred_payload_.data(), payload, len);
     this->deferred_payload_len_ = len;
     // set_timeout() takes milliseconds; round the microsecond delay up so we never fire early.
-    this->set_timeout("deferred_send", (this->tx_delay_remaining() + US_PER_MS - 1) / US_PER_MS, [this]() {
-      ModbusFrame frame(this->deferred_payload_[0], this->deferred_payload_.data() + 1,
-                        this->deferred_payload_len_ - 1);
-      if (!this->send_frame_(frame)) {
-        ESP_LOGE(TAG, "Deferred server reply dropped: transmission still blocked");
-      }
-    });
+    this->set_timeout("deferred_send", (this->tx_delay_remaining() + US_PER_MS - 1) / US_PER_MS,
+                      [this]() { this->send_deferred_(true); });
     return;
   }
 
   ModbusFrame frame(payload[0], payload + 1, len - 1);
   if (!this->send_frame_(frame)) {
     ESP_LOGE(TAG, "Server reply dropped: a frame arrived during the send delay");
+  }
+}
+
+void ModbusServerHub::send_deferred_(bool drop_if_blocked) {
+  if (this->deferred_payload_len_ == 0)
+    return;
+  // What blocked the send is usually bytes still arriving, and waiting here would not drain them. A caller
+  // that comes back keeps the reply instead of spending its only attempt on a wire that cannot take it.
+  if (!drop_if_blocked && this->tx_blocked())
+    return;
+  ModbusFrame frame(this->deferred_payload_[0], this->deferred_payload_.data() + 1, this->deferred_payload_len_ - 1);
+  const bool sent = this->send_frame_(frame);
+  // Kept only for a caller that is coming back: send_frame_ re-checks after its own delay, so a failure here
+  // is still a busy wire rather than a reply the controller has stopped waiting for.
+  if (sent || drop_if_blocked)
+    this->deferred_payload_len_ = 0;
+  if (!sent) {
+    ESP_LOGE(TAG, "Deferred server reply %s: transmission still blocked", drop_if_blocked ? "dropped" : "held");
   }
 }
 

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -317,7 +317,12 @@ class ModbusServerHub : public Modbus {
  public:
   ModbusServerHub() = default;
   void dump_config() override;
-  void register_device(ModbusServerDevice *device) { this->devices_.push_back(device); }
+  void register_device(ModbusServerDevice *device);
+  /// Runs one pass of the bus and sends anything a device is still owed. For a device that has to keep
+  /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
+  /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
+  /// re-enter it.
+  bool service();
 
  protected:
   void parse_modbus_frames() override;
@@ -363,7 +368,13 @@ class ModbusServerHub : public Modbus {
   bool rejected_(uint8_t address, uint8_t function_code, ResponseStatus status);
   void send_exception_(uint8_t address, uint8_t function_code, ExceptionCode exception_code);
   void send_response_(uint8_t address, uint8_t function_code, const uint8_t *payload, uint16_t payload_len);
+  /// Sends a reply that was held back, if one is waiting. With drop_if_blocked the reply is given its one
+  /// chance and discarded, which is what the scheduler timeout wants; without it a busy wire is a reason to
+  /// keep the reply for the next pass.
+  void send_deferred_(bool drop_if_blocked);
   uint8_t expecting_peer_response_{0};
+  // Set while a frame is being handed to a device, so service() cannot be re-entered from a handler.
+  bool in_dispatch_{false};
   std::vector<ModbusServerDevice *> devices_;
 
   // Holds the raw payload of a single reply deferred for sending when tx was blocked at send time.
@@ -648,7 +659,15 @@ class ModbusServerDevice {
   };
 
  protected:
+  /// Runs one pass of the bus, so a device can keep answering during a bounded wait the main loop does not
+  /// cover. Returns whether it ran: it does not while the hub is dispatching a frame, or before the device
+  /// is registered.
+  bool service_bus_();
+
+  ModbusServerHub *hub_{nullptr};
   uint8_t address_{0};
+
+  friend class ModbusServerHub;
 };
 
 }  // namespace esphome::modbus

--- a/tests/components/hoermann_hcp/common.h
+++ b/tests/components/hoermann_hcp/common.h
@@ -1,10 +1,15 @@
 #pragma once
 #include <chrono>
+#include <cstring>
 #include <initializer_list>
+#include <span>
 #include <thread>
 #include <utility>
+#include <vector>
 #include <gtest/gtest.h>
 #include "esphome/components/hoermann_hcp/hoermann_hcp.h"
+#include "esphome/components/modbus/modbus.h"
+#include "esphome/components/uart/uart_component.h"
 
 namespace esphome::hoermann_hcp::testing {
 
@@ -14,6 +19,12 @@ using modbus::RegisterValues;
 constexpr uint16_t COMMAND_REG = 0x9C41;
 constexpr uint16_t STATE_REG = 0x9CB9;
 constexpr uint16_t BROADCAST_REG = 0x9D31;
+
+// Answer codes mirrored from hoermann_hcp.cpp, so the tests below can name what they assert.
+constexpr uint16_t RESPONSE_STATUS = 0x0001;
+constexpr uint16_t RESPONSE_PAUSE = 0x0029;
+constexpr uint16_t TRANSFER_ACK_ANSWER = 0x04FD;
+constexpr uint16_t TRANSFER_NAK_ANSWER = 0x04FE;
 
 // The tests shorten the key-press delay to zero, so the release only needs the millis() clock to tick on.
 constexpr auto KEY_PRESS_ELAPSED = std::chrono::milliseconds(2);
@@ -62,7 +73,121 @@ class TestableHoermannHcp : public HoermannHcp {
   using HoermannHcp::is_light_toggle_pending_;
   using HoermannHcp::light_toggle_released_at_;
   using HoermannHcp::light_toggles_in_flight_;
+  using HoermannHcp::announcing_;
+  using HoermannHcp::pause_ack_timeout_ms_;
+  using HoermannHcp::pause_confirmed_;
+  using HoermannHcp::pause_quiet_ms_;
+  using HoermannHcp::pause_settle_ms_;
+  using HoermannHcp::pause_state_;
+  using HoermannHcp::pause_total_timeout_ms_;
   using HoermannHcp::set_valid_;
+  using HoermannHcp::transfer_answer_pending_;
+};
+
+// A UART the test can inject received bytes into and read written bytes back from.
+class FakeWire : public uart::UARTComponent {
+ public:
+  FakeWire() {
+    this->set_baud_rate(57600);
+    this->set_data_bits(8);
+    this->set_stop_bits(1);
+    this->set_parity(uart::UART_CONFIG_PARITY_EVEN);
+  }
+  void write_array(const uint8_t *data, size_t len) override {
+    this->written.insert(this->written.end(), data, data + len);
+  }
+  bool peek_byte(uint8_t *data) override {
+    if (this->rx_.empty())
+      return false;
+    *data = this->rx_.front();
+    return true;
+  }
+  bool read_array(uint8_t *data, size_t len) override {
+    if (len > this->rx_.size())
+      return false;
+    std::memcpy(data, this->rx_.data(), len);
+    this->rx_.erase(this->rx_.begin(), this->rx_.begin() + len);
+    return true;
+  }
+  size_t available() override { return this->rx_.size(); }
+  uart::UARTFlushResult flush() override { return uart::UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS; }
+#if defined(USE_ESP8266) || defined(USE_ESP32)
+  void load_settings(bool dump_config) override {}
+#endif
+  void check_logger_conflict() override {}
+
+  // A 0x17 request the way the bus controller sends it: write the command block, read the state block back.
+  void inject_poll(uint8_t address, std::initializer_list<uint16_t> command_registers, uint8_t read_count) {
+    std::vector<uint8_t> pdu = {0x17,
+                                0x9C,
+                                0xB9,
+                                0x00,
+                                read_count,
+                                0x9C,
+                                0x41,
+                                0x00,
+                                static_cast<uint8_t>(command_registers.size()),
+                                static_cast<uint8_t>(command_registers.size() * 2)};
+    for (uint16_t value : command_registers) {
+      pdu.push_back(static_cast<uint8_t>(value >> 8));
+      pdu.push_back(static_cast<uint8_t>(value & 0xFF));
+    }
+    const size_t start = this->rx_.size();
+    this->rx_.push_back(address);
+    this->rx_.insert(this->rx_.end(), pdu.begin(), pdu.end());
+    const uint16_t crc = crc16(this->rx_.data() + start, this->rx_.size() - start);
+    this->rx_.push_back(crc & 0xFF);
+    this->rx_.push_back(crc >> 8);
+  }
+
+  // Register i of the first reply since the last clear: address, function code, byte count, then registers.
+  uint16_t reply_register(size_t i) const {
+    const size_t offset = 3 + 2 * i;
+    EXPECT_GE(this->written.size(), offset + 2) << "no register " << i << " on the wire";
+    if (this->written.size() < offset + 2)
+      return 0xFFFF;
+    EXPECT_EQ(this->written[1], 0x17) << "reply is not a read/write response";
+    return static_cast<uint16_t>((this->written[offset] << 8) | this->written[offset + 1]);
+  }
+
+  std::vector<uint8_t> written;
+
+ private:
+  std::vector<uint8_t> rx_;
+};
+
+// The wire is never busy, so no reply is held back through the scheduler, which the host test binary has
+// no working scheduler for.
+class FreeWireHub : public modbus::ModbusServerHub {
+ public:
+  bool tx_blocked() override { return false; }
+  void prime_send_timestamps_for_test() {
+    const uint32_t now = millis();
+    this->last_modbus_byte_ = now;
+    this->last_send_ = now;
+  }
+};
+
+struct BusFixture {
+  BusFixture() {
+    hub.set_uart_parent(&wire);
+    hub.setup();
+    hub.prime_send_timestamps_for_test();
+    door.set_address(0x02);
+    door.pause_ack_timeout_ms_ = 200;
+    door.pause_quiet_ms_ = 1;
+    door.pause_settle_ms_ = 5;
+    door.pause_total_timeout_ms_ = 500;
+    hub.register_device(&door);
+    // The controller has to have talked to us, or there is nobody to announce anything to.
+    wire.inject_poll(0x02, {0x0000, 0x0000}, 8);
+    hub.loop();
+    wire.written.clear();
+  }
+
+  FakeWire wire;
+  FreeWireHub hub;
+  TestableHoermannHcp door;
 };
 
 }  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/hoermann_hcp/common.yaml
+++ b/tests/components/hoermann_hcp/common.yaml
@@ -1,3 +1,9 @@
+esphome:
+  # Only so the action is compiled. Its place in a real configuration is the ota on_begin trigger.
+  on_boot:
+    then:
+      - hoermann_hcp.announce_pause: hoermann_hcp_hub
+
 hoermann_hcp:
   id: hoermann_hcp_hub
   modbus_id: modbus_server_bus

--- a/tests/components/hoermann_hcp/hoermann_hcp_bus_test.cpp
+++ b/tests/components/hoermann_hcp/hoermann_hcp_bus_test.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include "common.h"
+
+// The tests in hoermann_hcp_test.cpp call the register handlers directly, so they say nothing about the
+// announcement reaching a real hub. These drive it through ModbusServerHub and a fake wire instead.
+namespace esphome::hoermann_hcp::testing {
+
+// The whole exchange through the real hub: the announcement serves the bus itself, the controller's
+// acknowledgement arrives as a 0x17 request, is taken, answered on the read half, and the announcement
+// reports success.
+TEST(HoermannHcpBus, AcknowledgementArrivesThroughTheHub) {
+  BusFixture f;
+  f.wire.inject_poll(0x02, {0x8104, 0x1900, 0x0200}, 8);
+
+  EXPECT_TRUE(f.door.announce_pause());
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(0), 0x0100);
+  EXPECT_EQ(f.wire.reply_register(1), 0x04FD);  // the transfer acknowledged
+}
+
+// The first poll during an announcement carries the pause on the wire, not the state.
+TEST(HoermannHcpBus, PauseGoesOutOnTheWire) {
+  BusFixture f;
+  f.door.pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK;
+  f.wire.inject_poll(0x02, {0x3400, 0x0000}, 8);
+
+  f.hub.loop();
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(0), 0x3400);
+  EXPECT_EQ(f.wire.reply_register(1), 0x0029);
+  EXPECT_EQ(f.wire.reply_register(2), 0x0002);
+}
+
+// With the controller polling but never acknowledging, the announcement gives up on time and the device is
+// answering with the state again afterwards.
+TEST(HoermannHcpBus, UnacknowledgedAnnouncementGivesUpAndRecovers) {
+  BusFixture f;
+  f.wire.inject_poll(0x02, {0x0000, 0x0000}, 8);
+
+  EXPECT_FALSE(f.door.announce_pause());
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(1), 0x0029);  // what the poll during the announcement got
+
+  f.wire.written.clear();
+  f.wire.inject_poll(0x02, {0x0000, 0x0000}, 8);
+  f.hub.loop();
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(1), 0x0001);
+}
+
+// A second announcement while one is running would reset the state machine under the first one's feet.
+TEST(HoermannHcpBus, ASecondAnnouncementIsRefusedWhileOneRuns) {
+  BusFixture f;
+  f.door.announcing_ = true;
+
+  EXPECT_FALSE(f.door.announce_pause());
+  EXPECT_EQ(f.door.pause_state_, PauseState::PAUSE_STATE_IDLE);
+}
+
+}  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
+++ b/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
@@ -385,4 +385,311 @@ TEST(HoermannHcpPosition, TargetIsDroppedWhenTheDoorNeverTurnsAround) {
   EXPECT_EQ(poll_command(door).first, 0x0000);
 }
 
+// Puts the device into the state where the next status poll carries the pause, without running the wait.
+inline void start_announcing(TestableHoermannHcp &door) { door.pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK; }
+
+// While a pause is announced, the command poll carries the pause code and the address it applies to instead of
+// the state, and it keeps echoing the controller's counter and command byte as every other answer does.
+TEST(HoermannHcpPause, PausePollNamesOurAddressInsteadOfState) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  door.on_write_registers(COMMAND_REG, make_registers({0x3407, 0x0000}));
+  door.open_door();
+  start_announcing(door);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[0], 0x3400);  // the controller's counter, echoed as every answer echoes it
+  EXPECT_EQ(response[1], 0x0729);  // command byte echoed alongside RESPONSE_PAUSE
+  EXPECT_EQ(response[2], 0x0002);  // the address being paused
+  EXPECT_EQ(response[3], 0x0000);
+}
+
+// Other block lengths keep their ordinary answers, so a bus scan arriving mid announcement still identifies us.
+TEST(HoermannHcpPause, OnlyTheCommandPollCarriesThePause) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 2, response).has_value());
+  ASSERT_EQ(response.size(), 2u);
+  EXPECT_EQ(response[0], 0x0004);
+}
+
+// The controller confirms with a payload transfer naming the address it is pausing, which is answered on the
+// read half of the same request.
+TEST(HoermannHcpPause, AcknowledgementIsTakenAndAnswered) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  // Command 0x04 with running counter 0x81, sub code 0x19, and address 0x0002 astride the last two registers.
+  ASSERT_FALSE(door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200})).has_value());
+  EXPECT_TRUE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[0], 0x0100);  // counter echoed with the split-payload bit masked off
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// The answer belongs to the request that asked for it. Left armed it would replace every later poll, and the
+// pause the controller is waiting on would never be sent again.
+TEST(HoermannHcpPause, TransferIsAnsweredOnlyOnce) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+
+  RegisterValues first;
+  door.on_read_holding_registers(STATE_REG, 8, first);
+  ASSERT_EQ(first.size(), 8u);
+  ASSERT_EQ(first[1], TRANSFER_ACK_ANSWER);
+
+  RegisterValues second;
+  door.on_read_holding_registers(STATE_REG, 8, second);
+  ASSERT_EQ(second.size(), 8u);
+  // Back to announcing the pause, with the transfer's own command byte echoed as every answer echoes it.
+  EXPECT_EQ(second[1], 0x0429);
+}
+
+// A confirmation naming another accessory is still answered, but it is not ours to take.
+TEST(HoermannHcpPause, AcknowledgementForAnotherAddressIsAnsweredButNotTaken) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  ASSERT_FALSE(door.on_write_registers(COMMAND_REG, make_registers({0x0104, 0x1900, 0x0300})).has_value());
+  EXPECT_FALSE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// The address straddles two registers. One whose high half is not ours names a different accessory even when
+// the low half matches.
+TEST(HoermannHcpPause, AcknowledgementWithANonZeroAddressHighHalfIsNotOurs) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  // Address 0x0102: the low half matches, the high half does not.
+  door.on_write_registers(COMMAND_REG, make_registers({0x0104, 0x1901, 0x0200}));
+  EXPECT_FALSE(door.pause_confirmed_);
+}
+
+// Payload transfers carry other sub codes. Only the pause acknowledgement is ours to take, but every transfer
+// is answered rather than left open.
+TEST(HoermannHcpPause, TransferWithAnotherSubCodeIsRefusedRatherThanIgnored) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x2500, 0x0200}));
+  EXPECT_FALSE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_NAK_ANSWER);
+}
+
+// Outside an announcement the command byte alone means nothing: the poll is answered with the ordinary state
+// and no transfer answer is armed to pre-empt the next read.
+TEST(HoermannHcpPause, TransferOutsideAnAnnouncementIsLeftAlone) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+  EXPECT_FALSE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], 0x0401);  // the ordinary state, with the command byte echoed
+}
+
+// A command taken while the pause is out could only be presented afterwards, to a door that has moved on.
+TEST(HoermannHcpPause, CommandsAreRefusedWhileThePauseIsOut) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  EXPECT_FALSE(door.open_door());
+}
+
+// A transfer too short to name an address is still answered. Leaving it open would strand the controller
+// waiting, and the announcement would then run to its timeout for nothing.
+TEST(HoermannHcpPause, AcknowledgementWithoutAnAddressIsStillAnswered) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900}));
+  EXPECT_FALSE(door.pause_confirmed_);  // no address, so nothing to match ours against
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// An answer armed but never read must not survive into the next announcement, where it would pre-empt the
+// pause the controller is waiting for.
+TEST(HoermannHcpPause, AStaleTransferAnswerDoesNotSurviveIntoTheNextAnnouncement) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+  ASSERT_TRUE(door.transfer_answer_pending_);
+
+  // A fresh announcement, without the armed answer ever having been read.
+  door.pause_state_ = PauseState::PAUSE_STATE_IDLE;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  door.pause_total_timeout_ms_ = 20;
+  door.announce_pause();
+  EXPECT_FALSE(door.transfer_answer_pending_);
+}
+
+// Nor across a connection loss: it would be delivered on the first read after the controller returns, which
+// is the bus scan.
+TEST(HoermannHcpPause, AStaleTransferAnswerDoesNotSurviveAConnectionLoss) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+  ASSERT_TRUE(door.transfer_answer_pending_);
+
+  door.set_valid_(false);
+  EXPECT_FALSE(door.transfer_answer_pending_);
+}
+
+// A read too short to carry the answer keeps it for the next one instead of swallowing it, and answers the
+// length that was asked for.
+TEST(HoermannHcpPause, AShortReadKeepsTheTransferAnswer) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+
+  RegisterValues short_read;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 1, short_read).has_value());
+  EXPECT_EQ(short_read.size(), 1u);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// With no bus controller there is nobody to tell, so the announcement returns at once rather than holding up
+// the restart for an answer that cannot come.
+TEST(HoermannHcpPause, AnnouncementWithoutControllerDoesNotWait) {
+  TestableHoermannHcp door;
+  const uint32_t started = millis();
+  EXPECT_FALSE(door.announce_pause());
+  EXPECT_LT(millis() - started, 50u);
+}
+
+// Unconfirmed, the announcement gives up rather than holding the restart for ever, and puts the device back to
+// answering normally so a restart that never happens does not leave it paused.
+TEST(HoermannHcpPause, UnconfirmedAnnouncementGivesUpAndStopsAnnouncing) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  connect_controller(door);
+
+  EXPECT_FALSE(door.announce_pause());
+  door.update();
+
+  RegisterValues response;
+  door.on_read_holding_registers(STATE_REG, 8, response);
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], RESPONSE_STATUS);  // ordinary state again, not the pause
+}
+
+// A key press that was never shown to the controller is dropped, so it cannot fire after the restart.
+TEST(HoermannHcpPause, AnnouncementDropsTheUnsentKeyPress) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  connect_controller(door);
+  door.open_door();
+
+  door.announce_pause();
+  door.update();
+  EXPECT_EQ(poll_command(door).first, 0x0000);
+}
+
+// A press already shown to the controller holds the announcement off, because the pause replaces the answer
+// that would carry its release value and the controller would be left holding a key that is never let go.
+TEST(HoermannHcpPause, AnnouncementIsHeldOffWhileAPressIsUnreleased) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  door.pause_total_timeout_ms_ = 20;
+  connect_controller(door);
+  door.open_door();
+  ASSERT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed, release still owed
+
+  EXPECT_FALSE(door.announce_pause());
+  // No pause was announced, so the poll still carries the release the controller is owed.
+  RegisterValues response;
+  door.on_read_holding_registers(STATE_REG, 8, response);
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], RESPONSE_STATUS);
+  EXPECT_EQ(response[2], 0x0110);  // COMMAND_OPEN released
+}
+
+// Running out of time must not leave the pause standing: it replaces the answer that carries key presses, so
+// the door would stop taking commands until the next restart.
+TEST(HoermannHcpPause, GivingUpDoesNotLeaveThePauseStanding) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5000;  // never reached within the ceiling below
+  door.pause_total_timeout_ms_ = 20;
+  connect_controller(door);
+
+  EXPECT_FALSE(door.announce_pause());
+  door.update();
+  door.open_door();
+  EXPECT_EQ(poll_command(door).first, 0x0210);  // commands are delivered again
+}
+
+// A position the door was told to travel to survives the announcement: without a restart the door still has to
+// be stopped where it was asked to stop.
+TEST(HoermannHcpPause, AnnouncementKeepsTheTravelTarget) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  connect_controller(door);
+  door.set_position(0.5f);
+  consume_command(door);
+  // The door reports it is opening and passes the target, which has to still stop it.
+  door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0000, 0x0100}));
+
+  door.announce_pause();
+  door.update();
+
+  door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0080, 0x0100}));
+  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed, stopping the door
+}
+
 }  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -88,11 +88,14 @@ struct ServerFixture {
 }  // namespace
 
 // Registration is what hands a device its hub, and a device that has one can turn it: the injected frame is
-// answered from service_bus_() alone, with no call to the hub's loop() from the test.
-TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
+// answered from service_bus_() alone, with no call to the hub's loop() from the test. Every registered device
+// gets its own hub, not just the first one.
+TEST(ModbusServerService, ServiceBusRunsAPassForEveryRegisteredDevice) {
   ServerFixture f;
   ServicingDevice device(0x02);
+  ServicingDevice second(0x03);
   f.hub.register_device(&device);
+  f.hub.register_device(&second);
 
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   EXPECT_TRUE(device.pump());
@@ -104,6 +107,7 @@ TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
   EXPECT_EQ(f.uart.written[2], 0x02);
   EXPECT_EQ(f.uart.written[3], 0x12);
   EXPECT_EQ(f.uart.written[4], 0x34);
+  EXPECT_TRUE(second.pump());
 }
 
 // A device that was never registered has no hub to turn, and says so instead of reaching through a null
@@ -113,21 +117,10 @@ TEST(ModbusServerService, ServiceBusIsRefusedWithoutAHub) {
   EXPECT_FALSE(device.pump());
 }
 
-// Each registered device gets its own hub, not just the first one.
-TEST(ModbusServerService, EveryRegisteredDeviceCanTurnTheHub) {
-  ServerFixture f;
-  ServicingDevice first(0x02);
-  ServicingDevice second(0x03);
-  f.hub.register_device(&first);
-  f.hub.register_device(&second);
-
-  EXPECT_TRUE(first.pump());
-  EXPECT_TRUE(second.pump());
-}
-
 // Turning the hub from inside a handler would answer a later frame before the one being handled. The second
-// frame below is what a re-entrant pass would reach for, and it has to wait its turn.
-TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
+// frame below is what a re-entrant pass would reach for, and it has to wait its turn. The refusal lasts only
+// as long as the dispatch: a hub left marked as dispatching would be deaf to every later call.
+TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandlerOnly) {
   ServerFixture f;
   ServicingDevice device(0x02);
   device.service_from_handler = true;
@@ -140,38 +133,14 @@ TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
   // Both frames are answered by this one pass, but one after the other rather than one inside the other.
   EXPECT_EQ(device.reads, 2);
   EXPECT_FALSE(device.reentered);
-}
-
-// The refusal lasts only as long as the dispatch. A hub left marked as dispatching would be deaf to every
-// later call, which is the whole feature gone.
-TEST(ModbusServerService, ServiceBusWorksAgainOnceTheDispatchEnded) {
-  ServerFixture f;
-  ServicingDevice device(0x02);
-  device.service_from_handler = true;
-  f.hub.register_device(&device);
-
-  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
-  f.hub.loop();
-  ASSERT_FALSE(device.serviced_from_handler);
 
   device.service_from_handler = false;
   EXPECT_TRUE(device.pump());
 }
 
-// A reply held back for a busy wire is normally sent by the scheduler, which does not run during the waits
-// service_bus_() exists for. It goes out on the pass instead of being lost.
-TEST(ModbusServerService, HeldBackReplyGoesOutOnThePass) {
-  ServerFixture f;
-  ServicingDevice device(0x02);
-  f.hub.register_device(&device);
-  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
-
-  EXPECT_TRUE(device.pump());
-  EXPECT_FALSE(f.uart.written.empty());
-}
-
-// What held the reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
-// for the next one rather than spending its only attempt on a wire that cannot take it.
+// What held a reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
+// for the next one rather than spending its only attempt on a wire that cannot take it, and goes out there:
+// the scheduler that would otherwise send it does not run during the waits service_bus_() exists for.
 TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
   ServerFixture f;
   ServicingDevice device(0x02);

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -1,0 +1,248 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "common.h"
+#include "esphome/components/modbus/modbus.h"
+
+namespace esphome::modbus {
+
+using testing::InjectableUART;
+
+namespace {
+
+// Reads holding register 0x0000, one register. The device below answers 0x1234, so the reply on the wire is
+// fully determined: address, function code, byte count, value, CRC.
+constexpr uint8_t READ_HOLDING_PDU[] = {0x03, 0x00, 0x00, 0x00, 0x01};
+
+// A server device that answers one holding register and can turn its own hub, which is what a device
+// announcing a restart needs while the main loop is not running.
+class ServicingDevice : public ModbusServerDevice {
+ public:
+  explicit ServicingDevice(uint8_t address) { this->set_address(address); }
+
+  ResponseStatus on_read_holding_registers(uint16_t start_address, uint16_t number_of_registers,
+                                           RegisterValues &registers) override {
+    const int reads_on_entry = ++this->reads;
+    if (this->service_from_handler)
+      this->serviced_from_handler = this->service_bus_();
+    if (this->loop_from_handler) {
+      this->loop_from_handler = false;  // one level only
+      this->hub_->loop();
+      this->serviced_after_nested_loop = this->service_bus_();
+    }
+    // A pass that ran from here would have answered the next frame before this one returned.
+    this->reentered |= this->reads != reads_on_entry;
+    for (uint16_t i = 0; i < number_of_registers; i++)
+      registers.push_back(0x1234);
+    return std::nullopt;
+  }
+
+  bool pump() { return this->service_bus_(); }
+
+  int reads{0};
+  bool service_from_handler{false};
+  bool serviced_from_handler{true};
+  bool reentered{false};
+  // Turns the hub from inside the handler through the public loop(), then asks whether the guard still holds.
+  bool loop_from_handler{false};
+  bool serviced_after_nested_loop{true};
+};
+
+// Lets a test decide when the wire is free, and stash a reply the way send_raw_ does when it is not. Stashed
+// directly because send_raw_'s own deferral arms a scheduler timeout, and reaching the scheduler from the
+// host test binary faults on an uninitialised lock.
+class TestServerHub : public ModbusServerHub {
+ public:
+  bool tx_blocked() override { return this->blocked; }
+
+  void stash_deferred_for_test(uint8_t address, std::span<const uint8_t> pdu) {
+    this->deferred_payload_[0] = address;
+    std::memcpy(this->deferred_payload_.data() + 1, pdu.data(), pdu.size());
+    this->deferred_payload_len_ = static_cast<uint16_t>(pdu.size() + 1);
+  }
+
+  // Without this every reply waits out the real interframe delay.
+  void prime_send_timestamps_for_test() {
+    const uint32_t now = millis();
+    this->last_modbus_byte_ = now;
+    this->last_send_ = now;
+  }
+
+  bool blocked{false};
+};
+
+struct ServerFixture {
+  ServerFixture() {
+    hub.set_uart_parent(&uart);
+    hub.setup();
+    hub.prime_send_timestamps_for_test();
+  }
+
+  InjectableUART uart;
+  TestServerHub hub;
+};
+
+}  // namespace
+
+// Registration is what hands a device its hub, and a device that has one can turn it: the injected frame is
+// answered from service_bus_() alone, with no call to the hub's loop() from the test.
+TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  EXPECT_TRUE(device.pump());
+  EXPECT_EQ(device.reads, 1);
+  // Address, function code, byte count, the register value, then the CRC.
+  ASSERT_EQ(f.uart.written.size(), 7u);
+  EXPECT_EQ(f.uart.written[0], 0x02);
+  EXPECT_EQ(f.uart.written[1], 0x03);
+  EXPECT_EQ(f.uart.written[2], 0x02);
+  EXPECT_EQ(f.uart.written[3], 0x12);
+  EXPECT_EQ(f.uart.written[4], 0x34);
+}
+
+// A device that was never registered has no hub to turn, and says so instead of reaching through a null
+// pointer.
+TEST(ModbusServerService, ServiceBusIsRefusedWithoutAHub) {
+  ServicingDevice device(0x02);
+  EXPECT_FALSE(device.pump());
+}
+
+// Each registered device gets its own hub, not just the first one.
+TEST(ModbusServerService, EveryRegisteredDeviceCanTurnTheHub) {
+  ServerFixture f;
+  ServicingDevice first(0x02);
+  ServicingDevice second(0x03);
+  f.hub.register_device(&first);
+  f.hub.register_device(&second);
+
+  EXPECT_TRUE(first.pump());
+  EXPECT_TRUE(second.pump());
+}
+
+// Turning the hub from inside a handler would answer a later frame before the one being handled. The second
+// frame below is what a re-entrant pass would reach for, and it has to wait its turn.
+TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.service_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  EXPECT_FALSE(device.serviced_from_handler);
+  // Both frames are answered by this one pass, but one after the other rather than one inside the other.
+  EXPECT_EQ(device.reads, 2);
+  EXPECT_FALSE(device.reentered);
+}
+
+// The refusal lasts only as long as the dispatch. A hub left marked as dispatching would be deaf to every
+// later call, which is the whole feature gone.
+TEST(ModbusServerService, ServiceBusWorksAgainOnceTheDispatchEnded) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.service_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  ASSERT_FALSE(device.serviced_from_handler);
+
+  device.service_from_handler = false;
+  EXPECT_TRUE(device.pump());
+}
+
+// A reply held back for a busy wire is normally sent by the scheduler, which does not run during the waits
+// service_bus_() exists for. It goes out on the pass instead of being lost.
+TEST(ModbusServerService, HeldBackReplyGoesOutOnThePass) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// What held the reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
+// for the next one rather than spending its only attempt on a wire that cannot take it.
+TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.blocked = true;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+
+  f.hub.blocked = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// The held-back reply belongs to one request. Sending it twice would put a stale answer on the wire behind a
+// newer one.
+TEST(ModbusServerService, HeldBackReplyIsSentOnlyOnce) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  device.pump();
+  const size_t after_first = f.uart.written.size();
+  ASSERT_GT(after_first, 0u);
+
+  device.pump();
+  EXPECT_EQ(f.uart.written.size(), after_first);
+}
+
+// With nothing held back and nothing arriving, a pass says nothing. Reading a reply out of an empty buffer
+// would build a frame from a length of zero.
+TEST(ModbusServerService, PassWithNothingPendingWritesNothing) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_EQ(device.reads, 0);
+}
+
+// A reply held back earlier goes out before the pass can produce a newer one, so the two cannot reach the
+// wire in the wrong order.
+TEST(ModbusServerService, HeldBackReplyGoesOutBeforeTheNewOne) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+
+  EXPECT_TRUE(device.pump());
+  ASSERT_GE(f.uart.written.size(), 8u);
+  // The stashed frame is the request echoed back, so its third byte is 0x00; the pass's own reply carries a
+  // byte count of 0x02 there.
+  EXPECT_EQ(f.uart.written[2], 0x00);
+}
+
+// The guard is restored rather than cleared, so a nested pass through the public loop() cannot release the
+// dispatch the outer frame is still inside.
+TEST(ModbusServerService, ANestedPassDoesNotReleaseTheOuterDispatch) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.loop_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  EXPECT_FALSE(device.serviced_after_nested_loop);
+}
+
+}  // namespace esphome::modbus


### PR DESCRIPTION
# What does this implement/fix?

`hoermann_hcp` goes silent when the device restarts, and the motor's bus
controller reports a fault. HCP2 has a pause handshake for this; the
component now uses it.

- `modbus`: `ModbusServerHub::service()` and `ModbusServerDevice::service_bus_()`
  let a server device keep answering while the main loop is blocked. Refused
  while the hub is dispatching a frame.
- `hoermann_hcp`: `on_shutdown()` answers the status poll with `0x29` and our
  address, waits up to 800 ms for the controller's `0x04`/`0x19` acknowledgement,
  then for a gap on the bus. Bounded at 1.5 s per hub, whether or not the
  controller answers.
- `hoermann_hcp.announce_pause` action for `ota: on_begin`, since an update
  writes flash long before `on_shutdown()` runs.

Not `teardown()`: every `on_shutdown()` runs first, and
`IDFUARTComponent::on_shutdown()` deletes the UART driver. Moving that to
`on_powerdown()` would make this non-blocking, but it changes `uart` for every
platform. `service()` would still be needed either way, since teardown does not
run `loop()` either.

The same handshake runs on two Series 4 motors in a fork of mine. This port has
not talked to a motor yet.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome#18739

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7345

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
hoermann_hcp:
  id: garage_hcp

ota:
  - platform: esphome
    on_begin:
      then:
        - hoermann_hcp.announce_pause:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
