### PR TITLE
[noise] Bump noise-c to 0.1.30 and libsodium to 1.10021.11

### DIFF
--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -88,7 +88,7 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.26")
+    cg.add_library("esphome/noise-c", "0.1.27")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
@@ -97,3 +97,8 @@ async def to_code(config: ConfigType) -> None:
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")
+    # The handshake is built from algorithm ids and never names a protocol, so
+    # noise-c can leave its name tables and the fallback and hfs modifiers out
+    cg.add_build_flag("-DNOISE_USE_PROTOCOL_NAME_TABLE=0")
+    cg.add_build_flag("-DNOISE_USE_FALLBACK=0")
+    cg.add_build_flag("-DNOISE_USE_HFS=0")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -88,12 +88,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.29")
+    cg.add_library("esphome/noise-c", "0.1.30")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.10")
+    cg.add_library("esphome/libsodium", "1.10021.11")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -88,12 +88,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.28")
+    cg.add_library("esphome/noise-c", "0.1.29")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.9")
+    cg.add_library("esphome/libsodium", "1.10021.10")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -88,16 +88,12 @@ def encryption_schema(config: ConfigType | None) -> ConfigType:
 
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_NOISE")
-    cg.add_library("esphome/noise-c", "0.1.27")
+    cg.add_library("esphome/noise-c", "0.1.28")
     # noise-c depends on libsodium, but declaring it here too lets the
     # library manager see the full set up front instead of discovering
     # libsodium only after noise-c has downloaded, so the two can download
     # in parallel. The version must match noise-c's library.json.
-    cg.add_library("esphome/libsodium", "1.10021.8")
+    cg.add_library("esphome/libsodium", "1.10021.9")
     # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")
-    # The handshake is built from algorithm ids and never names a protocol, so
-    # noise-c can leave its name tables and the unused handshake modifiers out
-    for switch in ("PROTOCOL_NAME_TABLE", "FALLBACK", "HFS"):
-        cg.add_build_flag(f"-DNOISE_USE_{switch}=0")

--- a/esphome/components/noise/__init__.py
+++ b/esphome/components/noise/__init__.py
@@ -98,7 +98,6 @@ async def to_code(config: ConfigType) -> None:
     cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
     cg.add_build_flag("-DHAVE_INLINE_ASM=1")
     # The handshake is built from algorithm ids and never names a protocol, so
-    # noise-c can leave its name tables and the fallback and hfs modifiers out
-    cg.add_build_flag("-DNOISE_USE_PROTOCOL_NAME_TABLE=0")
-    cg.add_build_flag("-DNOISE_USE_FALLBACK=0")
-    cg.add_build_flag("-DNOISE_USE_HFS=0")
+    # noise-c can leave its name tables and the unused handshake modifiers out
+    for switch in ("PROTOCOL_NAME_TABLE", "FALLBACK", "HFS"):
+        cg.add_build_flag(f"-DNOISE_USE_{switch}=0")

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.27                 ; noise (api, ota)
+    esphome/noise-c@0.1.28                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.27                ; noise (api, ota)
+    esphome/noise-c@0.1.28                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.27  ; used by noise (api, ota)
+    esphome/noise-c@0.1.28  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.29                 ; noise (api, ota)
+    esphome/noise-c@0.1.30                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.29                ; noise (api, ota)
+    esphome/noise-c@0.1.30                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.29  ; used by noise (api, ota)
+    esphome/noise-c@0.1.30  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.26                 ; noise (api, ota)
+    esphome/noise-c@0.1.27                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.26                ; noise (api, ota)
+    esphome/noise-c@0.1.27                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.26  ; used by noise (api, ota)
+    esphome/noise-c@0.1.27  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps_base =
 lib_deps =
     ${common.lib_deps_base}
     https://github.com/dudanov/MideaUART.git#eeea6c3e9b4474f067054592b435be1c4e466815 ; midea
-    esphome/noise-c@0.1.28                 ; noise (api, ota)
+    esphome/noise-c@0.1.29                 ; noise (api, ota)
     improv/Improv@1.2.7                    ; improv_serial / esp32_improv
     kikuchan98/pngle@1.1.0                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
