### PR TITLE
[hoermann_hcp] Send each command once, and the lamp as a state

### DIFF
--- a/esphome/components/hoermann_hcp/__init__.py
+++ b/esphome/components/hoermann_hcp/__init__.py
@@ -20,6 +20,12 @@ HoermannHcp = hoermann_hcp_ns.class_(
 AnnouncePauseAction = hoermann_hcp_ns.class_(
     "AnnouncePauseAction", automation.Action, cg.Parented.template(HoermannHcp)
 )
+VentAction = hoermann_hcp_ns.class_(
+    "VentAction", automation.Action, cg.Parented.template(HoermannHcp)
+)
+HalfOpenAction = hoermann_hcp_ns.class_(
+    "HalfOpenAction", automation.Action, cg.Parented.template(HoermannHcp)
+)
 
 # The Hoermann UAP module answers on Modbus server address 2.
 CONFIG_SCHEMA = (
@@ -33,13 +39,24 @@ FINAL_VALIDATE_SCHEMA = modbus.final_validate_modbus_device(
 )
 
 
+HUB_ACTION_SCHEMA = automation.maybe_simple_id(
+    {cv.GenerateID(): cv.use_id(HoermannHcp)}
+)
+
+
 @automation.register_action(
     "hoermann_hcp.announce_pause",
     AnnouncePauseAction,
-    automation.maybe_simple_id({cv.GenerateID(): cv.use_id(HoermannHcp)}),
+    HUB_ACTION_SCHEMA,
     synchronous=True,
 )
-async def announce_pause_action_to_code(
+@automation.register_action(
+    "hoermann_hcp.vent", VentAction, HUB_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "hoermann_hcp.half_open", HalfOpenAction, HUB_ACTION_SCHEMA, synchronous=True
+)
+async def hub_action_to_code(
     config: ConfigType,
     action_id: ID,
     template_arg: cg.TemplateArguments,

--- a/esphome/components/hoermann_hcp/__init__.py
+++ b/esphome/components/hoermann_hcp/__init__.py
@@ -1,7 +1,10 @@
+from esphome import automation
 import esphome.codegen as cg
 from esphome.components import modbus
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.core import ID
+from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@zweckj"]
@@ -14,6 +17,9 @@ hoermann_hcp_ns = cg.esphome_ns.namespace("hoermann_hcp")
 HoermannHcp = hoermann_hcp_ns.class_(
     "HoermannHcp", cg.PollingComponent, modbus.ModbusServerDevice
 )
+AnnouncePauseAction = hoermann_hcp_ns.class_(
+    "AnnouncePauseAction", automation.Action, cg.Parented.template(HoermannHcp)
+)
 
 # The Hoermann UAP module answers on Modbus server address 2.
 CONFIG_SCHEMA = (
@@ -25,6 +31,23 @@ CONFIG_SCHEMA = (
 FINAL_VALIDATE_SCHEMA = modbus.final_validate_modbus_device(
     "hoermann_hcp", role="server"
 )
+
+
+@automation.register_action(
+    "hoermann_hcp.announce_pause",
+    AnnouncePauseAction,
+    automation.maybe_simple_id({cv.GenerateID(): cv.use_id(HoermannHcp)}),
+    synchronous=True,
+)
+async def announce_pause_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
 
 
 async def to_code(config: ConfigType) -> None:

--- a/esphome/components/hoermann_hcp/automation.h
+++ b/esphome/components/hoermann_hcp/automation.h
@@ -14,4 +14,15 @@ template<typename... Ts> class AnnouncePauseAction final : public Action<Ts...>,
   void play(const Ts &...x) override { this->parent_->announce_pause(); }
 };
 
+// The intermediate positions as automation actions, for a config that wants them without a button entity.
+template<typename... Ts> class VentAction final : public Action<Ts...>, public Parented<HoermannHcp> {
+ public:
+  void play(const Ts &...x) override { this->parent_->vent_door(); }
+};
+
+template<typename... Ts> class HalfOpenAction final : public Action<Ts...>, public Parented<HoermannHcp> {
+ public:
+  void play(const Ts &...x) override { this->parent_->half_open_door(); }
+};
+
 }  // namespace esphome::hoermann_hcp

--- a/esphome/components/hoermann_hcp/automation.h
+++ b/esphome/components/hoermann_hcp/automation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+
+#include "hoermann_hcp.h"
+
+namespace esphome::hoermann_hcp {
+
+// Tells the bus controller the accessory is about to go quiet. An ordinary restart announces itself during
+// teardown; an update has to say so when the transfer starts, because by the time teardown runs the image
+// has been written and the controller has been unanswered throughout.
+template<typename... Ts> class AnnouncePauseAction final : public Action<Ts...>, public Parented<HoermannHcp> {
+ public:
+  void play(const Ts &...x) override { this->parent_->announce_pause(); }
+};
+
+}  // namespace esphome::hoermann_hcp

--- a/esphome/components/hoermann_hcp/automation.h
+++ b/esphome/components/hoermann_hcp/automation.h
@@ -7,9 +7,8 @@
 
 namespace esphome::hoermann_hcp {
 
-// Tells the bus controller the accessory is about to go quiet. An ordinary restart announces itself during
-// teardown; an update has to say so when the transfer starts, because by the time teardown runs the image
-// has been written and the controller has been unanswered throughout.
+// For the ota on_begin trigger. An ordinary restart announces itself from on_shutdown, but an update is
+// written to flash long before that runs, so it has to say so when the transfer starts.
 template<typename... Ts> class AnnouncePauseAction final : public Action<Ts...>, public Parented<HoermannHcp> {
  public:
   void play(const Ts &...x) override { this->parent_->announce_pause(); }

--- a/esphome/components/hoermann_hcp/hoermann_hcp.cpp
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.cpp
@@ -77,6 +77,10 @@ static bool is_moving(DoorState state) {
 
 void HoermannHcp::update() {
   const uint32_t now = millis();
+  if (this->sent_command_ != nullptr) {
+    ESP_LOGI(TAG, "Sent '%s' command to door", this->sent_command_->name);
+    this->sent_command_ = nullptr;
+  }
   // Time out the connection flag if the bus controller stopped polling.
   if (this->valid_ && now - this->last_response_ > this->connection_timeout_ms_)
     this->set_valid_(false);
@@ -215,7 +219,9 @@ void HoermannHcp::push_command_registers_(modbus::RegisterValues &registers) {
     push_zeros(registers, 2);
     return;
   }
-  ESP_LOGI(TAG, "Sending '%s' command to door", command->name);
+  // Recorded rather than logged: this builds the answer the bus controller is timing, and a console line can
+  // outlast that window. update() says it a moment later.
+  this->sent_command_ = command;
   // Spent as soon as it is fetched. Nothing puts it back, so the door sees each command exactly once.
   this->next_command_ = nullptr;
   if (is_light_command(command))
@@ -431,17 +437,16 @@ bool HoermannHcp::vent_door() { return this->queue_command_(COMMAND_VENT); }
 bool HoermannHcp::half_open_door() { return this->queue_command_(COMMAND_HALF_OPEN); }
 bool HoermannHcp::set_light(bool on) {
   const HoermannHcpCommand &command = on ? COMMAND_LIGHT_ON : COMMAND_LIGHT_OFF;
-  // A lamp request the controller has not fetched is replaced: the newer one says what is wanted now, and
-  // nothing has reached the door yet. One that only takes back the first is withdrawn outright.
+  // A lamp request the controller has not fetched can be taken back: the newer one says what is wanted now,
+  // and nothing has reached the door yet. Withdrawn outright when it only asks for the lamp as it already is.
+  // Emptying the slot rather than writing over it keeps the request going through the checks below.
   if (is_light_command(this->next_command_)) {
-    if (on == this->light_on_) {
-      this->drop_unsent_command_();
+    this->drop_unsent_command_();
+    if (on == this->light_on_)
       return true;
-    }
-    this->next_command_ = &command;
-  } else if (!this->queue_command_(command)) {
-    return false;
   }
+  if (!this->queue_command_(command))
+    return false;
   this->light_request_pending_ = true;
   this->light_request_on_ = on;
   this->light_request_sent_at_ = 0;

--- a/esphome/components/hoermann_hcp/hoermann_hcp.cpp
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.cpp
@@ -14,8 +14,6 @@ static constexpr uint16_t STATE_REG = 0x9CB9;      // Internal state read back b
 static constexpr uint16_t BROADCAST_REG = 0x9D31;  // Door status broadcast by the bus controller
 static constexpr float CLOSE_POSITION_THRESHOLD = 0.05f;
 static constexpr float OPEN_POSITION_THRESHOLD = 0.95f;
-// Only the parity of the outstanding toggles says where the lamp is heading, so the count must not run away.
-static constexpr uint8_t MAX_LIGHT_TOGGLES_IN_FLIGHT = 4;
 
 // Replaces the ordinary 0x0001 status while a pause is announced. The protocol calls this a pause, not a
 // departure: the accessory is going quiet, it is not asking to be forgotten.
@@ -29,17 +27,21 @@ static constexpr uint8_t TRANSFER_NAK = 0xFE;
 // transfers carry it, so only the answer to one masks it off; the ordinary echo is left as it was.
 static constexpr uint16_t COUNTER_MASK = 0x7F00;
 
-// Command encoding: the high byte of the first register is the phase (0x02 pressed, 0x01 released) and the
-// rest names the button - the low byte for the door commands, the second register for those that do not fit
-// there. Both halves repeat that name, so neither register is a level to hold; they carry one event each.
-static constexpr HoermannHcpCommand COMMAND_OPEN{"open", 0x0210, 0x0110};
-static constexpr HoermannHcpCommand COMMAND_CLOSE{"close", 0x0220, 0x0120};
-static constexpr HoermannHcpCommand COMMAND_IMPULSE{"impulse", 0x0240, 0x0140};
-// The intermediate positions are named in the second register, so the first only carries the phase.
-static constexpr HoermannHcpCommand COMMAND_VENT{"vent", 0x0200, 0x0100, 0x4000, 0x4000};
-static constexpr HoermannHcpCommand COMMAND_HALF_OPEN{"half open", 0x0200, 0x0100, 0x0400, 0x0400};
-// The lamp is named in the second register, but its phase bytes follow no scheme the door commands share.
-static constexpr HoermannHcpCommand COMMAND_TOGGLE_LAMP{"toggle light", 0x0100, 0x0800, 0x0200, 0x0200, false};
+// Command encoding: the low byte of the first register names the door commands, the second register those that
+// do not fit there. Each is presented once; the door acts on the value itself, not on a press being held.
+static constexpr HoermannHcpCommand COMMAND_OPEN{"open", 0x0110};
+static constexpr HoermannHcpCommand COMMAND_CLOSE{"close", 0x0120};
+static constexpr HoermannHcpCommand COMMAND_IMPULSE{"impulse", 0x0140};
+static constexpr HoermannHcpCommand COMMAND_VENT{"vent", 0x0100, 0x4000};
+static constexpr HoermannHcpCommand COMMAND_HALF_OPEN{"half open", 0x0100, 0x0400};
+// The lamp has a command per direction. A toggle could only mean "the other one", so asking twice would undo
+// it, and "on" would be nothing anyone could ask for.
+static constexpr HoermannHcpCommand COMMAND_LIGHT_ON{"light on", 0x0880, 0x0000, false};
+static constexpr HoermannHcpCommand COMMAND_LIGHT_OFF{"light off", 0x0800, 0x0100, false};
+
+static bool is_light_command(const HoermannHcpCommand *command) {
+  return command == &COMMAND_LIGHT_ON || command == &COMMAND_LIGHT_OFF;
+}
 
 // High byte of the state register and the door state it stands for. State 0x00 is decoded separately because
 // its low byte tells a plain stop from the vent position.
@@ -81,14 +83,7 @@ void HoermannHcp::update() {
   // Status broadcasts alone keep the connection alive, so a command the controller never fetches would
   // otherwise block every later one for as long as it keeps broadcasting.
   if (this->next_command_ != nullptr && now - this->command_queued_at_ > this->connection_timeout_ms_) {
-    // Dropping after the press was presented leaves the door without its release value, which is worth saying
-    // apart from a command the controller never looked at.
-    if (this->command_written_at_ != 0) {
-      ESP_LOGW(TAG, "Bus controller stopped polling during '%s' command, dropping it mid key press",
-               this->next_command_->name);
-    } else {
-      ESP_LOGW(TAG, "Bus controller did not fetch '%s' command, dropping it", this->next_command_->name);
-    }
+    ESP_LOGW(TAG, "Bus controller did not fetch '%s' command, dropping it", this->next_command_->name);
     this->drop_command_();
     // Children may have assumed the command would land, so let them re-derive from the door.
     this->changed_ = true;
@@ -99,10 +94,10 @@ void HoermannHcp::update() {
     ESP_LOGW(TAG, "Door did not start moving towards the requested position, dropping it");
     this->clear_target_();
   }
-  // The door took the lamp key press but never reported the lamp changing, so stop expecting it to.
-  if (this->light_toggle_released_at_ != 0 && now - this->light_toggle_released_at_ > this->connection_timeout_ms_) {
-    ESP_LOGW(TAG, "Door did not report the lamp changing, giving up on the toggle");
-    this->forget_light_toggles_();
+  // The door took the lamp request but never reported the lamp changing, so stop expecting it to.
+  if (this->light_request_sent_at_ != 0 && now - this->light_request_sent_at_ > this->connection_timeout_ms_) {
+    ESP_LOGW(TAG, "Door did not report the lamp changing, giving up on the request");
+    this->forget_light_request_();
   }
   if (this->changed_) {
     this->changed_ = false;
@@ -220,29 +215,13 @@ void HoermannHcp::push_command_registers_(modbus::RegisterValues &registers) {
     push_zeros(registers, 2);
     return;
   }
-  if (this->command_written_at_ == 0) {
-    // First read after the command was queued: present the "key pressed" values.
-    this->command_written_at_ = millis();
-    ESP_LOGI(TAG, "Sending '%s' command to door", command->name);
-    registers.push_back(command->pressed_value);
-    registers.push_back(command->pressed_value_2);
-    return;
-  }
-  if (millis() - this->command_written_at_ <= this->key_press_delay_ms_) {
-    // Between the two events there is nothing to report, including in the second register.
-    push_zeros(registers, 2);
-    return;
-  }
-  // Enough time passed: present the "key released" values and clear the command.
-  ESP_LOGD(TAG, "Released '%s' command", command->name);
-  this->command_written_at_ = 0;
+  ESP_LOGI(TAG, "Sending '%s' command to door", command->name);
+  // Spent as soon as it is fetched. Nothing puts it back, so the door sees each command exactly once.
   this->next_command_ = nullptr;
-  // A toggle whose count was already settled, by a lamp change reported from the door's side, has nothing left
-  // to wait for, so it must not re-arm the watchdog.
-  if (command == &COMMAND_TOGGLE_LAMP && this->light_toggles_in_flight_ != 0)
-    this->light_toggle_released_at_ = millis();
-  registers.push_back(command->released_value);
-  registers.push_back(command->released_value_2);
+  if (is_light_command(command))
+    this->light_request_sent_at_ = millis();
+  registers.push_back(command->value);
+  registers.push_back(command->value_2);
 }
 
 void HoermannHcp::take_transfer_(const modbus::RegisterValues &registers) {
@@ -283,11 +262,9 @@ void HoermannHcp::push_transfer_answer_(modbus::RegisterValues &registers, uint1
 }
 
 void HoermannHcp::drop_unsent_command_() {
-  // Cleared first so the settling below no longer counts this command among the toggles still to be sent.
-  const bool was_light_toggle = this->is_light_toggle_pending_();
+  if (is_light_command(this->next_command_))
+    this->forget_light_request_();
   this->next_command_ = nullptr;
-  if (was_light_toggle)
-    this->light_toggle_settled_();
   this->changed_ = true;
 }
 
@@ -306,10 +283,6 @@ bool HoermannHcp::advance_pause_() {
         this->end_pause_();
         return true;
       }
-      // A key press already shown to the controller has to be released first. Dropping it here would leave
-      // the controller holding a key that is never let go.
-      if (this->command_written_at_ != 0)
-        return false;
       this->drop_unsent_command_();
       this->pause_started_at_ = now;
       this->pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK;
@@ -456,29 +429,24 @@ bool HoermannHcp::close_door() { return this->queue_command_(COMMAND_CLOSE); }
 bool HoermannHcp::impulse_door() { return this->queue_command_(COMMAND_IMPULSE); }
 bool HoermannHcp::vent_door() { return this->queue_command_(COMMAND_VENT); }
 bool HoermannHcp::half_open_door() { return this->queue_command_(COMMAND_HALF_OPEN); }
-bool HoermannHcp::toggle_light() {
-  if (this->light_toggles_in_flight_ >= MAX_LIGHT_TOGGLES_IN_FLIGHT) {
-    ESP_LOGW(TAG, "Too many lamp toggles are still waiting to be confirmed, dropping this one");
+bool HoermannHcp::set_light(bool on) {
+  const HoermannHcpCommand &command = on ? COMMAND_LIGHT_ON : COMMAND_LIGHT_OFF;
+  // A lamp request the controller has not fetched is replaced: the newer one says what is wanted now, and
+  // nothing has reached the door yet. One that only takes back the first is withdrawn outright.
+  if (is_light_command(this->next_command_)) {
+    if (on == this->light_on_) {
+      this->drop_unsent_command_();
+      return true;
+    }
+    this->next_command_ = &command;
+  } else if (!this->queue_command_(command)) {
     return false;
   }
-  if (!this->queue_command_(COMMAND_TOGGLE_LAMP))
-    return false;
-  this->light_toggles_in_flight_++;
-  return true;
-}
-bool HoermannHcp::is_light_toggle_pending_() const { return this->next_command_ == &COMMAND_TOGGLE_LAMP; }
-
-uint8_t HoermannHcp::unsent_light_toggles_() const {
-  return this->is_light_toggle_pending_() && this->command_written_at_ == 0 ? 1 : 0;
-}
-
-bool HoermannHcp::cancel_light_toggle() {
-  // Once the pressed value has been presented the key press is already on the wire, so only an untouched
-  // command can be withdrawn.
-  if (!this->is_light_toggle_pending_() || this->command_written_at_ != 0)
-    return false;
-  ESP_LOGD(TAG, "Cancelling '%s' command the controller had not fetched", this->next_command_->name);
-  this->drop_command_();
+  this->light_request_pending_ = true;
+  this->light_request_on_ = on;
+  this->light_request_sent_at_ = 0;
+  // The light shows where the lamp is heading, so it has to be told.
+  this->changed_ = true;
   return true;
 }
 
@@ -533,44 +501,26 @@ void HoermannHcp::set_valid_(bool valid) {
   this->drop_command_();
   // The door cannot be watched while the bus is quiet, so a target left armed would stop it long afterwards.
   this->clear_target_();
-  this->forget_light_toggles_();
+  this->forget_light_request_();
   // The lamp can be switched at the door while the bus is quiet, so what was last read is no longer trusted.
   this->set_light_seen_(false);
   this->short_broadcast_logged_ = false;
 }
 
 void HoermannHcp::drop_command_() {
-  const bool was_light_toggle = this->is_light_toggle_pending_();
-  // Cleared first so the settling below no longer counts this command among the toggles still to be sent.
-  this->next_command_ = nullptr;
-  this->command_written_at_ = 0;
-  if (was_light_toggle) {
-    // A lamp toggle says nothing about where the door was going, so it leaves the target alone.
-    this->light_toggle_settled_();
-  } else {
+  // A lamp request says nothing about where the door was going, so it leaves the target alone.
+  const bool was_light_request = is_light_command(this->next_command_);
+  this->drop_unsent_command_();
+  if (!was_light_request)
     this->clear_target_();
-  }
 }
 
-void HoermannHcp::light_toggle_settled_() {
-  if (this->light_toggles_in_flight_ == 0)
+void HoermannHcp::forget_light_request_() {
+  if (!this->light_request_pending_)
     return;
-  this->light_toggles_in_flight_--;
-  // Only a toggle the door has been shown can still be confirmed, so unsent ones leave nothing to wait for.
-  if (this->light_toggles_in_flight_ == this->unsent_light_toggles_())
-    this->light_toggle_released_at_ = 0;
+  this->light_request_pending_ = false;
+  this->light_request_sent_at_ = 0;
   // The light was showing where the lamp was heading, so it has to be told to look again.
-  this->changed_ = true;
-}
-
-void HoermannHcp::forget_light_toggles_() {
-  // Nothing outstanding must always mean nothing to wait for, or the watchdog below would fire for ever.
-  this->light_toggle_released_at_ = 0;
-  // A toggle the door has not been shown yet is still going to fire, so it keeps counting.
-  const uint8_t unsent = this->unsent_light_toggles_();
-  if (this->light_toggles_in_flight_ == unsent)
-    return;
-  this->light_toggles_in_flight_ = unsent;
   this->changed_ = true;
 }
 
@@ -611,17 +561,16 @@ void HoermannHcp::clear_target_() {
 }
 
 void HoermannHcp::set_light_on_(bool on) {
+  // The lamp is where it was asked to be, whether by our command or by a hand at the door. A request still in
+  // the slot goes out regardless; it names a state, so it changes nothing.
+  if (this->light_request_pending_ && on == this->light_request_on_) {
+    this->light_request_pending_ = false;
+    this->light_request_sent_at_ = 0;
+  }
   if (this->light_on_ == on)
     return;
   this->light_on_ = on;
   this->changed_ = true;
-  if (this->light_toggles_in_flight_ <= this->unsent_light_toggles_()) {
-    // The door has not been shown a toggle that could explain this, so the lamp was switched at the door.
-    ESP_LOGD(TAG, "Lamp %s at the door", ONOFF(on));
-    return;
-  }
-  // The door acted, so one of the toggles it has seen has arrived. Any others still count.
-  this->light_toggle_settled_();
 }
 
 void HoermannHcp::set_light_seen_(bool seen) {

--- a/esphome/components/hoermann_hcp/hoermann_hcp.cpp
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.cpp
@@ -140,7 +140,6 @@ modbus::ResponseStatus HoermannHcp::on_read_holding_registers(uint16_t start_add
   switch (number_of_registers) {
     case 8:
       if (this->announcing_pause_()) {
-        // Announced in place of the ordinary state, naming the address it applies to.
         registers.push_back(counter);
         registers.push_back(static_cast<uint16_t>(RESPONSE_PAUSE | command));
         registers.push_back(this->get_address());
@@ -329,9 +328,8 @@ bool HoermannHcp::advance_pause_() {
       return false;
 
     case PauseState::PAUSE_STATE_SETTLING:
-      // Wait for a gap in what the controller sends us, so the last exchange is finished rather than cut
-      // short. This measures frames addressed to us, not every byte on the wire, so it is a courtesy and
-      // not a guarantee. Give up rather than let a busy bus hold up the restart.
+      // A gap in what the controller sends us, so the last exchange is finished rather than cut short.
+      // Only frames addressed to us, so it is a courtesy rather than a guarantee, and it gives up.
       if (now - this->last_response_ > this->pause_quiet_ms_ ||
           now - this->pause_started_at_ >= this->pause_settle_ms_) {
         this->end_pause_();

--- a/esphome/components/hoermann_hcp/hoermann_hcp.cpp
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.cpp
@@ -1,5 +1,6 @@
 #include "hoermann_hcp.h"
 
+#include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
@@ -15,6 +16,18 @@ static constexpr float CLOSE_POSITION_THRESHOLD = 0.05f;
 static constexpr float OPEN_POSITION_THRESHOLD = 0.95f;
 // Only the parity of the outstanding toggles says where the lamp is heading, so the count must not run away.
 static constexpr uint8_t MAX_LIGHT_TOGGLES_IN_FLIGHT = 4;
+
+// Replaces the ordinary 0x0001 status while a pause is announced. The protocol calls this a pause, not a
+// departure: the accessory is going quiet, it is not asking to be forgotten.
+static constexpr uint16_t RESPONSE_PAUSE = 0x0029;
+// Payload transfers arrive as this command in the low byte of the command register.
+static constexpr uint8_t TRANSFER_COMMAND = 0x04;
+static constexpr uint8_t TRANSFER_SUB_PAUSE_ACK = 0x19;
+static constexpr uint8_t TRANSFER_ACK = 0xFD;
+static constexpr uint8_t TRANSFER_NAK = 0xFE;
+// Bit 15 of the counter register selects the half of a split payload and is not part of the count. Only
+// transfers carry it, so only the answer to one masks it off; the ordinary echo is left as it was.
+static constexpr uint16_t COUNTER_MASK = 0x7F00;
 
 // Command encoding: the high byte of the first register is the phase (0x02 pressed, 0x01 released) and the
 // rest names the button - the low byte for the door commands, the second register for those that do not fit
@@ -113,6 +126,12 @@ modbus::ResponseStatus HoermannHcp::on_read_holding_registers(uint16_t start_add
 
   this->record_response_();
 
+  // A payload transfer the write half just took is answered here, whatever the controller reads next.
+  if (this->transfer_answer_pending_) {
+    this->push_transfer_answer_(registers, number_of_registers);
+    return {};
+  }
+
   // 0x17 read half: STATE_REG is read back right after COMMAND_REG was written, so echo the stored message
   // counter (high byte) and command (low byte). The read length identifies which internal block is requested.
   const uint16_t counter = this->command_reg_value_ & 0xFF00;
@@ -120,6 +139,14 @@ modbus::ResponseStatus HoermannHcp::on_read_holding_registers(uint16_t start_add
 
   switch (number_of_registers) {
     case 8:
+      if (this->announcing_pause_()) {
+        // Announced in place of the ordinary state, naming the address it applies to.
+        registers.push_back(counter);
+        registers.push_back(static_cast<uint16_t>(RESPONSE_PAUSE | command));
+        registers.push_back(this->get_address());
+        push_zeros(registers, 5);
+        break;
+      }
       // Command request: return the internal state, injecting any pending command.
       registers.push_back(counter);
       registers.push_back(static_cast<uint16_t>(0x0001 | command));
@@ -156,6 +183,8 @@ modbus::ResponseStatus HoermannHcp::on_write_registers(uint16_t start_address,
     // command byte back from STATE_REG. The hub always runs the write before the read within one request.
     this->record_response_();
     this->command_reg_value_ = registers[0];
+    // The same block carries payload transfers, which are answered rather than ignored.
+    this->take_transfer_(registers);
     return {};
   }
 
@@ -217,6 +246,137 @@ void HoermannHcp::push_command_registers_(modbus::RegisterValues &registers) {
   registers.push_back(command->released_value_2);
 }
 
+void HoermannHcp::take_transfer_(const modbus::RegisterValues &registers) {
+  // Only while a pause is out. The command byte alone is too thin a discriminator to start answering
+  // transfers in steady state, and an answer armed there would pre-empt the next read of any length.
+  if (!this->announcing_pause_() || registers.size() < 2)
+    return;
+  // Low byte of the first register is what the controller wants from us, high byte its running counter.
+  if (static_cast<uint8_t>(registers[0] & 0x00FF) != TRANSFER_COMMAND)
+    return;
+
+  const bool is_pause_ack = static_cast<uint8_t>(registers[1] >> 8) == TRANSFER_SUB_PAUSE_ACK;
+  // Answered either way. Leaving a transfer open is worse than refusing one we did not understand, and an
+  // undefined answer code is worse still.
+  this->transfer_answer_counter_ = static_cast<uint8_t>(registers[0] >> 8);
+  this->transfer_answer_code_ = is_pause_ack ? TRANSFER_ACK : TRANSFER_NAK;
+  this->transfer_answer_pending_ = true;
+
+  // The address the controller is pausing sits astride two registers: the low byte of the sub-code register
+  // and the high byte of the next.
+  if (!is_pause_ack || registers.size() < 3)
+    return;
+  const uint16_t named = static_cast<uint16_t>(((registers[1] & 0x00FF) << 8) | (registers[2] >> 8));
+  if (named == this->get_address())
+    this->pause_confirmed_ = true;
+}
+
+void HoermannHcp::push_transfer_answer_(modbus::RegisterValues &registers, uint16_t number_of_registers) {
+  // A read too short to carry the answer leaves it armed for the next one rather than swallowing it.
+  if (number_of_registers < 2) {
+    push_zeros(registers, number_of_registers);
+    return;
+  }
+  this->transfer_answer_pending_ = false;
+  registers.push_back(static_cast<uint16_t>((this->transfer_answer_counter_ << 8) & COUNTER_MASK));
+  registers.push_back(static_cast<uint16_t>((TRANSFER_COMMAND << 8) | this->transfer_answer_code_));
+  push_zeros(registers, number_of_registers - 2);
+}
+
+void HoermannHcp::drop_unsent_command_() {
+  // Cleared first so the settling below no longer counts this command among the toggles still to be sent.
+  const bool was_light_toggle = this->is_light_toggle_pending_();
+  this->next_command_ = nullptr;
+  if (was_light_toggle)
+    this->light_toggle_settled_();
+  this->changed_ = true;
+}
+
+void HoermannHcp::end_pause_() {
+  this->transfer_answer_pending_ = false;
+  this->pause_state_ = PauseState::PAUSE_STATE_DONE;
+}
+
+bool HoermannHcp::advance_pause_() {
+  const uint32_t now = millis();
+  switch (this->pause_state_) {
+    case PauseState::PAUSE_STATE_IDLE:
+      // Nobody to tell: nothing has ever arrived, or nothing recently enough for anyone to still be
+      // listening. A restart must not pay for that.
+      if (this->last_response_ == 0 || now - this->last_response_ > this->connection_timeout_ms_) {
+        this->end_pause_();
+        return true;
+      }
+      // A key press already shown to the controller has to be released first. Dropping it here would leave
+      // the controller holding a key that is never let go.
+      if (this->command_written_at_ != 0)
+        return false;
+      this->drop_unsent_command_();
+      this->pause_started_at_ = now;
+      this->pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK;
+      return false;
+
+    case PauseState::PAUSE_STATE_WAITING_FOR_ACK:
+      if (this->pause_confirmed_) {
+        ESP_LOGI(TAG, "Bus controller confirmed the pause");
+      } else if (now - this->pause_started_at_ < this->pause_ack_timeout_ms_) {
+        return false;
+      } else {
+        ESP_LOGW(TAG, "Bus controller did not confirm the pause, going quiet anyway");
+      }
+      this->pause_started_at_ = now;
+      this->pause_state_ = PauseState::PAUSE_STATE_SETTLING;
+      return false;
+
+    case PauseState::PAUSE_STATE_SETTLING:
+      // Wait for a gap in what the controller sends us, so the last exchange is finished rather than cut
+      // short. This measures frames addressed to us, not every byte on the wire, so it is a courtesy and
+      // not a guarantee. Give up rather than let a busy bus hold up the restart.
+      if (now - this->last_response_ > this->pause_quiet_ms_ ||
+          now - this->pause_started_at_ >= this->pause_settle_ms_) {
+        this->end_pause_();
+        return true;
+      }
+      return false;
+
+    default:
+      return true;
+  }
+}
+
+bool HoermannHcp::announce_pause() {
+  // Re-entering would clear the announcement the outer call is still waiting on, and would turn the hub from
+  // inside its own frame handling.
+  if (this->announcing_)
+    return false;
+  this->announcing_ = true;
+  // Every announcement starts afresh. The guard above means no other one is in flight, and every exit below
+  // ends in PAUSE_STATE_DONE, so there is never anything here worth carrying over.
+  this->pause_confirmed_ = false;
+  this->pause_state_ = PauseState::PAUSE_STATE_IDLE;
+  const uint32_t started = millis();
+  while (!this->advance_pause_() && millis() - started < this->pause_total_timeout_ms_) {
+    App.feed_wdt();
+    // The loop cannot turn the hub from here, so the bus is served by hand for as long as this takes.
+    this->service_bus_();
+    delay(1);
+  }
+  // Out of time with the announcement unfinished. It must not be left standing: the pause replaces the
+  // answer that carries key presses, so the door would stop taking commands until the next restart.
+  if (this->pause_state_ != PauseState::PAUSE_STATE_DONE) {
+    ESP_LOGW(TAG, "Gave up announcing the pause, going quiet without it");
+    this->end_pause_();
+  }
+  // One more pass, so a reply the last one parked still reaches the wire.
+  this->service_bus_();
+  this->announcing_ = false;
+  return this->pause_confirmed_;
+}
+
+// The UART driver is deleted in its own on_shutdown, and components are torn down in reverse setup
+// priority, so this is the last point at which the controller can still be told anything.
+void HoermannHcp::on_shutdown() { this->announce_pause(); }
+
 void HoermannHcp::on_position_reg_(uint16_t value) {
   // Low byte: current position.
   const uint8_t position = static_cast<uint8_t>(value);
@@ -270,6 +430,12 @@ void HoermannHcp::on_light_reg_(uint16_t value) {
 }
 
 bool HoermannHcp::queue_command_(const HoermannHcpCommand &command) {
+  // The pause replaces the answer a key press travels in, so one taken here could only be presented after
+  // the announcement, to a door that has moved on since. Refusing says so at once.
+  if (this->announcing_pause_()) {
+    ESP_LOGW(TAG, "Refused '%s' command: the restart has been announced to the bus controller", command.name);
+    return false;
+  }
   if (!this->valid_) {
     // Queueing now would fire the command whenever the controller comes back, which may be much later.
     ESP_LOGW(TAG, "Not connected to the bus controller, dropping '%s' command", command.name);
@@ -365,6 +531,7 @@ void HoermannHcp::set_valid_(bool valid) {
   }
   ESP_LOGW(TAG, "Bus controller connection lost (no request for %" PRIu32 "ms)", millis() - this->last_response_);
   // Drop what the controller never fetched, so it neither blocks later commands nor fires on reconnect.
+  this->transfer_answer_pending_ = false;
   this->drop_command_();
   // The door cannot be watched while the bus is quiet, so a target left armed would stop it long afterwards.
   this->clear_target_();

--- a/esphome/components/hoermann_hcp/hoermann_hcp.h
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.h
@@ -29,15 +29,12 @@ enum class PauseState : uint8_t {
   PAUSE_STATE_DONE,
 };
 
-// A HCP command is a simulated key press: the pressed value is presented to the bus controller, then after a
-// short delay the released value. Each half also carries a second register, which names the buttons that do
-// not fit into the first.
+// A HCP command is one event: the value is presented to the bus controller once, on the next poll that fetches
+// it. The second register names the buttons that do not fit into the first.
 struct HoermannHcpCommand {
   const char *name;
-  uint16_t pressed_value;
-  uint16_t released_value;
-  uint16_t pressed_value_2{0x0000};
-  uint16_t released_value_2{0x0000};
+  uint16_t value;
+  uint16_t value_2{0x0000};
   // A door command supersedes a half-open target; the lamp has no bearing on where the door is going.
   bool clears_target{true};
 };
@@ -78,7 +75,8 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   bool half_open_door();
   bool stop_door();
   bool set_position(float position);
-  bool toggle_light();
+  // Asks for the lamp to be on or off. A request still waiting to be fetched is replaced rather than refused.
+  bool set_light(bool on);
 
   DoorState get_door_state() const { return this->door_state_; }
   float get_current_position() const { return this->current_position_; }
@@ -87,28 +85,18 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // False until a broadcast has actually carried the lamp register. Bus traffic alone makes the connection
   // valid without saying anything about the lamp, so is_light_on() would still be its default.
   bool is_light_known() const { return this->light_seen_; }
-  // Where the lamp ends up once every toggle on its way has landed, each of which inverts it. Until then the
-  // lamp still reads as its old self, so this is what a request has to be judged against.
-  bool is_light_heading_on() const { return this->light_on_ != (this->light_toggles_in_flight_ % 2 != 0); }
-  // Drops a lamp toggle the controller has not started reading, so a reversing request cancels it outright
-  // instead of fighting it. Returns false if there is nothing to cancel.
-  bool cancel_light_toggle();
+  // The lamp is reported a moment after it was told, so until then a request is what the lamp is heading for.
+  bool is_light_heading_on() const { return this->light_request_pending_ ? this->light_request_on_ : this->light_on_; }
 
  protected:
-  // True while a lamp toggle is queued but not yet fetched, so the lamp is about to invert.
-  bool is_light_toggle_pending_() const;
-  // Toggles the door has not been shown yet, which is at most the one still waiting in the command slot.
-  uint8_t unsent_light_toggles_() const;
   void record_response_();
   // Returns false when the bus controller has not fetched the previous command yet.
   bool queue_command_(const HoermannHcpCommand &command);
-  // Throws away the pending command, taking any armed target with it unless the command was the lamp toggle.
+  // Throws away the pending command, taking any armed target with it unless the command was a lamp request.
   void drop_command_();
-  // One outstanding toggle reached the lamp, was withdrawn, or was thrown away.
-  void light_toggle_settled_();
-  // Stops expecting the toggles the door has already been shown to reach the lamp.
-  void forget_light_toggles_();
-  // Appends the two key-press registers and advances the pending command's press/release state.
+  // Stops expecting the lamp to report the state it was asked for.
+  void forget_light_request_();
+  // Appends the two command registers, spending the pending command.
   void push_command_registers_(modbus::RegisterValues &registers);
   void on_position_reg_(uint16_t value);
   void on_state_reg_(uint16_t value);
@@ -150,20 +138,17 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // Position the door was told to travel to; 0.0 means no target is armed.
   float target_position_{0.0f};
 
-  // Pending command / key-press state machine.
+  // The command waiting for the controller's next fetch. There is one slot: the controller takes one per poll.
   const HoermannHcpCommand *next_command_{nullptr};
   uint32_t command_queued_at_{0};
   // Separate from command_queued_at_ so an unrelated command cannot extend the target's start deadline.
   uint32_t target_queued_at_{0};
-  uint32_t command_written_at_{0};
   uint32_t last_response_{0};
-  // When the door was last handed a lamp key press. It reports the lamp a moment later, so this bounds the
-  // wait. Queueing another toggle deliberately leaves it alone, so the one already sent keeps its deadline.
-  uint32_t light_toggle_released_at_{0};
+  // When the door fetched the lamp request. It reports the lamp a moment later, so this bounds the wait; zero
+  // while the request is still in the slot.
+  uint32_t light_request_sent_at_{0};
   uint32_t pause_started_at_{0};
 
-  // A command is "pressed" for this long before its end value is sent.
-  uint16_t key_press_delay_ms_{100};
   // Drop the "connected" flag if the bus controller has not polled us for this long.
   uint16_t connection_timeout_ms_{2000};
   // How long the announcement waits to be acknowledged. The controller polls several times a second.
@@ -187,7 +172,9 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   DoorState target_direction_{DoorState::STOPPED};
   // Position as reported by the bus controller, 0..200 across the full travel.
   uint8_t position_raw_{0};
-  uint8_t light_toggles_in_flight_{0};
+  // A lamp request the door has not reported back yet, and which way it asked.
+  bool light_request_pending_{false};
+  bool light_request_on_{false};
   // Running counter and code of a payload transfer still to be answered on the following read half.
   uint8_t transfer_answer_counter_{0};
   uint8_t transfer_answer_code_{0};

--- a/esphome/components/hoermann_hcp/hoermann_hcp.h
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.h
@@ -140,6 +140,8 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
 
   // The command waiting for the controller's next fetch. There is one slot: the controller takes one per poll.
   const HoermannHcpCommand *next_command_{nullptr};
+  // The command the controller has just fetched, waiting to be logged off the answer path.
+  const HoermannHcpCommand *sent_command_{nullptr};
   uint32_t command_queued_at_{0};
   // Separate from command_queued_at_ so an unrelated command cannot extend the target's start deadline.
   uint32_t target_queued_at_{0};

--- a/esphome/components/hoermann_hcp/hoermann_hcp.h
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.h
@@ -21,6 +21,14 @@ enum class DoorState : uint8_t {
   STOPPED,
 };
 
+// Steps of announcing that the accessory is about to go quiet.
+enum class PauseState : uint8_t {
+  PAUSE_STATE_IDLE,
+  PAUSE_STATE_WAITING_FOR_ACK,
+  PAUSE_STATE_SETTLING,
+  PAUSE_STATE_DONE,
+};
+
 // A HCP command is a simulated key press: the pressed value is presented to the bus controller, then after a
 // short delay the released value. Each half also carries a second register, which names the buttons that do
 // not fit into the first.
@@ -38,6 +46,15 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
  public:
   void update() override;
   void dump_config() override;
+  void on_shutdown() override;
+
+  /** Tells the bus controller the accessory is about to go quiet and waits for it to agree.
+   *
+   * The controller registered this accessory during its bus scan, so one that simply stops answering is a
+   * fault to it rather than an absence. Blocks, serving the bus itself, because neither caller runs where
+   * the main loop would turn it. Returns whether it was acknowledged; the caller carries on either way.
+   */
+  bool announce_pause();
 
   // Registered by child entities to be notified when the door state changes.
   template<typename F> void add_on_state_callback(F &&callback) {
@@ -96,6 +113,27 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   void on_state_reg_(uint16_t value);
   void on_light_reg_(uint16_t value);
 
+  // Reads a payload transfer and arms the answer the controller expects on the read half of the same request.
+  void take_transfer_(const modbus::RegisterValues &registers);
+  void push_transfer_answer_(modbus::RegisterValues &registers, uint16_t number_of_registers);
+  /** Moves the announcement along one step and reports whether anything is left to say.
+   *
+   * Decides everything from the clock so it can be called repeatedly, which is what lets the restart path
+   * and the ota trigger share the same steps and makes them testable without a bus.
+   */
+  bool advance_pause_();
+  // Drops a command the controller has not been shown yet. Unlike drop_command_ it keeps the travel target:
+  // nothing can be sent until the announcement is over, but if no restart follows, the next position the
+  // door reports still stops it where it was told to stop.
+  void drop_unsent_command_();
+  // Ends the announcement, however it ended, and puts the device back to answering normally.
+  void end_pause_();
+  // The pause replaces the ordinary state answer until the whole announcement is over.
+  bool announcing_pause_() const {
+    return this->pause_state_ == PauseState::PAUSE_STATE_WAITING_FOR_ACK ||
+           this->pause_state_ == PauseState::PAUSE_STATE_SETTLING;
+  }
+
   void set_valid_(bool valid);
   void set_door_state_(DoorState state);
   // Recomputes the reported position from position_raw_ and the current door state.
@@ -121,11 +159,21 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // When the door was last handed a lamp key press. It reports the lamp a moment later, so this bounds the
   // wait. Queueing another toggle deliberately leaves it alone, so the one already sent keeps its deadline.
   uint32_t light_toggle_released_at_{0};
+  // When the current step of the announcement began.
+  uint32_t pause_started_at_{0};
 
   // A command is "pressed" for this long before its end value is sent.
   uint16_t key_press_delay_ms_{100};
   // Drop the "connected" flag if the bus controller has not polled us for this long.
   uint16_t connection_timeout_ms_{2000};
+  // How long the announcement waits to be acknowledged. The controller polls several times a second.
+  uint16_t pause_ack_timeout_ms_{800};
+  // Nothing arriving for this long means no telegram is in flight, so a restart lands between them.
+  uint16_t pause_quiet_ms_{40};
+  // A controller that never falls quiet must not hold up the restart for longer than this.
+  uint16_t pause_settle_ms_{200};
+  // Ceiling on the whole announcement, so a controller that keeps a key press open cannot hold it open.
+  uint16_t pause_total_timeout_ms_{1500};
   // The state starts on a value the bus controller never reports, so the first broadcast is decoded even when
   // it reads 0x0000.
   uint16_t prev_state_reg_{0xFFFF};
@@ -140,6 +188,14 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // Position as reported by the bus controller, 0..200 across the full travel.
   uint8_t position_raw_{0};
   uint8_t light_toggles_in_flight_{0};
+  // Running counter and code of a payload transfer still to be answered on the following read half.
+  uint8_t transfer_answer_counter_{0};
+  uint8_t transfer_answer_code_{0};
+  bool transfer_answer_pending_{false};
+  PauseState pause_state_{PauseState::PAUSE_STATE_IDLE};
+  bool pause_confirmed_{false};
+  // Guards the blocking announcement against being entered from inside itself.
+  bool announcing_{false};
   bool target_started_{false};
   bool valid_{false};
   bool changed_{false};

--- a/esphome/components/hoermann_hcp/hoermann_hcp.h
+++ b/esphome/components/hoermann_hcp/hoermann_hcp.h
@@ -48,11 +48,12 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   void dump_config() override;
   void on_shutdown() override;
 
-  /** Tells the bus controller the accessory is about to go quiet and waits for it to agree.
+  /** Tells the bus controller the accessory is about to go quiet, then waits briefly for it to answer.
    *
    * The controller registered this accessory during its bus scan, so one that simply stops answering is a
    * fault to it rather than an absence. Blocks, serving the bus itself, because neither caller runs where
-   * the main loop would turn it. Returns whether it was acknowledged; the caller carries on either way.
+   * the main loop would turn it. Goes quiet either way; the return value only says whether it was
+   * acknowledged.
    */
   bool announce_pause();
 
@@ -159,7 +160,6 @@ class HoermannHcp : public PollingComponent, public modbus::ModbusServerDevice {
   // When the door was last handed a lamp key press. It reports the lamp a moment later, so this bounds the
   // wait. Queueing another toggle deliberately leaves it alone, so the one already sent keeps its deadline.
   uint32_t light_toggle_released_at_{0};
-  // When the current step of the announcement began.
   uint32_t pause_started_at_{0};
 
   // A command is "pressed" for this long before its end value is sent.

--- a/esphome/components/hoermann_hcp/light/hoermann_hcp_light.cpp
+++ b/esphome/components/hoermann_hcp/light/hoermann_hcp_light.cpp
@@ -40,8 +40,7 @@ void HoermannHcpLight::write_state(light::LightState *state) {
     if (!this->parent_->is_light_known()) {
       // Commanding a lamp that has not been read could switch off one that is already on.
       ESP_LOGW(TAG, "Door has not reported the lamp yet, ignoring the requested state");
-    } else if (this->parent_->cancel_light_toggle() || this->parent_->toggle_light()) {
-      // A toggle the controller has not fetched is withdrawn outright rather than fought with a second one.
+    } else if (this->parent_->set_light(binary)) {
       return;
     } else {
       ESP_LOGW(TAG, "Light command was not accepted by the door");

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -420,8 +420,9 @@ bool ModbusServerHub::service() {
   // the single reply this hub can hold back.
   if (this->in_dispatch_)
     return false;
-  // Owed first, so a reply held back earlier cannot end up on the wire behind one this pass produces. The
-  // scheduler that would otherwise send it does not run during the waits this method exists for.
+  // Owed first, so a reply held back earlier goes out ahead of one this pass produces, unless the wire cannot
+  // take it yet; then it waits for the next pass. The scheduler that would otherwise send it does not run
+  // during the waits this method exists for.
   this->send_deferred_(false);
   this->loop();
   return true;
@@ -1248,8 +1249,12 @@ void ModbusServerHub::send_deferred_(bool drop_if_blocked) {
   // is still a busy wire rather than a reply the controller has stopped waiting for.
   if (sent || drop_if_blocked)
     this->deferred_payload_len_ = 0;
-  if (!sent) {
-    ESP_LOGE(TAG, "Deferred server reply %s: transmission still blocked", drop_if_blocked ? "dropped" : "held");
+  if (sent)
+    return;
+  if (drop_if_blocked) {
+    ESP_LOGE(TAG, "Deferred server reply dropped: transmission still blocked");
+  } else {
+    ESP_LOGV(TAG, "Deferred server reply held: a byte arrived during the send delay, next pass retries");
   }
 }
 

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -412,10 +412,10 @@ void ModbusServerHub::register_device(ModbusServerDevice *device) {
 bool ModbusServerDevice::service_bus_() {
   if (this->hub_ == nullptr)
     return false;
-  return this->hub_->service();
+  return this->hub_->service_();
 }
 
-bool ModbusServerHub::service() {
+bool ModbusServerHub::service_() {
   // Re-entering from a handler would answer a later frame before the one being handled, and would overwrite
   // the single reply this hub can hold back.
   if (this->in_dispatch_)

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -319,12 +319,16 @@ bool ModbusServerHub::parse_modbus_client_frame_() {
   std::span<const uint8_t> data(data_buffer, data_len);
   this->clear_rx_buffer_(LOG_STR("parse succeeded"), false, frame_length);
 
+  // Restored rather than cleared: loop() is public, so a nested pass must not free the outer dispatch.
+  const bool was_dispatching = this->in_dispatch_;
+  this->in_dispatch_ = true;
   if (address == BROADCAST_ADDRESS) {
     // Keep the unicast response buffers out of the broadcast call chain.
     this->process_broadcast_frame_(function_code, data);
   } else {
     this->process_modbus_client_frame_(address, function_code, data);
   }
+  this->in_dispatch_ = was_dispatching;
 
   return true;
 }
@@ -397,6 +401,30 @@ void ModbusServerHub::process_modbus_server_frame(uint8_t address, std::span<con
   // This always resets, even if the address doesn't match.
   // If an unexpected response is received, we can't trust that a correct response will follow (it shouldn't).
   this->expecting_peer_response_ = 0;
+}
+
+// Out of line: ModbusServerDevice is not yet defined at this point in the header.
+void ModbusServerHub::register_device(ModbusServerDevice *device) {
+  device->hub_ = this;
+  this->devices_.push_back(device);
+}
+
+bool ModbusServerDevice::service_bus_() {
+  if (this->hub_ == nullptr)
+    return false;
+  return this->hub_->service();
+}
+
+bool ModbusServerHub::service() {
+  // Re-entering from a handler would answer a later frame before the one being handled, and would overwrite
+  // the single reply this hub can hold back.
+  if (this->in_dispatch_)
+    return false;
+  // Owed first, so a reply held back earlier cannot end up on the wire behind one this pass produces. The
+  // scheduler that would otherwise send it does not run during the waits this method exists for.
+  this->send_deferred_(false);
+  this->loop();
+  return true;
 }
 
 ModbusServerDevice *ModbusServerHub::find_device_(uint8_t address) {
@@ -1196,19 +1224,32 @@ void ModbusServerHub::send_raw_(const uint8_t *payload, uint16_t len) {
     std::memcpy(this->deferred_payload_.data(), payload, len);
     this->deferred_payload_len_ = len;
     // set_timeout() takes milliseconds; round the microsecond delay up so we never fire early.
-    this->set_timeout("deferred_send", (this->tx_delay_remaining() + US_PER_MS - 1) / US_PER_MS, [this]() {
-      ModbusFrame frame(this->deferred_payload_[0], this->deferred_payload_.data() + 1,
-                        this->deferred_payload_len_ - 1);
-      if (!this->send_frame_(frame)) {
-        ESP_LOGE(TAG, "Deferred server reply dropped: transmission still blocked");
-      }
-    });
+    this->set_timeout("deferred_send", (this->tx_delay_remaining() + US_PER_MS - 1) / US_PER_MS,
+                      [this]() { this->send_deferred_(true); });
     return;
   }
 
   ModbusFrame frame(payload[0], payload + 1, len - 1);
   if (!this->send_frame_(frame)) {
     ESP_LOGE(TAG, "Server reply dropped: a frame arrived during the send delay");
+  }
+}
+
+void ModbusServerHub::send_deferred_(bool drop_if_blocked) {
+  if (this->deferred_payload_len_ == 0)
+    return;
+  // What blocked the send is usually bytes still arriving, and waiting here would not drain them. A caller
+  // that comes back keeps the reply instead of spending its only attempt on a wire that cannot take it.
+  if (!drop_if_blocked && this->tx_blocked())
+    return;
+  ModbusFrame frame(this->deferred_payload_[0], this->deferred_payload_.data() + 1, this->deferred_payload_len_ - 1);
+  const bool sent = this->send_frame_(frame);
+  // Kept only for a caller that is coming back: send_frame_ re-checks after its own delay, so a failure here
+  // is still a busy wire rather than a reply the controller has stopped waiting for.
+  if (sent || drop_if_blocked)
+    this->deferred_payload_len_ = 0;
+  if (!sent) {
+    ESP_LOGE(TAG, "Deferred server reply %s: transmission still blocked", drop_if_blocked ? "dropped" : "held");
   }
 }
 

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -317,7 +317,12 @@ class ModbusServerHub : public Modbus {
  public:
   ModbusServerHub() = default;
   void dump_config() override;
-  void register_device(ModbusServerDevice *device) { this->devices_.push_back(device); }
+  void register_device(ModbusServerDevice *device);
+  /// Runs one pass of the bus and sends anything a device is still owed. For a device that has to keep
+  /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
+  /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
+  /// re-enter it.
+  bool service();
 
  protected:
   void parse_modbus_frames() override;
@@ -363,7 +368,13 @@ class ModbusServerHub : public Modbus {
   bool rejected_(uint8_t address, uint8_t function_code, ResponseStatus status);
   void send_exception_(uint8_t address, uint8_t function_code, ExceptionCode exception_code);
   void send_response_(uint8_t address, uint8_t function_code, const uint8_t *payload, uint16_t payload_len);
+  /// Sends a reply that was held back, if one is waiting. With drop_if_blocked the reply is given its one
+  /// chance and discarded, which is what the scheduler timeout wants; without it a busy wire is a reason to
+  /// keep the reply for the next pass.
+  void send_deferred_(bool drop_if_blocked);
   uint8_t expecting_peer_response_{0};
+  // Set while a frame is being handed to a device, so service() cannot be re-entered from a handler.
+  bool in_dispatch_{false};
   std::vector<ModbusServerDevice *> devices_;
 
   // Holds the raw payload of a single reply deferred for sending when tx was blocked at send time.
@@ -648,7 +659,15 @@ class ModbusServerDevice {
   };
 
  protected:
+  /// Runs one pass of the bus, so a device can keep answering during a bounded wait the main loop does not
+  /// cover. Returns whether it ran: it does not while the hub is dispatching a frame, or before the device
+  /// is registered.
+  bool service_bus_();
+
+  ModbusServerHub *hub_{nullptr};
   uint8_t address_{0};
+
+  friend class ModbusServerHub;
 };
 
 }  // namespace esphome::modbus

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -324,7 +324,7 @@ class ModbusServerHub : public Modbus {
   /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
   /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
   /// re-enter it. Reached through ModbusServerDevice::service_bus_() only.
-  bool service();
+  bool service_();
   friend class ModbusServerDevice;
 
   void parse_modbus_frames() override;

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -318,13 +318,15 @@ class ModbusServerHub : public Modbus {
   ModbusServerHub() = default;
   void dump_config() override;
   void register_device(ModbusServerDevice *device);
+
+ protected:
   /// Runs one pass of the bus and sends anything a device is still owed. For a device that has to keep
   /// answering during a bounded wait the main loop does not cover, such as announcing a restart.
   /// Returns false without doing anything while the hub is dispatching a frame, so a handler cannot
-  /// re-enter it.
+  /// re-enter it. Reached through ModbusServerDevice::service_bus_() only.
   bool service();
+  friend class ModbusServerDevice;
 
- protected:
   void parse_modbus_frames() override;
   bool parse_modbus_client_frame_();
   void process_modbus_server_frame(uint8_t address, std::span<const uint8_t> pdu) override;

--- a/tests/components/hoermann_hcp/button/hoermann_hcp_button_test.cpp
+++ b/tests/components/hoermann_hcp/button/hoermann_hcp_button_test.cpp
@@ -6,43 +6,35 @@
 
 namespace esphome::hoermann_hcp::testing {
 
-// The intermediate positions are named in the second register, which repeats that name on release.
+// The intermediate positions are named in the second register.
 TEST(HoermannHcpButtonTest, VentButtonSendsTheVentCommand) {
-  TestableHoermannHcp door;
+  HoermannHcp door;
   HoermannHcpVentButton vent(&door);
   connect_controller(door);
 
   vent.press();
 
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0200);
-  EXPECT_EQ(pressed_2, 0x4000);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  auto [released, released_2] = poll_command(door);
-  EXPECT_EQ(released, 0x0100);
-  EXPECT_EQ(released_2, 0x4000);
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0100);
+  EXPECT_EQ(value_2, 0x4000);
 }
 
 TEST(HoermannHcpButtonTest, HalfOpenButtonSendsTheHalfOpenCommand) {
-  TestableHoermannHcp door;
+  HoermannHcp door;
   HoermannHcpHalfOpenButton half_open(&door);
   connect_controller(door);
 
   half_open.press();
 
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0200);
-  EXPECT_EQ(pressed_2, 0x0400);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  auto [released, released_2] = poll_command(door);
-  EXPECT_EQ(released, 0x0100);
-  EXPECT_EQ(released_2, 0x0400);
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0100);
+  EXPECT_EQ(value_2, 0x0400);
 }
 
 // The door drives to the vent position on its own, so a position the cover was still travelling to must not
 // stop it on the way there.
 TEST(HoermannHcpButtonTest, VentAbandonsAnArmedTarget) {
-  TestableHoermannHcp door;  // starts out fully closed
+  HoermannHcp door;  // starts out fully closed
   HoermannHcpVentButton vent(&door);
   connect_controller(door);
   door.set_position(0.5f);

--- a/tests/components/hoermann_hcp/common.h
+++ b/tests/components/hoermann_hcp/common.h
@@ -1,10 +1,15 @@
 #pragma once
 #include <chrono>
+#include <cstring>
 #include <initializer_list>
+#include <span>
 #include <thread>
 #include <utility>
+#include <vector>
 #include <gtest/gtest.h>
 #include "esphome/components/hoermann_hcp/hoermann_hcp.h"
+#include "esphome/components/modbus/modbus.h"
+#include "esphome/components/uart/uart_component.h"
 
 namespace esphome::hoermann_hcp::testing {
 
@@ -14,6 +19,12 @@ using modbus::RegisterValues;
 constexpr uint16_t COMMAND_REG = 0x9C41;
 constexpr uint16_t STATE_REG = 0x9CB9;
 constexpr uint16_t BROADCAST_REG = 0x9D31;
+
+// Answer codes mirrored from hoermann_hcp.cpp, so the tests below can name what they assert.
+constexpr uint16_t RESPONSE_STATUS = 0x0001;
+constexpr uint16_t RESPONSE_PAUSE = 0x0029;
+constexpr uint16_t TRANSFER_ACK_ANSWER = 0x04FD;
+constexpr uint16_t TRANSFER_NAK_ANSWER = 0x04FE;
 
 // The tests shorten the key-press delay to zero, so the release only needs the millis() clock to tick on.
 constexpr auto KEY_PRESS_ELAPSED = std::chrono::milliseconds(2);
@@ -62,7 +73,121 @@ class TestableHoermannHcp : public HoermannHcp {
   using HoermannHcp::is_light_toggle_pending_;
   using HoermannHcp::light_toggle_released_at_;
   using HoermannHcp::light_toggles_in_flight_;
+  using HoermannHcp::announcing_;
+  using HoermannHcp::pause_ack_timeout_ms_;
+  using HoermannHcp::pause_confirmed_;
+  using HoermannHcp::pause_quiet_ms_;
+  using HoermannHcp::pause_settle_ms_;
+  using HoermannHcp::pause_state_;
+  using HoermannHcp::pause_total_timeout_ms_;
   using HoermannHcp::set_valid_;
+  using HoermannHcp::transfer_answer_pending_;
+};
+
+// A UART the test can inject received bytes into and read written bytes back from.
+class FakeWire : public uart::UARTComponent {
+ public:
+  FakeWire() {
+    this->set_baud_rate(57600);
+    this->set_data_bits(8);
+    this->set_stop_bits(1);
+    this->set_parity(uart::UART_CONFIG_PARITY_EVEN);
+  }
+  void write_array(const uint8_t *data, size_t len) override {
+    this->written.insert(this->written.end(), data, data + len);
+  }
+  bool peek_byte(uint8_t *data) override {
+    if (this->rx_.empty())
+      return false;
+    *data = this->rx_.front();
+    return true;
+  }
+  bool read_array(uint8_t *data, size_t len) override {
+    if (len > this->rx_.size())
+      return false;
+    std::memcpy(data, this->rx_.data(), len);
+    this->rx_.erase(this->rx_.begin(), this->rx_.begin() + len);
+    return true;
+  }
+  size_t available() override { return this->rx_.size(); }
+  uart::UARTFlushResult flush() override { return uart::UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS; }
+#if defined(USE_ESP8266) || defined(USE_ESP32)
+  void load_settings(bool dump_config) override {}
+#endif
+  void check_logger_conflict() override {}
+
+  // A 0x17 request the way the bus controller sends it: write the command block, read the state block back.
+  void inject_poll(uint8_t address, std::initializer_list<uint16_t> command_registers, uint8_t read_count) {
+    std::vector<uint8_t> pdu = {0x17,
+                                0x9C,
+                                0xB9,
+                                0x00,
+                                read_count,
+                                0x9C,
+                                0x41,
+                                0x00,
+                                static_cast<uint8_t>(command_registers.size()),
+                                static_cast<uint8_t>(command_registers.size() * 2)};
+    for (uint16_t value : command_registers) {
+      pdu.push_back(static_cast<uint8_t>(value >> 8));
+      pdu.push_back(static_cast<uint8_t>(value & 0xFF));
+    }
+    const size_t start = this->rx_.size();
+    this->rx_.push_back(address);
+    this->rx_.insert(this->rx_.end(), pdu.begin(), pdu.end());
+    const uint16_t crc = crc16(this->rx_.data() + start, this->rx_.size() - start);
+    this->rx_.push_back(crc & 0xFF);
+    this->rx_.push_back(crc >> 8);
+  }
+
+  // Register i of the first reply since the last clear: address, function code, byte count, then registers.
+  uint16_t reply_register(size_t i) const {
+    const size_t offset = 3 + 2 * i;
+    EXPECT_GE(this->written.size(), offset + 2) << "no register " << i << " on the wire";
+    if (this->written.size() < offset + 2)
+      return 0xFFFF;
+    EXPECT_EQ(this->written[1], 0x17) << "reply is not a read/write response";
+    return static_cast<uint16_t>((this->written[offset] << 8) | this->written[offset + 1]);
+  }
+
+  std::vector<uint8_t> written;
+
+ private:
+  std::vector<uint8_t> rx_;
+};
+
+// The wire is never busy, so no reply is held back through the scheduler, which the host test binary has
+// no working scheduler for.
+class FreeWireHub : public modbus::ModbusServerHub {
+ public:
+  bool tx_blocked() override { return false; }
+  void prime_send_timestamps_for_test() {
+    const uint32_t now = millis();
+    this->last_modbus_byte_ = now;
+    this->last_send_ = now;
+  }
+};
+
+struct BusFixture {
+  BusFixture() {
+    hub.set_uart_parent(&wire);
+    hub.setup();
+    hub.prime_send_timestamps_for_test();
+    door.set_address(0x02);
+    door.pause_ack_timeout_ms_ = 200;
+    door.pause_quiet_ms_ = 1;
+    door.pause_settle_ms_ = 5;
+    door.pause_total_timeout_ms_ = 500;
+    hub.register_device(&door);
+    // The controller has to have talked to us, or there is nobody to announce anything to.
+    wire.inject_poll(0x02, {0x0000, 0x0000}, 8);
+    hub.loop();
+    wire.written.clear();
+  }
+
+  FakeWire wire;
+  FreeWireHub hub;
+  TestableHoermannHcp door;
 };
 
 }  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/hoermann_hcp/common.h
+++ b/tests/components/hoermann_hcp/common.h
@@ -26,9 +26,6 @@ constexpr uint16_t RESPONSE_PAUSE = 0x0029;
 constexpr uint16_t TRANSFER_ACK_ANSWER = 0x04FD;
 constexpr uint16_t TRANSFER_NAK_ANSWER = 0x04FE;
 
-// The tests shorten the key-press delay to zero, so the release only needs the millis() clock to tick on.
-constexpr auto KEY_PRESS_ELAPSED = std::chrono::milliseconds(2);
-
 inline RegisterValues make_registers(std::initializer_list<uint16_t> values) {
   RegisterValues registers;
   for (uint16_t value : values)
@@ -46,7 +43,7 @@ inline void connect_controller(HoermannHcp &door) {
   door.on_write_registers(COMMAND_REG, make_registers({0x0000, 0x0000}));
 }
 
-// Runs one command poll (write 2 / read 8) and returns both key-press registers.
+// Runs one command poll (write 2 / read 8) and returns both command registers.
 inline std::pair<uint16_t, uint16_t> poll_command(HoermannHcp &door) {
   door.on_write_registers(COMMAND_REG, make_registers({0x0000, 0x0000}));
   RegisterValues response;
@@ -57,22 +54,15 @@ inline std::pair<uint16_t, uint16_t> poll_command(HoermannHcp &door) {
   return {response[2], response[3]};
 }
 
-// Presents and then releases the queued command, leaving the slot free.
-inline void consume_command(HoermannHcp &door) {
-  poll_command(door);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(door);
-}
+// Lets the controller fetch the queued command, leaving the slot free.
+inline void consume_command(HoermannHcp &door) { poll_command(door); }
 
 // Exposes the internal timings and the connection bookkeeping, so no test has to wait out a real delay.
 class TestableHoermannHcp : public HoermannHcp {
  public:
-  TestableHoermannHcp() { this->key_press_delay_ms_ = 0; }
-
   using HoermannHcp::connection_timeout_ms_;
-  using HoermannHcp::is_light_toggle_pending_;
-  using HoermannHcp::light_toggle_released_at_;
-  using HoermannHcp::light_toggles_in_flight_;
+  using HoermannHcp::light_request_pending_;
+  using HoermannHcp::light_request_sent_at_;
   using HoermannHcp::announcing_;
   using HoermannHcp::pause_ack_timeout_ms_;
   using HoermannHcp::pause_confirmed_;

--- a/tests/components/hoermann_hcp/common.yaml
+++ b/tests/components/hoermann_hcp/common.yaml
@@ -1,3 +1,9 @@
+esphome:
+  # Only so the action is compiled. Its place in a real configuration is the ota on_begin trigger.
+  on_boot:
+    then:
+      - hoermann_hcp.announce_pause: hoermann_hcp_hub
+
 hoermann_hcp:
   id: hoermann_hcp_hub
   modbus_id: modbus_server_bus

--- a/tests/components/hoermann_hcp/cover/hoermann_hcp_cover_test.cpp
+++ b/tests/components/hoermann_hcp/cover/hoermann_hcp_cover_test.cpp
@@ -68,7 +68,7 @@ TEST(HoermannHcpCoverTest, OpenCommandOpensTheDoor) {
   connect_controller(door);
 
   cover.make_call().set_command_open().perform();
-  EXPECT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 }
 
 // The same for cover.close, which arrives as a position of 0.0.
@@ -79,7 +79,7 @@ TEST(HoermannHcpCoverTest, CloseCommandClosesTheDoor) {
   connect_controller(door);
 
   cover.make_call().set_command_close().perform();
-  EXPECT_EQ(poll_command(door).first, 0x0220);  // COMMAND_CLOSE pressed
+  EXPECT_EQ(poll_command(door).first, 0x0120);  // COMMAND_CLOSE
 }
 
 TEST(HoermannHcpCoverTest, ToggleCommandSendsAnImpulse) {
@@ -89,7 +89,7 @@ TEST(HoermannHcpCoverTest, ToggleCommandSendsAnImpulse) {
   connect_controller(door);
 
   cover.make_call().set_command_toggle().perform();
-  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed
+  EXPECT_EQ(poll_command(door).first, 0x0140);  // COMMAND_IMPULSE
 }
 
 TEST(HoermannHcpCoverTest, StopCommandStopsAMovingDoor) {
@@ -101,7 +101,7 @@ TEST(HoermannHcpCoverTest, StopCommandStopsAMovingDoor) {
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0064, 0x0100}));
 
   cover.make_call().set_command_stop().perform();
-  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed
+  EXPECT_EQ(poll_command(door).first, 0x0140);  // COMMAND_IMPULSE
 }
 
 // A position between the end stops starts the door in the right direction; it is stopped there later.
@@ -112,7 +112,7 @@ TEST(HoermannHcpCoverTest, PositionCommandStartsTheDoorTowardsTheTarget) {
   connect_controller(door);
 
   cover.make_call().set_position(0.5f).perform();
-  EXPECT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 }
 
 // A command the door cannot take is assumed to have worked by whoever sent it, so the unchanged state has

--- a/tests/components/hoermann_hcp/hoermann_hcp_bus_test.cpp
+++ b/tests/components/hoermann_hcp/hoermann_hcp_bus_test.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include "common.h"
+
+// The tests in hoermann_hcp_test.cpp call the register handlers directly, so they say nothing about the
+// announcement reaching a real hub. These drive it through ModbusServerHub and a fake wire instead.
+namespace esphome::hoermann_hcp::testing {
+
+// The whole exchange through the real hub: the announcement serves the bus itself, the controller's
+// acknowledgement arrives as a 0x17 request, is taken, answered on the read half, and the announcement
+// reports success.
+TEST(HoermannHcpBus, AcknowledgementArrivesThroughTheHub) {
+  BusFixture f;
+  f.wire.inject_poll(0x02, {0x8104, 0x1900, 0x0200}, 8);
+
+  EXPECT_TRUE(f.door.announce_pause());
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(0), 0x0100);
+  EXPECT_EQ(f.wire.reply_register(1), 0x04FD);  // the transfer acknowledged
+}
+
+// The first poll during an announcement carries the pause on the wire, not the state.
+TEST(HoermannHcpBus, PauseGoesOutOnTheWire) {
+  BusFixture f;
+  f.door.pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK;
+  f.wire.inject_poll(0x02, {0x3400, 0x0000}, 8);
+
+  f.hub.loop();
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(0), 0x3400);
+  EXPECT_EQ(f.wire.reply_register(1), 0x0029);
+  EXPECT_EQ(f.wire.reply_register(2), 0x0002);
+}
+
+// With the controller polling but never acknowledging, the announcement gives up on time and the device is
+// answering with the state again afterwards.
+TEST(HoermannHcpBus, UnacknowledgedAnnouncementGivesUpAndRecovers) {
+  BusFixture f;
+  f.wire.inject_poll(0x02, {0x0000, 0x0000}, 8);
+
+  EXPECT_FALSE(f.door.announce_pause());
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(1), 0x0029);  // what the poll during the announcement got
+
+  f.wire.written.clear();
+  f.wire.inject_poll(0x02, {0x0000, 0x0000}, 8);
+  f.hub.loop();
+  ASSERT_GE(f.wire.written.size(), 3u + 16u);
+  EXPECT_EQ(f.wire.reply_register(1), 0x0001);
+}
+
+// A second announcement while one is running would reset the state machine under the first one's feet.
+TEST(HoermannHcpBus, ASecondAnnouncementIsRefusedWhileOneRuns) {
+  BusFixture f;
+  f.door.announcing_ = true;
+
+  EXPECT_FALSE(f.door.announce_pause());
+  EXPECT_EQ(f.door.pause_state_, PauseState::PAUSE_STATE_IDLE);
+}
+
+}  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
+++ b/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
@@ -385,4 +385,311 @@ TEST(HoermannHcpPosition, TargetIsDroppedWhenTheDoorNeverTurnsAround) {
   EXPECT_EQ(poll_command(door).first, 0x0000);
 }
 
+// Puts the device into the state where the next status poll carries the pause, without running the wait.
+inline void start_announcing(TestableHoermannHcp &door) { door.pause_state_ = PauseState::PAUSE_STATE_WAITING_FOR_ACK; }
+
+// While a pause is announced, the command poll carries the pause code and the address it applies to instead of
+// the state, and it keeps echoing the controller's counter and command byte as every other answer does.
+TEST(HoermannHcpPause, PausePollNamesOurAddressInsteadOfState) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  door.on_write_registers(COMMAND_REG, make_registers({0x3407, 0x0000}));
+  door.open_door();
+  start_announcing(door);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[0], 0x3400);  // the controller's counter, echoed as every answer echoes it
+  EXPECT_EQ(response[1], 0x0729);  // command byte echoed alongside RESPONSE_PAUSE
+  EXPECT_EQ(response[2], 0x0002);  // the address being paused
+  EXPECT_EQ(response[3], 0x0000);
+}
+
+// Other block lengths keep their ordinary answers, so a bus scan arriving mid announcement still identifies us.
+TEST(HoermannHcpPause, OnlyTheCommandPollCarriesThePause) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 2, response).has_value());
+  ASSERT_EQ(response.size(), 2u);
+  EXPECT_EQ(response[0], 0x0004);
+}
+
+// The controller confirms with a payload transfer naming the address it is pausing, which is answered on the
+// read half of the same request.
+TEST(HoermannHcpPause, AcknowledgementIsTakenAndAnswered) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  // Command 0x04 with running counter 0x81, sub code 0x19, and address 0x0002 astride the last two registers.
+  ASSERT_FALSE(door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200})).has_value());
+  EXPECT_TRUE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[0], 0x0100);  // counter echoed with the split-payload bit masked off
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// The answer belongs to the request that asked for it. Left armed it would replace every later poll, and the
+// pause the controller is waiting on would never be sent again.
+TEST(HoermannHcpPause, TransferIsAnsweredOnlyOnce) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+
+  RegisterValues first;
+  door.on_read_holding_registers(STATE_REG, 8, first);
+  ASSERT_EQ(first.size(), 8u);
+  ASSERT_EQ(first[1], TRANSFER_ACK_ANSWER);
+
+  RegisterValues second;
+  door.on_read_holding_registers(STATE_REG, 8, second);
+  ASSERT_EQ(second.size(), 8u);
+  // Back to announcing the pause, with the transfer's own command byte echoed as every answer echoes it.
+  EXPECT_EQ(second[1], 0x0429);
+}
+
+// A confirmation naming another accessory is still answered, but it is not ours to take.
+TEST(HoermannHcpPause, AcknowledgementForAnotherAddressIsAnsweredButNotTaken) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  ASSERT_FALSE(door.on_write_registers(COMMAND_REG, make_registers({0x0104, 0x1900, 0x0300})).has_value());
+  EXPECT_FALSE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// The address straddles two registers. One whose high half is not ours names a different accessory even when
+// the low half matches.
+TEST(HoermannHcpPause, AcknowledgementWithANonZeroAddressHighHalfIsNotOurs) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  // Address 0x0102: the low half matches, the high half does not.
+  door.on_write_registers(COMMAND_REG, make_registers({0x0104, 0x1901, 0x0200}));
+  EXPECT_FALSE(door.pause_confirmed_);
+}
+
+// Payload transfers carry other sub codes. Only the pause acknowledgement is ours to take, but every transfer
+// is answered rather than left open.
+TEST(HoermannHcpPause, TransferWithAnotherSubCodeIsRefusedRatherThanIgnored) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x2500, 0x0200}));
+  EXPECT_FALSE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_NAK_ANSWER);
+}
+
+// Outside an announcement the command byte alone means nothing: the poll is answered with the ordinary state
+// and no transfer answer is armed to pre-empt the next read.
+TEST(HoermannHcpPause, TransferOutsideAnAnnouncementIsLeftAlone) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+  EXPECT_FALSE(door.pause_confirmed_);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], 0x0401);  // the ordinary state, with the command byte echoed
+}
+
+// A command taken while the pause is out could only be presented afterwards, to a door that has moved on.
+TEST(HoermannHcpPause, CommandsAreRefusedWhileThePauseIsOut) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  EXPECT_FALSE(door.open_door());
+}
+
+// A transfer too short to name an address is still answered. Leaving it open would strand the controller
+// waiting, and the announcement would then run to its timeout for nothing.
+TEST(HoermannHcpPause, AcknowledgementWithoutAnAddressIsStillAnswered) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900}));
+  EXPECT_FALSE(door.pause_confirmed_);  // no address, so nothing to match ours against
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// An answer armed but never read must not survive into the next announcement, where it would pre-empt the
+// pause the controller is waiting for.
+TEST(HoermannHcpPause, AStaleTransferAnswerDoesNotSurviveIntoTheNextAnnouncement) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+  ASSERT_TRUE(door.transfer_answer_pending_);
+
+  // A fresh announcement, without the armed answer ever having been read.
+  door.pause_state_ = PauseState::PAUSE_STATE_IDLE;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  door.pause_total_timeout_ms_ = 20;
+  door.announce_pause();
+  EXPECT_FALSE(door.transfer_answer_pending_);
+}
+
+// Nor across a connection loss: it would be delivered on the first read after the controller returns, which
+// is the bus scan.
+TEST(HoermannHcpPause, AStaleTransferAnswerDoesNotSurviveAConnectionLoss) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+  ASSERT_TRUE(door.transfer_answer_pending_);
+
+  door.set_valid_(false);
+  EXPECT_FALSE(door.transfer_answer_pending_);
+}
+
+// A read too short to carry the answer keeps it for the next one instead of swallowing it, and answers the
+// length that was asked for.
+TEST(HoermannHcpPause, AShortReadKeepsTheTransferAnswer) {
+  TestableHoermannHcp door;
+  door.set_address(0x02);
+  connect_controller(door);
+  start_announcing(door);
+  door.on_write_registers(COMMAND_REG, make_registers({0x8104, 0x1900, 0x0200}));
+
+  RegisterValues short_read;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 1, short_read).has_value());
+  EXPECT_EQ(short_read.size(), 1u);
+
+  RegisterValues response;
+  ASSERT_FALSE(door.on_read_holding_registers(STATE_REG, 8, response).has_value());
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], TRANSFER_ACK_ANSWER);
+}
+
+// With no bus controller there is nobody to tell, so the announcement returns at once rather than holding up
+// the restart for an answer that cannot come.
+TEST(HoermannHcpPause, AnnouncementWithoutControllerDoesNotWait) {
+  TestableHoermannHcp door;
+  const uint32_t started = millis();
+  EXPECT_FALSE(door.announce_pause());
+  EXPECT_LT(millis() - started, 50u);
+}
+
+// Unconfirmed, the announcement gives up rather than holding the restart for ever, and puts the device back to
+// answering normally so a restart that never happens does not leave it paused.
+TEST(HoermannHcpPause, UnconfirmedAnnouncementGivesUpAndStopsAnnouncing) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  connect_controller(door);
+
+  EXPECT_FALSE(door.announce_pause());
+  door.update();
+
+  RegisterValues response;
+  door.on_read_holding_registers(STATE_REG, 8, response);
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], RESPONSE_STATUS);  // ordinary state again, not the pause
+}
+
+// A key press that was never shown to the controller is dropped, so it cannot fire after the restart.
+TEST(HoermannHcpPause, AnnouncementDropsTheUnsentKeyPress) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  connect_controller(door);
+  door.open_door();
+
+  door.announce_pause();
+  door.update();
+  EXPECT_EQ(poll_command(door).first, 0x0000);
+}
+
+// A press already shown to the controller holds the announcement off, because the pause replaces the answer
+// that would carry its release value and the controller would be left holding a key that is never let go.
+TEST(HoermannHcpPause, AnnouncementIsHeldOffWhileAPressIsUnreleased) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  door.pause_total_timeout_ms_ = 20;
+  connect_controller(door);
+  door.open_door();
+  ASSERT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed, release still owed
+
+  EXPECT_FALSE(door.announce_pause());
+  // No pause was announced, so the poll still carries the release the controller is owed.
+  RegisterValues response;
+  door.on_read_holding_registers(STATE_REG, 8, response);
+  ASSERT_EQ(response.size(), 8u);
+  EXPECT_EQ(response[1], RESPONSE_STATUS);
+  EXPECT_EQ(response[2], 0x0110);  // COMMAND_OPEN released
+}
+
+// Running out of time must not leave the pause standing: it replaces the answer that carries key presses, so
+// the door would stop taking commands until the next restart.
+TEST(HoermannHcpPause, GivingUpDoesNotLeaveThePauseStanding) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5000;  // never reached within the ceiling below
+  door.pause_total_timeout_ms_ = 20;
+  connect_controller(door);
+
+  EXPECT_FALSE(door.announce_pause());
+  door.update();
+  door.open_door();
+  EXPECT_EQ(poll_command(door).first, 0x0210);  // commands are delivered again
+}
+
+// A position the door was told to travel to survives the announcement: without a restart the door still has to
+// be stopped where it was asked to stop.
+TEST(HoermannHcpPause, AnnouncementKeepsTheTravelTarget) {
+  TestableHoermannHcp door;
+  door.pause_ack_timeout_ms_ = 5;
+  door.pause_settle_ms_ = 5;
+  connect_controller(door);
+  door.set_position(0.5f);
+  consume_command(door);
+  // The door reports it is opening and passes the target, which has to still stop it.
+  door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0000, 0x0100}));
+
+  door.announce_pause();
+  door.update();
+
+  door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0080, 0x0100}));
+  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed, stopping the door
+}
+
 }  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
