### PR TITLE
[light] Harden addressable lights against setup failures

### DIFF
--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -297,7 +297,7 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView BekenSPILEDStripLightOutput::get_view_internal(int32_t index) const {
-  if (this->buf_ == nullptr) {
+  if (this->buf_ == nullptr || this->effect_data_ == nullptr) {
     return {&this->correction_};
   }
   const light::ChannelColors &colors = this->channel_colors_;

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -245,6 +245,9 @@ void BekenSPILEDStripLightOutput::set_led_params(uint8_t bit0, uint8_t bit1, uin
 }
 
 void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   // protect from refreshing too often
   uint32_t now = micros();
   if (this->max_refresh_rate_.has_value() && *this->max_refresh_rate_ != 0 &&
@@ -257,12 +260,6 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
   this->mark_shown_();
 
   ESP_LOGVV(TAG, "Writing RGB values to bus");
-
-  if (spi_data == nullptr) {
-    ESP_LOGE(TAG, "SPI not initialized");
-    this->status_set_warning();
-    return;
-  }
 
   if (!spi_data->first_run && !xSemaphoreTake(spi_data->dma_tx_semaphore, 10 / portTICK_PERIOD_MS)) {
     ESP_LOGE(TAG, "Timed out waiting for semaphore");
@@ -300,6 +297,9 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView BekenSPILEDStripLightOutput::get_view_internal(int32_t index) const {
+  if (this->buf_ == nullptr) {
+    return {&this->correction_};
+  }
   const light::ChannelColors &colors = this->channel_colors_;
   uint8_t *led = this->buf_ + (index * colors.bytes_per_led());
   return {led + colors.r,

--- a/esphome/components/beken_spi_led_strip/led_strip.h
+++ b/esphome/components/beken_spi_led_strip/led_strip.h
@@ -38,6 +38,8 @@ class BekenSPILEDStripLightOutput final : public light::AddressableLight {
   void set_led_params(uint8_t bit0, uint8_t bit1, uint32_t spi_frequency);
 
   void clear_effect_data() override {
+    if (this->effect_data_ == nullptr)
+      return;
     for (int i = 0; i < this->size(); i++)
       this->effect_data_[i] = 0;
   }

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -224,7 +224,7 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index) const {
-  if (this->buf_ == nullptr) {
+  if (this->buf_ == nullptr || this->effect_data_ == nullptr) {
     return {&this->correction_};
   }
   const light::ChannelColors &colors = this->channel_colors_;

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -157,6 +157,9 @@ void ESP32RMTLEDStripLightOutput::set_led_params(uint32_t bit0_high, uint32_t bi
 }
 
 void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   // protect from refreshing too often
   uint32_t now = micros();
   auto rate = this->max_refresh_rate_.value_or(0);
@@ -221,6 +224,9 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index) const {
+  if (this->buf_ == nullptr) {
+    return {&this->correction_};
+  }
   const light::ChannelColors &colors = this->channel_colors_;
   uint8_t *led = this->buf_ + (index * colors.bytes_per_led());
   return {led + colors.r,

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -55,6 +55,8 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
   void set_rmt_symbols(uint32_t rmt_symbols) { this->rmt_symbols_ = rmt_symbols; }
 
   void clear_effect_data() override {
+    if (this->effect_data_ == nullptr)
+      return;
     for (int i = 0; i < this->size(); i++)
       this->effect_data_[i] = 0;
   }

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -23,6 +23,9 @@ void FastLEDLightOutput::dump_config() {
                 this->num_leds_, this->max_refresh_rate_.value_or(0));
 }
 void FastLEDLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   // protect from refreshing too often
   uint32_t now = micros();
   uint32_t max_rate = this->max_refresh_rate_.value_or(0);

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -216,13 +216,15 @@ class FastLEDLightOutput final : public light::AddressableLight {
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
   void clear_effect_data() override {
+    if (this->effect_data_ == nullptr)
+      return;
     for (int i = 0; i < this->size(); i++)
       this->effect_data_[i] = 0;
   }
 
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override {
-    if (this->leds_ == nullptr) {
+    if (this->leds_ == nullptr || this->effect_data_ == nullptr) {
       return {&this->correction_};
     }
     return {&this->leds_[index].r,      &this->leds_[index].g, &this->leds_[index].b, nullptr,

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -222,6 +222,9 @@ class FastLEDLightOutput final : public light::AddressableLight {
 
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override {
+    if (this->leds_ == nullptr) {
+      return {&this->correction_};
+    }
     return {&this->leds_[index].r,      &this->leds_[index].g, &this->leds_[index].b, nullptr,
             &this->effect_data_[index], &this->correction_};
   }

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -72,7 +72,11 @@ class AddressableLight : public LightOutput, public Component {
     this->state_parent_ = state;
   }
   void update_state(LightState *state) override;
-  void schedule_show() { this->state_parent_->schedule_write_(); }
+  void schedule_show() {
+    if (this->state_parent_ != nullptr) {
+      this->state_parent_->schedule_write_();
+    }
+  }
 
 #ifdef USE_POWER_SUPPLY
   void set_power_supply(power_supply::PowerSupply *power_supply) { this->power_.set_parent(power_supply); }

--- a/esphome/components/light/esp_color_view.h
+++ b/esphome/components/light/esp_color_view.h
@@ -34,7 +34,7 @@ class ESPColorSettable {
   }
 };
 
-class ESPColorView : public ESPColorSettable {
+class ESPColorView final : public ESPColorSettable {
  public:
   ESPColorView(uint8_t *red, uint8_t *green, uint8_t *blue, uint8_t *white, uint8_t *effect_data,
                const ESPColorCorrection *color_correction)
@@ -43,6 +43,13 @@ class ESPColorView : public ESPColorSettable {
         blue_(blue),
         white_(white),
         effect_data_(effect_data),
+        color_correction_(color_correction) {}
+  ESPColorView(const ESPColorCorrection *color_correction)
+      : red_(nullptr),
+        green_(nullptr),
+        blue_(nullptr),
+        white_(nullptr),
+        effect_data_(nullptr),
         color_correction_(color_correction) {}
   ESPColorView &operator=(const Color &rhs) {
     this->set(rhs);
@@ -53,9 +60,21 @@ class ESPColorView : public ESPColorSettable {
     return *this;
   }
   void set(const Color &color) override { this->set_rgbw(color.r, color.g, color.b, color.w); }
-  void set_red(uint8_t red) override { *this->red_ = this->color_correction_->color_correct_red(red); }
-  void set_green(uint8_t green) override { *this->green_ = this->color_correction_->color_correct_green(green); }
-  void set_blue(uint8_t blue) override { *this->blue_ = this->color_correction_->color_correct_blue(blue); }
+  void set_red(uint8_t red) override {
+    if (this->red_ == nullptr)
+      return;
+    *this->red_ = this->color_correction_->color_correct_red(red);
+  }
+  void set_green(uint8_t green) override {
+    if (this->green_ == nullptr)
+      return;
+    *this->green_ = this->color_correction_->color_correct_green(green);
+  }
+  void set_blue(uint8_t blue) override {
+    if (this->blue_ == nullptr)
+      return;
+    *this->blue_ = this->color_correction_->color_correct_blue(blue);
+  }
   void set_white(uint8_t white) override {
     if (this->white_ == nullptr)
       return;
@@ -71,12 +90,36 @@ class ESPColorView : public ESPColorSettable {
   void lighten(uint8_t delta) override { this->set(this->get().lighten(delta)); }
   void darken(uint8_t delta) override { this->set(this->get().darken(delta)); }
   Color get() const { return Color(this->get_red(), this->get_green(), this->get_blue(), this->get_white()); }
-  uint8_t get_red() const { return this->color_correction_->color_uncorrect_red(*this->red_); }
-  uint8_t get_red_raw() const { return *this->red_; }
-  uint8_t get_green() const { return this->color_correction_->color_uncorrect_green(*this->green_); }
-  uint8_t get_green_raw() const { return *this->green_; }
-  uint8_t get_blue() const { return this->color_correction_->color_uncorrect_blue(*this->blue_); }
-  uint8_t get_blue_raw() const { return *this->blue_; }
+  uint8_t get_red() const {
+    if (this->red_ == nullptr)
+      return 0;
+    return this->color_correction_->color_uncorrect_red(*this->red_);
+  }
+  uint8_t get_red_raw() const {
+    if (this->red_ == nullptr)
+      return 0;
+    return *this->red_;
+  }
+  uint8_t get_green() const {
+    if (this->green_ == nullptr)
+      return 0;
+    return this->color_correction_->color_uncorrect_green(*this->green_);
+  }
+  uint8_t get_green_raw() const {
+    if (this->green_ == nullptr)
+      return 0;
+    return *this->green_;
+  }
+  uint8_t get_blue() const {
+    if (this->blue_ == nullptr)
+      return 0;
+    return this->color_correction_->color_uncorrect_blue(*this->blue_);
+  }
+  uint8_t get_blue_raw() const {
+    if (this->blue_ == nullptr)
+      return 0;
+    return *this->blue_;
+  }
   uint8_t get_white() const {
     if (this->white_ == nullptr)
       return 0;

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
@@ -37,7 +37,7 @@ void M5Stack8AngleLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView M5Stack8AngleLightOutput::get_view_internal(int32_t index) const {
-  if (this->buf_ == nullptr) {
+  if (this->buf_ == nullptr || this->effect_data_ == nullptr) {
     return {&this->correction_};
   }
   size_t pos = index * M5STACK_8ANGLE_BYTES_PER_LED;

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
@@ -26,6 +26,9 @@ void M5Stack8AngleLightOutput::setup() {
 }
 
 void M5Stack8AngleLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   for (int i = 0; i < M5STACK_8ANGLE_NUM_LEDS;
        i++) {  // write one LED at a time, otherwise the message will be truncated
     this->parent_->write_register(M5STACK_8ANGLE_REGISTER_RGB_24B + i * M5STACK_8ANGLE_BYTES_PER_LED,
@@ -34,6 +37,9 @@ void M5Stack8AngleLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView M5Stack8AngleLightOutput::get_view_internal(int32_t index) const {
+  if (this->buf_ == nullptr) {
+    return {&this->correction_};
+  }
   size_t pos = index * M5STACK_8ANGLE_BYTES_PER_LED;
   // red, green, blue, white, effect_data, color_correction
   return {this->buf_ + pos, this->buf_ + pos + 1,       this->buf_ + pos + 2,

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
@@ -23,7 +23,11 @@ class M5Stack8AngleLightOutput final : public light::AddressableLight, public Pa
     return traits;
   };
 
-  void clear_effect_data() override { memset(this->effect_data_, 0x00, M5STACK_8ANGLE_NUM_LEDS); };
+  void clear_effect_data() override {
+    if (this->effect_data_ == nullptr)
+      return;
+    memset(this->effect_data_, 0x00, M5STACK_8ANGLE_NUM_LEDS);
+  }
 
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override;

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -135,7 +135,7 @@ void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t index) const {
-  if (this->buf_ == nullptr) {
+  if (this->buf_ == nullptr || this->effect_data_ == nullptr) {
     return {&this->correction_};
   }
   const light::ChannelColors &colors = this->channel_colors_;

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -124,17 +124,10 @@ void RP2040PIOLEDStripLightOutput::setup() {
 }
 
 void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   ESP_LOGVV(TAG, "Writing state");
-
-  if (this->is_failed()) {
-    ESP_LOGW(TAG, "Light is in failed state, not writing state.");
-    return;
-  }
-
-  if (this->buf_ == nullptr) {
-    ESP_LOGW(TAG, "Buffer is null, not writing state.");
-    return;
-  }
 
   // the bits are already in the correct order for the pio program so we can just copy the buffer using DMA
   sem_acquire_blocking(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem[this->dma_chan_]);
@@ -142,6 +135,9 @@ void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
 }
 
 light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t index) const {
+  if (this->buf_ == nullptr) {
+    return {&this->correction_};
+  }
   const light::ChannelColors &colors = this->channel_colors_;
   uint8_t *led = this->buf_ + (index * colors.bytes_per_led());
   return {led + colors.r,

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -56,6 +56,8 @@ class RP2040PIOLEDStripLightOutput final : public light::AddressableLight {
 
   void set_chipset(Chipset chipset) { this->chipset_ = chipset; };
   void clear_effect_data() override {
+    if (this->effect_data_ == nullptr)
+      return;
     for (int i = 0; i < this->size(); i++) {
       this->effect_data_[i] = 0;
     }

--- a/esphome/components/spi_led_strip/spi_led_strip.cpp
+++ b/esphome/components/spi_led_strip/spi_led_strip.cpp
@@ -61,7 +61,7 @@ void SpiLedStrip::write_state(light::LightState *state) {
   this->disable();
 }
 light::ESPColorView SpiLedStrip::get_view_internal(int32_t index) const {
-  if (this->buf_ == nullptr) {
+  if (this->buf_ == nullptr || this->effect_data_ == nullptr) {
     return {&this->correction_};
   }
   size_t pos = index * 4 + 5;

--- a/esphome/components/spi_led_strip/spi_led_strip.cpp
+++ b/esphome/components/spi_led_strip/spi_led_strip.cpp
@@ -45,8 +45,9 @@ void SpiLedStrip::dump_config() {
   }
 }
 void SpiLedStrip::write_state(light::LightState *state) {
-  if (this->is_failed())
+  if (!this->is_ready()) {
     return;
+  }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   {
     char strbuf[49];  // format_hex_pretty_size(16) = 48, fits 16 bytes
@@ -60,6 +61,9 @@ void SpiLedStrip::write_state(light::LightState *state) {
   this->disable();
 }
 light::ESPColorView SpiLedStrip::get_view_internal(int32_t index) const {
+  if (this->buf_ == nullptr) {
+    return {&this->correction_};
+  }
   size_t pos = index * 4 + 5;
   return {this->buf_ + pos + 2,       this->buf_ + pos + 1, this->buf_ + pos + 0, nullptr,
           this->effect_data_ + index, &this->correction_};

--- a/esphome/components/spi_led_strip/spi_led_strip.h
+++ b/esphome/components/spi_led_strip/spi_led_strip.h
@@ -24,7 +24,11 @@ class SpiLedStrip final : public light::AddressableLight,
 
   void write_state(light::LightState *state) override;
 
-  void clear_effect_data() override { memset(this->effect_data_, 0, this->num_leds_ * sizeof(this->effect_data_[0])); }
+  void clear_effect_data() override {
+    if (this->effect_data_ == nullptr)
+      return;
+    memset(this->effect_data_, 0, this->num_leds_ * sizeof(this->effect_data_[0]));
+  }
 
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override;


### PR DESCRIPTION
# What does this implement/fix?

Prevent runtime crashes when an addressable light component fails setup and the pixel buffer or hardware resources haven't been initialized.  Some components checked some conditions but they weren't particularly consistent about it.  Components shouldn't crash at runtime even when setup fails.

Changes:

Ensure buffer is valid in get_view_internal().
Ensure component is ready (setup and not failed) in write_state().
Remove redundant checks.
Make ESPColorView final to allow setters to be devirtualized (might make up the slight runtime cost of the extra checks).

# Possible alternative

As an alternative to this change, we could instead modify the API to reflect the fact that the component's pixel buffer might not exist (because allocations can fail).  For example, we could define an `ESPColorBuffer` interface to hold the pixel access methods `size()`, `operator[]`, `get()`, `clear_effect_data()`, `range()`, etc.  `AddressableLight` could have an accessor method return a `ESPColorBuffer*` which might be `nullptr` in case the buffer isn't available and thus the caller could easily check once up-front. 

Such a refactoring would enable re-use of buffer implementations (most of them can be defined by a stride and offset).  And it would make it easier to implement components such as `copy_light` as less delegation would be required.

I considered such a refactoring outside the scope of this change and I would be interested in the maintainer's thoughts on improving the API.  Thanks!

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A 

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: esp32_rmt_led_strip
  # etc...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
