### PR TITLE
[pmsa003i] Fix read from uninitialized stack memory

### DIFF
--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -88,9 +88,9 @@ void PMSA003IComponent::update() {
 bool PMSA003IComponent::read_data_(PM25AQIData *data) {
   uint8_t buffer[COUNT_DATA_BYTES];
 
-  const auto error = this->read(buffer, COUNT_DATA_BYTES);
-  if (error != esphome::i2c::ERROR_OK) {
-    ESP_LOGW(TAG, "Could not communicate with the device: I2C error code %d", error);
+  const i2c::ErrorCode error = this->read(buffer, COUNT_DATA_BYTES);
+  if (error != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "I2C error %d", error);
     return false;
   }
 

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -88,7 +88,11 @@ void PMSA003IComponent::update() {
 bool PMSA003IComponent::read_data_(PM25AQIData *data) {
   uint8_t buffer[COUNT_DATA_BYTES];
 
-  this->read_bytes_raw(buffer, COUNT_DATA_BYTES);
+  const auto error = this->read(buffer, COUNT_DATA_BYTES);
+  if (error != esphome::i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Could not communicate with the device: I2C error code %d", error);
+    return false;
+  }
 
   // https://github.com/adafruit/Adafruit_PM25AQI
 


### PR DESCRIPTION
# What does this implement/fix?

Check the return code of the I2C read.  Previously the function would continue onwards and access the uninitialized buffer and print garbage to the log.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  platfom: pmsa003i
  # etc...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