+++ b/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <thread>
 
+#include "esphome/components/hoermann_hcp/automation.h"
+
 #include "common.h"
 
 namespace esphome::hoermann_hcp::testing {
@@ -46,7 +48,7 @@ TEST(HoermannHcpReadWrite, IdleCommandPollHasNoCommand) {
   EXPECT_EQ(response[3], 0x0000);
 }
 
-// A queued control command is injected into the next command poll as a simulated key press.
+// A queued control command is injected into the next command poll.
 TEST(HoermannHcpReadWrite, QueuedCommandIsInjectedIntoPoll) {
   HoermannHcp door;
   connect_controller(door);
@@ -56,7 +58,7 @@ TEST(HoermannHcpReadWrite, QueuedCommandIsInjectedIntoPoll) {
   auto status = door.on_read_holding_registers(STATE_REG, 8, response);
   EXPECT_FALSE(status.has_value());
   ASSERT_EQ(response.size(), 8u);
-  EXPECT_EQ(response[2], 0x0210);  // COMMAND_OPEN "key pressed" value
+  EXPECT_EQ(response[2], 0x0110);  // COMMAND_OPEN
   EXPECT_EQ(response[3], 0x0000);
 }
 
@@ -68,20 +70,19 @@ TEST(HoermannHcpReadWrite, UnknownAddressIsRejected) {
   EXPECT_EQ(door.on_write_registers(0x1234, make_registers({0x0000})), modbus::ExceptionCode::ILLEGAL_DATA_ADDRESS);
 }
 
-// A command is held for the key-press duration, then released, and only then can the next one be queued.
-TEST(HoermannHcpReadWrite, CommandIsReleasedAfterTheKeyPressDelay) {
-  TestableHoermannHcp door;
+// A command goes out on the poll that fetches it and on no other, and only then can the next one be queued.
+TEST(HoermannHcpReadWrite, CommandGoesOutOnceAndFreesTheSlot) {
+  HoermannHcp door;
   connect_controller(door);
   door.open_door();
-  EXPECT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed
-  // Refused while one is pending: were it accepted, the release below would carry COMMAND_CLOSE's 0x0120.
-  door.close_door();
+  // Refused while one is waiting: were it accepted, the poll below would carry COMMAND_CLOSE instead.
+  EXPECT_FALSE(door.close_door());
 
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN released
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
+  EXPECT_EQ(poll_command(door).first, 0x0000);  // spent, nothing is put back
   // With the command gone, the next one is accepted again.
-  door.close_door();
-  EXPECT_EQ(poll_command(door).first, 0x0220);  // COMMAND_CLOSE pressed
+  EXPECT_TRUE(door.close_door());
+  EXPECT_EQ(poll_command(door).first, 0x0120);  // COMMAND_CLOSE
 }
 
 // Commands issued while the bus controller is absent are dropped instead of firing when it returns.
@@ -106,7 +107,7 @@ TEST(HoermannHcpReadWrite, ConnectionLossDropsThePendingCommand) {
   EXPECT_EQ(poll_command(door).first, 0x0000);
   // And the slot is free, so a new command is accepted.
   door.close_door();
-  EXPECT_EQ(poll_command(door).first, 0x0220);
+  EXPECT_EQ(poll_command(door).first, 0x0120);  // COMMAND_CLOSE
 }
 
 // The connection is dropped by update() once the controller stops polling, which is what releases a
@@ -147,7 +148,7 @@ TEST(HoermannHcpReadWrite, UnfetchedCommandExpiresWhileConnected) {
 
   // With the stale command gone, the door accepts commands again.
   door.close_door();
-  EXPECT_EQ(poll_command(door).first, 0x0220);
+  EXPECT_EQ(poll_command(door).first, 0x0120);  // COMMAND_CLOSE
 }
 
 // The 0x17 read half echoes the message counter and command byte written to COMMAND_REG, packed
@@ -235,7 +236,7 @@ TEST(HoermannHcpPosition, NearlyClosedTargetClosesTheDoor) {
   RegisterValues response;
   door.on_read_holding_registers(STATE_REG, 8, response);
   ASSERT_EQ(response.size(), 8u);
-  EXPECT_EQ(response[2], 0x0220);  // COMMAND_CLOSE "key pressed" value
+  EXPECT_EQ(response[2], 0x0120);  // COMMAND_CLOSE
 }
 
 // A half-open target starts the door moving towards the requested position.
@@ -246,7 +247,7 @@ TEST(HoermannHcpPosition, HalfOpenTargetOpensTheDoor) {
   RegisterValues response;
   door.on_read_holding_registers(STATE_REG, 8, response);
   ASSERT_EQ(response.size(), 8u);
-  EXPECT_EQ(response[2], 0x0210);  // COMMAND_OPEN "key pressed" value
+  EXPECT_EQ(response[2], 0x0110);  // COMMAND_OPEN
 }
 
 // The door has no notion of a target, so it is stopped with an impulse once it travels past the request.
@@ -254,9 +255,7 @@ TEST(HoermannHcpPosition, TargetPositionStopsTheDoor) {
   TestableHoermannHcp door;
   connect_controller(door);
   door.set_position(0.5f);
-  EXPECT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN released
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 
   // Position 20/200 = 0.1 while opening: short of the target, so the door keeps going.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0014, 0x0100}));
@@ -265,7 +264,7 @@ TEST(HoermannHcpPosition, TargetPositionStopsTheDoor) {
 
   // Position 120/200 = 0.6 is past the target, so the door is stopped.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0078, 0x0100}));
-  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed
+  EXPECT_EQ(poll_command(door).first, 0x0140);  // COMMAND_IMPULSE
 }
 
 // An impulse restarts a stopped door, so a frame reporting the stop and the target crossing at once
@@ -274,9 +273,7 @@ TEST(HoermannHcpPosition, StopReportedWithTheCrossingSendsNoImpulse) {
   TestableHoermannHcp door;
   connect_controller(door);
   door.set_position(0.5f);
-  EXPECT_EQ(poll_command(door).first, 0x0210);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0014, 0x0100}));
   ASSERT_EQ(door.get_door_state(), DoorState::OPENING);
@@ -292,9 +289,7 @@ TEST(HoermannHcpPosition, TargetIsDroppedWhenTheDoorStopsShort) {
   TestableHoermannHcp door;
   connect_controller(door);
   door.set_position(0.5f);
-  EXPECT_EQ(poll_command(door).first, 0x0210);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 
   // The door is stopped at 0.3 by a wall button, short of the requested 0.5.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0014, 0x0100}));
@@ -317,9 +312,7 @@ TEST(HoermannHcpPosition, TargetArmedWhileMovingTheOtherWayWaitsForTheTurnaround
   ASSERT_EQ(door.get_door_state(), DoorState::CLOSING);
 
   door.set_position(0.5f);
-  EXPECT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN released
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 
   // Still closing at 58/200 = 0.29: below the target, but not on the way to it.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x003A, 0x0200}));
@@ -331,7 +324,7 @@ TEST(HoermannHcpPosition, TargetArmedWhileMovingTheOtherWayWaitsForTheTurnaround
 
   // Past the target at 110/200 = 0.55, so the door is stopped.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x006E, 0x0100}));
-  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed
+  EXPECT_EQ(poll_command(door).first, 0x0140);  // COMMAND_IMPULSE
 }
 
 // A motor turning around can report a momentary stop; dropping the target there would let the door run on
@@ -343,9 +336,7 @@ TEST(HoermannHcpPosition, MomentaryStopWhileTurningAroundKeepsTheTarget) {
   ASSERT_EQ(door.get_door_state(), DoorState::CLOSING);
 
   door.set_position(0.5f);
-  EXPECT_EQ(poll_command(door).first, 0x0210);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 
   // The stop reported on the way from closing to opening.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x003C, 0x0000}));
@@ -355,7 +346,7 @@ TEST(HoermannHcpPosition, MomentaryStopWhileTurningAroundKeepsTheTarget) {
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x003E, 0x0100}));
   EXPECT_EQ(poll_command(door).first, 0x0000);
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x006E, 0x0100}));
-  EXPECT_EQ(poll_command(door).first, 0x0240);
+  EXPECT_EQ(poll_command(door).first, 0x0140);  // COMMAND_IMPULSE
 }
 
 // A door that never turns around has to lose the target as well, otherwise it would cut a later move short.