@@ -244,7 +244,7 @@ lib_deps =
     ${common:idf-component-libs.lib_deps}
     ESP32Async/ESPAsyncWebServer@3.9.6    ; web_server_base
     droscy/esp_wireguard@0.4.5            ; wireguard
-    esphome/noise-c@0.1.28                ; noise (api, ota)
+    esphome/noise-c@0.1.29                ; noise (api, ota)
     ESP32Async/AsyncTCP@3.4.5             ; async_tcp
     DNSServer                             ; captive_portal
     heman/AsyncMqttClient-esphome@2.0.0   ; mqtt
@@ -641,7 +641,7 @@ build_unflags =
 extends = common
 platform = platformio/native
 lib_deps =
-    esphome/noise-c@0.1.28  ; used by noise (api, ota)
+    esphome/noise-c@0.1.29  ; used by noise (api, ota)
     lvgl/lvgl@9.5.0         ; lvgl
 build_flags =
     ${common.build_flags}

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.26") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.26") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 0.1.27") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@0.1.27") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.26\n"
+        "    esphome/noise-c @ 0.1.27\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.26\n"
+        "    esphome/noise-c @ 0.1.27\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.26"]
+    assert libs == ["esphome/noise-c @ 0.1.27"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.26",
+        "esphome/noise-c @ 0.1.27",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.26",
-            "esphome/noise-c @ 0.1.26",
+            "esphome/noise-c @ 0.1.27",
+            "esphome/noise-c @ 0.1.27",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.26"]
+    assert cls.calls == ["esphome/noise-c @ 0.1.27"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.26": [
+        "esphome/noise-c @ 0.1.27": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.26", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.27", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.26"] is None
+    assert compats["esphome/noise-c @ 0.1.27"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.26": [
+        "esphome/noise-c @ 0.1.27": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.26"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.27"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.26"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.27"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.26": [
+        "esphome/noise-c @ 0.1.27": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.26"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.27"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/script/test_platformio_install_deps.py
+++ b/tests/script/test_platformio_install_deps.py
@@ -35,8 +35,8 @@ def _load_script():
 def test_spec_key_collapses_destinations() -> None:
     """Two specs delivering one package share a directory and one key."""
     mod = _load_script()
-    assert mod.spec_key("esphome/noise-c @ 0.1.27") == "noise-c"
-    assert mod.spec_key("esphome/noise-c@0.1.27") == "noise-c"
+    assert mod.spec_key("esphome/noise-c @ 1.0") == "noise-c"
+    assert mod.spec_key("esphome/noise-c@1.0") == "noise-c"
     assert mod.spec_key("ESP32Async/AsyncTCP @ ^3.4.10") == mod.spec_key(
         "esp32async/asynctcp @ 3.5.0"
     )
@@ -54,23 +54,23 @@ def test_parse_specs_and_cli_args(tmp_path: Path) -> None:
         "[env:a]\n"
         "platform = fake/platform@1\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.27\n"
+        "    esphome/noise-c @ 1.0\n"
         "    ${common.lib_deps}\n"
         "    internal_lib\n"
         "[env:b]\n"
         "lib_deps =\n"
-        "    esphome/noise-c @ 0.1.27\n"
+        "    esphome/noise-c @ 1.0\n"
     )
     mod = _load_script()
     args = Namespace(libraries=True, platforms=True, tools=False)
     libs, platforms, tools = mod.parse_specs(str(ini), args)
     # exact-string duplicates collapse; distinct version pins survive
-    assert libs == ["esphome/noise-c @ 0.1.27"]
+    assert libs == ["esphome/noise-c @ 1.0"]
     assert platforms == ["fake/platform@1"]
     assert tools == []
     assert mod.build_cli_args(libs, platforms, tools) == [
         "-l",
-        "esphome/noise-c @ 0.1.27",
+        "esphome/noise-c @ 1.0",
         "-p",
         "fake/platform@1",
     ]
@@ -162,13 +162,13 @@ def test_parallel_install_behavior(tmp_path: Path) -> None:
     mod.parallel_install(
         cls,
         [
-            "esphome/noise-c @ 0.1.27",
-            "esphome/noise-c @ 0.1.27",
+            "esphome/noise-c @ 1.0",
+            "esphome/noise-c @ 1.0",
             "esphome/already @ 1.0",
             "https://x/framework.tar.xz",
         ],
     )
-    assert cls.calls == ["esphome/noise-c @ 0.1.27"]
+    assert cls.calls == ["esphome/noise-c @ 1.0"]
     assert cls.lock_events == ["lock", "unlock"]
 
 
@@ -205,7 +205,7 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.27": [
+        "esphome/noise-c @ 1.0": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
             {"name": "SPI"},
         ],
@@ -213,12 +213,12 @@ def test_parallel_install_runs_dependency_waves(tmp_path: Path) -> None:
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.27", "esphome/wg @ 1.0"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 1.0", "esphome/wg @ 1.0"])
     assert len(cls.calls) == 3  # the shared dep installs exactly once
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c", "wg", "libsodium"}
     # Wave-1 strings carry no compatibility; the dependency wave does
     compats = dict(cls.compat_calls)
