### PR TITLE
[i2s_audio] Rate-limit the retry after a failed speaker task setup

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -107,8 +107,9 @@ void I2SAudioSpeakerBase::loop() {
   }
 
   if (event_group_bits & SpeakerEventGroupBits::ERR_ESP_NO_MEM) {
-    ESP_LOGE(TAG, "Speaker task setup failed (allocation, preload, or channel enable)");
+    ESP_LOGE(TAG, "Speaker task setup failed (allocation, preload, or channel enable); retrying in 1 second");
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ERR_ESP_NO_MEM);
+    this->status_momentary_error("setup-failure", 1000);
   }
 
   // Handle the speaker's state


### PR DESCRIPTION
# What does this implement/fix?

When the speaker task fails to set up — allocation, preload, or channel enable — `loop()` logs the error and clears `ERR_ESP_NO_MEM`, but does nothing to slow the next attempt down. The retry rate is therefore whatever the caller's write rate is: `play()` auto-starts the speaker, so a client that keeps writing audio retries the failing setup as fast as it writes.

Observed on hardware: a single failed PSRAM allocation produced 689 identical `Speaker task setup failed` lines before the board was rebooted, at roughly 25 attempts a second.

With the change in place, the same failure (a ring buffer too large to allocate) now retries at 1040, 1055, 1047 and 1046 ms intervals instead of as fast as the client writes, and the five log lines it produced were readable rather than a flood.

This adds `status_momentary_error("setup-failure", 1000)`, which is exactly what the two neighbouring failure paths in the same function already do — `STATE_STARTING` breaks out while `status_has_error()`, so the retry becomes once a second.

This does not make the failure recoverable and is not meant to; it stops it burning CPU and filling the log while it lasts. The log line now says the retry interval, matching `Driver failed to start; retrying in 1 second` a few lines below.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- n/a

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change.
# Reproduce by making the speaker task's setup fail (a buffer_duration large enough
# that the ring buffer cannot be allocated)while a client keeps writing to the speaker.

speaker:
  - platform: i2s_audio
    id: my_speaker
    i2s_audio_id: i2s_out
    i2s_dout_pin: GPIO27
    dac_type: external
    buffer_duration: 8s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