@@ -367,9 +358,7 @@ TEST(HoermannHcpPosition, TargetIsDroppedWhenTheDoorNeverTurnsAround) {
   ASSERT_EQ(door.get_door_state(), DoorState::CLOSING);
 
   door.set_position(0.5f);
-  EXPECT_EQ(poll_command(door).first, 0x0210);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  EXPECT_EQ(poll_command(door).first, 0x0110);
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // COMMAND_OPEN
 
   std::this_thread::sleep_for(std::chrono::milliseconds(220));
   // The door ignored the command and closed all the way. Its broadcast keeps the connection alive, so the
@@ -626,8 +615,8 @@ TEST(HoermannHcpPause, UnconfirmedAnnouncementGivesUpAndStopsAnnouncing) {
   EXPECT_EQ(response[1], RESPONSE_STATUS);  // ordinary state again, not the pause
 }
 
-// A key press that was never shown to the controller is dropped, so it cannot fire after the restart.
-TEST(HoermannHcpPause, AnnouncementDropsTheUnsentKeyPress) {
+// A command the controller has not fetched is dropped, so it cannot fire after the restart.
+TEST(HoermannHcpPause, AnnouncementDropsTheUnsentCommand) {
   TestableHoermannHcp door;
   door.pause_ack_timeout_ms_ = 5;
   door.pause_settle_ms_ = 5;
@@ -637,26 +626,6 @@ TEST(HoermannHcpPause, AnnouncementDropsTheUnsentKeyPress) {
   door.announce_pause();
   door.update();
   EXPECT_EQ(poll_command(door).first, 0x0000);
-}
-
-// A press already shown to the controller holds the announcement off, because the pause replaces the answer
-// that would carry its release value and the controller would be left holding a key that is never let go.
-TEST(HoermannHcpPause, AnnouncementIsHeldOffWhileAPressIsUnreleased) {
-  TestableHoermannHcp door;
-  door.pause_ack_timeout_ms_ = 5;
-  door.pause_settle_ms_ = 5;
-  door.pause_total_timeout_ms_ = 20;
-  connect_controller(door);
-  door.open_door();
-  ASSERT_EQ(poll_command(door).first, 0x0210);  // COMMAND_OPEN pressed, release still owed
-
-  EXPECT_FALSE(door.announce_pause());
-  // No pause was announced, so the poll still carries the release the controller is owed.
-  RegisterValues response;
-  door.on_read_holding_registers(STATE_REG, 8, response);
-  ASSERT_EQ(response.size(), 8u);
-  EXPECT_EQ(response[1], RESPONSE_STATUS);
-  EXPECT_EQ(response[2], 0x0110);  // COMMAND_OPEN released
 }
 
 // Running out of time must not leave the pause standing: it replaces the answer that carries key presses, so
@@ -670,7 +639,7 @@ TEST(HoermannHcpPause, GivingUpDoesNotLeaveThePauseStanding) {
   EXPECT_FALSE(door.announce_pause());
   door.update();
   door.open_door();
-  EXPECT_EQ(poll_command(door).first, 0x0210);  // commands are delivered again
+  EXPECT_EQ(poll_command(door).first, 0x0110);  // commands are delivered again
 }
 
 // A position the door was told to travel to survives the announcement: without a restart the door still has to
@@ -689,7 +658,34 @@ TEST(HoermannHcpPause, AnnouncementKeepsTheTravelTarget) {
   door.update();
 
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0080, 0x0100}));
-  EXPECT_EQ(poll_command(door).first, 0x0240);  // COMMAND_IMPULSE pressed, stopping the door
+  EXPECT_EQ(poll_command(door).first, 0x0140);  // COMMAND_IMPULSE, stopping the door
+}
+
+// The intermediate positions are reachable from an automation without a button entity standing in for it.
+TEST(HoermannHcpAction, VentActionSendsTheVentCommand) {
+  HoermannHcp door;
+  connect_controller(door);
+  VentAction<> action;
+  action.set_parent(&door);
+
+  action.play();
+
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0100);
+  EXPECT_EQ(value_2, 0x4000);
+}
+
+TEST(HoermannHcpAction, HalfOpenActionSendsTheHalfOpenCommand) {
+  HoermannHcp door;
+  connect_controller(door);
+  HalfOpenAction<> action;
+  action.set_parent(&door);
+
+  action.play();
+
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0100);
+  EXPECT_EQ(value_2, 0x0400);
 }
 
 }  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