-    assert compats["esphome/noise-c @ 0.1.27"] is None
+    assert compats["esphome/noise-c @ 1.0"] is None
     dep_compat = next(v for k, v in cls.compat_calls if "libsodium" in k)
     assert dep_compat is not None  # mirrors pio's install_dependency
 
@@ -229,11 +229,11 @@ def test_dependency_wave_excludes_url_specs(tmp_path: Path) -> None:
     mod = _load_script()
     cls = _reset_fake(str(tmp_path))
     cls.deps = {
-        "esphome/noise-c @ 0.1.27": [
+        "esphome/noise-c @ 1.0": [
             {"name": "vendored", "version": "https://github.com/x/y.git"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.27"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 1.0"])
     assert {mod.spec_key(c) for c in cls.calls} == {"noise-c"}
 
 
@@ -348,13 +348,13 @@ def test_warm_store_still_walks_dependencies(tmp_path: Path) -> None:
     """Already-installed top-level packages still feed the dependency
     wave; a warm store can be missing a transitive dep."""
     mod = _load_script()
-    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 0.1.27"})
+    cls = _reset_fake(str(tmp_path), installed={"esphome/noise-c @ 1.0"})
     cls.deps = {
-        "esphome/noise-c @ 0.1.27": [
+        "esphome/noise-c @ 1.0": [
             {"owner": "esphome", "name": "libsodium", "version": "^1.0"},
         ],
     }
-    mod.parallel_install(cls, ["esphome/noise-c @ 0.1.27"])
+    mod.parallel_install(cls, ["esphome/noise-c @ 1.0"])
     assert [mod.spec_key(c) for c in cls.calls] == ["libsodium"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1663,7 +1663,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.26", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.27", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1683,7 +1683,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.26", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@0.1.27", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 

--- a/tests/unit_tests/test_platformio_prefetch.py
+++ b/tests/unit_tests/test_platformio_prefetch.py
@@ -1663,7 +1663,7 @@ def test_preinstall_runs_dependency_waves(tmp_path: Path) -> None:
         {"name": "SPI"},
     ]
     m.dependency_to_spec.side_effect = lambda dep: _FakeSpec(name=dep["name"])
-    pf._preinstall(m, [("noise-c@0.1.27", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@1.0", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c", "libsodium"]  # dep deduped, SPI left out
     # The dep wave carries its compatibility so _install searches qualified
     dep_call = m._install.call_args_list[-1]
@@ -1683,7 +1683,7 @@ def test_preinstall_dependency_wave_skips_seen_names(tmp_path: Path) -> None:
     m._install.side_effect = lambda spec, skip_dependencies, compatibility=None: (
         installed.append(getattr(spec, "name", str(spec)))
     )
-    pf._preinstall(m, [("noise-c@0.1.27", _FakeSpec(name="noise-c"))])
+    pf._preinstall(m, [("noise-c@1.0", _FakeSpec(name="noise-c"))])
     assert installed == ["noise-c"]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Bumps noise-c from 0.1.26 to 0.1.30 and libsodium from 1.10021.8 to 1.10021.11.

noise-c 0.1.28 adds three size switches, `NOISE_USE_PROTOCOL_NAME_TABLE`, `NOISE_USE_FALLBACK` and `NOISE_USE_HFS`, and turns them off in its own library.json (esphome-libs/noise-c#34, esphome-libs/noise-c#40). ESPHome builds its handshake from algorithm ids and never names a protocol, so the tables that turn names into ids and back go, along with the fallback and hfs pattern modifiers it never asks for; the one pattern left expands from a constant, the modifier scan and the 64 byte token buffer go with it (esphome-libs/noise-c#39, esphome-libs/noise-c#41, esphome-libs/noise-c#42). No build flags are needed on this side, which also covers the Zephyr backend where project flags never reached the library. 0.1.29 and 0.1.30 only move the libsodium pin.

libsodium 1.10021.9 replaces the fully unrolled SHA256 transform with four rounds per pass on every target (esphome-libs/libsodium#41). Hot it matches the unrolled one per block; cold, which is every hash in a handshake, it is two to three times faster because it is 600 bytes instead of 2508 and no longer has to be refilled from flash. 1.10021.10 takes the SHA256 padding block, the SHA256 initial state and the AEAD zero pad out of DRAM on the ESP8266 (esphome-libs/libsodium#42, esphome-libs/libsodium#43, esphome-libs/libsodium#44), 112 bytes. 1.10021.11 computes the ephemeral key on the ESP8266 and RP2040 with the same 13 bit field arithmetic the ladder already uses, so ref10's field and Edwards code leaves those images and the base point multiply gets a third faster (esphome-libs/libsodium#45), and on the ESP32 the two ref10 files share one copy of the field functions instead of each carrying their own (esphome-libs/libsodium#46).

Image sizes of one build (logger, wifi, api with encryption, ota), dev against this branch, registry packages:

| board | dev flash | this PR flash | flash saved | dev RAM | this PR RAM | RAM saved |
| --- | --- | --- | --- | --- | --- | --- |
| ESP8266 d1 mini | 389791 B | 373483 B | 16308 B | 30188 B | 29468 B | 720 B |
| ESP32 AtomU (IDF) | 741811 B | 731911 B | 9900 B | 44512 B | 44512 B | 0 |
| Pico W (RP2040) | 484304 B | 470656 B | 13648 B | 78824 B | 78824 B | 0 |

The RAM saving is ESP8266 only, where the name and pattern tables and the three SHA256 and AEAD constants sat in DRAM; the other two keep them in flash.

Timing from a bench firmware that hashes fixed inputs, hashes once right after a base point multiply, runs the two scalar multiplies and five handshakes in memory taking the best, dev against this branch, one boot each with two sets per boot:

| | ESP8266 dev | ESP8266 PR | AtomU dev | AtomU PR | Pico W dev | Pico W PR |
| --- | --- | --- | --- | --- | --- | --- |
| SHA256 per 64 B block, hot | 55.4 us | 54.3 us | 18.5 us | 18.4 us | 55.5 us | 54.9 us |
| SHA256 of 32 B after a base point multiply | 217 us | 221 us | 412 us | 53 us | 386 us | 192 us |
| handshake state new and free | 249 us | 221 us | 275 us | 221 us | 317 us | 197 us |
| base point multiply, best of 5 | 50.5, 52.0 ms | 35.1, 35.3 ms | 5.79, 5.79 ms | 5.81, 5.82 ms | 37.3, 36.4 ms | 27.5, 27.5 ms |
| DH, best of 5 | 91.7, 92.2 ms | 106.4, 106.7 ms | 14.02, 14.01 ms | 14.05, 14.05 ms | 67.8, 67.8 ms | 66.9, 66.6 ms |
| handshake, min of 5 | 303, 303 ms | 302, 304 ms | 49.0, 49.0 ms | 46.1, 46.4 ms | 227, 225 ms | 207, 201 ms |

ESP8266 at 80 MHz. The ESP8266 and Pico W handshakes move by several milliseconds between boots from WiFi, so those lines are direction only; the AtomU repeats to a few tenths of a millisecond. The ESP8266 DH code is unchanged; its number moves with where the linker places the ladder against the code that runs during its yields, the extra time being flash cache stall (the same at 80 and 160 MHz), and the base point multiply gain more than covers it in the handshake.

Encrypted OTA retested on all three boards with this image: serial flash, then the same image pushed again over the noise transport with `encryption:` required under the ota platform. All three reported an encrypted connection and a successful update, rebooted onto the image, rejoined WiFi and ran the bench again.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  encryption:
    key: "..."
ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


