### PR TITLE
[spd2010] Add I2C touchscreen platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -503,6 +503,7 @@ esphome/components/sound_level/* @kahrendt
 esphome/components/spa06_base/* @danielkent-net
 esphome/components/spa06_i2c/* @danielkent-net
 esphome/components/spa06_spi/* @danielkent-net
+esphome/components/spd2010/* @grischard
 esphome/components/speaker/* @jesserockz @kahrendt
 esphome/components/speaker/media_player/* @kahrendt @synesthesiam
 esphome/components/speaker_source/* @kahrendt

--- a/esphome/components/spd2010/__init__.py
+++ b/esphome/components/spd2010/__init__.py
@@ -1,0 +1,2 @@
+CODEOWNERS = ["@grischard"]
+DEPENDENCIES = ["i2c"]

--- a/esphome/components/spd2010/spd2010_touchscreen.cpp
+++ b/esphome/components/spd2010/spd2010_touchscreen.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+// SPDX-License-Identifier: Apache-2.0
+// Protocol adapted from esp_lcd_touch_spd2010 2.0.1 for ESPHome.
+// https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_spd2010
+
+#include "spd2010_touchscreen.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome::spd2010 {
+
+static const char *const TAG = "spd2010.touchscreen";
+static constexpr uint16_t REG_CLEAR_INTERRUPT = 0x0002;
+static constexpr uint16_t REG_CPU_START = 0x0004;
+static constexpr uint16_t REG_STATUS = 0x0020;
+static constexpr uint16_t REG_VERSION = 0x0026;
+static constexpr uint16_t REG_TOUCH_START = 0x0046;
+static constexpr uint16_t REG_POINT_MODE = 0x0050;
+static constexpr uint16_t REG_HDP_STATUS = 0x02FC;
+static constexpr uint16_t REG_HDP = 0x0300;
+static constexpr uint8_t STATUS_BIOS = 0x40;
+static constexpr uint8_t STATUS_CPU = 0x20;
+static constexpr uint8_t STATUS_RUNNING = 0x08;
+static constexpr size_t MAX_REPORT_LENGTH = 4 + 10 * 6;
+
+bool SPD2010Touchscreen::read_register_(uint16_t reg, uint8_t *data, size_t length) {
+  const uint8_t command[] = {static_cast<uint8_t>(reg), static_cast<uint8_t>(reg >> 8)};
+  if (this->write(command, sizeof(command)) != i2c::ERROR_OK)
+    return false;
+  // The controller needs a STOP and a delay before a commandless receive.
+  delay_microseconds_safe(200);
+  if (this->read(data, length) != i2c::ERROR_OK)
+    return false;
+  delay_microseconds_safe(200);
+  return true;
+}
+
+bool SPD2010Touchscreen::write_command_(uint16_t reg, uint16_t value) {
+  const uint8_t command[] = {static_cast<uint8_t>(reg), static_cast<uint8_t>(reg >> 8), static_cast<uint8_t>(value),
+                             static_cast<uint8_t>(value >> 8)};
+  if (this->write(command, sizeof(command)) != i2c::ERROR_OK)
+    return false;
+  delay_microseconds_safe(200);
+  return true;
+}
+
+void SPD2010Touchscreen::setup() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(false);
+    this->set_timeout(2, [this]() {
+      this->reset_pin_->digital_write(true);
+      this->set_timeout(22, [this]() { this->initialize_(); });
+    });
+  } else {
+    this->initialize_();
+  }
+}
+
+bool SPD2010Touchscreen::start_controller_(uint8_t status) {
+  if (status & STATUS_BIOS) {
+    return this->write_command_(REG_CLEAR_INTERRUPT, 1) && this->write_command_(REG_CPU_START, 1);
+  }
+  if (status & STATUS_CPU) {
+    return this->write_command_(REG_POINT_MODE, 0) && this->write_command_(REG_TOUCH_START, 0) &&
+           this->write_command_(REG_CLEAR_INTERRUPT, 1);
+  }
+  return true;
+}
+
+void SPD2010Touchscreen::initialize_() {
+  uint8_t status[4];
+  if (this->read_register_(REG_STATUS, status, sizeof(status)) && this->start_controller_(status[1]) &&
+      (status[1] & STATUS_RUNNING) && !(status[1] & (STATUS_BIOS | STATUS_CPU))) {
+    uint8_t version[18];
+    if (!this->read_register_(REG_VERSION, version, sizeof(version))) {
+      ESP_LOGE(TAG, "Failed to read firmware version");
+      this->mark_failed();
+      return;
+    }
+    ESP_LOGD(TAG, "Firmware version: 0x%04X", encode_uint16(version[5], version[4]));
+    this->ready_ = true;
+    if (this->interrupt_pin_ != nullptr) {
+      this->interrupt_pin_->setup();
+      this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
+    }
+    // Service a report that may already have pulled the interrupt line low.
+    this->store_.touched = true;
+    return;
+  }
+  if (++this->setup_attempts_ >= 20) {
+    ESP_LOGE(TAG, "Controller did not enter point mode");
+    this->mark_failed();
+    return;
+  }
+  this->set_timeout(50, [this]() { this->initialize_(); });
+}
+
+bool SPD2010Touchscreen::finish_report_() {
+  // A corrupt status must not cause an unbounded drain loop or buffer overflow.
+  for (uint8_t attempt = 0; attempt < 8; attempt++) {
+    uint8_t status[8];
+    if (!this->read_register_(REG_HDP_STATUS, status, sizeof(status)))
+      return false;
+    if (status[5] == 0x82)
+      return this->write_command_(REG_CLEAR_INTERRUPT, 1);
+    const uint16_t length = encode_uint16(status[3], status[2]);
+    if (status[5] != 0 || length == 0 || length > MAX_REPORT_LENGTH)
+      break;
+    uint8_t remaining[MAX_REPORT_LENGTH];
+    if (!this->read_register_(REG_HDP, remaining, length))
+      return false;
+  }
+  ESP_LOGW(TAG, "Invalid or unfinished report");
+  this->write_command_(REG_CLEAR_INTERRUPT, 1);
+  return false;
+}
+
+bool SPD2010Touchscreen::read_data_() {
+  uint8_t status[4];
+  if (!this->read_register_(REG_STATUS, status, sizeof(status)))
+    return false;
+  if (status[1] & (STATUS_BIOS | STATUS_CPU)) {
+    this->skip_update_ = true;
+    // Recover if the controller restarts without producing another edge.
+    this->set_timeout(50, [this]() { this->store_.touched = true; });
+    return this->start_controller_(status[1]);
+  }
+  const uint16_t length = encode_uint16(status[3], status[2]);
+  if ((status[1] & STATUS_RUNNING) && length == 0)
+    return this->write_command_(REG_CLEAR_INTERRUPT, 1);
+  if (!(status[0] & 0x03)) {
+    this->skip_update_ = true;
+    if ((status[1] & STATUS_RUNNING) && (status[0] & 0x08))
+      return this->write_command_(REG_CLEAR_INTERRUPT, 1);
+    return true;
+  }
+  if (length < 4 || length > MAX_REPORT_LENGTH) {
+    ESP_LOGW(TAG, "Invalid report length: %u", length);
+    this->write_command_(REG_CLEAR_INTERRUPT, 1);
+    return false;
+  }
+  uint8_t report[MAX_REPORT_LENGTH];
+  if (!this->read_register_(REG_HDP, report, length) || !this->finish_report_())
+    return false;
+  if (!(status[0] & 0x01)) {
+    this->skip_update_ = true;
+    return true;
+  }
+  if ((length - 4) % 6 != 0)
+    return false;
+  // Validate the whole frame before publishing any points.
+  for (size_t offset = 4; offset < length; offset += 6) {
+    if (report[offset] > 0x0A)
+      return false;
+  }
+  for (size_t offset = 4; offset < length; offset += 6) {
+    const uint8_t strength = report[offset + 4];
+    if (strength == 0)
+      continue;
+    const uint16_t x = ((report[offset + 3] & 0xF0) << 4) | report[offset + 1];
+    const uint16_t y = ((report[offset + 3] & 0x0F) << 8) | report[offset + 2];
+    this->add_raw_touch_position_(report[offset], x, y, strength);
+  }
+  return true;
+}
+
+void SPD2010Touchscreen::update_touches() {
+  if (!this->ready_) {
+    this->skip_update_ = true;
+    return;
+  }
+  if (!this->read_data_()) {
+    this->skip_update_ = true;
+    this->status_set_warning();
+    this->set_timeout(50, [this]() { this->store_.touched = true; });
+  } else {
+    this->status_clear_warning();
+  }
+}
+
+void SPD2010Touchscreen::dump_config() {
+  ESP_LOGCONFIG(TAG, "SPD2010 Touchscreen:");
+  LOG_I2C_DEVICE(this);
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+}
+
+}  // namespace esphome::spd2010

--- a/esphome/components/spd2010/spd2010_touchscreen.h
+++ b/esphome/components/spd2010/spd2010_touchscreen.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/touchscreen/touchscreen.h"
+
+namespace esphome::spd2010 {
+
+class SPD2010Touchscreen final : public touchscreen::Touchscreen, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+  void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }
+
+ protected:
+  void initialize_();
+  void update_touches() override;
+  bool read_data_();
+  bool read_register_(uint16_t reg, uint8_t *data, size_t length);
+  bool write_command_(uint16_t reg, uint16_t value);
+  bool start_controller_(uint8_t status);
+  bool finish_report_();
+
+  InternalGPIOPin *interrupt_pin_{nullptr};
+  GPIOPin *reset_pin_{nullptr};
+  uint8_t setup_attempts_{0};
+  bool ready_{false};
+};
+
+}  // namespace esphome::spd2010

--- a/esphome/components/spd2010/touchscreen.py
+++ b/esphome/components/spd2010/touchscreen.py
@@ -1,0 +1,35 @@
+from esphome import pins
+import esphome.codegen as cg
+from esphome.components import i2c, touchscreen
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_RESET_PIN
+from esphome.types import ConfigType
+
+spd2010_ns = cg.esphome_ns.namespace("spd2010")
+SPD2010Touchscreen = spd2010_ns.class_(
+    "SPD2010Touchscreen", touchscreen.Touchscreen, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    touchscreen.touchscreen_schema(
+        "50ms", defaults={"x_min": 0, "x_max": 411, "y_min": 0, "y_max": 411}
+    )
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(SPD2010Touchscreen),
+            cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x53))
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await touchscreen.register_touchscreen(var, config)
+    await i2c.register_i2c_device(var, config)
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))
+    if reset_pin := config.get(CONF_RESET_PIN):
+        cg.add(var.set_reset_pin(await cg.gpio_pin_expression(reset_pin)))

--- a/tests/components/spd2010/common.yaml
+++ b/tests/components/spd2010/common.yaml
@@ -1,0 +1,25 @@
+display:
+  - platform: ssd1306_i2c
+    id: spd2010_display
+    model: SSD1306_128X64
+
+touchscreen:
+  - platform: spd2010
+    id: spd2010_touchscreen
+    display: spd2010_display
+    interrupt_pin: ${interrupt_pin}
+    reset_pin: ${reset_pin}
+  - platform: spd2010
+    id: spd2010_polling_touchscreen
+    display: spd2010_display
+    address: 0x54
+    update_interval: 100ms
+    calibration:
+      x_min: 0
+      x_max: 479
+      y_min: 0
+      y_max: 479
+    transform:
+      swap_xy: true
+      mirror_x: true
+      mirror_y: false

--- a/tests/components/spd2010/test.esp32-idf.yaml
+++ b/tests/components/spd2010/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  interrupt_pin: "20"
+  reset_pin: "21"
+
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+  spd2010: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds the `spd2010` I²C touchscreen platform for the controller used on the Waveshare ESP32-S3-Touch-LCD-1.46.

The driver uses ESPHome's I²C and touchscreen interfaces, supports interrupts or polling, accepts an optional reset pin (including an expander GPIO), and defaults to the board's 412×412 calibration. It handles BIOS/CPU startup without blocking delays, preserves controller contact IDs, and releases zero-strength contacts. Register selection and commandless reads are separate transactions with the controller's required delay.

The protocol is adapted directly to ESPHome, with bounded packet lengths and packet draining. No Espressif library dependency or ESP-IDF panel-IO shim is required.

Validation:
- New component YAML covers interrupt/reset configuration and polling with a custom address, calibration, and transforms; ESP32-IDF firmware compiled successfully.
- Combined ESP32-S3 firmware with the companion `mipi_spi` model, PCA9554 reset, and LVGL compiled successfully.
- Full Python unit/component suite: 6,156 passed, 13 skipped (with the machine's stale IDF_PATH removed from the test environment).
- `prek` checks passed.
- Local C++ protocol harness with AddressSanitizer and UndefinedBehaviorSanitizer passed startup, contact IDs/coordinates, release, I²C failure, malformed-length, and bounded-drain checks.

Hardware validation of this native protocol implementation was successful.

Protocol adapted from [Espressif esp_lcd_touch_spd2010](https://github.com/espressif/esp-bsp/tree/master/components/lcd_touch/esp_lcd_touch_spd2010), version 2.0.1, retaining its Apache-2.0 attribution. Integration work builds on [the external component repository](https://github.com/grischard/waveshare-lcd-1.46-touch), originally forked from chickymonkey's project.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Companion implementation: https://github.com/esphome/esphome/pull/19056

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- https://github.com/esphome/esphome.io/pull/7353

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- Not applicable; no developer API changes.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO11
  scl: GPIO10

# main_display is an existing display ID.
touchscreen:
  - platform: spd2010
    display: main_display
    interrupt_pin:
      number: GPIO4
      mode: INPUT_PULLUP

```

## Checklist:
  - [x] The code change is tested and works locally. Compile and automated checks pass; physical hardware testing was successful.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