+++ b/tests/components/hoermann_hcp/hoermann_hcp_test.cpp
@@ -511,13 +511,17 @@ TEST(HoermannHcpPause, TransferOutsideAnAnnouncementIsLeftAlone) {
 }
 
 // A command taken while the pause is out could only be presented afterwards, to a door that has moved on.
+// A lamp request takes the same route, so it is refused there too rather than reaching the slot directly.
 TEST(HoermannHcpPause, CommandsAreRefusedWhileThePauseIsOut) {
   TestableHoermannHcp door;
   door.set_address(0x02);
   connect_controller(door);
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
   start_announcing(door);
 
   EXPECT_FALSE(door.open_door());
+  EXPECT_FALSE(door.set_light(true));
+  EXPECT_FALSE(door.light_request_pending_);
 }
 
 // A transfer too short to name an address is still answered. Leaving it open would strand the controller

--- a/tests/components/hoermann_hcp/light/hoermann_hcp_light_test.cpp
+++ b/tests/components/hoermann_hcp/light/hoermann_hcp_light_test.cpp
@@ -89,76 +89,72 @@ TEST(HoermannHcpLightTest, LampStateIsDecodedFromTheBroadcast) {
   EXPECT_FALSE(door.is_light_on());
 }
 
-// The lamp command is the only one that drives the second command register, on both halves of the press.
-TEST(HoermannHcpLightTest, LampCommandUsesTheSecondRegister) {
-  TestableHoermannHcp door;
+// The lamp is asked for a state rather than toggled, so each direction has its own value, sent once.
+TEST(HoermannHcpLightTest, LampCommandsNameTheState) {
+  HoermannHcp door;
   connect_controller(door);
-  ASSERT_FALSE(door.is_light_on());
-  ASSERT_TRUE(door.toggle_light());
 
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0100);
-  EXPECT_EQ(pressed_2, 0x0200);
-
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  auto [released, released_2] = poll_command(door);
-  EXPECT_EQ(released, 0x0800);
-  EXPECT_EQ(released_2, 0x0200);
-
+  ASSERT_TRUE(door.set_light(true));
+  auto [on, on_2] = poll_command(door);
+  EXPECT_EQ(on, 0x0880);
+  EXPECT_EQ(on_2, 0x0000);
   // The command is spent, so the next poll carries nothing.
   auto [idle, idle_2] = poll_command(door);
   EXPECT_EQ(idle, 0x0000);
   EXPECT_EQ(idle_2, 0x0000);
+
+  ASSERT_TRUE(door.set_light(false));
+  auto [off, off_2] = poll_command(door);
+  EXPECT_EQ(off, 0x0800);
+  EXPECT_EQ(off_2, 0x0100);
 }
 
