### PR TITLE
[esp32_ble_tracker] Re-register GATT clients after ble.disable and ble.enable

### DIFF
--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -57,7 +57,7 @@ void BluedroidGattClient::loop() {
       ESP_LOGE(TAG, "gattc app register failed: app_id=%d code=%d", this->app_id, ret);
       this->mark_failed();
     }
-    // Do not wait for REG_EVT; a dropped event must not wedge the slot.
+    // Do not wait for REG_EVT; connect() rejects until it lands.
     this->set_idle_();
   } else if (st == ClientState::DISCONNECTING || this->disconnect_pending()) {
     // The one teardown safety net: a lost CLOSE_EVT, or a scheduled

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -45,15 +45,9 @@ void BluedroidGattClient::setup() {
 
 void BluedroidGattClient::loop() {
   if (!esp32_ble::global_ble->is_active()) {
-    // Stack down: no CLOSE_EVT will come. Settle a live link so the consumer
-    // frees its slot, then re-register the app on the next enable.
-    auto down_st = this->state();
-    if (down_st != ClientState::IDLE && down_st != ClientState::INIT) {
-      this->release_services();
-      this->set_idle_();
-      this->listener_->on_connection_state(false, 0, ble_device_base::GATT_ERR_NOT_CONNECTED);
-    }
-    this->set_state(ClientState::INIT);
+    // Backstop for the window between disable() and the teardown; the
+    // tracker's before-disabled hook is the primary path.
+    this->reset_for_stack_down_();
     return;
   }
   auto st = this->state();
@@ -87,6 +81,30 @@ void BluedroidGattClient::loop() {
   }
 }
 
+// Stack down: no CLOSE_EVT will come. Settle a live link so the consumer
+// frees its slot, then re-register the app on the next enable.
+void BluedroidGattClient::reset_for_stack_down_() {
+  auto st = this->state();
+  if (st == ClientState::INIT) {
+    return;
+  }
+  if (st != ClientState::IDLE) {
+    this->release_services();
+    this->set_idle_();
+    this->listener_->on_connection_state(false, 0, ble_device_base::GATT_ERR_NOT_CONNECTED);
+  }
+  // The interface belongs to the torn-down stack; Bluedroid drops an open
+  // issued with it without any event.
+  this->gattc_if_ = ESP_GATT_IF_NONE;
+  this->set_state(ClientState::INIT);
+}
+
+void BluedroidGattClient::ble_before_disabled_event_handler() {
+  this->reset_for_stack_down_();
+  // An idle slot runs no loop; the INIT branch must run to register again.
+  this->enable_loop();
+}
+
 void BluedroidGattClient::dump_config() {
   ESP_LOGCONFIG(TAG, "Bluedroid GATT client %d", this->connection_index_);
   if (this->is_failed()) {
@@ -97,9 +115,15 @@ void BluedroidGattClient::dump_config() {
 // ---- contract ops ----
 
 int BluedroidGattClient::connect(uint64_t address, uint8_t addr_type) {
+  auto st = this->state();
+  if (st == ClientState::INIT) {
+    // Nothing can be opened until the app is registered on a running stack.
+    ESP_LOGW(TAG, "[%d] Connect rejected, BLE stack not ready", this->connection_index_);
+    return ble_device_base::GATT_ERR_NOT_CONNECTED;
+  }
   // Only from idle: clobbering DISCONNECTING would open a new link the
   // stale CLOSE_EVT then tears down.
-  if (this->state() != ClientState::IDLE) {
+  if (st != ClientState::IDLE) {
     ESP_LOGW(TAG, "[%d] Connect rejected, slot busy", this->connection_index_);
     return ESP_GATT_BUSY;
   }
@@ -119,6 +143,14 @@ void BluedroidGattClient::tracker_connect_() {
   }
   if (st == ClientState::DISCONNECTING) {
     ESP_LOGW(TAG, "[%d] Cannot connect, still waiting for CLOSE_EVT", this->connection_index_);
+    return;
+  }
+  if (this->gattc_if_ == ESP_GATT_IF_NONE) {
+    // REG_EVT has not landed on this stack; Bluedroid drops an open on an
+    // unknown interface without any event, which would wedge the slot.
+    ESP_LOGW(TAG, "[%d] Connect failed, GATT app not registered", this->connection_index_);
+    this->set_idle_();
+    this->listener_->on_connection_state(false, 0, ble_device_base::GATT_ERR_NOT_CONNECTED);
     return;
   }
   ESP_LOGI(TAG, "[%d] 0x%02x Connecting", this->connection_index_, this->remote_addr_type_);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -70,8 +70,8 @@ void BluedroidGattClient::loop() {
       this->listener_->on_connection_state(false, 0, ESP_GATT_CONN_TIMEOUT);
     }
   } else {
-    // The loop stays on while a link exists (stack-down watch, pre-started
-    // search flush); it settles only back at IDLE.
+    // The loop stays on while a link exists (pre-started search flush); it
+    // settles only back at IDLE.
     this->deliver_pending_search_();
     if (this->state() == ClientState::IDLE) {
       this->disable_loop();

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.cpp
@@ -45,9 +45,7 @@ void BluedroidGattClient::setup() {
 
 void BluedroidGattClient::loop() {
   if (!esp32_ble::global_ble->is_active()) {
-    // Backstop for the window between disable() and the teardown; the
-    // tracker's before-disabled hook is the primary path.
-    this->reset_for_stack_down_();
+    // ble_before_disabled_event_handler() settles the slot.
     return;
   }
   auto st = this->state();
@@ -82,25 +80,17 @@ void BluedroidGattClient::loop() {
 }
 
 // Stack down: no CLOSE_EVT will come. Settle a live link so the consumer
-// frees its slot, then re-register the app on the next enable.
-void BluedroidGattClient::reset_for_stack_down_() {
+// frees its slot, then register the app again on the next enable.
+void BluedroidGattClient::ble_before_disabled_event_handler() {
   auto st = this->state();
-  if (st == ClientState::INIT) {
-    return;
-  }
-  if (st != ClientState::IDLE) {
+  if (st != ClientState::IDLE && st != ClientState::INIT) {
     this->release_services();
     this->set_idle_();
     this->listener_->on_connection_state(false, 0, ble_device_base::GATT_ERR_NOT_CONNECTED);
   }
-  // The interface belongs to the torn-down stack; Bluedroid drops an open
-  // issued with it without any event.
+  // The interface belongs to the torn-down stack.
   this->gattc_if_ = ESP_GATT_IF_NONE;
   this->set_state(ClientState::INIT);
-}
-
-void BluedroidGattClient::ble_before_disabled_event_handler() {
-  this->reset_for_stack_down_();
   // An idle slot runs no loop; the INIT branch must run to register again.
   this->enable_loop();
 }
@@ -115,15 +105,14 @@ void BluedroidGattClient::dump_config() {
 // ---- contract ops ----
 
 int BluedroidGattClient::connect(uint64_t address, uint8_t addr_type) {
-  auto st = this->state();
-  if (st == ClientState::INIT) {
-    // Nothing can be opened until the app is registered on a running stack.
-    ESP_LOGW(TAG, "[%d] Connect rejected, BLE stack not ready", this->connection_index_);
+  if (this->gattc_if_ == ESP_GATT_IF_NONE) {
+    // Bluedroid drops an open on an unknown interface without any event.
+    ESP_LOGW(TAG, "[%d] Connect rejected, GATT app not registered", this->connection_index_);
     return ble_device_base::GATT_ERR_NOT_CONNECTED;
   }
   // Only from idle: clobbering DISCONNECTING would open a new link the
   // stale CLOSE_EVT then tears down.
-  if (st != ClientState::IDLE) {
+  if (this->state() != ClientState::IDLE) {
     ESP_LOGW(TAG, "[%d] Connect rejected, slot busy", this->connection_index_);
     return ESP_GATT_BUSY;
   }
@@ -143,14 +132,6 @@ void BluedroidGattClient::tracker_connect_() {
   }
   if (st == ClientState::DISCONNECTING) {
     ESP_LOGW(TAG, "[%d] Cannot connect, still waiting for CLOSE_EVT", this->connection_index_);
-    return;
-  }
-  if (this->gattc_if_ == ESP_GATT_IF_NONE) {
-    // REG_EVT has not landed on this stack; Bluedroid drops an open on an
-    // unknown interface without any event, which would wedge the slot.
-    ESP_LOGW(TAG, "[%d] Connect failed, GATT app not registered", this->connection_index_);
-    this->set_idle_();
-    this->listener_->on_connection_state(false, 0, ble_device_base::GATT_ERR_NOT_CONNECTED);
     return;
   }
   ESP_LOGI(TAG, "[%d] 0x%02x Connecting", this->connection_index_, this->remote_addr_type_);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.h
@@ -56,6 +56,7 @@ class BluedroidGattClient final : public esp32_ble_tracker::ESPBTClient, public 
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
   void connect() override;
   void disconnect() override;
+  void ble_before_disabled_event_handler() override;
   bool wants_parsed_advertisements() override { return false; }
   void on_scan_end() override {}
   bool parse_device(const ble_device_base::ESPBTDevice &device) override { return false; }
@@ -98,6 +99,7 @@ class BluedroidGattClient final : public esp32_ble_tracker::ESPBTClient, public 
   void unconditional_disconnect_();
   void set_idle_();
   void set_disconnecting_();
+  void reset_for_stack_down_();
   esp_err_t update_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
                                 const char *param_type);
   int check_and_log_error_(const char *operation, esp_err_t err);

--- a/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.h
+++ b/esphome/components/bluetooth_connection/bluetooth_connection_bluedroid.h
@@ -99,7 +99,6 @@ class BluedroidGattClient final : public esp32_ble_tracker::ESPBTClient, public 
   void unconditional_disconnect_();
   void set_idle_();
   void set_disconnecting_();
-  void reset_for_stack_down_();
   esp_err_t update_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
                                 const char *param_type);
   int check_and_log_error_(const char *operation, esp_err_t err);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -580,9 +580,7 @@ void ESP32BLE::loop_handle_state_transition_not_active_() {
       this->mark_failed();
       return;
     }
-    // Whatever the old stack queued while going down (close events for the
-    // links it tore down, scan completions) must not replay against the next
-    // stack, which hands out the same interface ids.
+    // Drop what the old stack queued; the next stack reuses the same interface ids.
     BLEEvent *ble_event;
     while ((ble_event = this->ble_events_.pop()) != nullptr) {
       this->ble_event_pool_.release(ble_event);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -84,11 +84,8 @@ void ESP32BLE::setup() {
 }
 
 void ESP32BLE::enable() {
-  if (this->state_ == BLE_COMPONENT_STATE_DISABLE) {
-    // The teardown has not run yet; the stack is still up.
-    this->state_ = BLE_COMPONENT_STATE_ACTIVE;
+  if (this->cancel_pending_(BLE_COMPONENT_STATE_DISABLE, BLE_COMPONENT_STATE_ACTIVE))
     return;
-  }
   if (this->state_ != BLE_COMPONENT_STATE_DISABLED)
     return;
 
@@ -96,11 +93,8 @@ void ESP32BLE::enable() {
 }
 
 void ESP32BLE::disable() {
-  if (this->state_ == BLE_COMPONENT_STATE_ENABLE) {
-    // The bring-up has not run yet; the stack is still down.
-    this->state_ = BLE_COMPONENT_STATE_DISABLED;
+  if (this->cancel_pending_(BLE_COMPONENT_STATE_ENABLE, BLE_COMPONENT_STATE_DISABLED))
     return;
-  }
   if (this->state_ == BLE_COMPONENT_STATE_DISABLED)
     return;
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -580,12 +580,7 @@ void ESP32BLE::loop_handle_state_transition_not_active_() {
       this->mark_failed();
       return;
     }
-    // Drop what the old stack queued; the next stack reuses the same interface ids.
-    BLEEvent *ble_event;
-    while ((ble_event = this->ble_events_.pop()) != nullptr) {
-      this->ble_event_pool_.release(ble_event);
-    }
-    this->ble_events_.get_and_reset_dropped_count();
+    this->drain_ble_events_();
     this->state_ = BLE_COMPONENT_STATE_DISABLED;
   } else if (this->state_ == BLE_COMPONENT_STATE_ENABLE) {
     ESP_LOGD(TAG, "Enabling");

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -83,32 +83,22 @@ void ESP32BLE::setup() {
   }
 }
 
-void ESP32BLE::enable() { this->request_state_(true); }
-void ESP32BLE::disable() { this->request_state_(false); }
-
 // Queue the transition for loop(). A pending transition the other way is
 // cancelled instead, since nothing was torn down or brought up yet; any other
 // state is already there or on its way.
 void ESP32BLE::request_state_(bool enable) {
-  switch (this->state_) {
-    case BLE_COMPONENT_STATE_DISABLE:
-      if (enable)
-        this->state_ = BLE_COMPONENT_STATE_ACTIVE;
-      break;
-    case BLE_COMPONENT_STATE_ENABLE:
-      if (!enable)
-        this->state_ = BLE_COMPONENT_STATE_DISABLED;
-      break;
-    case BLE_COMPONENT_STATE_DISABLED:
-      if (enable)
-        this->state_ = BLE_COMPONENT_STATE_ENABLE;
-      break;
-    case BLE_COMPONENT_STATE_ACTIVE:
-      if (!enable)
-        this->state_ = BLE_COMPONENT_STATE_DISABLE;
-      break;
-    default:
-      break;
+  if (enable) {
+    if (this->state_ == BLE_COMPONENT_STATE_DISABLED) {
+      this->state_ = BLE_COMPONENT_STATE_ENABLE;
+    } else if (this->state_ == BLE_COMPONENT_STATE_DISABLE) {
+      this->state_ = BLE_COMPONENT_STATE_ACTIVE;
+    }
+  } else {
+    if (this->state_ == BLE_COMPONENT_STATE_ACTIVE) {
+      this->state_ = BLE_COMPONENT_STATE_DISABLE;
+    } else if (this->state_ == BLE_COMPONENT_STATE_ENABLE) {
+      this->state_ = BLE_COMPONENT_STATE_DISABLED;
+    }
   }
 }
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -84,6 +84,11 @@ void ESP32BLE::setup() {
 }
 
 void ESP32BLE::enable() {
+  if (this->state_ == BLE_COMPONENT_STATE_DISABLE) {
+    // The teardown has not run yet; the stack is still up.
+    this->state_ = BLE_COMPONENT_STATE_ACTIVE;
+    return;
+  }
   if (this->state_ != BLE_COMPONENT_STATE_DISABLED)
     return;
 
@@ -91,6 +96,11 @@ void ESP32BLE::enable() {
 }
 
 void ESP32BLE::disable() {
+  if (this->state_ == BLE_COMPONENT_STATE_ENABLE) {
+    // The bring-up has not run yet; the stack is still down.
+    this->state_ = BLE_COMPONENT_STATE_DISABLED;
+    return;
+  }
   if (this->state_ == BLE_COMPONENT_STATE_DISABLED)
     return;
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -580,6 +580,14 @@ void ESP32BLE::loop_handle_state_transition_not_active_() {
       this->mark_failed();
       return;
     }
+    // Whatever the old stack queued while going down (close events for the
+    // links it tore down, scan completions) must not replay against the next
+    // stack, which hands out the same interface ids.
+    BLEEvent *ble_event;
+    while ((ble_event = this->ble_events_.pop()) != nullptr) {
+      this->ble_event_pool_.release(ble_event);
+    }
+    this->ble_events_.get_and_reset_dropped_count();
     this->state_ = BLE_COMPONENT_STATE_DISABLED;
   } else if (this->state_ == BLE_COMPONENT_STATE_ENABLE) {
     ESP_LOGD(TAG, "Enabling");

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -83,22 +83,33 @@ void ESP32BLE::setup() {
   }
 }
 
-void ESP32BLE::enable() {
-  if (this->cancel_pending_(BLE_COMPONENT_STATE_DISABLE, BLE_COMPONENT_STATE_ACTIVE))
-    return;
-  if (this->state_ != BLE_COMPONENT_STATE_DISABLED)
-    return;
+void ESP32BLE::enable() { this->request_state_(true); }
+void ESP32BLE::disable() { this->request_state_(false); }
 
-  this->state_ = BLE_COMPONENT_STATE_ENABLE;
-}
-
-void ESP32BLE::disable() {
-  if (this->cancel_pending_(BLE_COMPONENT_STATE_ENABLE, BLE_COMPONENT_STATE_DISABLED))
-    return;
-  if (this->state_ == BLE_COMPONENT_STATE_DISABLED)
-    return;
-
-  this->state_ = BLE_COMPONENT_STATE_DISABLE;
+// Queue the transition for loop(). A pending transition the other way is
+// cancelled instead, since nothing was torn down or brought up yet; any other
+// state is already there or on its way.
+void ESP32BLE::request_state_(bool enable) {
+  switch (this->state_) {
+    case BLE_COMPONENT_STATE_DISABLE:
+      if (enable)
+        this->state_ = BLE_COMPONENT_STATE_ACTIVE;
+      break;
+    case BLE_COMPONENT_STATE_ENABLE:
+      if (!enable)
+        this->state_ = BLE_COMPONENT_STATE_DISABLED;
+      break;
+    case BLE_COMPONENT_STATE_DISABLED:
+      if (enable)
+        this->state_ = BLE_COMPONENT_STATE_ENABLE;
+      break;
+    case BLE_COMPONENT_STATE_ACTIVE:
+      if (!enable)
+        this->state_ = BLE_COMPONENT_STATE_DISABLE;
+      break;
+    default:
+      break;
+  }
 }
 
 #ifdef USE_ESP32_BLE_ADVERTISING

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -586,7 +586,10 @@ void ESP32BLE::loop_handle_state_transition_not_active_() {
       return;
     }
     this->drain_ble_events_();
-    this->state_ = BLE_COMPONENT_STATE_DISABLED;
+    // A status callback may have asked for BLE back; the stack is down now, so
+    // that request becomes a bring-up.
+    this->state_ =
+        this->state_ == BLE_COMPONENT_STATE_ACTIVE ? BLE_COMPONENT_STATE_ENABLE : BLE_COMPONENT_STATE_DISABLED;
   } else if (this->state_ == BLE_COMPONENT_STATE_ENABLE) {
     ESP_LOGD(TAG, "Enabling");
     this->state_ = BLE_COMPONENT_STATE_OFF;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -176,14 +176,7 @@ class ESP32BLE final : public Component {
 
   bool ble_setup_();
   bool ble_dismantle_();
-  // A request that arrives while the opposite transition is still pending just
-  // cancels it: loop() has not run, so nothing was torn down or brought up.
-  bool cancel_pending_(BLEComponentState pending, BLEComponentState restored) {
-    if (this->state_ != pending)
-      return false;
-    this->state_ = restored;
-    return true;
-  }
+  void request_state_(bool enable);
   // Drop what the old stack queued; the next stack reuses the same interface ids.
   void drain_ble_events_() {
     BLEEvent *ble_event;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -176,6 +176,14 @@ class ESP32BLE final : public Component {
 
   bool ble_setup_();
   bool ble_dismantle_();
+  // Drop what the old stack queued; the next stack reuses the same interface ids.
+  void drain_ble_events_() {
+    BLEEvent *ble_event;
+    while ((ble_event = this->ble_events_.pop()) != nullptr) {
+      this->ble_event_pool_.release(ble_event);
+    }
+    this->ble_events_.get_and_reset_dropped_count();
+  }
   bool ble_pre_setup_();
 #ifdef USE_ESP32_BLE_ADVERTISING
   void advertising_init_();

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -176,6 +176,14 @@ class ESP32BLE final : public Component {
 
   bool ble_setup_();
   bool ble_dismantle_();
+  // A request that arrives while the opposite transition is still pending just
+  // cancels it: loop() has not run, so nothing was torn down or brought up.
+  bool cancel_pending_(BLEComponentState pending, BLEComponentState restored) {
+    if (this->state_ != pending)
+      return false;
+    this->state_ = restored;
+    return true;
+  }
   // Drop what the old stack queued; the next stack reuses the same interface ids.
   void drain_ble_events_() {
     BLEEvent *ble_event;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -102,8 +102,8 @@ class ESP32BLE final : public Component {
   }
   uint32_t get_advertising_cycle_time() const { return this->advertising_cycle_time_; }
 
-  void enable();
-  void disable();
+  void enable() { this->request_state_(true); }
+  void disable() { this->request_state_(false); }
   ESPHOME_ALWAYS_INLINE bool is_active() { return this->state_ == BLE_COMPONENT_STATE_ACTIVE; }
   void setup() override;
   void loop() override;

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -108,6 +108,10 @@ bool BLEClientBase::parse_device(const espbt::ESPBTDevice &device) {
     return false;
   if (this->state() != espbt::ClientState::IDLE)
     return false;
+  // Not registered on this stack yet; promoting now would stop the scan for a
+  // connect that connect() rejects anyway.
+  if (this->gattc_if_ == ESP_GATT_IF_NONE)
+    return false;
 
   this->log_event_("Found device");
   if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG)

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -72,6 +72,13 @@ void BLEClientBase::loop() {
 
 float BLEClientBase::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
+void BLEClientBase::ble_before_disabled_event_handler() {
+  // Same reset as the stack-down branch of loop(); an idle client has its
+  // loop disabled, so enable it for the INIT registration on the next enable.
+  this->set_state(espbt::ClientState::INIT);
+  this->enable_loop();
+}
+
 void BLEClientBase::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Address: %s\n"

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -139,7 +139,10 @@ void BLEClientBase::connect() {
   if (this->gattc_if_ == ESP_GATT_IF_NONE) {
     // Bluedroid drops an open on an unknown interface without any event.
     this->log_warning_("Connect rejected, GATT app not registered");
-    this->set_state(espbt::ClientState::IDLE);
+    // INIT stays so loop() still registers; only a promoted client goes back.
+    if (this->state() == espbt::ClientState::DISCOVERED) {
+      this->set_state(espbt::ClientState::IDLE);
+    }
     return;
   }
   ESP_LOGI(TAG, "[%d] [%s] 0x%02x Connecting", this->connection_index_, this->address_str_, this->remote_addr_type_);

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -134,7 +134,7 @@ void BLEClientBase::connect() {
   }
   if (this->gattc_if_ == ESP_GATT_IF_NONE) {
     // Bluedroid drops an open on an unknown interface without any event.
-    ESP_LOGW(TAG, "[%d] [%s] Connect rejected, GATT app not registered", this->connection_index_, this->address_str_);
+    this->log_warning_("Connect rejected, GATT app not registered");
     this->set_state(espbt::ClientState::IDLE);
     return;
   }
@@ -220,7 +220,10 @@ void BLEClientBase::release_services() {
 #ifndef CONFIG_BT_GATTC_CACHE_NVS_FLASH
   // Only the cache clean makes the stack's database unsafe to walk.
   this->services_released_ = true;
-  esp_ble_gattc_cache_clean(this->remote_bda_);
+  // A stack on its way down frees its own cache.
+  if (esp32_ble::global_ble->is_active()) {
+    esp_ble_gattc_cache_clean(this->remote_bda_);
+  }
 #endif
 }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -73,6 +73,15 @@ void BLEClientBase::loop() {
 float BLEClientBase::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
 void BLEClientBase::ble_before_disabled_event_handler() {
+  auto st = this->state();
+  if (st != espbt::ClientState::IDLE && st != espbt::ClientState::INIT) {
+    // No CLOSE_EVT will come: free the services and settle the link.
+    this->release_services();
+    this->set_idle_();
+    this->on_disconnect_complete(ESP_GATT_CONN_TERMINATE_LOCAL_HOST);
+  }
+  // The interface belongs to the torn-down stack.
+  this->gattc_if_ = ESP_GATT_IF_NONE;
   this->set_state(espbt::ClientState::INIT);
   // An idle client runs no loop; the INIT branch must run to register again.
   this->enable_loop();
@@ -121,6 +130,12 @@ void BLEClientBase::connect() {
   } else if (this->state() == espbt::ClientState::DISCONNECTING) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot connect, still waiting for CLOSE_EVT to complete disconnect",
              this->connection_index_, this->address_str_);
+    return;
+  }
+  if (this->gattc_if_ == ESP_GATT_IF_NONE) {
+    // Bluedroid drops an open on an unknown interface without any event.
+    ESP_LOGW(TAG, "[%d] [%s] Connect rejected, GATT app not registered", this->connection_index_, this->address_str_);
+    this->set_state(espbt::ClientState::IDLE);
     return;
   }
   ESP_LOGI(TAG, "[%d] [%s] 0x%02x Connecting", this->connection_index_, this->address_str_, this->remote_addr_type_);

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -42,7 +42,7 @@ void BLEClientBase::set_state(espbt::ClientState st) {
 
 void BLEClientBase::loop() {
   if (!esp32_ble::global_ble->is_active()) {
-    this->set_state(espbt::ClientState::INIT);
+    // ble_before_disabled_event_handler() resets the client.
     return;
   }
   if (this->state() == espbt::ClientState::INIT) {
@@ -73,9 +73,8 @@ void BLEClientBase::loop() {
 float BLEClientBase::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
 void BLEClientBase::ble_before_disabled_event_handler() {
-  // Same reset as the stack-down branch of loop(); an idle client has its
-  // loop disabled, so enable it for the INIT registration on the next enable.
   this->set_state(espbt::ClientState::INIT);
+  // An idle client runs no loop; the INIT branch must run to register again.
   this->enable_loop();
 }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -140,7 +140,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   uint8_t pending_notify_regs_{0};
   bool auto_connect_{false};
   bool paired_{false};
-  // Set only when release_services() cleans the stack's GATT cache, which no API may then walk
+  // Always set by release_services(); the stack's GATT database must not be walked after it
   bool services_released_{false};
   // 8 bytes used, no padding
 

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -156,10 +156,11 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void log_connection_params_(const char *param_type);
   void handle_connection_result_(esp_err_t ret);
   /// Hook called once a connection has been fully torn down (after release_services() and
-  /// set_idle_()), from both the CLOSE_EVT handler and the DISCONNECTING safety timeout.
+  /// set_idle_()): CLOSE_EVT, the DISCONNECTING safety timeout, or the BLE stack going down.
   /// Subclasses with extra per-connection accounting (e.g. bluetooth_proxy slot state)
-  /// override this to release that state. `reason` is the controller reason code, or
-  /// ESP_GATT_CONN_TIMEOUT for the safety-timeout path.
+  /// override this to release that state. `reason` is the controller reason code,
+  /// ESP_GATT_CONN_TIMEOUT for the safety timeout, or ESP_GATT_CONN_TERMINATE_LOCAL_HOST
+  /// for the stack going down.
   virtual void on_disconnect_complete(esp_err_t reason) {}
   /// Transition to IDLE and reset conn_id — call when the connection is fully dead.
   void set_idle_() {

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -115,7 +115,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
 #endif
 
   // Group 3: 4-byte types
-  int gattc_if_;
+  int gattc_if_{ESP_GATT_IF_NONE};
   esp_gatt_status_t status_{ESP_GATT_OK};
 
   // Group 4: Arrays

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -140,7 +140,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   uint8_t pending_notify_regs_{0};
   bool auto_connect_{false};
   bool paired_{false};
-  // Always set by release_services(); the stack's GATT database must not be walked after it
+  // Set by release_services() on RAM-cache builds; the stack's GATT database must not be walked after it
   bool services_released_{false};
   // 8 bytes used, no padding
 

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -41,6 +41,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void connect() override;
   esp_err_t pair();
   void disconnect() override;
+  void ble_before_disabled_event_handler() override;
   void unconditional_disconnect();
   void release_services();
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -225,9 +225,8 @@ void ESP32BLETracker::ble_before_disabled_event_handler() {
     client->ble_before_disabled_event_handler();
   }
 #endif
-  // The stop above never completes: the stack is torn down and its queued
-  // events are dropped, so settle the scanner here. start_scan_() refuses
-  // anything but IDLE once the stack is back.
+  // The stop above never completes (stack torn down, events dropped); settle
+  // here so start_scan_() sees IDLE once the stack is back.
   if (this->scanner_state_ != ScannerState::IDLE) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
     this->skip_next_scan_end_ = false;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -74,13 +74,12 @@ void ESP32BLETracker::on_ota_global_state(ota::OTAState state, float progress, u
 
 void ESP32BLETracker::loop() {
   if (!this->parent_->is_active()) {
-    this->ble_was_disabled_ = true;
     return;
-  } else if (this->ble_was_disabled_) {
+  }
+  if (this->ble_was_disabled_) {
     this->ble_was_disabled_ = false;
-    // Start the scan again after a disable. A cancelled disable never stopped
-    // it, so only start from IDLE.
-    if (this->scan_continuous_ && this->scanner_state_ == ScannerState::IDLE) {
+    // First start after boot or after the stack came back.
+    if (this->scan_continuous_) {
       this->start_scan();
     }
   }
@@ -228,12 +227,13 @@ void ESP32BLETracker::ble_before_disabled_event_handler() {
 #endif
   // The stop above never completes (stack torn down, events dropped); settle
   // here so start_scan_() sees IDLE once the stack is back.
-  if (this->scanner_state_ != ScannerState::IDLE) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-    this->skip_next_scan_end_ = false;
+  this->skip_next_scan_end_ = false;
 #endif
+  if (this->scanner_state_ != ScannerState::IDLE) {
     this->cleanup_scan_state_(true);
   }
+  this->ble_was_disabled_ = true;
 }
 
 bool ESP32BLETracker::stop_scan_() {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -219,17 +219,18 @@ void ESP32BLETracker::stop_scan() {
 }
 
 void ESP32BLETracker::ble_before_disabled_event_handler() {
-  this->stop_scan_();
+  // Tell the controller to stop; a scan still starting has nothing to stop yet.
+  if (this->scanner_state_ == ScannerState::RUNNING || this->scanner_state_ == ScannerState::FAILED) {
+    this->stop_scan_();
+  }
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   for (auto *client : this->clients_) {
     client->ble_before_disabled_event_handler();
   }
+  this->skip_next_scan_end_ = false;
 #endif
   // The stop above never completes (stack torn down, events dropped); settle
   // here so start_scan_() sees IDLE once the stack is back.
-#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
-  this->skip_next_scan_end_ = false;
-#endif
   if (this->scanner_state_ != ScannerState::IDLE) {
     this->cleanup_scan_state_(true);
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -78,8 +78,9 @@ void ESP32BLETracker::loop() {
     return;
   } else if (this->ble_was_disabled_) {
     this->ble_was_disabled_ = false;
-    // If the BLE stack was disabled, we need to start the scan again.
-    if (this->scan_continuous_) {
+    // Start the scan again after a disable. A cancelled disable never stopped
+    // it, so only start from IDLE.
+    if (this->scan_continuous_ && this->scanner_state_ == ScannerState::IDLE) {
       this->start_scan();
     }
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -225,6 +225,15 @@ void ESP32BLETracker::ble_before_disabled_event_handler() {
     client->ble_before_disabled_event_handler();
   }
 #endif
+  // The stop above never completes: the stack is torn down and its queued
+  // events are dropped, so settle the scanner here. start_scan_() refuses
+  // anything but IDLE once the stack is back.
+  if (this->scanner_state_ != ScannerState::IDLE) {
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
+    this->skip_next_scan_end_ = false;
+#endif
+    this->cleanup_scan_state_(true);
+  }
 }
 
 bool ESP32BLETracker::stop_scan_() {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -234,6 +234,9 @@ void ESP32BLETracker::ble_before_disabled_event_handler() {
   if (this->scanner_state_ != ScannerState::IDLE) {
     this->cleanup_scan_state_(true);
   }
+  // A failure latched by the old stack must not be handled against the next.
+  this->scan_start_failed_ = ESP_BT_STATUS_SUCCESS;
+  this->scan_set_param_failed_ = ESP_BT_STATUS_SUCCESS;
   this->ble_was_disabled_ = true;
 }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -218,7 +218,14 @@ void ESP32BLETracker::stop_scan() {
   this->stop_scan_();
 }
 
-void ESP32BLETracker::ble_before_disabled_event_handler() { this->stop_scan_(); }
+void ESP32BLETracker::ble_before_disabled_event_handler() {
+  this->stop_scan_();
+#ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
+  for (auto *client : this->clients_) {
+    client->ble_before_disabled_event_handler();
+  }
+#endif
+}
 
 bool ESP32BLETracker::stop_scan_() {
   if (this->scanner_state_ != ScannerState::RUNNING && this->scanner_state_ != ScannerState::FAILED) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -113,6 +113,9 @@ class ESPBTClient : public ESPBTDeviceListener {
   virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;
   virtual void connect() = 0;
   virtual void disconnect() = 0;
+  /// Called right before the BLE stack is dismantled. Nothing in flight will
+  /// complete, and the GATT app must register again once the stack is back.
+  virtual void ble_before_disabled_event_handler() {}
   bool disconnect_pending() const { return this->want_disconnect_; }
   void cancel_pending_disconnect() { this->want_disconnect_ = false; }
 


### PR DESCRIPTION
# What does this implement/fix?

After a `ble.disable` / `ble.enable` cycle a bluetooth proxy connection slot can get stuck in CONNECTING forever, which also stops scanning (see https://github.com/esphome/esphome/issues/16900, fixes #16900). An idle slot has its loop disabled, so the stack down reset in `loop()` never runs; the slot keeps the gattc interface of the torn down stack and never registers again. The next `esp_ble_gattc_open` on that interface is dropped by Bluedroid without any event, and there is no timeout in CONNECTING.

The tracker now tells every registered client before the stack is dismantled; the client settles any link, goes back to INIT and enables its loop so it registers on the new stack. This applies to both the proxy backend and `ble_client`; both also forget the old interface and refuse to open before the app is registered on the new stack, instead of waiting for an event that cannot come.

The second commit drains the events the old stack queued while going down, since they were replayed against the next stack which hands out the same interface ids, and settles the scanner in the same handler because the stop it issued can no longer complete.

One behaviour change on top of the fix: `ble.enable` while a disable is still pending now cancels that disable, and `ble.disable` while an enable is still pending cancels that enable. Previously an enable issued right after a disable, before the next loop pass, was ignored and BLE stayed off. The tracker learns about a disable from the same hook rather than by polling, so a cancelled disable never reaches it and its scan keeps running.

Compile tested with the bluetooth_proxy, ble_client, esp32_ble and esp32_ble_tracker component tests on ESP32 IDF.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble:
esp32_ble_tracker:
bluetooth_proxy:
  active: true

interval:
  - interval: 6h
    then:
      - ble.disable
      - delay: 20s
      - ble.enable
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
