### PR TITLE
[sendspin] Fix codec enum codegen when codecs is not set

### DIFF
--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -307,7 +307,7 @@ async def to_code(config: ConfigType) -> None:
         player_cfg = data.player_config
         sample_rate = player_cfg[CONF_SAMPLE_RATE]
 
-        codecs = player_cfg[CONF_CODECS]
+        codecs = [CODECS[codec] for codec in player_cfg[CONF_CODECS]]
 
         def _audio_format(codec: MockObj, channels: int) -> cg.StructInitializer:
             return cg.StructInitializer(

--- a/tests/components/sendspin/common-media_source.yaml
+++ b/tests/components/sendspin/common-media_source.yaml
@@ -9,4 +9,3 @@ media_source:
     static_delay_adjustable: true
     fixed_delay: 480us
     decode_memory: internal
-    codecs: [pcm, opus, flac]


### PR DESCRIPTION
# What does this implement/fix?

`_resolve_codecs()` fills in the default codec preference list from `DEFAULT_CODECS`,
which holds the plain config keys (`"flac"`, `"opus"`, `"pcm"`). Those keys were passed
straight into the `AudioSupportedFormatObject` struct initializer, so codegen emitted
string literals where `codec` is a `sendspin::SendspinCodecFormat`:

error: cannot convert 'const char*' to 'sendspin::SendspinCodecFormat' in initialization
error: could not convert '{<expression error>, ...}' from '<brace-enclosed initializer list>'
       to 'std::vectorsendspin::AudioSupportedFormatObject'

One error per advertised format (codecs x {stereo, mono}), then the enclosing vector
initializer. An explicit `codecs:` list was unaffected, because `cv.enum()` returns an
`EnumValue` that carries the mapped expression — only the default path bypasses the
mapping, so every config that does not set `codecs:` fails to compile.

Fixed by mapping the keys onto the enum in `to_code()`, which covers both paths since
`EnumValue` is a `str` subclass and hashes as its key.

Regression from #19047, first shipped in 2026.9.0b3.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #19047 (no issue filed)

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sendspin:
  id: sendspin_hub

media_source:
  - platform: sendspin
    id: sendspin_media_source
    # no `codecs:` — the default list is what breaks

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