-// Toggling the lamp must not disturb a cover position the door is still travelling to.
-TEST(HoermannHcpLightTest, LampToggleKeepsTheCoverTarget) {
-  TestableHoermannHcp door;
+// A lamp request must not disturb a cover position the door is still travelling to.
+TEST(HoermannHcpLightTest, LampRequestKeepsTheCoverTarget) {
+  HoermannHcp door;
   connect_controller(door);
   // Position 60/200 = 0.3 while opening, so a 0.5 target is armed and under way.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x003C, 0x0100}));
   ASSERT_TRUE(door.set_position(0.5f));
   consume_command(door);
 
-  ASSERT_TRUE(door.toggle_light());
+  ASSERT_TRUE(door.set_light(true));
   consume_command(door);
 
   // Past the target: the door still has to be stopped despite the lamp command in between.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0078, 0x0100}));
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0240);  // COMMAND_IMPULSE
-  EXPECT_EQ(pressed_2, 0x0000);
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0140);  // COMMAND_IMPULSE
+  EXPECT_EQ(value_2, 0x0000);
 }
 
-// A lamp toggle occupies the single command slot, so a target stop falling due while it waits to be fetched
+// A lamp request occupies the single command slot, so a target stop falling due while it waits to be fetched
 // has to wait too. The target stays armed and the stop goes out on the next position report, which costs the
 // door a little overshoot but never loses the stop.
