### PR TITLE
[modbus] Let a server device keep answering during a bounded wait

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -1230,6 +1230,9 @@ void ModbusServerHub::send_raw_(const uint8_t *payload, uint16_t len) {
     return;
   }
 
+  // Anything still stashed is older than the reply going out now, and the controller has moved on to the
+  // request this one answers. Sending it later would put a stale frame on the wire behind a newer one.
+  this->deferred_payload_len_ = 0;
   ModbusFrame frame(payload[0], payload + 1, len - 1);
   if (!this->send_frame_(frame)) {
     ESP_LOGE(TAG, "Server reply dropped: a frame arrived during the send delay");

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -420,8 +420,9 @@ bool ModbusServerHub::service() {
   // the single reply this hub can hold back.
   if (this->in_dispatch_)
     return false;
-  // Owed first, so a reply held back earlier cannot end up on the wire behind one this pass produces. The
-  // scheduler that would otherwise send it does not run during the waits this method exists for.
+  // Owed first, so a reply held back earlier goes out ahead of one this pass produces, unless the wire cannot
+  // take it yet; then it waits for the next pass. The scheduler that would otherwise send it does not run
+  // during the waits this method exists for.
   this->send_deferred_(false);
   this->loop();
   return true;
@@ -1248,8 +1249,12 @@ void ModbusServerHub::send_deferred_(bool drop_if_blocked) {
   // is still a busy wire rather than a reply the controller has stopped waiting for.
   if (sent || drop_if_blocked)
     this->deferred_payload_len_ = 0;
-  if (!sent) {
-    ESP_LOGE(TAG, "Deferred server reply %s: transmission still blocked", drop_if_blocked ? "dropped" : "held");
+  if (sent)
+    return;
+  if (drop_if_blocked) {
+    ESP_LOGE(TAG, "Deferred server reply dropped: transmission still blocked");
+  } else {
+    ESP_LOGV(TAG, "Deferred server reply held: a byte arrived during the send delay, next pass retries");
   }
 }
 

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -412,10 +412,10 @@ void ModbusServerHub::register_device(ModbusServerDevice *device) {
 bool ModbusServerDevice::service_bus_() {
   if (this->hub_ == nullptr)
     return false;
-  return this->hub_->service();
+  return this->hub_->service_();
 }
 
-bool ModbusServerHub::service() {
+bool ModbusServerHub::service_() {
   // Re-entering from a handler would answer a later frame before the one being handled, and would overwrite
   // the single reply this hub can hold back.
   if (this->in_dispatch_)

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -319,6 +319,13 @@ bool ModbusServerHub::parse_modbus_client_frame_() {
   std::span<const uint8_t> data(data_buffer, data_len);
   this->clear_rx_buffer_(LOG_STR("parse succeeded"), false, frame_length);
 
+  // This frame means the controller has moved on from the request a held reply answers. Clearing here rather
+  // than at the send also covers the frames we do not answer: a broadcast, or a request to another device.
+  if (this->deferred_payload_len_ != 0) {
+    ESP_LOGV(TAG, "Discarding a held server reply: a newer request arrived");
+    this->deferred_payload_len_ = 0;
+  }
+
   // Restored rather than cleared: loop() is public, so a nested pass must not free the outer dispatch.
   const bool was_dispatching = this->in_dispatch_;
   this->in_dispatch_ = true;
@@ -1230,9 +1237,6 @@ void ModbusServerHub::send_raw_(const uint8_t *payload, uint16_t len) {
     return;
   }
 
-  // Anything still stashed is older than the reply going out now, and the controller has moved on to the
-  // request this one answers. Sending it later would put a stale frame on the wire behind a newer one.
-  this->deferred_payload_len_ = 0;
   ModbusFrame frame(payload[0], payload + 1, len - 1);
   if (!this->send_frame_(frame)) {
     ESP_LOGE(TAG, "Server reply dropped: a frame arrived during the send delay");

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -319,12 +319,16 @@ bool ModbusServerHub::parse_modbus_client_frame_() {
   std::span<const uint8_t> data(data_buffer, data_len);
   this->clear_rx_buffer_(LOG_STR("parse succeeded"), false, frame_length);
 
+  // Restored rather than cleared: loop() is public, so a nested pass must not free the outer dispatch.
+  const bool was_dispatching = this->in_dispatch_;
+  this->in_dispatch_ = true;
   if (address == BROADCAST_ADDRESS) {
     // Keep the unicast response buffers out of the broadcast call chain.
     this->process_broadcast_frame_(function_code, data);
   } else {
     this->process_modbus_client_frame_(address, function_code, data);
   }
+  this->in_dispatch_ = was_dispatching;
 
   return true;
 }
@@ -397,6 +401,30 @@ void ModbusServerHub::process_modbus_server_frame(uint8_t address, std::span<con
   // This always resets, even if the address doesn't match.
   // If an unexpected response is received, we can't trust that a correct response will follow (it shouldn't).
   this->expecting_peer_response_ = 0;
+}
+
+// Out of line: ModbusServerDevice is not yet defined at this point in the header.
+void ModbusServerHub::register_device(ModbusServerDevice *device) {
+  device->hub_ = this;
+  this->devices_.push_back(device);
+}
+
+bool ModbusServerDevice::service_bus_() {
+  if (this->hub_ == nullptr)
+    return false;
+  return this->hub_->service();
+}
+
+bool ModbusServerHub::service() {
+  // Re-entering from a handler would answer a later frame before the one being handled, and would overwrite
+  // the single reply this hub can hold back.
+  if (this->in_dispatch_)
+    return false;
+  // Owed first, so a reply held back earlier cannot end up on the wire behind one this pass produces. The
+  // scheduler that would otherwise send it does not run during the waits this method exists for.
+  this->send_deferred_(false);
+  this->loop();
+  return true;
 }
 
 ModbusServerDevice *ModbusServerHub::find_device_(uint8_t address) {
@@ -1196,19 +1224,32 @@ void ModbusServerHub::send_raw_(const uint8_t *payload, uint16_t len) {
     std::memcpy(this->deferred_payload_.data(), payload, len);
     this->deferred_payload_len_ = len;
     // set_timeout() takes milliseconds; round the microsecond delay up so we never fire early.
-    this->set_timeout("deferred_send", (this->tx_delay_remaining() + US_PER_MS - 1) / US_PER_MS, [this]() {
-      ModbusFrame frame(this->deferred_payload_[0], this->deferred_payload_.data() + 1,
-                        this->deferred_payload_len_ - 1);
-      if (!this->send_frame_(frame)) {
-        ESP_LOGE(TAG, "Deferred server reply dropped: transmission still blocked");
-      }
-    });
+    this->set_timeout("deferred_send", (this->tx_delay_remaining() + US_PER_MS - 1) / US_PER_MS,
+                      [this]() { this->send_deferred_(true); });
     return;
   }
 
   ModbusFrame frame(payload[0], payload + 1, len - 1);
   if (!this->send_frame_(frame)) {
     ESP_LOGE(TAG, "Server reply dropped: a frame arrived during the send delay");
+  }
+}
+
+void ModbusServerHub::send_deferred_(bool drop_if_blocked) {
+  if (this->deferred_payload_len_ == 0)
+    return;
+  // What blocked the send is usually bytes still arriving, and waiting here would not drain them. A caller
+  // that comes back keeps the reply instead of spending its only attempt on a wire that cannot take it.
+  if (!drop_if_blocked && this->tx_blocked())
+    return;
+  ModbusFrame frame(this->deferred_payload_[0], this->deferred_payload_.data() + 1, this->deferred_payload_len_ - 1);
+  const bool sent = this->send_frame_(frame);
+  // Kept only for a caller that is coming back: send_frame_ re-checks after its own delay, so a failure here
+  // is still a busy wire rather than a reply the controller has stopped waiting for.
+  if (sent || drop_if_blocked)
+    this->deferred_payload_len_ = 0;
+  if (!sent) {
+    ESP_LOGE(TAG, "Deferred server reply %s: transmission still blocked", drop_if_blocked ? "dropped" : "held");
   }
 }
 

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -375,7 +375,7 @@ class ModbusServerHub : public Modbus {
   /// keep the reply for the next pass.
   void send_deferred_(bool drop_if_blocked);
   uint8_t expecting_peer_response_{0};
-  // Set while a frame is being handed to a device, so service() cannot be re-entered from a handler.
+  // Set while a frame is being handed to a device, so service_() cannot be re-entered from a handler.
   bool in_dispatch_{false};
   std::vector<ModbusServerDevice *> devices_;
 
@@ -666,8 +666,12 @@ class ModbusServerDevice {
   /// is registered.
   bool service_bus_();
 
-  ModbusServerHub *hub_{nullptr};
   uint8_t address_{0};
+
+ private:
+  // Private, not protected: the hub's loop() is public, so a device holding the pointer could dispatch a
+  // frame from inside a handler and answer a later one first. service_bus_() is the only way through.
+  ModbusServerHub *hub_{nullptr};
 
   friend class ModbusServerHub;
 };

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -317,7 +317,12 @@ class ModbusServerHub : public Modbus {
  public:
   ModbusServerHub() = default;
   void dump_config() override;
-  void register_device(ModbusServerDevice *device) { this->devices_.push_back(device); }
+  void register_device(ModbusServerDevice *device);
+  /// Runs one pass of the bus and sends anything a device is still owed. For a device that has to keep
+  /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
+  /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
+  /// re-enter it.
+  bool service();
 
  protected:
   void parse_modbus_frames() override;
@@ -363,7 +368,13 @@ class ModbusServerHub : public Modbus {
   bool rejected_(uint8_t address, uint8_t function_code, ResponseStatus status);
   void send_exception_(uint8_t address, uint8_t function_code, ExceptionCode exception_code);
   void send_response_(uint8_t address, uint8_t function_code, const uint8_t *payload, uint16_t payload_len);
+  /// Sends a reply that was held back, if one is waiting. With drop_if_blocked the reply is given its one
+  /// chance and discarded, which is what the scheduler timeout wants; without it a busy wire is a reason to
+  /// keep the reply for the next pass.
+  void send_deferred_(bool drop_if_blocked);
   uint8_t expecting_peer_response_{0};
+  // Set while a frame is being handed to a device, so service() cannot be re-entered from a handler.
+  bool in_dispatch_{false};
   std::vector<ModbusServerDevice *> devices_;
 
   // Holds the raw payload of a single reply deferred for sending when tx was blocked at send time.
@@ -648,7 +659,15 @@ class ModbusServerDevice {
   };
 
  protected:
+  /// Runs one pass of the bus, so a device can keep answering during a bounded wait the main loop does not
+  /// cover. Returns whether it ran: it does not while the hub is dispatching a frame, or before the device
+  /// is registered.
+  bool service_bus_();
+
+  ModbusServerHub *hub_{nullptr};
   uint8_t address_{0};
+
+  friend class ModbusServerHub;
 };
 
 }  // namespace esphome::modbus

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -324,7 +324,7 @@ class ModbusServerHub : public Modbus {
   /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
   /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
   /// re-enter it. Reached through ModbusServerDevice::service_bus_() only.
-  bool service();
+  bool service_();
   friend class ModbusServerDevice;
 
   void parse_modbus_frames() override;

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -318,13 +318,15 @@ class ModbusServerHub : public Modbus {
   ModbusServerHub() = default;
   void dump_config() override;
   void register_device(ModbusServerDevice *device);
+
+ protected:
   /// Runs one pass of the bus and sends anything a device is still owed. For a device that has to keep
   /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
   /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
-  /// re-enter it.
+  /// re-enter it. Reached through ModbusServerDevice::service_bus_() only.
   bool service();
+  friend class ModbusServerDevice;
 
- protected:
   void parse_modbus_frames() override;
   bool parse_modbus_client_frame_();
   void process_modbus_server_frame(uint8_t address, std::span<const uint8_t> pdu) override;

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -88,11 +88,14 @@ struct ServerFixture {
 }  // namespace
 
 // Registration is what hands a device its hub, and a device that has one can turn it: the injected frame is
-// answered from service_bus_() alone, with no call to the hub's loop() from the test.
-TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
+// answered from service_bus_() alone, with no call to the hub's loop() from the test. Every registered device
+// gets its own hub, not just the first one.
+TEST(ModbusServerService, ServiceBusRunsAPassForEveryRegisteredDevice) {
   ServerFixture f;
   ServicingDevice device(0x02);
+  ServicingDevice second(0x03);
   f.hub.register_device(&device);
+  f.hub.register_device(&second);
 
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   EXPECT_TRUE(device.pump());
@@ -104,6 +107,7 @@ TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
   EXPECT_EQ(f.uart.written[2], 0x02);
   EXPECT_EQ(f.uart.written[3], 0x12);
   EXPECT_EQ(f.uart.written[4], 0x34);
+  EXPECT_TRUE(second.pump());
 }
 
 // A device that was never registered has no hub to turn, and says so instead of reaching through a null
@@ -113,21 +117,10 @@ TEST(ModbusServerService, ServiceBusIsRefusedWithoutAHub) {
   EXPECT_FALSE(device.pump());
 }
 
-// Each registered device gets its own hub, not just the first one.
-TEST(ModbusServerService, EveryRegisteredDeviceCanTurnTheHub) {
-  ServerFixture f;
-  ServicingDevice first(0x02);
-  ServicingDevice second(0x03);
-  f.hub.register_device(&first);
-  f.hub.register_device(&second);
-
-  EXPECT_TRUE(first.pump());
-  EXPECT_TRUE(second.pump());
-}
-
 // Turning the hub from inside a handler would answer a later frame before the one being handled. The second
-// frame below is what a re-entrant pass would reach for, and it has to wait its turn.
-TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
+// frame below is what a re-entrant pass would reach for, and it has to wait its turn. The refusal lasts only
+// as long as the dispatch: a hub left marked as dispatching would be deaf to every later call.
+TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandlerOnly) {
   ServerFixture f;
   ServicingDevice device(0x02);
   device.service_from_handler = true;
@@ -140,38 +133,14 @@ TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
   // Both frames are answered by this one pass, but one after the other rather than one inside the other.
   EXPECT_EQ(device.reads, 2);
   EXPECT_FALSE(device.reentered);
-}
-
-// The refusal lasts only as long as the dispatch. A hub left marked as dispatching would be deaf to every
-// later call, which is the whole feature gone.
-TEST(ModbusServerService, ServiceBusWorksAgainOnceTheDispatchEnded) {
-  ServerFixture f;
-  ServicingDevice device(0x02);
-  device.service_from_handler = true;
-  f.hub.register_device(&device);
-
-  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
-  f.hub.loop();
-  ASSERT_FALSE(device.serviced_from_handler);
 
   device.service_from_handler = false;
   EXPECT_TRUE(device.pump());
 }
 
-// A reply held back for a busy wire is normally sent by the scheduler, which does not run during the waits
-// service_bus_() exists for. It goes out on the pass instead of being lost.
-TEST(ModbusServerService, HeldBackReplyGoesOutOnThePass) {
-  ServerFixture f;
-  ServicingDevice device(0x02);
-  f.hub.register_device(&device);
-  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
-
-  EXPECT_TRUE(device.pump());
-  EXPECT_FALSE(f.uart.written.empty());
-}
-
-// What held the reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
-// for the next one rather than spending its only attempt on a wire that cannot take it.
+// What held a reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
+// for the next one rather than spending its only attempt on a wire that cannot take it, and goes out there:
+// the scheduler that would otherwise send it does not run during the waits service_bus_() exists for.
 TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
   ServerFixture f;
   ServicingDevice device(0x02);

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -1,0 +1,248 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "common.h"
+#include "esphome/components/modbus/modbus.h"
+
+namespace esphome::modbus {
+
+using testing::InjectableUART;
+
+namespace {
+
+// Reads holding register 0x0000, one register. The device below answers 0x1234, so the reply on the wire is
+// fully determined: address, function code, byte count, value, CRC.
+constexpr uint8_t READ_HOLDING_PDU[] = {0x03, 0x00, 0x00, 0x00, 0x01};
+
+// A server device that answers one holding register and can turn its own hub, which is what a device
+// announcing a restart needs while the main loop is not running.
+class ServicingDevice : public ModbusServerDevice {
+ public:
+  explicit ServicingDevice(uint8_t address) { this->set_address(address); }
+
+  ResponseStatus on_read_holding_registers(uint16_t start_address, uint16_t number_of_registers,
+                                           RegisterValues &registers) override {
+    const int reads_on_entry = ++this->reads;
+    if (this->service_from_handler)
+      this->serviced_from_handler = this->service_bus_();
+    if (this->loop_from_handler) {
+      this->loop_from_handler = false;  // one level only
+      this->hub_->loop();
+      this->serviced_after_nested_loop = this->service_bus_();
+    }
+    // A pass that ran from here would have answered the next frame before this one returned.
+    this->reentered |= this->reads != reads_on_entry;
+    for (uint16_t i = 0; i < number_of_registers; i++)
+      registers.push_back(0x1234);
+    return std::nullopt;
+  }
+
+  bool pump() { return this->service_bus_(); }
+
+  int reads{0};
+  bool service_from_handler{false};
+  bool serviced_from_handler{true};
+  bool reentered{false};
+  // Turns the hub from inside the handler through the public loop(), then asks whether the guard still holds.
+  bool loop_from_handler{false};
+  bool serviced_after_nested_loop{true};
+};
+
+// Lets a test decide when the wire is free, and stash a reply the way send_raw_ does when it is not. Stashed
+// directly because send_raw_'s own deferral arms a scheduler timeout, and reaching the scheduler from the
+// host test binary faults on an uninitialised lock.
+class TestServerHub : public ModbusServerHub {
+ public:
+  bool tx_blocked() override { return this->blocked; }
+
+  void stash_deferred_for_test(uint8_t address, std::span<const uint8_t> pdu) {
+    this->deferred_payload_[0] = address;
+    std::memcpy(this->deferred_payload_.data() + 1, pdu.data(), pdu.size());
+    this->deferred_payload_len_ = static_cast<uint16_t>(pdu.size() + 1);
+  }
+
+  // Without this every reply waits out the real interframe delay.
+  void prime_send_timestamps_for_test() {
+    const uint32_t now = millis();
+    this->last_modbus_byte_ = now;
+    this->last_send_ = now;
+  }
+
+  bool blocked{false};
+};
+
+struct ServerFixture {
+  ServerFixture() {
+    hub.set_uart_parent(&uart);
+    hub.setup();
+    hub.prime_send_timestamps_for_test();
+  }
+
+  InjectableUART uart;
+  TestServerHub hub;
+};
+
+}  // namespace
+
+// Registration is what hands a device its hub, and a device that has one can turn it: the injected frame is
+// answered from service_bus_() alone, with no call to the hub's loop() from the test.
+TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  EXPECT_TRUE(device.pump());
+  EXPECT_EQ(device.reads, 1);
+  // Address, function code, byte count, the register value, then the CRC.
+  ASSERT_EQ(f.uart.written.size(), 7u);
+  EXPECT_EQ(f.uart.written[0], 0x02);
+  EXPECT_EQ(f.uart.written[1], 0x03);
+  EXPECT_EQ(f.uart.written[2], 0x02);
+  EXPECT_EQ(f.uart.written[3], 0x12);
+  EXPECT_EQ(f.uart.written[4], 0x34);
+}
+
+// A device that was never registered has no hub to turn, and says so instead of reaching through a null
+// pointer.
+TEST(ModbusServerService, ServiceBusIsRefusedWithoutAHub) {
+  ServicingDevice device(0x02);
+  EXPECT_FALSE(device.pump());
+}
+
+// Each registered device gets its own hub, not just the first one.
+TEST(ModbusServerService, EveryRegisteredDeviceCanTurnTheHub) {
+  ServerFixture f;
+  ServicingDevice first(0x02);
+  ServicingDevice second(0x03);
+  f.hub.register_device(&first);
+  f.hub.register_device(&second);
+
+  EXPECT_TRUE(first.pump());
+  EXPECT_TRUE(second.pump());
+}
+
+// Turning the hub from inside a handler would answer a later frame before the one being handled. The second
+// frame below is what a re-entrant pass would reach for, and it has to wait its turn.
+TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.service_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  EXPECT_FALSE(device.serviced_from_handler);
+  // Both frames are answered by this one pass, but one after the other rather than one inside the other.
+  EXPECT_EQ(device.reads, 2);
+  EXPECT_FALSE(device.reentered);
+}
+
+// The refusal lasts only as long as the dispatch. A hub left marked as dispatching would be deaf to every
+// later call, which is the whole feature gone.
+TEST(ModbusServerService, ServiceBusWorksAgainOnceTheDispatchEnded) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.service_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  ASSERT_FALSE(device.serviced_from_handler);
+
+  device.service_from_handler = false;
+  EXPECT_TRUE(device.pump());
+}
+
+// A reply held back for a busy wire is normally sent by the scheduler, which does not run during the waits
+// service_bus_() exists for. It goes out on the pass instead of being lost.
+TEST(ModbusServerService, HeldBackReplyGoesOutOnThePass) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// What held the reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
+// for the next one rather than spending its only attempt on a wire that cannot take it.
+TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.blocked = true;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+
+  f.hub.blocked = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// The held-back reply belongs to one request. Sending it twice would put a stale answer on the wire behind a
+// newer one.
+TEST(ModbusServerService, HeldBackReplyIsSentOnlyOnce) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  device.pump();
+  const size_t after_first = f.uart.written.size();
+  ASSERT_GT(after_first, 0u);
+
+  device.pump();
+  EXPECT_EQ(f.uart.written.size(), after_first);
+}
+
+// With nothing held back and nothing arriving, a pass says nothing. Reading a reply out of an empty buffer
+// would build a frame from a length of zero.
+TEST(ModbusServerService, PassWithNothingPendingWritesNothing) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_EQ(device.reads, 0);
+}
+
+// A reply held back earlier goes out before the pass can produce a newer one, so the two cannot reach the
+// wire in the wrong order.
+TEST(ModbusServerService, HeldBackReplyGoesOutBeforeTheNewOne) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+
+  EXPECT_TRUE(device.pump());
+  ASSERT_GE(f.uart.written.size(), 8u);
+  // The stashed frame is the request echoed back, so its third byte is 0x00; the pass's own reply carries a
+  // byte count of 0x02 there.
+  EXPECT_EQ(f.uart.written[2], 0x00);
+}
+
+// The guard is restored rather than cleared, so a nested pass through the public loop() cannot release the
+// dispatch the outer frame is still inside.
+TEST(ModbusServerService, ANestedPassDoesNotReleaseTheOuterDispatch) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.loop_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  EXPECT_FALSE(device.serviced_after_nested_loop);
+}
+
+}  // namespace esphome::modbus

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -56,7 +56,13 @@ class ServicingDevice : public ModbusServerDevice {
 // host test binary faults on an uninitialised lock.
 class TestServerHub : public ModbusServerHub {
  public:
-  bool tx_blocked() override { return this->blocked; }
+  // With block_on_recheck the wire is free at the first check and busy at send_frame_'s own re-check, which
+  // is a byte arriving during the send delay.
+  bool tx_blocked() override {
+    if (this->block_on_recheck)
+      return this->checks_++ > 0;
+    return this->blocked;
+  }
 
   void stash_deferred_for_test(uint8_t address, std::span<const uint8_t> pdu) {
     this->deferred_payload_[0] = address;
@@ -64,21 +70,22 @@ class TestServerHub : public ModbusServerHub {
     this->deferred_payload_len_ = static_cast<uint16_t>(pdu.size() + 1);
   }
 
-  // Without this every reply waits out the real interframe delay.
-  void prime_send_timestamps_for_test() {
-    const uint32_t now = millis();
-    this->last_modbus_byte_ = now;
-    this->last_send_ = now;
-  }
+  // What the scheduler timeout does, without the scheduler.
+  void drop_deferred_for_test() { this->send_deferred_(true); }
+
+  bool has_deferred() const { return this->deferred_payload_len_ != 0; }
 
   bool blocked{false};
+  bool block_on_recheck{false};
+
+ private:
+  int checks_{0};
 };
 
 struct ServerFixture {
   ServerFixture() {
     hub.set_uart_parent(&uart);
     hub.setup();
-    hub.prime_send_timestamps_for_test();
   }
 
   InjectableUART uart;
@@ -156,6 +163,42 @@ TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
   EXPECT_FALSE(f.uart.written.empty());
 }
 
+// The wire can also turn busy between the pass's own check and the send: a byte arriving during the send
+// delay. That is still a busy wire, not a reply nobody waits for, so it is kept as well.
+TEST(ModbusServerService, ReplyBlockedDuringTheSendDelayIsKept) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.block_on_recheck = true;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_TRUE(f.hub.has_deferred());
+
+  f.hub.block_on_recheck = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// The scheduler gives the reply its one chance and lets it go. A pass afterwards must not find it and put a
+// reply the controller has stopped waiting for on the wire behind newer traffic.
+TEST(ModbusServerService, ReplyDroppedByTheSchedulerIsNotSentByALaterPass) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.blocked = true;
+  f.hub.drop_deferred_for_test();
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_FALSE(f.hub.has_deferred());
+
+  f.hub.blocked = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+}
+
 // The held-back reply belongs to one request. Sending it twice would put a stale answer on the wire behind a
 // newer one.
 TEST(ModbusServerService, HeldBackReplyIsSentOnlyOnce) {
@@ -194,10 +237,12 @@ TEST(ModbusServerService, HeldBackReplyGoesOutBeforeTheNewOne) {
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
 
   EXPECT_TRUE(device.pump());
-  ASSERT_GE(f.uart.written.size(), 8u);
-  // The stashed frame is the request echoed back, so its third byte is 0x00; the pass's own reply carries a
-  // byte count of 0x02 there.
+  // The stashed frame is the request echoed back (8 bytes, third byte 0x00); the pass's own reply follows it
+  // (7 bytes, byte count 0x02 in its third byte).
+  ASSERT_EQ(f.uart.written.size(), 15u);
   EXPECT_EQ(f.uart.written[2], 0x00);
+  EXPECT_EQ(f.uart.written[8], 0x02);
+  EXPECT_EQ(f.uart.written[10], 0x02);
 }
 
 // The guard is restored rather than cleared, so a nested pass through the public loop() cannot release the
@@ -211,6 +256,8 @@ TEST(ModbusServerService, ANestedPassDoesNotReleaseTheOuterDispatch) {
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   f.hub.loop();
+  // The nested pass did dispatch the second frame, so the guard was really re-entered rather than left alone.
+  EXPECT_EQ(device.reads, 2);
   EXPECT_FALSE(device.serviced_after_nested_loop);
 }
 

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -17,6 +17,10 @@ namespace {
 // fully determined: address, function code, byte count, value, CRC.
 constexpr uint8_t READ_HOLDING_PDU[] = {0x03, 0x00, 0x00, 0x00, 0x01};
 
+// Writes 0x0001 to holding register 0x0000. A broadcast is never answered, so this is a frame the hub parses
+// and dispatches without producing a reply of its own.
+constexpr uint8_t WRITE_SINGLE_PDU[] = {0x06, 0x00, 0x00, 0x00, 0x01};
+
 // A server device that answers one holding register and can turn its own hub, which is what a device
 // announcing a restart needs while the main loop is not running.
 class ServicingDevice : public ModbusServerDevice {
@@ -188,8 +192,8 @@ TEST(ModbusServerService, ReplyBlockedDuringTheSendDelayIsKept) {
   EXPECT_FALSE(f.uart.written.empty());
 }
 
-// A reply the pass itself produces goes out at once, and it is newer than anything still held back. The held
-// one must go with it, or a later pass would put a stale frame on the wire behind the reply it answered.
+// A frame the pass answers is newer than anything still held back, so the held one goes when that frame
+// arrives. A later pass must not put it on the wire behind the reply that answered the newer request.
 TEST(ModbusServerService, AReplySentOnThePassDiscardsAnOlderHeldOne) {
   ServerFixture f;
   ServicingDevice device(0x02);
@@ -209,6 +213,45 @@ TEST(ModbusServerService, AReplySentOnThePassDiscardsAnOlderHeldOne) {
   // Nothing is left over to be sent behind the reply that just went out.
   EXPECT_TRUE(device.pump());
   EXPECT_EQ(f.uart.written.size(), after_pass);
+}
+
+// A broadcast is never answered, so no reply of our own goes out to clear the one still held back. The
+// controller has moved on all the same, and the held reply must not reach the wire on a later pass.
+TEST(ModbusServerService, ABroadcastDiscardsAHeldReply) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(BROADCAST_ADDRESS, WRITE_SINGLE_PDU);
+
+  // Busy at the start of the pass, so the held reply survives long enough for the broadcast to be parsed.
+  f.hub.block_first_check = true;
+  EXPECT_TRUE(device.pump());
+  f.hub.block_first_check = false;
+  // Gone means the broadcast really was parsed: nothing else in this pass touches the stash.
+  EXPECT_FALSE(f.hub.has_deferred());
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+}
+
+// Same for a request addressed to another device on the wire: we do not answer it, and the reply still held
+// back is just as stale as it is after a broadcast.
+TEST(ModbusServerService, ARequestToAPeerDiscardsAHeldReply) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x09, READ_HOLDING_PDU);
+
+  f.hub.block_first_check = true;
+  EXPECT_TRUE(device.pump());
+  f.hub.block_first_check = false;
+  EXPECT_FALSE(f.hub.has_deferred());
+  EXPECT_EQ(device.reads, 0);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
 }
 
 // The scheduler gives the reply its one chance and lets it go. A pass afterwards must not find it and put a

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -30,7 +30,9 @@ class ServicingDevice : public ModbusServerDevice {
       this->serviced_from_handler = this->service_bus_();
     if (this->loop_from_handler) {
       this->loop_from_handler = false;  // one level only
-      this->hub_->loop();
+      // Deliberately the hostile route: a device cannot reach its own hub, so the test holds its own
+      // pointer to turn it through the public loop().
+      this->hostile_hub->loop();
       this->serviced_after_nested_loop = this->service_bus_();
     }
     // A pass that ran from here would have answered the next frame before this one returned.
@@ -49,6 +51,7 @@ class ServicingDevice : public ModbusServerDevice {
   // Turns the hub from inside the handler through the public loop(), then asks whether the guard still holds.
   bool loop_from_handler{false};
   bool serviced_after_nested_loop{true};
+  ModbusServerHub *hostile_hub{nullptr};
 };
 
 // Lets a test decide when the wire is free, and stash a reply the way send_raw_ does when it is not. Stashed
@@ -56,11 +59,14 @@ class ServicingDevice : public ModbusServerDevice {
 // host test binary faults on an uninitialised lock.
 class TestServerHub : public ModbusServerHub {
  public:
-  // With block_on_recheck the wire is free at the first check and busy at send_frame_'s own re-check, which
-  // is a byte arriving during the send delay.
+  // block_on_recheck: free at the first check, busy at send_frame_'s own re-check, which is a byte arriving
+  // during the send delay. block_first_check: the reverse, so a pass starts on a busy wire and frees up.
   bool tx_blocked() override {
+    const int check = this->checks_++;
     if (this->block_on_recheck)
-      return this->checks_++ > 0;
+      return check > 0;
+    if (this->block_first_check)
+      return check == 0;
     return this->blocked;
   }
 
@@ -77,6 +83,7 @@ class TestServerHub : public ModbusServerHub {
 
   bool blocked{false};
   bool block_on_recheck{false};
+  bool block_first_check{false};
 
  private:
   int checks_{0};
@@ -181,6 +188,29 @@ TEST(ModbusServerService, ReplyBlockedDuringTheSendDelayIsKept) {
   EXPECT_FALSE(f.uart.written.empty());
 }
 
+// A reply the pass itself produces goes out at once, and it is newer than anything still held back. The held
+// one must go with it, or a later pass would put a stale frame on the wire behind the reply it answered.
+TEST(ModbusServerService, AReplySentOnThePassDiscardsAnOlderHeldOne) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+
+  // Busy at the start of the pass, so the held reply is kept; free by the time the pass answers the frame.
+  f.hub.block_first_check = true;
+  EXPECT_TRUE(device.pump());
+  f.hub.block_first_check = false;
+  ASSERT_EQ(device.reads, 1);
+  const size_t after_pass = f.uart.written.size();
+  ASSERT_GT(after_pass, 0u);
+  EXPECT_FALSE(f.hub.has_deferred());
+
+  // Nothing is left over to be sent behind the reply that just went out.
+  EXPECT_TRUE(device.pump());
+  EXPECT_EQ(f.uart.written.size(), after_pass);
+}
+
 // The scheduler gives the reply its one chance and lets it go. A pass afterwards must not find it and put a
 // reply the controller has stopped waiting for on the wire behind newer traffic.
 TEST(ModbusServerService, ReplyDroppedByTheSchedulerIsNotSentByALaterPass) {
@@ -251,6 +281,7 @@ TEST(ModbusServerService, ANestedPassDoesNotReleaseTheOuterDispatch) {
   ServerFixture f;
   ServicingDevice device(0x02);
   device.loop_from_handler = true;
+  device.hostile_hub = &f.hub;
   f.hub.register_device(&device);
 
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);


### PR DESCRIPTION
# What does this implement/fix?

Lets a Modbus server device keep answering while the main loop is blocked, for
a bounded wait such as announcing a restart from `on_shutdown()`.

`ModbusServerDevice::service_bus_()` runs one pass of the bus, sending a reply
held back for a busy wire first. Refused from inside a handler. First user:
esphome/esphome#19043.

A held-back reply is now dropped as soon as the next request arrives, for every
server hub. Before, only the scheduler ended its life a millisecond later, and
it could still reach the wire after the controller had moved on. Holding it
across a bounded wait would have widened that window to the whole wait.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome#18739

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Not applicable: no configuration change.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#174

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change. A server device calls service_bus_() from C++.
modbus:
  uart_id: uart_bus
  role: server
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

