### PR TITLE
[esp32_ble_tracker] Revert coexistence preference to balanced when OTA starts

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -62,10 +62,11 @@ void ESP32BLETracker::on_ota_global_state(ota::OTAState state, float progress, u
     for (auto *client : this->clients_) {
       client->disconnect();
     }
-#endif
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
-    // The OTA transfer blocks the main loop, so the revert in loop() cannot run.
+    // The OTA transfer blocks the main loop, so the revert in loop() cannot run. No
+    // active-connection gate here: every client was just told to disconnect.
     this->update_coex_preference_(false);
+#endif
 #endif
   } else if ((state == ota::OTA_ERROR || state == ota::OTA_ABORT) && this->scan_continuous_before_ota_) {
     this->scan_continuous_before_ota_ = false;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -63,6 +63,10 @@ void ESP32BLETracker::on_ota_global_state(ota::OTAState state, float progress, u
       client->disconnect();
     }
 #endif
+#ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
+    // The OTA transfer blocks the main loop, so the revert in loop() cannot run.
+    this->update_coex_preference_(false);
+#endif
   } else if ((state == ota::OTA_ERROR || state == ota::OTA_ABORT) && this->scan_continuous_before_ota_) {
     this->scan_continuous_before_ota_ = false;
     this->scan_continuous_ = true;


### PR DESCRIPTION
# What does this implement/fix?

When a client is connecting or connected, the tracker sets the coexistence preference to Bluetooth. The only place it goes back to balanced is in `loop()`, but the OTA transfer blocks the main loop, so that revert never runs during the transfer. If an OTA started while a connection was active, the radio stayed biased toward Bluetooth for the whole update even though the tracker had already told every client to disconnect.

This reverts the preference to balanced in the OTA start handler, right after the clients are told to disconnect; on error or abort the next connect promotion sets it back to Bluetooth as before.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_tracker:
  software_coexistence: true

bluetooth_proxy:
  active: true

ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