-TEST(HoermannHcpLightTest, LampToggleDelaysButDoesNotLoseTheTargetStop) {
-  TestableHoermannHcp door;
+TEST(HoermannHcpLightTest, LampRequestDelaysButDoesNotLoseTheTargetStop) {
+  HoermannHcp door;
   connect_controller(door);
   // Position 60/200 = 0.3 while opening, so a 0.5 target is armed and under way.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x003C, 0x0100}));
   ASSERT_TRUE(door.set_position(0.5f));
   consume_command(door);
 
-  ASSERT_TRUE(door.toggle_light());
-  // The door passes the target while the lamp toggle still holds the slot, so the lamp goes out first.
+  ASSERT_TRUE(door.set_light(true));
+  // The door passes the target while the lamp request still holds the slot, so the lamp goes out first.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0078, 0x0100}));
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0100);
-  EXPECT_EQ(pressed_2, 0x0200);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(door);
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0880);
+  EXPECT_EQ(value_2, 0x0000);
 
   // The target survived the refusal, so the next position report still stops the door.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0079, 0x0100}));
   auto [stop, stop_2] = poll_command(door);
-  EXPECT_EQ(stop, 0x0240);  // COMMAND_IMPULSE
+  EXPECT_EQ(stop, 0x0140);  // COMMAND_IMPULSE
   EXPECT_EQ(stop_2, 0x0000);
 }
 
-// The target's start deadline is its own, so toggling the lamp cannot keep a stale target alive.
-TEST(HoermannHcpLightTest, LampToggleDoesNotExtendTheTargetWatchdog) {
+// The target's start deadline is its own, so a lamp request cannot keep a stale target alive.
+TEST(HoermannHcpLightTest, LampRequestDoesNotExtendTheTargetWatchdog) {
   TestableHoermannHcp door;
   door.connection_timeout_ms_ = 20;
   connect_controller(door);
@@ -168,37 +164,97 @@ TEST(HoermannHcpLightTest, LampToggleDoesNotExtendTheTargetWatchdog) {
   consume_command(door);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(30));
-  ASSERT_TRUE(door.toggle_light());
+  ASSERT_TRUE(door.set_light(true));
   consume_command(door);
   door.update();
 
   // The target expired on its own schedule, so a later opening move runs freely.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0050, 0x0100}));
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0078, 0x0100}));
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0000);
-  EXPECT_EQ(pressed_2, 0x0000);
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0000);
+  EXPECT_EQ(value_2, 0x0000);
 }
 
 // Without a bus controller the command cannot be delivered, and the caller is told.
 TEST(HoermannHcpLightTest, LampCommandIsRefusedWhileDisconnected) {
   HoermannHcp door;
-  EXPECT_FALSE(door.toggle_light());
+  EXPECT_FALSE(door.set_light(true));
 }
 
