### PR TITLE
[ci] Ignore platformio updates in dependabot until upstream platforms support 6.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     ignore:
       # Hypotehsis is only used for testing and is updated quite often
       - dependency-name: hypothesis
+      # PlatformIO 6.2.0 is not supported by the pioarduino ESP32 platform or
+      # LibreTiny yet, remove once both platforms support it
+      - dependency-name: platformio
   - package-ecosystem: github-actions
     labels:
       - "dependencies"


### PR DESCRIPTION
# What does this implement/fix?

PlatformIO 6.2.0 bumps its bundled SCons to 4.11.1, and neither of the platforms we build against handle that yet. The pioarduino ESP32 platform wipes the core SCons package mid build because of a version mismatch, see https://github.com/pioarduino/platform-espressif32/issues/529; LibreTiny's build scripts fail under the new SCons with a dataclass error. Both showed up in the dependabot bump in #19058.

This tells dependabot to stop proposing platformio updates until upstream supports 6.2.0, then the ignore entry can be removed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
