### PR TITLE
[core] Support set_internal() during setup, log error after setup

### DIFF
--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -56,6 +56,14 @@ void EntityBase::configure_entity_(const char *name, uint32_t object_id_hash, ui
   this->flags_.entity_category = (entity_fields >> ENTITY_FIELD_ENTITY_CATEGORY_SHIFT) & 0x3;
 }
 
+void EntityBase::set_internal(bool internal) {
+  if (App.is_setup_complete()) {
+    ESP_LOGE(TAG, "'%s': set_internal() called after setup, ignored", this->get_name().c_str());
+    return;
+  }
+  this->flags_.internal = internal;
+}
+
 // Weak default lookup functions — overridden by generated code in main.cpp
 __attribute__((weak)) const char *entity_device_class_lookup(uint8_t) { return ""; }
 __attribute__((weak)) const char *entity_uom_lookup(uint8_t) { return ""; }

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -57,9 +57,10 @@ void EntityBase::configure_entity_(const char *name, uint32_t object_id_hash, ui
 }
 
 void EntityBase::set_internal(bool internal) {
+  // Remove the after-setup path in 2027.3.0 and ignore the call instead.
   if (App.is_setup_complete()) {
-    ESP_LOGE(TAG, "'%s': set_internal() called after setup, ignored", this->get_name().c_str());
-    return;
+    ESP_LOGE(TAG, "'%s': set_internal() after setup is undefined behavior, stops working in 2027.3.0",
+             this->get_name().c_str());
   }
   this->flags_.internal = internal;
 }

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -90,13 +90,14 @@ class EntityBase {
 
   // Set whether this Entity should be hidden outside ESPHome. Must be called before MQTT and the
   // API read the flag: from on_boot at the default priority, or a setup() that runs above
-  // setup_priority::AFTER_CONNECTION. Calls after setup finishes are ignored and log an error.
+  // setup_priority::AFTER_WIFI. Calls after setup finishes are ignored and log an error.
   //
   // Known limitations, all by design and not going to be fixed:
   // - No consumer is notified of a change, so the flag can only be decided once per boot.
-  // - The guard is coarse: a call from a priority below AFTER_CONNECTION (an on_boot with a low
-  //   priority, or a setup() at LATE) still passes, but MQTT has already cached the flag and the
-  //   API camera listener is already registered, so those consumers keep the old value.
+  // - The guard is coarse: a call from a priority below AFTER_WIFI (an on_boot with a low priority,
+  //   or a setup() at LATE) still passes, but the API camera listener is already registered, MQTT
+  //   (AFTER_CONNECTION) has cached the flag, and an API client that connected while setup was
+  //   stalled on a slow component has already listed the entities, so they keep the old value.
   // - Un-hiding an entity declared 'internal: true' in YAML skips the duplicate name check that
   //   codegen runs for exposed entities, so a name collision can surface at runtime. Entities with
   //   only an 'id:' are forced internal and use the id as their name.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -88,9 +88,10 @@ class EntityBase {
   // Get whether this Entity should be hidden outside ESPHome
   bool is_internal() const { return this->flags_.internal; }
 
-  // Set whether this Entity should be hidden outside ESPHome. Must be called before MQTT and the
-  // API read the flag: from on_boot at the default priority, or a setup() that runs above
-  // setup_priority::AFTER_WIFI. Calls after setup finishes are ignored and log an error.
+  // Set whether this Entity should be hidden outside ESPHome. Kept for existing projects that
+  // decide the flag at boot; new designs should use the 'internal:' YAML key. Must be called before
+  // MQTT and the API read the flag: from on_boot at the default priority, or a setup() that runs
+  // above setup_priority::AFTER_WIFI. Calls after setup finishes are ignored and log an error.
   //
   // Known limitations, all by design and not going to be fixed:
   // - No consumer is notified of a change, so the flag can only be decided once per boot.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -92,7 +92,8 @@ class EntityBase {
   // whenever possible: it is guaranteed and has none of the limitations below. Use this only when
   // the decision can only be made at boot. Must be called before MQTT and the API read the flag:
   // from on_boot at the default priority, or a setup() that runs above setup_priority::AFTER_WIFI.
-  // Calls after setup finishes are ignored and log an error.
+  // Calls after setup finishes are undefined behavior: the flag is still written and an error is
+  // logged, and from 2027.3.0 the call will be ignored.
   //
   // Known limitations. Not bugs, so no issue reports please; a PR that removes one with no RAM
   // or performance cost would be considered.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -94,7 +94,8 @@ class EntityBase {
   // from on_boot at the default priority, or a setup() that runs above setup_priority::AFTER_WIFI.
   // Calls after setup finishes are ignored and log an error.
   //
-  // Known limitations, all by design and not going to be fixed:
+  // Known limitations. Not bugs, so no issue reports please; a PR that removes one with no RAM
+  // or performance cost would be considered.
   // - No consumer is notified of a change, so the flag can only be decided once per boot.
   // - The guard is coarse: a call from a priority below AFTER_WIFI (an on_boot with a low priority,
   //   or a setup() at LATE) still passes, but the API camera listener is already registered, MQTT

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -88,10 +88,11 @@ class EntityBase {
   // Get whether this Entity should be hidden outside ESPHome
   bool is_internal() const { return this->flags_.internal; }
 
-  // Set whether this Entity should be hidden outside ESPHome. Kept for existing projects that
-  // decide the flag at boot; new designs should use the 'internal:' YAML key. Must be called before
-  // MQTT and the API read the flag: from on_boot at the default priority, or a setup() that runs
-  // above setup_priority::AFTER_WIFI. Calls after setup finishes are ignored and log an error.
+  // Set whether this Entity should be hidden outside ESPHome. Prefer the 'internal:' YAML key
+  // whenever possible: it is guaranteed and has none of the limitations below. Use this only when
+  // the decision can only be made at boot. Must be called before MQTT and the API read the flag:
+  // from on_boot at the default priority, or a setup() that runs above setup_priority::AFTER_WIFI.
+  // Calls after setup finishes are ignored and log an error.
   //
   // Known limitations, all by design and not going to be fixed:
   // - No consumer is notified of a change, so the flag can only be decided once per boot.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -92,6 +92,7 @@ class EntityBase {
   // whenever possible: it is guaranteed and has none of the limitations below. Use this only when
   // the decision can only be made at boot. Must be called before MQTT and the API read the flag:
   // from on_boot at the default priority, or a setup() that runs above setup_priority::AFTER_WIFI.
+  // If the answer comes from a device handshake, hold setup with can_proceed() until it arrives.
   // Calls after setup finishes are undefined behavior: the flag is still written and an error is
   // logged, and from 2027.3.0 the call will be ignored.
   //

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -88,13 +88,10 @@ class EntityBase {
   // Get whether this Entity should be hidden outside ESPHome
   bool is_internal() const { return this->flags_.internal; }
 
-  // Deprecated: Calling set_internal() at runtime is undefined behavior. Components and clients
-  // are NOT notified of the change, the flag may have already been read during setup, and there
-  // is NO guarantee any consumer will observe the new value. Use the 'internal:' YAML key instead.
-  ESPDEPRECATED("set_internal() is undefined behavior at runtime — components and Home Assistant are NOT "
-                "notified. Use the 'internal:' YAML key instead. Will be removed in 2027.3.0.",
-                "2026.3.0")
-  void set_internal(bool internal) { this->flags_.internal = internal; }
+  // Set whether this Entity should be hidden outside ESPHome. Must be called before MQTT and the
+  // API read the flag: from on_boot at the default priority, or a setup() that runs above
+  // setup_priority::AFTER_CONNECTION. Calls after setup finishes are ignored and log an error.
+  void set_internal(bool internal);
 
   // Check if this object is declared to be disabled by default.
   // That means that when the device gets added to Home Assistant (or other clients) it should

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -91,6 +91,16 @@ class EntityBase {
   // Set whether this Entity should be hidden outside ESPHome. Must be called before MQTT and the
   // API read the flag: from on_boot at the default priority, or a setup() that runs above
   // setup_priority::AFTER_CONNECTION. Calls after setup finishes are ignored and log an error.
+  //
+  // Known limitations, all by design and not going to be fixed:
+  // - No consumer is notified of a change, so the flag can only be decided once per boot.
+  // - The guard is coarse: a call from a priority below AFTER_CONNECTION (an on_boot with a low
+  //   priority, or a setup() at LATE) still passes, but MQTT has already cached the flag and the
+  //   API camera listener is already registered, so those consumers keep the old value.
+  // - Un-hiding an entity declared 'internal: true' in YAML skips the duplicate name check that
+  //   codegen runs for exposed entities, so a name collision can surface at runtime. Entities with
+  //   only an 'id:' are forced internal and use the id as their name.
+  // - Zigbee codegen skips YAML internal entities entirely, so un-hiding cannot add them to Zigbee.
   void set_internal(bool internal);
 
   // Check if this object is declared to be disabled by default.

--- a/tests/integration/fixtures/set_internal_at_boot.yaml
+++ b/tests/integration/fixtures/set_internal_at_boot.yaml
@@ -1,0 +1,34 @@
+esphome:
+  name: set-internal-at-boot
+  on_boot:
+    then:
+      - lambda: |-
+          id(hidden_at_boot).set_internal(true);
+          id(shown_at_boot).set_internal(false);
+
+host:
+
+api:
+  actions:
+    - action: set_internal_late
+      then:
+        - lambda: id(untouched).set_internal(true);
+
+logger:
+
+sensor:
+  - platform: template
+    name: "Hidden At Boot"
+    id: hidden_at_boot
+    lambda: return 1.0;
+
+  - platform: template
+    name: "Shown At Boot"
+    id: shown_at_boot
+    internal: true
+    lambda: return 2.0;
+
+  - platform: template
+    name: "Untouched"
+    id: untouched
+    lambda: return 3.0;

--- a/tests/integration/test_set_internal_at_boot.py
+++ b/tests/integration/test_set_internal_at_boot.py
@@ -14,7 +14,7 @@ async def test_set_internal_at_boot(
     run_compiled: RunCompiledFunction,
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
-    """set_internal() in on_boot changes API exposure, later calls are rejected."""
+    """set_internal() in on_boot changes API exposure, later calls log an error."""
     waiter = LineWaiter()
 
     async with (
@@ -31,8 +31,11 @@ async def test_set_internal_at_boot(
         late = next(s for s in services if s.name == "set_internal_late")
         await client.execute_service(late, {})
         await waiter.wait_for(
-            "'Untouched'", "set_internal() called after setup", timeout=5.0
+            "'Untouched'",
+            "set_internal() after setup is undefined behavior",
+            timeout=5.0,
         )
 
+        # Still written during the deprecation window, ignored from 2027.3.0
         entities, _ = await client.list_entities_services()
-        assert "Untouched" in {entity.name for entity in entities}
+        assert "Untouched" not in {entity.name for entity in entities}

--- a/tests/integration/test_set_internal_at_boot.py
+++ b/tests/integration/test_set_internal_at_boot.py
@@ -1,0 +1,38 @@
+"""Integration test for set_internal() called during and after setup."""
+
+from __future__ import annotations
+
+import pytest
+
+from .log_utils import LineWaiter
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_set_internal_at_boot(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """set_internal() in on_boot changes API exposure, later calls are rejected."""
+    waiter = LineWaiter()
+
+    async with (
+        run_compiled(yaml_config, line_callback=waiter.callback),
+        api_client_connected() as client,
+    ):
+        entities, services = await client.list_entities_services()
+        names = {entity.name for entity in entities}
+
+        assert "Hidden At Boot" not in names
+        assert "Shown At Boot" in names
+        assert "Untouched" in names
+
+        late = next(s for s in services if s.name == "set_internal_late")
+        await client.execute_service(late, {})
+        await waiter.wait_for(
+            "'Untouched'", "set_internal() called after setup", timeout=5.0
+        )
+
+        entities, _ = await client.list_entities_services()
+        assert "Untouched" in {entity.name for entity in entities}


### PR DESCRIPTION
# What does this implement/fix?

Un-deprecates `set_internal()`. The flag is only read during setup by MQTT (AFTER_CONNECTION) and the API camera listener (AFTER_WIFI); every other consumer reads it live, so calling it from `on_boot` at the default priority or a `setup()` above AFTER_WIFI is safe. After setup the flag is still written but an error is logged; from 2027.3.0 the call will be ignored. Prefer the `internal:` YAML key when possible, and hold setup with `can_proceed()` when the answer comes from a device handshake.

Known limitations, documented inline: un-hiding a YAML `internal: true` entity skips the duplicate name check, and Zigbee never registers it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#176

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  on_boot:
    then:
      - lambda: |-
          bool single_unit = id(setup_pref).load();
          id(hp2_temperature).set_internal(single_unit);
          id(hp2_power).set_internal(single_unit);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).