-// Switching the entity on sends one toggle, and the door's own report does not send a second.
-TEST(HoermannHcpLightPlatformTest, CommandTogglesOnceAndSettles) {
+// A request the controller has not fetched is replaced by a newer one asking for something else, so the door
+// only ever sees what is wanted now.
+TEST(HoermannHcpLightTest, NewerRequestReplacesTheOneStillQueued) {
+  HoermannHcp door;
+  connect_controller(door);
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
+  ASSERT_TRUE(door.set_light(false));  // the hub does not judge a request against the lamp; the platform does
+
+  ASSERT_TRUE(door.set_light(true));
+  EXPECT_TRUE(door.is_light_heading_on());
+
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0880);
+  EXPECT_EQ(value_2, 0x0000);
+  EXPECT_EQ(poll_command(door).first, 0x0000);
+}
+
+// A request that only takes back one still waiting is withdrawn, so the door sees neither.
+TEST(HoermannHcpLightTest, ReversingRequestBeforeFetchWithdrawsIt) {
+  TestableHoermannHcp door;
+  connect_controller(door);
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
+  ASSERT_TRUE(door.set_light(true));
+
+  ASSERT_TRUE(door.set_light(false));
+  EXPECT_FALSE(door.light_request_pending_);
+  EXPECT_FALSE(door.is_light_heading_on());
+  EXPECT_EQ(poll_command(door).first, 0x0000);
+}
+
+// The lamp reported in the requested state settles the request, whoever switched it. A request still in the
+// slot goes out regardless: it names a state, so it changes nothing.
+TEST(HoermannHcpLightTest, LampReportedAsRequestedSettlesTheRequest) {
+  TestableHoermannHcp door;
+  connect_controller(door);
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
+  ASSERT_TRUE(door.set_light(true));
+
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0010));
+  EXPECT_FALSE(door.light_request_pending_);
+  EXPECT_TRUE(door.is_light_heading_on());
+  EXPECT_EQ(poll_command(door).first, 0x0880);
+}
+
+// The lamp is reported a moment after the door acted, so a broadcast still carrying the old state is the one
+// from before, not a refusal.
+TEST(HoermannHcpLightTest, LampStillReportedUnchangedKeepsTheRequest) {
+  TestableHoermannHcp door;
+  connect_controller(door);
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
+  ASSERT_TRUE(door.set_light(true));
+  consume_command(door);
+
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
+  EXPECT_TRUE(door.light_request_pending_);
+  EXPECT_TRUE(door.is_light_heading_on());
+
+  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0010));
+  EXPECT_FALSE(door.light_request_pending_);
+  EXPECT_EQ(door.light_request_sent_at_, 0u);
+}
+
+// Switching the entity on sends one command, and the door's own report does not send a second.
+TEST(HoermannHcpLightPlatformTest, CommandIsSentOnceAndSettles) {
   LightFixture fixture;
   fixture.bring_up();
 
   fixture.command(true);
-  auto [pressed, pressed_2] = poll_command(fixture.door);
-  EXPECT_EQ(pressed, 0x0100);
-  EXPECT_EQ(pressed_2, 0x0200);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(fixture.door);  // release, clearing the slot
+  auto [value, value_2] = poll_command(fixture.door);
+  EXPECT_EQ(value, 0x0880);
+  EXPECT_EQ(value_2, 0x0000);
 
-  // The lamp is now on, and the resulting broadcast must not queue another toggle.
+  // The lamp is now on, and the resulting broadcast must not queue another command.
   fixture.report_lamp(true);
   EXPECT_TRUE(fixture.entity_on());
   auto [idle, idle_2] = poll_command(fixture.door);
@@ -206,20 +262,21 @@ TEST(HoermannHcpLightPlatformTest, CommandTogglesOnceAndSettles) {
   EXPECT_EQ(idle_2, 0x0000);
 }
 
-// A broadcast arriving while a toggle is queued must not reconcile against the not-yet-inverted lamp, which
+// A broadcast arriving while a request is queued must not reconcile against the lamp as it still is, which
 // would cancel the user's own command.
-TEST(HoermannHcpLightPlatformTest, BroadcastDuringPendingToggleKeepsTheCommand) {
+TEST(HoermannHcpLightPlatformTest, BroadcastDuringPendingRequestKeepsTheCommand) {
   LightFixture fixture;
   fixture.bring_up();
 
   fixture.command(true);
-  ASSERT_TRUE(fixture.door.is_light_toggle_pending_());
+  ASSERT_TRUE(fixture.door.light_request_pending_);
 
-  // A door movement sets changed_, firing the state callback while the toggle is still queued.
+  // A door movement sets changed_, firing the state callback while the request is still queued.
   fixture.report_broadcast(make_registers({0x0000, 0x0064, 0x0100}));
 
-  EXPECT_TRUE(fixture.door.is_light_toggle_pending_());
+  EXPECT_TRUE(fixture.door.light_request_pending_);
   EXPECT_TRUE(fixture.entity_on());
+  EXPECT_EQ(poll_command(fixture.door).first, 0x0880);
 }
 
 // A lamp switched on at the door itself has to reach the entity.
@@ -243,55 +300,55 @@ TEST(HoermannHcpLightPlatformTest, RefusedCommandRepublishesTheLamp) {
   EXPECT_FALSE(fixture.entity_on());
 }
 
-// A reversing press once the toggle is already on the wire cannot stop it, so the entity has to end up
-// showing the lamp rather than the request that was refused.
-TEST(HoermannHcpLightPlatformTest, RefusedPressAfterFetchShowsWhereTheLampIsHeading) {
+// A reversing request once the first is on the wire is a second command, and the entity shows the newer one
+// until the lamp agrees with it.
+TEST(HoermannHcpLightPlatformTest, ReversingRequestAfterFetchIsSentAsWell) {
   LightFixture fixture;
   fixture.bring_up();
 
   fixture.command(true);
-  poll_command(fixture.door);  // the controller fetches the press, so it can no longer be cancelled
-  ASSERT_TRUE(fixture.door.is_light_toggle_pending_());
+  poll_command(fixture.door);  // the controller fetches the request
 
   fixture.command(false);
-  EXPECT_TRUE(fixture.entity_on());
+  auto [value, value_2] = poll_command(fixture.door);
+  EXPECT_EQ(value, 0x0800);
+  EXPECT_EQ(value_2, 0x0100);
+  EXPECT_FALSE(fixture.entity_on());
 
-  // A door movement while the refused toggle is still on the wire must not pull the entity back either.
-  fixture.report_broadcast(make_registers({0x0000, 0x0064, 0x0100}));
-  EXPECT_TRUE(fixture.entity_on());
-
-  // The toggle lands and the door confirms it; the entity must already agree.
+  // The first request lands and is reported, but the entity is already heading for off.
   fixture.report_lamp(true);
-  EXPECT_TRUE(fixture.entity_on());
+  EXPECT_FALSE(fixture.entity_on());
+
+  // The second lands too, and the lamp finally agrees with the request.
+  fixture.report_lamp(false);
+  EXPECT_FALSE(fixture.entity_on());
+  EXPECT_FALSE(fixture.door.light_request_pending_);
 }
 
-// The lamp is only reported some time after the key press is released, so an unrelated door broadcast in
-// that gap must not publish the state the lamp is about to leave.
+// The lamp is only reported some time after the command was fetched, so an unrelated door broadcast in that
+// gap must not publish the state the lamp is about to leave.
 TEST(HoermannHcpLightPlatformTest, DoorMovementDoesNotFlipTheEntityBeforeTheLampReports) {
   LightFixture fixture;
   fixture.bring_up();
 
   fixture.command(true);
-  poll_command(fixture.door);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(fixture.door);  // release, so nothing is pending any more
-  ASSERT_FALSE(fixture.door.is_light_toggle_pending_());
-  ASSERT_FALSE(fixture.door.is_light_on());  // the lamp has still not been reported
+  poll_command(fixture.door);  // fetched, so the slot is free and the lamp still unreported
+  ASSERT_FALSE(fixture.door.is_light_on());
 
   fixture.report_broadcast(make_registers({0x0000, 0x0064, 0x0100}));
 
   EXPECT_TRUE(fixture.entity_on());
 }
 
-// A toggle the controller never fetches is eventually dropped, and nothing else will ever report the lamp
+// A request the controller never fetches is eventually dropped, and nothing else will ever report the lamp
 // moving, so the entity has to be brought back to what the lamp actually is.
-TEST(HoermannHcpLightPlatformTest, DroppedToggleReturnsTheEntityToTheLamp) {
+TEST(HoermannHcpLightPlatformTest, DroppedRequestReturnsTheEntityToTheLamp) {
   LightFixture fixture;
   fixture.door.connection_timeout_ms_ = 20;
   fixture.bring_up();
 
   fixture.command(true);
-  ASSERT_TRUE(fixture.door.is_light_toggle_pending_());
+  ASSERT_TRUE(fixture.door.light_request_pending_);
   EXPECT_TRUE(fixture.entity_on());
 
   // The controller keeps broadcasting but never fetches the command, so the connection stays up.
@@ -299,19 +356,19 @@ TEST(HoermannHcpLightPlatformTest, DroppedToggleReturnsTheEntityToTheLamp) {
   fixture.door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
   fixture.pump();
 
-  EXPECT_FALSE(fixture.door.is_light_toggle_pending_());
+  EXPECT_FALSE(fixture.door.light_request_pending_);
   EXPECT_FALSE(fixture.entity_on());
 }
 
-// Losing the bus controller discards the queued toggle too, so the entity must not keep showing it once the
+// Losing the bus controller discards the queued request too, so the entity must not keep showing it once the
 // controller is back and still reporting the lamp unchanged.
-TEST(HoermannHcpLightPlatformTest, ToggleLostWithTheConnectionReturnsTheEntityToTheLamp) {
+TEST(HoermannHcpLightPlatformTest, RequestLostWithTheConnectionReturnsTheEntityToTheLamp) {
   LightFixture fixture;
   fixture.door.connection_timeout_ms_ = 20;
   fixture.bring_up();
 
   fixture.command(true);
-  ASSERT_TRUE(fixture.door.is_light_toggle_pending_());
+  ASSERT_TRUE(fixture.door.light_request_pending_);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(30));
   fixture.pump();  // the connection times out and the command goes with it
@@ -323,7 +380,7 @@ TEST(HoermannHcpLightPlatformTest, ToggleLostWithTheConnectionReturnsTheEntityTo
 }
 
 // The lamp can be switched at the door while the bus is quiet, so what was read before an outage must not
-// decide whether a toggle is needed after it.
+// decide whether a command is needed after it.
 TEST(HoermannHcpLightPlatformTest, LampIsNotTrustedAcrossAConnectionLoss) {
   LightFixture fixture;
   fixture.door.connection_timeout_ms_ = 20;
@@ -359,27 +416,6 @@ TEST(HoermannHcpLightPlatformTest, UnreportedLampIsFlaggedOnTheEntity) {
   EXPECT_FALSE(fixture.output.status_has_warning());
 }
 
-// Two outstanding toggles leave the lamp where it started, so a third tap has to be judged against that and
-// withdraw the one still waiting rather than deciding nothing is needed.
-TEST(HoermannHcpLightPlatformTest, ThirdTapWithTwoTogglesOutstandingIsHonoured) {
-  LightFixture fixture;
-  fixture.bring_up();
-
-  fixture.command(true);
-  poll_command(fixture.door);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(fixture.door);  // the first toggle is released but not reported back
-  fixture.command(false);
-  ASSERT_TRUE(fixture.door.is_light_toggle_pending_());
-  ASSERT_EQ(fixture.door.light_toggles_in_flight_, 2);
-
-  // Two toggles cancel out, so asking for on again means withdrawing the second one.
-  fixture.command(true);
-  EXPECT_FALSE(fixture.door.is_light_toggle_pending_());
-  EXPECT_EQ(fixture.door.light_toggles_in_flight_, 1);
-  EXPECT_TRUE(fixture.entity_on());
-}
-
 // The boot replay is the first write and nothing else, so a real command arriving before the hub's next poll
 // must not be mistaken for it and swallowed.
 TEST(HoermannHcpLightPlatformTest, CommandBeforeTheFirstPollIsNotMistakenForTheBootReplay) {
@@ -392,9 +428,9 @@ TEST(HoermannHcpLightPlatformTest, CommandBeforeTheFirstPollIsNotMistakenForTheB
   ASSERT_TRUE(fixture.door.is_light_known());
 
   fixture.command(true);
-  auto [pressed, pressed_2] = poll_command(fixture.door);
-  EXPECT_EQ(pressed, 0x0100);  // COMMAND_TOGGLE_LAMP
-  EXPECT_EQ(pressed_2, 0x0200);
+  auto [value, value_2] = poll_command(fixture.door);
+  EXPECT_EQ(value, 0x0880);  // COMMAND_LIGHT_ON
+  EXPECT_EQ(value_2, 0x0000);
 }
 
 // On boot the restored state is replayed through write_state() before the lamp has ever been read. A lamp
@@ -432,39 +468,9 @@ TEST(HoermannHcpLightPlatformTest, RequestBeforeTheLampIsReportedDoesNotCommandT
   EXPECT_FALSE(fixture.entity_on());
 }
 
-// A toggle that has been released onto the wire is no longer pending, but the lamp has not reported it yet.
-// A reversing request in that window is a real request and has to be sent, not swallowed.
-TEST(HoermannHcpLightPlatformTest, ReversingRequestAfterReleaseQueuesASecondToggle) {
-  LightFixture fixture;
-  fixture.bring_up();
-
-  fixture.command(true);
-  poll_command(fixture.door);
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(fixture.door);  // released, so nothing is pending and the lamp is still unreported
-  ASSERT_FALSE(fixture.door.is_light_toggle_pending_());
-  ASSERT_FALSE(fixture.door.is_light_on());
-
-  fixture.command(false);
-  auto [pressed, pressed_2] = poll_command(fixture.door);
-  EXPECT_EQ(pressed, 0x0100);  // COMMAND_TOGGLE_LAMP
-  EXPECT_EQ(pressed_2, 0x0200);
-  EXPECT_FALSE(fixture.entity_on());
-
-  // The first toggle lands and is reported, but the entity is already heading for off.
-  fixture.report_lamp(true);
-  EXPECT_FALSE(fixture.entity_on());
-
-  // The second toggle lands too, and the lamp finally agrees with the request.
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(fixture.door);
-  fixture.report_lamp(false);
-  EXPECT_FALSE(fixture.entity_on());
-}
-
-// A refusal that has no toggle on the wire leaves nothing outstanding, so it must not latch the entity
+// A refusal that has no request on the wire leaves nothing outstanding, so it must not latch the entity
 // against the next lamp change the door reports.
-TEST(HoermannHcpLightPlatformTest, RefusalWithoutAToggleStillFollowsTheLamp) {
+TEST(HoermannHcpLightPlatformTest, RefusalWithoutARequestStillFollowsTheLamp) {
   LightFixture fixture;
   fixture.door.connection_timeout_ms_ = 20;
   fixture.bring_up();
@@ -473,7 +479,7 @@ TEST(HoermannHcpLightPlatformTest, RefusalWithoutAToggleStillFollowsTheLamp) {
   fixture.pump();
   ASSERT_FALSE(fixture.door.is_valid());
 
-  // Refused because the bus is down, so no toggle is heading for the lamp.
+  // Refused because the bus is down, so no request is heading for the lamp.
   fixture.command(true);
   EXPECT_FALSE(fixture.entity_on());
 
@@ -483,8 +489,8 @@ TEST(HoermannHcpLightPlatformTest, RefusalWithoutAToggleStillFollowsTheLamp) {
   EXPECT_TRUE(fixture.entity_on());
 }
 
-// A lamp toggle carries no target, so dropping it unfetched must leave the cover's target alone.
-TEST(HoermannHcpLightTest, DroppedLampToggleKeepsTheCoverTarget) {
+// A lamp request carries no target, so dropping it unfetched must leave the cover's target alone.
+TEST(HoermannHcpLightTest, DroppedLampRequestKeepsTheCoverTarget) {
   TestableHoermannHcp door;
   door.connection_timeout_ms_ = 20;
   connect_controller(door);
@@ -493,33 +499,34 @@ TEST(HoermannHcpLightTest, DroppedLampToggleKeepsTheCoverTarget) {
   ASSERT_TRUE(door.set_position(0.5f));
   consume_command(door);
 
-  // The controller keeps broadcasting but stops fetching, so the lamp toggle expires on its own.
-  ASSERT_TRUE(door.toggle_light());
+  // The controller keeps broadcasting but stops fetching, so the lamp request expires on its own.
+  ASSERT_TRUE(door.set_light(true));
   std::this_thread::sleep_for(std::chrono::milliseconds(30));
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0050, 0x0100}));
   door.update();
 
-  // The target survived the lamp toggle being dropped, so the door is still stopped on the way.
+  // The target survived the lamp request being dropped, so the door is still stopped on the way.
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0078, 0x0100}));
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0240);  // COMMAND_IMPULSE
-  EXPECT_EQ(pressed_2, 0x0000);
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0140);  // COMMAND_IMPULSE
+  EXPECT_EQ(value_2, 0x0000);
 }
 
-// A door that takes the key press but never actually switches the lamp must not leave the entity showing the
+// A door that takes the command but never actually switches the lamp must not leave the entity showing the
 // request for ever; the wait has to end so the entity can settle back on what the door reports.
-TEST(HoermannHcpLightPlatformTest, ToggleTheDoorIgnoresStopsBeingWaitedFor) {
+TEST(HoermannHcpLightPlatformTest, RequestTheDoorIgnoresStopsBeingWaitedFor) {
   LightFixture fixture;
   fixture.door.connection_timeout_ms_ = 20;
   fixture.bring_up();
 
   fixture.command(true);
-  consume_command(fixture.door);  // the door takes press and release, then does nothing
-  ASSERT_FALSE(fixture.door.is_light_toggle_pending_());
+  consume_command(fixture.door);  // the door takes the command, then does nothing
+  ASSERT_NE(fixture.door.light_request_sent_at_, 0u);
   EXPECT_TRUE(fixture.entity_on());
 
   std::this_thread::sleep_for(std::chrono::milliseconds(30));
   fixture.report_lamp(false);  // the lamp is still off, and keeps saying so
+  EXPECT_FALSE(fixture.door.light_request_pending_);
   EXPECT_FALSE(fixture.entity_on());
 }
 
@@ -537,14 +544,14 @@ TEST(HoermannHcpLightPlatformTest, FirstLampReportReachesTheEntity) {
   ASSERT_TRUE(fixture.door.is_light_known());
 
   fixture.command(true);
-  auto [pressed, pressed_2] = poll_command(fixture.door);
-  EXPECT_EQ(pressed, 0x0100);  // COMMAND_TOGGLE_LAMP
-  EXPECT_EQ(pressed_2, 0x0200);
+  auto [value, value_2] = poll_command(fixture.door);
+  EXPECT_EQ(value, 0x0880);  // COMMAND_LIGHT_ON
+  EXPECT_EQ(value_2, 0x0000);
 }
 
 // A lost connection means the door can travel unwatched, so a target left armed would stop it long afterwards.
 // Which command happened to be in the slot must not change that.
-TEST(HoermannHcpLightTest, ConnectionLossWithALampTogglePendingClearsTheTarget) {
+TEST(HoermannHcpLightTest, ConnectionLossWithALampRequestPendingClearsTheTarget) {
   TestableHoermannHcp door;
   door.connection_timeout_ms_ = 20;
   connect_controller(door);
@@ -552,7 +559,7 @@ TEST(HoermannHcpLightTest, ConnectionLossWithALampTogglePendingClearsTheTarget) 
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x003C, 0x0100}));
   ASSERT_TRUE(door.set_position(0.5f));
   consume_command(door);
-  ASSERT_TRUE(door.toggle_light());
+  ASSERT_TRUE(door.set_light(true));
 
   std::this_thread::sleep_for(std::chrono::milliseconds(30));
   door.update();
@@ -561,30 +568,9 @@ TEST(HoermannHcpLightTest, ConnectionLossWithALampTogglePendingClearsTheTarget) 
   // Back on the bus and travelling past where the target was: nothing should stop the door now.
   connect_controller(door);
   door.on_write_registers(BROADCAST_REG, make_registers({0x0000, 0x0078, 0x0100}));
-  auto [pressed, pressed_2] = poll_command(door);
-  EXPECT_EQ(pressed, 0x0000);
-  EXPECT_EQ(pressed_2, 0x0000);
-}
-
-// Withdrawing a later toggle must not take the deadline of the one already on the wire with it, or a door
-// that never reports the lamp would leave the entity waiting for ever.
-TEST(HoermannHcpLightPlatformTest, WithdrawingALaterToggleKeepsTheWatchdogArmed) {
-  LightFixture fixture;
-  fixture.door.connection_timeout_ms_ = 20;
-  fixture.bring_up();
-
-  fixture.command(true);
-  consume_command(fixture.door);  // the first toggle is released but never reported back
-  fixture.command(false);
-  ASSERT_EQ(fixture.door.light_toggles_in_flight_, 2);
-  fixture.command(true);  // withdraws the second, leaving the first outstanding
-  ASSERT_EQ(fixture.door.light_toggles_in_flight_, 1);
-
-  // The door still says nothing about the lamp, so the wait has to time out on its own.
-  std::this_thread::sleep_for(std::chrono::milliseconds(30));
-  fixture.report_lamp(false);
-  EXPECT_EQ(fixture.door.light_toggles_in_flight_, 0);
-  EXPECT_FALSE(fixture.entity_on());
+  auto [value, value_2] = poll_command(door);
+  EXPECT_EQ(value, 0x0000);
+  EXPECT_EQ(value_2, 0x0000);
 }
 
 // A request refused while the lamp is unknown must leave the entity idle. Republishing unconditionally would
@@ -602,25 +588,6 @@ TEST(HoermannHcpLightPlatformTest, RefusedRequestLeavesTheEntityIdle) {
   EXPECT_EQ(fixture.output.writes, settled_writes);
 }
 
-// A door that acts on the key press and reports the lamp before the release is even fetched leaves nothing
-// outstanding. Arming the watchdog on that release anyway would leave it firing on every poll and abandoning
-// the next toggle the moment it is queued.
-TEST(HoermannHcpLightTest, ReleaseWithNothingOutstandingLeavesTheWatchdogDisarmed) {
-  TestableHoermannHcp door;
-  connect_controller(door);
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
-  ASSERT_TRUE(door.toggle_light());
-  poll_command(door);  // the door is shown the key press
-
-  // The door acts on it and reports the lamp straight away, which settles the count.
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0010));
-  ASSERT_EQ(door.light_toggles_in_flight_, 0);
-
-  std::this_thread::sleep_for(KEY_PRESS_ELAPSED);
-  poll_command(door);  // the release, with nothing left to wait for
-  EXPECT_EQ(door.light_toggle_released_at_, 0u);
-}
-
 // A restore mode that boots the entity on replays a lit state the door has never confirmed, so it has to be
 // adopted back to what is known rather than turned into a command.
 TEST(HoermannHcpLightPlatformTest, RestoredOnStateIsAdoptedNotCommanded) {
@@ -634,93 +601,34 @@ TEST(HoermannHcpLightPlatformTest, RestoredOnStateIsAdoptedNotCommanded) {
   EXPECT_FALSE(fixture.entity_on());
 }
 
-// A reversing press before the toggle is fetched cancels it, so the lamp never moves.
-TEST(HoermannHcpLightPlatformTest, ReversingPressCancelsTheQueuedToggle) {
+// A reversing request before the first is fetched withdraws it, so the lamp never moves.
+TEST(HoermannHcpLightPlatformTest, ReversingRequestBeforeFetchWithdrawsTheQueuedOne) {
   LightFixture fixture;
   fixture.bring_up();
 
   fixture.command(true);
-  ASSERT_TRUE(fixture.door.is_light_toggle_pending_());
+  ASSERT_TRUE(fixture.door.light_request_pending_);
 
   fixture.command(false);
-  EXPECT_FALSE(fixture.door.is_light_toggle_pending_());
+  EXPECT_FALSE(fixture.door.light_request_pending_);
   EXPECT_FALSE(fixture.entity_on());
 
   // Nothing is left for the controller to fetch, so the lamp stays off as asked.
-  auto [pressed, pressed_2] = poll_command(fixture.door);
-  EXPECT_EQ(pressed, 0x0000);
-  EXPECT_EQ(pressed_2, 0x0000);
+  auto [value, value_2] = poll_command(fixture.door);
+  EXPECT_EQ(value, 0x0000);
+  EXPECT_EQ(value_2, 0x0000);
 }
 
-// A lamp switched at the door itself is not one of our toggles landing, so a toggle the door has not even
-// been shown has to keep counting.
-TEST(HoermannHcpLightTest, DoorSideLampChangeLeavesAnUnsentToggleCounted) {
-  TestableHoermannHcp door;
-  connect_controller(door);
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
-  ASSERT_TRUE(door.toggle_light());
+// Asking for the state the lamp already reports is nothing to send.
+TEST(HoermannHcpLightPlatformTest, RequestForTheReportedStateSendsNothing) {
+  LightFixture fixture;
+  fixture.bring_up();
+  fixture.report_lamp(true);
+  ASSERT_TRUE(fixture.entity_on());
 
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0010));
-
-  EXPECT_EQ(door.light_toggles_in_flight_, 1);
-  // The toggle still in the slot will invert what the door just reported.
-  EXPECT_FALSE(door.is_light_heading_on());
-}
-
-// Once the toggles left over are all still waiting in the slot, nothing the door has seen is outstanding,
-// so the wait has to end rather than time out against toggles the door was never shown.
-TEST(HoermannHcpLightTest, SettlingTheLastSentToggleEndsTheWait) {
-  TestableHoermannHcp door;
-  connect_controller(door);
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
-  ASSERT_TRUE(door.toggle_light());
-  consume_command(door);             // shown to the door, so the wait for a lamp report starts
-  ASSERT_TRUE(door.toggle_light());  // queued behind it, never shown
-  ASSERT_NE(door.light_toggle_released_at_, 0u);
-
-  // The door reports the lamp change the first toggle caused, leaving only the unsent one.
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0010));
-
-  ASSERT_EQ(door.light_toggles_in_flight_, 1);
-  EXPECT_EQ(door.light_toggle_released_at_, 0u);
-}
-
-// The watchdog gives up on the toggles the door was shown, but one still waiting in the command slot is
-// going to fire, so it keeps counting.
-TEST(HoermannHcpLightTest, WatchdogKeepsAToggleTheDoorHasNotSeen) {
-  TestableHoermannHcp door;
-  // Wide enough that the toggle queued after the sleep cannot expire before update() runs.
-  door.connection_timeout_ms_ = 200;
-  connect_controller(door);
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
-  ASSERT_TRUE(door.toggle_light());
-  consume_command(door);  // shown to the door, which then says nothing about the lamp
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(220));
-  // Queued just now, so only the wait for the first toggle is overdue.
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
-  ASSERT_TRUE(door.toggle_light());
-  door.update();
-
-  EXPECT_EQ(door.light_toggles_in_flight_, 1);
-  EXPECT_TRUE(door.is_light_toggle_pending_());
-  EXPECT_TRUE(door.is_light_heading_on());
-}
-
-// Only the parity of the outstanding count says where the lamp is heading, so the count must not run away.
-TEST(HoermannHcpLightTest, TogglesAreRefusedOnceTooManyAreOutstanding) {
-  TestableHoermannHcp door;
-  connect_controller(door);
-  door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0000));
-
-  // The door takes every key press but never reports the lamp, so nothing is ever confirmed.
-  for (int i = 0; i < 4; i++) {
-    ASSERT_TRUE(door.toggle_light());
-    consume_command(door);
-  }
-
-  EXPECT_FALSE(door.toggle_light());
-  EXPECT_EQ(door.light_toggles_in_flight_, 4);
+  fixture.command(true);
+  EXPECT_EQ(poll_command(fixture.door).first, 0x0000);
+  EXPECT_TRUE(fixture.entity_on());
 }
 
 // A controller that stops carrying the lamp register leaves nothing refreshing it, so the entity has to flag
