### PR TITLE
[speaker_source] Don't remap a requested volume of zero

### DIFF
--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -810,7 +810,10 @@ void SpeakerSourceMediaPlayer::set_mute_state_(bool mute_state, bool publish) {
 
 void SpeakerSourceMediaPlayer::set_volume_(float volume, bool publish) {
   // Remap the volume to fit within the configured limits
-  float bounded_volume = remap<float, float>(volume, 0.0f, 1.0f, this->volume_min_, this->volume_max_);
+  // A volume that is effectively zero is passed through unremapped, so that requested silence still reaches
+  // the speaker as zero. The same threshold decides the mute state below.
+  float bounded_volume =
+      (volume < 0.001f) ? 0.0f : remap<float, float>(volume, 0.0f, 1.0f, this->volume_min_, this->volume_max_);
 
   for (auto &ps : this->pipelines_) {
     if (ps.is_configured()) {


### PR DESCRIPTION
# What does this implement/fix?

`SpeakerSourceMediaPlayer::set_volume_` remaps the requested 0..1 volume onto `[volume_min, volume_max]` and hands the result to the speaker:

```cpp
float bounded_volume = remap<float, float>(volume, 0.0f, 1.0f, this->volume_min_, this->volume_max_);
```

With `volume_min > 0`, a requested zero arrives at the speaker as `volume_min`, and `i2s_audio_speaker.cpp` unmutes the DAC for anything above zero:

```cpp
if (volume > 0.0f) {
  this->audio_dac_->set_mute_off();
}
```

`set_volume_` then calls `set_mute_state_(true)` to re-mute, but that early-returns when the player is already muted:

```cpp
if (this->is_muted_ == mute_state) {
  return;
}
```

So the first volume-down to zero mutes correctly, and every volume-down **after** that unmutes the DAC and never re-mutes it. The entity keeps reporting `is_volume_muted: true` while the DAC sits at `volume_min` and audio stays audible. It is only observable with audio playing, which is how it was reported.

This passes a volume that is effectively zero through unremapped, using the same `< 0.001f` threshold that already decides the mute state a few lines below. Requested silence then reaches the speaker as zero: no `set_mute_off()` is issued, and the DAC lands on its floor register rather than depending on the mute flag winning a race.

Two notes on the shape of the fix:

- The threshold is `< 0.001f` rather than `== 0.0f` on purpose. `VOLUME_DOWN` computes `std::max(0.0f, volume - increment)`, which in practice lands on float dust (`7.45e-09`) rather than exact zero, and that dust is self-sustaining once introduced. An exact-zero test would leave the reported bug in place. Reusing the existing mute threshold also keeps one definition of "effectively zero" in the function.
- `speaker`'s media player carries the identical remap, but does **not** have this bug: its `set_mute_state_` propagates unconditionally and only gates the *trigger* on the state change, so the DAC is unmuted and then immediately re-muted. I have deliberately left it alone rather than change behaviour where there is no defect. Happy to align the two in a follow-up if you would prefer them to match.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7253

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — no user-facing configuration change.

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# Any speaker_source media player with a non-zero volume_min reproduces it.
# tests/components/speaker_source/common.yaml with volume_min raised is enough:
media_player:
  - platform: speaker_source
    id: media_player_id
    name: Media Player
    volume_increment: 0.05
    volume_initial: 0.75
    volume_max: 0.95
    volume_min: 0.30   # dev's test config uses 0.0, which does not exercise this
    # ...pipelines unchanged
```

Reproduce on `dev`: play audio, send `volume_down` until it mutes (correct — audio stops), then send `volume_down` once more. Audio returns while the entity still reports `is_volume_muted: true`. With this change the second `volume_down` stays silent.

(The reported `volume_level` still carries the float dust from `VOLUME_DOWN`'s `std::max(0.0f, volume - increment)`; this PR deliberately does not touch the published value, only what is handed to the speaker.)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The behaviour needs a real DAC to observe (the bug is in what the audio_dac does with a non-zero volume), so I have not added a test under `tests/`. Happy to add one if there is a shape you would prefer.

---

Generated with [Claude Code](https://claude.com/claude-code)
