### PR TITLE
[i2s_audio] Fix spurious driver failure

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -118,21 +118,24 @@ void I2SAudioSpeakerBase::loop() {
         break;
       }
 
+      // Still starting up or winding down from a previous run
+      if ((this->tx_handle_ != nullptr) || (this->speaker_task_handle_ != nullptr)) {
+        break;
+      }
+
       if (this->start_i2s_driver(this->audio_stream_info_) != ESP_OK) {
         ESP_LOGE(TAG, "Driver failed to start; retrying in 1 second");
         this->status_momentary_error("driver-failure", 1000);
         break;
       }
 
-      if (this->speaker_task_handle_ == nullptr) {
-        xTaskCreate(I2SAudioSpeakerBase::speaker_task, "speaker_task", TASK_STACK_SIZE, (void *) this, TASK_PRIORITY,
-                    &this->speaker_task_handle_);
+      xTaskCreate(I2SAudioSpeakerBase::speaker_task, "speaker_task", TASK_STACK_SIZE, (void *) this, TASK_PRIORITY,
+                  &this->speaker_task_handle_);
 
-        if (this->speaker_task_handle_ == nullptr) {
-          ESP_LOGE(TAG, "Task failed to start, retrying in 1 second");
-          this->status_momentary_error("task-failure", 1000);
-          this->stop_i2s_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
-        }
+      if (this->speaker_task_handle_ == nullptr) {
+        ESP_LOGE(TAG, "Task failed to start, retrying in 1 second");
+        this->status_momentary_error("task-failure", 1000);
+        this->stop_i2s_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
       }
       break;
     case speaker::STATE_RUNNING:   // Intentional fallthrough


### PR DESCRIPTION
# What does this implement/fix?

The speaker's `STATE_STARTING` branch in loop() called `start_i2s_driver()` on every pass. Because the state only advances to `RUNNING` once the task reports `TASK_RUNNING`, and because `start()` marks `STARTING` even while a previous run is still stopping, the driver could be started a second time while this component still held the I2S bus lock. `try_lock()` then failed, logging "Parent bus is busy" and "Driver failed to start; retrying in 1 second" and forcing a one second delay before playback could actually begin.

Skips the start sequence while a driver handle or task handle is still present, since either one means the bus lock is already held by this component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

i2s_audio:
  - id: i2s_bus
    i2s_bclk_pin: GPIOXX
    i2s_lrclk_pin: GPIOXX

speaker:
  - platform: i2s_audio
    id: board_speaker
    i2s_audio_id: i2s_bus
    dac_type: external
    i2s_dout_pin: GPIOXX

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
