### PR TITLE
[esphome][core] Give a lost OTA chunk ack time to be retransmitted

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -41,7 +41,10 @@ const noise::NoiseContext &ESPHomeOTAComponent::noise_context_() const {
 #endif
 static constexpr uint16_t OTA_BLOCK_SIZE = 8192;
 static constexpr uint32_t OTA_SOCKET_TIMEOUT_HANDSHAKE = 20000;  // milliseconds for initial handshake
-static constexpr uint32_t OTA_SOCKET_TIMEOUT_DATA = 90000;       // milliseconds for data transfer
+// Milliseconds for data transfer. Outlasts lwIP retransmitting a lost chunk ack
+// six times (1.5 + 3 + 6 + 12 + 24 + 48 s); the CLI waits longer (160 s) so the
+// device is always free again before the CLI retries
+static constexpr uint32_t OTA_SOCKET_TIMEOUT_DATA = 105000;
 
 // Single-instance pointer — multi-port configs are rejected in final_validate.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -41,9 +41,9 @@ const noise::NoiseContext &ESPHomeOTAComponent::noise_context_() const {
 #endif
 static constexpr uint16_t OTA_BLOCK_SIZE = 8192;
 static constexpr uint32_t OTA_SOCKET_TIMEOUT_HANDSHAKE = 20000;  // milliseconds for initial handshake
-// Milliseconds for data transfer. Outlasts lwIP retransmitting a lost chunk ack
-// six times (1.5 + 3 + 6 + 12 + 24 + 48 s); the CLI waits longer (160 s) so the
-// device is always free again before the CLI retries
+// Milliseconds for data transfer. Covers the lwIP retransmit run seen in
+// practice for a lost chunk ack (1.5 + 3 + 6 + 12 + 24 + 48 s); the CLI waits
+// longer (espota2.DATA_PHASE_TIMEOUT) so the device is free before it retries
 static constexpr uint32_t OTA_SOCKET_TIMEOUT_DATA = 105000;
 
 // Single-instance pointer — multi-port configs are rejected in final_validate.

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -96,6 +96,10 @@ UPLOAD_BUFFER_SIZE = UPLOAD_BLOCK_SIZE * 8
 # across the addresses on top of that.
 EXTRA_UPLOAD_ATTEMPTS = 2
 UPLOAD_RETRY_DELAY = 5.0
+# Data phase timeout; must stay longer than the device's OTA_SOCKET_TIMEOUT_DATA
+# (105 s) so a stalled session is gone before a retry, and long enough for lwIP
+# to get a lost chunk ack through after the retransmit run seen in practice
+DATA_PHASE_TIMEOUT = 160.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -694,10 +698,7 @@ def perform_ota(
 
     _LOGGER.info("Handshake complete")
 
-    # Longer than the device's OTA_SOCKET_TIMEOUT_DATA (105 s) so a stalled
-    # session is gone before a retry, and long enough for lwIP to get a lost
-    # chunk ack through after six retransmissions
-    sock.settimeout(160.0)
+    sock.settimeout(DATA_PHASE_TIMEOUT)
 
     if extended_proto:
         send_check(sock, ota_type, "ota type")

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -694,8 +694,10 @@ def perform_ota(
 
     _LOGGER.info("Handshake complete")
 
-    # Timeout must match device-side OTA_SOCKET_TIMEOUT_DATA to prevent premature failures
-    sock.settimeout(90.0)
+    # Longer than the device's OTA_SOCKET_TIMEOUT_DATA (105 s) so a stalled
+    # session is gone before a retry, and long enough for lwIP to get a lost
+    # chunk ack through after six retransmissions
+    sock.settimeout(160.0)
 
     if extended_proto:
         send_check(sock, ota_type, "ota type")
@@ -854,7 +856,7 @@ def run_ota_impl_(
     # clean up a half-open connection (its handshake watchdog runs at 20s);
     # moving on to the next address family stays immediate. Known limitation:
     # a silent mid-transfer drop with no reset can wedge the device until its
-    # 90s data timeout, which outlasts this budget; the retries target the
+    # 105s data timeout, which outlasts this budget; the retries target the
     # common failures where the device resets or closes the link promptly.
     total_attempts = len(res) + EXTRA_UPLOAD_ATTEMPTS
     last_error = ""

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -754,8 +754,12 @@ def test_run_ota_impl_successful(
     assert result_code == 0
     assert result_host == "192.168.1.100"
 
-    # Verify socket was configured correctly
-    mock_socket.settimeout.assert_called_with(20.0)
+    # Verify socket was configured correctly: connect timeout first, then the
+    # data phase timeout, which must outlast the device's 105 s data timeout
+    timeouts = [c.args[0] for c in mock_socket.settimeout.call_args_list]
+    assert timeouts[0] == 20.0
+    assert espota2.DATA_PHASE_TIMEOUT in timeouts
+    assert espota2.DATA_PHASE_TIMEOUT > 105.0
     mock_socket.connect.assert_called_once_with(("192.168.1.100", 3232))
     mock_socket.close.assert_called_once()
 

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -416,6 +416,9 @@ def test_perform_ota_no_auth(
         "Update took 14.00 seconds (prepare 2.00, upload 5.00, commit 7.00)"
         in caplog.text
     )
+    # The data phase timeout must outlast the device's 105 s data timeout
+    mock_socket.settimeout.assert_any_call(espota2.DATA_PHASE_TIMEOUT)
+    assert espota2.DATA_PHASE_TIMEOUT > 105.0
 
 
 @pytest.mark.usefixtures("mock_time")
@@ -754,12 +757,8 @@ def test_run_ota_impl_successful(
     assert result_code == 0
     assert result_host == "192.168.1.100"
 
-    # Verify socket was configured correctly: connect timeout first, then the
-    # data phase timeout, which must outlast the device's 105 s data timeout
-    timeouts = [c.args[0] for c in mock_socket.settimeout.call_args_list]
-    assert timeouts[0] == 20.0
-    assert espota2.DATA_PHASE_TIMEOUT in timeouts
-    assert espota2.DATA_PHASE_TIMEOUT > 105.0
+    # Verify socket was configured correctly
+    mock_socket.settimeout.assert_called_with(20.0)
     mock_socket.connect.assert_called_once_with(("192.168.1.100", 3232))
     mock_socket.close.assert_called_once()
 


### PR DESCRIPTION
# What does this implement/fix?

On a lossy link an OTA upload can fail although the connection is alive. The device acks every 8 KB block with one byte; when that byte is lost, lwIP retransmits it at 1.5, 3, 6, 12, 24 and 48 s, so six drops in a row mean 94.5 s of silence. Both the device's data timeout and the CLI's ack timeout were 90 s, so the upload was abandoned just before the ack got through; and because both expired at the same moment, the CLI's retry connected while the device was still tearing down the old session and started its next 90 s window behind it.

The device now waits 105 s for data and the CLI 160 s for an ack: the device outlasts the retransmit run, and the CLI outlasts the device, so a retry always finds the device free. A peer that really vanished holds the device 15 s longer than before, and the CLI now waits 160 s instead of 90 s per attempt before it reports a silent device, so with the usual four attempts the worst case grows from about six minutes to about eleven. The retry count is unchanged.

Seen on an ESP32 with 40% packet loss simulated on the link (dummynet), where one upload in four stalled on exactly this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