@@ -737,7 +645,7 @@ TEST(HoermannHcpLightPlatformTest, BroadcastWithoutTheLampRegisterMarksItUnknown
 }
 
 // A publish of ours only reaches write_state() a loop pass later. If the lamp changed at the door in that
-// gap, the write still carries the old value and must not be taken for a request to invert the lamp.
+// gap, the write still carries the old value and must not be taken for a request to switch the lamp back.
 TEST(HoermannHcpLightPlatformTest, PublishOvertakenByTheLampIsNotARequest) {
   LightFixture fixture;
   fixture.bring_up();
@@ -754,8 +662,9 @@ TEST(HoermannHcpLightPlatformTest, PublishOvertakenByTheLampIsNotARequest) {
   fixture.door.on_write_registers(BROADCAST_REG, lamp_broadcast(0x0010));
   fixture.settle();
 
-  EXPECT_EQ(fixture.door.light_toggles_in_flight_, 0);
+  EXPECT_FALSE(fixture.door.light_request_pending_);
   EXPECT_TRUE(fixture.entity_on());
+  EXPECT_EQ(poll_command(fixture.door).first, 0x0000);
 }
 
 }  // namespace esphome::hoermann_hcp::testing

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -88,11 +88,14 @@ struct ServerFixture {
 }  // namespace
 
 // Registration is what hands a device its hub, and a device that has one can turn it: the injected frame is
-// answered from service_bus_() alone, with no call to the hub's loop() from the test.
-TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
+// answered from service_bus_() alone, with no call to the hub's loop() from the test. Every registered device
+// gets its own hub, not just the first one.
+TEST(ModbusServerService, ServiceBusRunsAPassForEveryRegisteredDevice) {
   ServerFixture f;
   ServicingDevice device(0x02);
+  ServicingDevice second(0x03);
   f.hub.register_device(&device);
+  f.hub.register_device(&second);
 
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   EXPECT_TRUE(device.pump());
@@ -104,6 +107,7 @@ TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
   EXPECT_EQ(f.uart.written[2], 0x02);
   EXPECT_EQ(f.uart.written[3], 0x12);
   EXPECT_EQ(f.uart.written[4], 0x34);
+  EXPECT_TRUE(second.pump());
 }
 
 // A device that was never registered has no hub to turn, and says so instead of reaching through a null
@@ -113,21 +117,10 @@ TEST(ModbusServerService, ServiceBusIsRefusedWithoutAHub) {
   EXPECT_FALSE(device.pump());
 }
 
-// Each registered device gets its own hub, not just the first one.
-TEST(ModbusServerService, EveryRegisteredDeviceCanTurnTheHub) {
-  ServerFixture f;
-  ServicingDevice first(0x02);
-  ServicingDevice second(0x03);
-  f.hub.register_device(&first);
-  f.hub.register_device(&second);
-
-  EXPECT_TRUE(first.pump());
-  EXPECT_TRUE(second.pump());
-}
-
 // Turning the hub from inside a handler would answer a later frame before the one being handled. The second
-// frame below is what a re-entrant pass would reach for, and it has to wait its turn.
-TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
+// frame below is what a re-entrant pass would reach for, and it has to wait its turn. The refusal lasts only
+// as long as the dispatch: a hub left marked as dispatching would be deaf to every later call.
+TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandlerOnly) {
   ServerFixture f;
   ServicingDevice device(0x02);
   device.service_from_handler = true;
@@ -140,38 +133,14 @@ TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
   // Both frames are answered by this one pass, but one after the other rather than one inside the other.
   EXPECT_EQ(device.reads, 2);
   EXPECT_FALSE(device.reentered);
-}
-
-// The refusal lasts only as long as the dispatch. A hub left marked as dispatching would be deaf to every
-// later call, which is the whole feature gone.
-TEST(ModbusServerService, ServiceBusWorksAgainOnceTheDispatchEnded) {
-  ServerFixture f;
-  ServicingDevice device(0x02);
-  device.service_from_handler = true;
-  f.hub.register_device(&device);
-
-  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
-  f.hub.loop();
-  ASSERT_FALSE(device.serviced_from_handler);
 
   device.service_from_handler = false;
   EXPECT_TRUE(device.pump());
 }
 
-// A reply held back for a busy wire is normally sent by the scheduler, which does not run during the waits
-// service_bus_() exists for. It goes out on the pass instead of being lost.
-TEST(ModbusServerService, HeldBackReplyGoesOutOnThePass) {
-  ServerFixture f;
-  ServicingDevice device(0x02);
-  f.hub.register_device(&device);
-  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
-
-  EXPECT_TRUE(device.pump());
-  EXPECT_FALSE(f.uart.written.empty());
-}
-
-// What held the reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
-// for the next one rather than spending its only attempt on a wire that cannot take it.
+// What held a reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
+// for the next one rather than spending its only attempt on a wire that cannot take it, and goes out there:
+// the scheduler that would otherwise send it does not run during the waits service_bus_() exists for.
 TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
   ServerFixture f;
   ServicingDevice device(0x02);

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -1,0 +1,248 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <span>
+#include <vector>
+
+#include "common.h"
+#include "esphome/components/modbus/modbus.h"
+
+namespace esphome::modbus {
+
+using testing::InjectableUART;
+
+namespace {
+
+// Reads holding register 0x0000, one register. The device below answers 0x1234, so the reply on the wire is
+// fully determined: address, function code, byte count, value, CRC.
+constexpr uint8_t READ_HOLDING_PDU[] = {0x03, 0x00, 0x00, 0x00, 0x01};
+
+// A server device that answers one holding register and can turn its own hub, which is what a device
+// announcing a restart needs while the main loop is not running.
+class ServicingDevice : public ModbusServerDevice {
+ public:
+  explicit ServicingDevice(uint8_t address) { this->set_address(address); }
+
+  ResponseStatus on_read_holding_registers(uint16_t start_address, uint16_t number_of_registers,
+                                           RegisterValues &registers) override {
+    const int reads_on_entry = ++this->reads;
+    if (this->service_from_handler)
+      this->serviced_from_handler = this->service_bus_();
+    if (this->loop_from_handler) {
+      this->loop_from_handler = false;  // one level only
+      this->hub_->loop();
+      this->serviced_after_nested_loop = this->service_bus_();
+    }
+    // A pass that ran from here would have answered the next frame before this one returned.
+    this->reentered |= this->reads != reads_on_entry;
+    for (uint16_t i = 0; i < number_of_registers; i++)
+      registers.push_back(0x1234);
+    return std::nullopt;
+  }
+
+  bool pump() { return this->service_bus_(); }
+
+  int reads{0};
+  bool service_from_handler{false};
+  bool serviced_from_handler{true};
+  bool reentered{false};
+  // Turns the hub from inside the handler through the public loop(), then asks whether the guard still holds.
+  bool loop_from_handler{false};
+  bool serviced_after_nested_loop{true};
+};
+
+// Lets a test decide when the wire is free, and stash a reply the way send_raw_ does when it is not. Stashed
+// directly because send_raw_'s own deferral arms a scheduler timeout, and reaching the scheduler from the
+// host test binary faults on an uninitialised lock.
+class TestServerHub : public ModbusServerHub {
+ public:
+  bool tx_blocked() override { return this->blocked; }
+
+  void stash_deferred_for_test(uint8_t address, std::span<const uint8_t> pdu) {
+    this->deferred_payload_[0] = address;
+    std::memcpy(this->deferred_payload_.data() + 1, pdu.data(), pdu.size());
+    this->deferred_payload_len_ = static_cast<uint16_t>(pdu.size() + 1);
+  }
+
+  // Without this every reply waits out the real interframe delay.
+  void prime_send_timestamps_for_test() {
+    const uint32_t now = millis();
+    this->last_modbus_byte_ = now;
+    this->last_send_ = now;
+  }
+
+  bool blocked{false};
+};
+
+struct ServerFixture {
+  ServerFixture() {
+    hub.set_uart_parent(&uart);
+    hub.setup();
+    hub.prime_send_timestamps_for_test();
+  }
+
+  InjectableUART uart;
+  TestServerHub hub;
+};
+
+}  // namespace
+
+// Registration is what hands a device its hub, and a device that has one can turn it: the injected frame is
+// answered from service_bus_() alone, with no call to the hub's loop() from the test.
+TEST(ModbusServerService, ServiceBusRunsAPassForARegisteredDevice) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  EXPECT_TRUE(device.pump());
+  EXPECT_EQ(device.reads, 1);
+  // Address, function code, byte count, the register value, then the CRC.
+  ASSERT_EQ(f.uart.written.size(), 7u);
+  EXPECT_EQ(f.uart.written[0], 0x02);
+  EXPECT_EQ(f.uart.written[1], 0x03);
+  EXPECT_EQ(f.uart.written[2], 0x02);
+  EXPECT_EQ(f.uart.written[3], 0x12);
+  EXPECT_EQ(f.uart.written[4], 0x34);
+}
+
+// A device that was never registered has no hub to turn, and says so instead of reaching through a null
+// pointer.
+TEST(ModbusServerService, ServiceBusIsRefusedWithoutAHub) {
+  ServicingDevice device(0x02);
+  EXPECT_FALSE(device.pump());
+}
+
+// Each registered device gets its own hub, not just the first one.
+TEST(ModbusServerService, EveryRegisteredDeviceCanTurnTheHub) {
+  ServerFixture f;
+  ServicingDevice first(0x02);
+  ServicingDevice second(0x03);
+  f.hub.register_device(&first);
+  f.hub.register_device(&second);
+
+  EXPECT_TRUE(first.pump());
+  EXPECT_TRUE(second.pump());
+}
+
+// Turning the hub from inside a handler would answer a later frame before the one being handled. The second
+// frame below is what a re-entrant pass would reach for, and it has to wait its turn.
+TEST(ModbusServerService, ServiceBusIsRefusedFromInsideAHandler) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.service_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  EXPECT_FALSE(device.serviced_from_handler);
+  // Both frames are answered by this one pass, but one after the other rather than one inside the other.
+  EXPECT_EQ(device.reads, 2);
+  EXPECT_FALSE(device.reentered);
+}
+
+// The refusal lasts only as long as the dispatch. A hub left marked as dispatching would be deaf to every
+// later call, which is the whole feature gone.
+TEST(ModbusServerService, ServiceBusWorksAgainOnceTheDispatchEnded) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.service_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  ASSERT_FALSE(device.serviced_from_handler);
+
+  device.service_from_handler = false;
+  EXPECT_TRUE(device.pump());
+}
+
+// A reply held back for a busy wire is normally sent by the scheduler, which does not run during the waits
+// service_bus_() exists for. It goes out on the pass instead of being lost.
+TEST(ModbusServerService, HeldBackReplyGoesOutOnThePass) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// What held the reply back is usually bytes still arriving, and a pass does not drain them. The reply is kept
+// for the next one rather than spending its only attempt on a wire that cannot take it.
+TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.blocked = true;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+
+  f.hub.blocked = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// The held-back reply belongs to one request. Sending it twice would put a stale answer on the wire behind a
+// newer one.
+TEST(ModbusServerService, HeldBackReplyIsSentOnlyOnce) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  device.pump();
+  const size_t after_first = f.uart.written.size();
+  ASSERT_GT(after_first, 0u);
+
+  device.pump();
+  EXPECT_EQ(f.uart.written.size(), after_first);
+}
+
+// With nothing held back and nothing arriving, a pass says nothing. Reading a reply out of an empty buffer
+// would build a frame from a length of zero.
+TEST(ModbusServerService, PassWithNothingPendingWritesNothing) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_EQ(device.reads, 0);
+}
+
+// A reply held back earlier goes out before the pass can produce a newer one, so the two cannot reach the
+// wire in the wrong order.
+TEST(ModbusServerService, HeldBackReplyGoesOutBeforeTheNewOne) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+
+  EXPECT_TRUE(device.pump());
+  ASSERT_GE(f.uart.written.size(), 8u);
+  // The stashed frame is the request echoed back, so its third byte is 0x00; the pass's own reply carries a
+  // byte count of 0x02 there.
+  EXPECT_EQ(f.uart.written[2], 0x00);
+}
+
+// The guard is restored rather than cleared, so a nested pass through the public loop() cannot release the
+// dispatch the outer frame is still inside.
+TEST(ModbusServerService, ANestedPassDoesNotReleaseTheOuterDispatch) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  device.loop_from_handler = true;
+  f.hub.register_device(&device);
+
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.uart.inject_frame(0x02, READ_HOLDING_PDU);
+  f.hub.loop();
+  EXPECT_FALSE(device.serviced_after_nested_loop);
+}
+
+}  // namespace esphome::modbus

--- a/tests/components/modbus/modbus_server_service_test.cpp
+++ b/tests/components/modbus/modbus_server_service_test.cpp
@@ -56,7 +56,13 @@ class ServicingDevice : public ModbusServerDevice {
 // host test binary faults on an uninitialised lock.
 class TestServerHub : public ModbusServerHub {
  public:
-  bool tx_blocked() override { return this->blocked; }
+  // With block_on_recheck the wire is free at the first check and busy at send_frame_'s own re-check, which
+  // is a byte arriving during the send delay.
+  bool tx_blocked() override {
+    if (this->block_on_recheck)
+      return this->checks_++ > 0;
+    return this->blocked;
+  }
 
   void stash_deferred_for_test(uint8_t address, std::span<const uint8_t> pdu) {
     this->deferred_payload_[0] = address;
@@ -64,21 +70,22 @@ class TestServerHub : public ModbusServerHub {
     this->deferred_payload_len_ = static_cast<uint16_t>(pdu.size() + 1);
   }
 
-  // Without this every reply waits out the real interframe delay.
-  void prime_send_timestamps_for_test() {
-    const uint32_t now = millis();
-    this->last_modbus_byte_ = now;
-    this->last_send_ = now;
-  }
+  // What the scheduler timeout does, without the scheduler.
+  void drop_deferred_for_test() { this->send_deferred_(true); }
+
+  bool has_deferred() const { return this->deferred_payload_len_ != 0; }
 
   bool blocked{false};
+  bool block_on_recheck{false};
+
+ private:
+  int checks_{0};
 };
 
 struct ServerFixture {
   ServerFixture() {
     hub.set_uart_parent(&uart);
     hub.setup();
-    hub.prime_send_timestamps_for_test();
   }
 
   InjectableUART uart;
@@ -156,6 +163,42 @@ TEST(ModbusServerService, HeldBackReplyIsKeptWhileTheWireIsBusy) {
   EXPECT_FALSE(f.uart.written.empty());
 }
 
+// The wire can also turn busy between the pass's own check and the send: a byte arriving during the send
+// delay. That is still a busy wire, not a reply nobody waits for, so it is kept as well.
+TEST(ModbusServerService, ReplyBlockedDuringTheSendDelayIsKept) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.block_on_recheck = true;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_TRUE(f.hub.has_deferred());
+
+  f.hub.block_on_recheck = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_FALSE(f.uart.written.empty());
+}
+
+// The scheduler gives the reply its one chance and lets it go. A pass afterwards must not find it and put a
+// reply the controller has stopped waiting for on the wire behind newer traffic.
+TEST(ModbusServerService, ReplyDroppedByTheSchedulerIsNotSentByALaterPass) {
+  ServerFixture f;
+  ServicingDevice device(0x02);
+  f.hub.register_device(&device);
+  f.hub.stash_deferred_for_test(0x02, READ_HOLDING_PDU);
+
+  f.hub.blocked = true;
+  f.hub.drop_deferred_for_test();
+  EXPECT_TRUE(f.uart.written.empty());
+  EXPECT_FALSE(f.hub.has_deferred());
+
+  f.hub.blocked = false;
+  EXPECT_TRUE(device.pump());
+  EXPECT_TRUE(f.uart.written.empty());
+}
+
 // The held-back reply belongs to one request. Sending it twice would put a stale answer on the wire behind a
 // newer one.
 TEST(ModbusServerService, HeldBackReplyIsSentOnlyOnce) {
@@ -194,10 +237,12 @@ TEST(ModbusServerService, HeldBackReplyGoesOutBeforeTheNewOne) {
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
 
   EXPECT_TRUE(device.pump());
-  ASSERT_GE(f.uart.written.size(), 8u);
-  // The stashed frame is the request echoed back, so its third byte is 0x00; the pass's own reply carries a
-  // byte count of 0x02 there.
+  // The stashed frame is the request echoed back (8 bytes, third byte 0x00); the pass's own reply follows it
+  // (7 bytes, byte count 0x02 in its third byte).
+  ASSERT_EQ(f.uart.written.size(), 15u);
   EXPECT_EQ(f.uart.written[2], 0x00);
+  EXPECT_EQ(f.uart.written[8], 0x02);
+  EXPECT_EQ(f.uart.written[10], 0x02);
 }
 
 // The guard is restored rather than cleared, so a nested pass through the public loop() cannot release the
@@ -211,6 +256,8 @@ TEST(ModbusServerService, ANestedPassDoesNotReleaseTheOuterDispatch) {
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   f.uart.inject_frame(0x02, READ_HOLDING_PDU);
   f.hub.loop();
+  // The nested pass did dispatch the second frame, so the guard was really re-entered rather than left alone.
+  EXPECT_EQ(device.reads, 2);
   EXPECT_FALSE(device.serviced_after_nested_loop);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Stacked on esphome/esphome#19042 and esphome/esphome#19043 (first five commits).

- One value per command, sent once, instead of a pressed and a released value
  100 ms apart. It is what Hörmann's own bus accessory sends.
- A lamp command per direction (`0x0880` on, `0x0800/0x0100` off) instead of a
  toggle; `set_light(bool)` replaces `toggle_light()` and `cancel_light_toggle()`.
- Actions `hoermann_hcp.vent` and `hoermann_hcp.half_open`.

Verified today on a Series 4 motor with a fork sending the same values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

`toggle_light()` and `cancel_light_toggle()` are removed, `set_light(bool)` replaces them. No YAML changes.

**Related issue or feature (if applicable):**

- esphome/esphome#19043

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7346

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
hoermann_hcp:
  id: garage_hcp

light:
  - platform: hoermann_hcp
    name: Garage Light

button:
  - platform: template
    name: Air the garage
    on_press:
      - hoermann_hcp.vent
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
