### PR TITLE
[uart] Add apply_settings_live() for in-place ESP-IDF reconfiguration

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -160,6 +160,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  this->last_good_baud_ = this->baud_rate_;
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
   int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
@@ -189,18 +190,10 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     setup_pin_if_needed(this->tx_pin_);
   }
 
-  uint32_t invert = 0;
-  if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {
-    invert |= UART_SIGNAL_TXD_INV;
-  }
-  if (this->rx_pin_ != nullptr && this->rx_pin_->is_inverted()) {
-    invert |= UART_SIGNAL_RXD_INV;
-  }
-  if (this->flow_control_pin_ != nullptr && this->flow_control_pin_->is_inverted()) {
-    invert |= UART_SIGNAL_RTS_INV;
-  }
-
-  err = uart_set_line_inverse(this->uart_num_, invert);
+  // apply_line_settings_() re-applies inversion below; this earlier write is the
+  // load-bearing one -- it sets the idle level before uart_set_pin() attaches the
+  // pins, so an inverted TX line never briefly presents the wrong idle level.
+  err = uart_set_line_inverse(this->uart_num_, this->line_inversion_mask_());
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_set_line_inverse failed: %s", esp_err_to_name(err));
     this->mark_failed();
@@ -214,25 +207,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-  err = uart_set_rx_full_threshold(this->uart_num_, this->rx_full_threshold_);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_set_rx_full_threshold failed: %s", esp_err_to_name(err));
-    this->mark_failed();
-    return;
-  }
-
-  err = uart_set_rx_timeout(this->uart_num_, this->rx_timeout_);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_set_rx_timeout failed: %s", esp_err_to_name(err));
-    this->mark_failed();
-    return;
-  }
-
-  // Per ESP-IDF docs, uart_set_mode() must be called only after uart_driver_install().
-  auto mode = this->flow_control_pin_ != nullptr ? UART_MODE_RS485_HALF_DUPLEX : UART_MODE_UART;
-  err = uart_set_mode(this->uart_num_, mode);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_set_mode failed: %s", esp_err_to_name(err));
+  if (this->apply_line_settings_() != ESP_OK) {
     this->mark_failed();
     return;
   }
@@ -248,6 +223,84 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     ESP_LOGCONFIG(TAG, "Reloaded UART %u", this->uart_num_);
     this->dump_config();
   }
+}
+
+uint32_t IDFUARTComponent::line_inversion_mask_() {
+  uint32_t invert = 0;
+  if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {
+    invert |= UART_SIGNAL_TXD_INV;
+  }
+  if (this->rx_pin_ != nullptr && this->rx_pin_->is_inverted()) {
+    invert |= UART_SIGNAL_RXD_INV;
+  }
+  if (this->flow_control_pin_ != nullptr && this->flow_control_pin_->is_inverted()) {
+    invert |= UART_SIGNAL_RTS_INV;
+  }
+  return invert;
+}
+
+esp_err_t IDFUARTComponent::apply_line_settings_() {
+  // uart_param_config()'s internal uart_hal_init() resets these, so re-apply after
+  // every uart_param_config() call (driver install and live reconfiguration alike).
+  esp_err_t err = uart_set_line_inverse(this->uart_num_, this->line_inversion_mask_());
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_set_line_inverse failed: %s", esp_err_to_name(err));
+    return err;
+  }
+
+  err = uart_set_rx_full_threshold(this->uart_num_, this->rx_full_threshold_);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_set_rx_full_threshold failed: %s", esp_err_to_name(err));
+    return err;
+  }
+
+  err = uart_set_rx_timeout(this->uart_num_, this->rx_timeout_);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_set_rx_timeout failed: %s", esp_err_to_name(err));
+    return err;
+  }
+
+  // Per ESP-IDF docs, uart_set_mode() must be called only after uart_driver_install().
+  auto mode = this->flow_control_pin_ != nullptr ? UART_MODE_RS485_HALF_DUPLEX : UART_MODE_UART;
+  err = uart_set_mode(this->uart_num_, mode);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_set_mode failed: %s", esp_err_to_name(err));
+    return err;
+  }
+
+  return ESP_OK;
+}
+
+void IDFUARTComponent::apply_settings_live() {
+  // If the driver isn't installed yet there are no live registers to update; do a
+  // full reload (which installs the driver) instead.
+  if (!uart_is_driver_installed(this->uart_num_)) {
+    this->load_settings(false);
+    return;
+  }
+  // Leaves the driver ring buffers alone (blocked read/write tasks are undisturbed)
+  // but flushes both hardware FIFOs, discarding in-flight bytes -- inherent to live
+  // reconfiguration; hosts normally re-code the line at port-open before data flows.
+  uart_config_t uart_config = this->get_config_();
+  esp_err_t err = uart_param_config(this->uart_num_, &uart_config);
+  if (err != ESP_OK) {
+    // Unachievable baud rates land here with the registers already reset (via the
+    // internal uart_hal_init()). Restore the last framing that worked; if that also
+    // fails (or none is recorded yet) the port is left reset -- mark failed.
+    ESP_LOGW(TAG, "uart_param_config (live) failed: %s; restoring %" PRIu32 " baud", esp_err_to_name(err),
+             this->last_good_baud_);
+    this->baud_rate_ = this->last_good_baud_;
+    uart_config = this->get_config_();
+    if (this->last_good_baud_ == 0 || uart_param_config(this->uart_num_, &uart_config) != ESP_OK) {
+      ESP_LOGE(TAG, "UART left unconfigured after failed live reconfigure");
+      this->mark_failed();
+      return;
+    }
+  } else {
+    this->last_good_baud_ = this->baud_rate_;
+  }
+  // Re-apply what uart_param_config() clobbered; errors are logged inside.
+  this->apply_line_settings_();
 }
 
 void IDFUARTComponent::dump_config() {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -190,9 +190,8 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     setup_pin_if_needed(this->tx_pin_);
   }
 
-  // apply_line_settings_() re-applies inversion below; this earlier write is the
-  // load-bearing one -- it sets the idle level before uart_set_pin() attaches the
-  // pins, so an inverted TX line never briefly presents the wrong idle level.
+  // Must precede uart_set_pin() so an inverted TX line never shows the wrong idle
+  // level; apply_line_settings_() repeats it later for the reset registers.
   err = uart_set_line_inverse(this->uart_num_, this->line_inversion_mask_());
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_set_line_inverse failed: %s", esp_err_to_name(err));
@@ -240,8 +239,7 @@ uint32_t IDFUARTComponent::line_inversion_mask_() {
 }
 
 esp_err_t IDFUARTComponent::apply_line_settings_() {
-  // uart_param_config()'s internal uart_hal_init() resets these, so re-apply after
-  // every uart_param_config() call (driver install and live reconfiguration alike).
+  // uart_param_config() resets these; call after every use of it.
   esp_err_t err = uart_set_line_inverse(this->uart_num_, this->line_inversion_mask_());
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_set_line_inverse failed: %s", esp_err_to_name(err));
@@ -279,22 +277,17 @@ void IDFUARTComponent::set_framing_(const Framing &framing) {
 }
 
 esp_err_t IDFUARTComponent::apply_settings_live() {
-  // If the driver isn't installed yet there are no live registers to update; do a
-  // full reload (which installs the driver) instead.
+  // No driver yet: nothing to reconfigure in place.
   if (!uart_is_driver_installed(this->uart_num_)) {
     this->load_settings(false);
     return this->is_failed() ? ESP_FAIL : ESP_OK;
   }
-  // Leaves the driver ring buffers alone (blocked read/write tasks are undisturbed)
-  // but flushes both hardware FIFOs, discarding in-flight bytes -- inherent to live
-  // reconfiguration; hosts normally re-code the line at port-open before data flows.
+  // Keeps the driver ring buffers; flushes both hardware FIFOs (in-flight bytes lost).
   uart_config_t uart_config = this->get_config_();
   esp_err_t err = uart_param_config(this->uart_num_, &uart_config);
   if (err != ESP_OK) {
-    // Unachievable baud rates land here with the registers already reset (via the
-    // internal uart_hal_init()). Restore the whole framing that last worked, so the
-    // getters keep describing the hardware; if none is recorded yet or that also
-    // fails, the port is left reset -- mark failed.
+    // Failure leaves the registers reset; put back the last accepted framing so the
+    // getters still describe the hardware.
     if (this->last_good_framing_.baud_rate == 0) {
       ESP_LOGE(TAG, "uart_param_config (live) failed: %s; no previous framing to restore", esp_err_to_name(err));
       this->mark_failed();
@@ -309,12 +302,11 @@ esp_err_t IDFUARTComponent::apply_settings_live() {
       this->mark_failed();
       return err;
     }
-    // The previous framing is live again; still report that the request was refused.
+    // Previous framing is live again; still report the refusal.
     esp_err_t line_err = this->apply_line_settings_();
     return line_err != ESP_OK ? line_err : err;
   }
   this->last_good_framing_ = this->framing_();
-  // Re-apply what uart_param_config() clobbered; errors are logged inside.
   return this->apply_line_settings_();
 }
 

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -277,6 +277,9 @@ void IDFUARTComponent::set_framing_(const Framing &framing) {
 }
 
 esp_err_t IDFUARTComponent::apply_settings_live() {
+  if (this->is_failed()) {
+    return ESP_ERR_INVALID_STATE;
+  }
   // No driver yet: nothing to reconfigure in place.
   if (!uart_is_driver_installed(this->uart_num_)) {
     this->load_settings(false);
@@ -302,9 +305,9 @@ esp_err_t IDFUARTComponent::apply_settings_live() {
       this->mark_failed();
       return err;
     }
-    // Previous framing is live again; still report the refusal.
-    esp_err_t line_err = this->apply_line_settings_();
-    return line_err != ESP_OK ? line_err : err;
+    // Previous framing is live again; report the refusal (line-setting errors log).
+    this->apply_line_settings_();
+    return err;
   }
   this->last_good_framing_ = this->framing_();
   return this->apply_line_settings_();

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -274,6 +274,7 @@ void IDFUARTComponent::set_framing_(const Framing &framing) {
   this->data_bits_ = framing.data_bits;
   this->stop_bits_ = framing.stop_bits;
   this->parity_ = framing.parity;
+  this->rx_full_threshold_ = framing.rx_full_threshold;
 }
 
 esp_err_t IDFUARTComponent::apply_settings_live() {
@@ -300,8 +301,9 @@ esp_err_t IDFUARTComponent::apply_settings_live() {
              this->last_good_framing_.baud_rate);
     this->set_framing_(this->last_good_framing_);
     uart_config = this->get_config_();
-    if (uart_param_config(this->uart_num_, &uart_config) != ESP_OK) {
-      ESP_LOGE(TAG, "UART left unconfigured after failed live reconfigure");
+    esp_err_t restore_err = uart_param_config(this->uart_num_, &uart_config);
+    if (restore_err != ESP_OK) {
+      ESP_LOGE(TAG, "UART left unconfigured after failed live reconfigure: %s", esp_err_to_name(restore_err));
       this->mark_failed();
       return err;
     }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -160,7 +160,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  this->last_good_baud_ = this->baud_rate_;
+  this->last_good_framing_ = this->framing_();
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
   int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
@@ -271,12 +271,19 @@ esp_err_t IDFUARTComponent::apply_line_settings_() {
   return ESP_OK;
 }
 
-void IDFUARTComponent::apply_settings_live() {
+void IDFUARTComponent::set_framing_(const Framing &framing) {
+  this->baud_rate_ = framing.baud_rate;
+  this->data_bits_ = framing.data_bits;
+  this->stop_bits_ = framing.stop_bits;
+  this->parity_ = framing.parity;
+}
+
+esp_err_t IDFUARTComponent::apply_settings_live() {
   // If the driver isn't installed yet there are no live registers to update; do a
   // full reload (which installs the driver) instead.
   if (!uart_is_driver_installed(this->uart_num_)) {
     this->load_settings(false);
-    return;
+    return this->is_failed() ? ESP_FAIL : ESP_OK;
   }
   // Leaves the driver ring buffers alone (blocked read/write tasks are undisturbed)
   // but flushes both hardware FIFOs, discarding in-flight bytes -- inherent to live
@@ -285,22 +292,25 @@ void IDFUARTComponent::apply_settings_live() {
   esp_err_t err = uart_param_config(this->uart_num_, &uart_config);
   if (err != ESP_OK) {
     // Unachievable baud rates land here with the registers already reset (via the
-    // internal uart_hal_init()). Restore the last framing that worked; if that also
-    // fails (or none is recorded yet) the port is left reset -- mark failed.
+    // internal uart_hal_init()). Restore the whole framing that last worked, so the
+    // getters keep describing the hardware; if that also fails (or none is recorded
+    // yet) the port is left reset -- mark failed.
     ESP_LOGW(TAG, "uart_param_config (live) failed: %s; restoring %" PRIu32 " baud", esp_err_to_name(err),
-             this->last_good_baud_);
-    this->baud_rate_ = this->last_good_baud_;
+             this->last_good_framing_.baud_rate);
+    this->set_framing_(this->last_good_framing_);
     uart_config = this->get_config_();
-    if (this->last_good_baud_ == 0 || uart_param_config(this->uart_num_, &uart_config) != ESP_OK) {
+    if (this->last_good_framing_.baud_rate == 0 || uart_param_config(this->uart_num_, &uart_config) != ESP_OK) {
       ESP_LOGE(TAG, "UART left unconfigured after failed live reconfigure");
       this->mark_failed();
-      return;
+      return err;
     }
-  } else {
-    this->last_good_baud_ = this->baud_rate_;
+    // The previous framing is live again; still report that the request was refused.
+    esp_err_t line_err = this->apply_line_settings_();
+    return line_err != ESP_OK ? line_err : err;
   }
+  this->last_good_framing_ = this->framing_();
   // Re-apply what uart_param_config() clobbered; errors are logged inside.
-  this->apply_line_settings_();
+  return this->apply_line_settings_();
 }
 
 void IDFUARTComponent::dump_config() {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -293,13 +293,18 @@ esp_err_t IDFUARTComponent::apply_settings_live() {
   if (err != ESP_OK) {
     // Unachievable baud rates land here with the registers already reset (via the
     // internal uart_hal_init()). Restore the whole framing that last worked, so the
-    // getters keep describing the hardware; if that also fails (or none is recorded
-    // yet) the port is left reset -- mark failed.
+    // getters keep describing the hardware; if none is recorded yet or that also
+    // fails, the port is left reset -- mark failed.
+    if (this->last_good_framing_.baud_rate == 0) {
+      ESP_LOGE(TAG, "uart_param_config (live) failed: %s; no previous framing to restore", esp_err_to_name(err));
+      this->mark_failed();
+      return err;
+    }
     ESP_LOGW(TAG, "uart_param_config (live) failed: %s; restoring %" PRIu32 " baud", esp_err_to_name(err),
              this->last_good_framing_.baud_rate);
     this->set_framing_(this->last_good_framing_);
     uart_config = this->get_config_();
-    if (this->last_good_framing_.baud_rate == 0 || uart_param_config(this->uart_num_, &uart_config) != ESP_OK) {
+    if (uart_param_config(this->uart_num_, &uart_config) != ESP_OK) {
       ESP_LOGE(TAG, "UART left unconfigured after failed live reconfigure");
       this->mark_failed();
       return err;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -312,7 +312,9 @@ esp_err_t IDFUARTComponent::apply_settings_live() {
     return err;
   }
   this->last_good_framing_ = this->framing_();
-  return this->apply_line_settings_();
+  // The new framing is live; a line-setting failure here only logs.
+  this->apply_line_settings_();
+  return ESP_OK;
 }
 
 void IDFUARTComponent::dump_config() {

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -52,11 +52,28 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   void load_settings(bool dump_config) override;
   using UARTComponent::load_settings;  // also bring in the no-arg overload for convenience
 
+  /**
+   * Apply the current framing settings (baud rate, parity, data/stop bits) to the
+   * already-installed driver without the driver delete/reinstall that load_settings()
+   * performs. The driver ring buffers and any tasks blocked in
+   * uart_read_bytes()/uart_write_bytes() survive, but uart_param_config() flushes
+   * both hardware FIFOs, so up to a FIFO's worth of in-flight bytes is discarded in
+   * each direction. Falls back to a full reload if the driver is not installed.
+   */
+  void apply_settings_live();
+
   void on_shutdown() override;
 
  protected:
   void check_logger_conflict() override;
+  // Signal-inversion flags derived from the configured pins' inverted markers.
+  uint32_t line_inversion_mask_();
+  // (Re)apply the settings that uart_param_config() resets: line inversion, RX full
+  // threshold, RX timeout, and port mode. Returns the first error, already logged.
+  esp_err_t apply_line_settings_();
   uart_port_t uart_num_{UART_NUM_MAX};
+  // Fallback for a failed live reconfiguration (unachievable requested rate).
+  uint32_t last_good_baud_{0};
   uart_config_t get_config_();
 
   bool has_peek_{false};

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -61,9 +61,10 @@ class IDFUARTComponent final : public UARTComponent, public Component {
    * rx_full_threshold is not rescaled; call set_rx_full_threshold_ms() first if it
    * should follow the new baud rate.
    *
-   * @return ESP_OK once the new framing is live. On rejection (unreachable baud rate)
-   * the previous framing is restored and the driver's error returned; if the restore
-   * fails too the component is marked failed. ESP_ERR_INVALID_STATE if already failed.
+   * @return ESP_OK once the new framing is live (a line-setting error after that only
+   * logs). On rejection (unreachable baud rate) the previous framing is restored and
+   * the driver's error returned; if the restore fails too the component is marked
+   * failed. ESP_ERR_INVALID_STATE if already failed.
    */
   esp_err_t apply_settings_live();
 

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -58,7 +58,10 @@ class IDFUARTComponent final : public UARTComponent, public Component {
    * performs. The driver ring buffers and any tasks blocked in
    * uart_read_bytes()/uart_write_bytes() survive, but uart_param_config() flushes
    * both hardware FIFOs, so up to a FIFO's worth of in-flight bytes is discarded in
-   * each direction. Falls back to a full reload if the driver is not installed.
+   * each direction: a frame being shifted out at that moment reaches the peer
+   * truncated. No driver lock is taken, so a caller whose peer cannot tolerate a
+   * partial frame must quiesce its writers first. Falls back to a full reload if the
+   * driver is not installed.
    *
    * @return ESP_OK once the requested framing is live. If the driver rejects it (for
    * example an unreachable baud rate), the previous framing is restored, the getters

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -57,10 +57,12 @@ class IDFUARTComponent final : public UARTComponent, public Component {
    * driver in place, without the delete/reinstall of load_settings(). Tasks blocked in
    * the driver survive; both hardware FIFOs are flushed, so a frame in flight reaches
    * the peer truncated. No lock is taken: quiesce writers first if that matters.
+   * rx_full_threshold is not rescaled; call set_rx_full_threshold_ms() first if it
+   * should follow the new baud rate.
    *
    * @return ESP_OK once the new framing is live. On rejection (unreachable baud rate)
    * the previous framing is restored and the driver's error returned; if the restore
-   * fails too the component is marked failed.
+   * fails too the component is marked failed. ESP_ERR_INVALID_STATE if already failed.
    */
   esp_err_t apply_settings_live();
 

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -59,8 +59,14 @@ class IDFUARTComponent final : public UARTComponent, public Component {
    * uart_read_bytes()/uart_write_bytes() survive, but uart_param_config() flushes
    * both hardware FIFOs, so up to a FIFO's worth of in-flight bytes is discarded in
    * each direction. Falls back to a full reload if the driver is not installed.
+   *
+   * @return ESP_OK once the requested framing is live. If the driver rejects it (for
+   * example an unreachable baud rate), the previous framing is restored, the getters
+   * reflect it again and the driver's error is returned; if that restore also fails
+   * the component is marked failed. Errors from the line settings re-applied after a
+   * successful reconfiguration are returned as well.
    */
-  void apply_settings_live();
+  esp_err_t apply_settings_live();
 
   void on_shutdown() override;
 
@@ -72,9 +78,19 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   // threshold, RX timeout, and port mode. Returns the first error, already logged.
   esp_err_t apply_line_settings_();
   uart_port_t uart_num_{UART_NUM_MAX};
-  // Fallback for a failed live reconfiguration (unachievable requested rate).
-  uint32_t last_good_baud_{0};
   uart_config_t get_config_();
+
+  struct Framing {
+    uint32_t baud_rate;
+    uint8_t data_bits;
+    uint8_t stop_bits;
+    UARTParityOptions parity;
+  };
+  Framing framing_() const { return {this->baud_rate_, this->data_bits_, this->stop_bits_, this->parity_}; }
+  void set_framing_(const Framing &framing);
+  // Recorded after every configuration the driver accepted; a failed live
+  // reconfiguration rolls back to it. baud_rate 0 means none yet.
+  Framing last_good_framing_{};
 
   bool has_peek_{false};
   uint8_t peek_byte_;

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -53,21 +53,14 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   using UARTComponent::load_settings;  // also bring in the no-arg overload for convenience
 
   /**
-   * Apply the current framing settings (baud rate, parity, data/stop bits) to the
-   * already-installed driver without the driver delete/reinstall that load_settings()
-   * performs. The driver ring buffers and any tasks blocked in
-   * uart_read_bytes()/uart_write_bytes() survive, but uart_param_config() flushes
-   * both hardware FIFOs, so up to a FIFO's worth of in-flight bytes is discarded in
-   * each direction: a frame being shifted out at that moment reaches the peer
-   * truncated. No driver lock is taken, so a caller whose peer cannot tolerate a
-   * partial frame must quiesce its writers first. Falls back to a full reload if the
-   * driver is not installed.
+   * Apply the current framing (baud rate, parity, data/stop bits) to the installed
+   * driver in place, without the delete/reinstall of load_settings(). Tasks blocked in
+   * the driver survive; both hardware FIFOs are flushed, so a frame in flight reaches
+   * the peer truncated. No lock is taken: quiesce writers first if that matters.
    *
-   * @return ESP_OK once the requested framing is live. If the driver rejects it (for
-   * example an unreachable baud rate), the previous framing is restored, the getters
-   * reflect it again and the driver's error is returned; if that restore also fails
-   * the component is marked failed. Errors from the line settings re-applied after a
-   * successful reconfiguration are returned as well.
+   * @return ESP_OK once the new framing is live. On rejection (unreachable baud rate)
+   * the previous framing is restored and the driver's error returned; if the restore
+   * fails too the component is marked failed.
    */
   esp_err_t apply_settings_live();
 
@@ -75,10 +68,8 @@ class IDFUARTComponent final : public UARTComponent, public Component {
 
  protected:
   void check_logger_conflict() override;
-  // Signal-inversion flags derived from the configured pins' inverted markers.
   uint32_t line_inversion_mask_();
-  // (Re)apply the settings that uart_param_config() resets: line inversion, RX full
-  // threshold, RX timeout, and port mode. Returns the first error, already logged.
+  // Re-applies what uart_param_config() resets: inversion, RX threshold/timeout, mode.
   esp_err_t apply_line_settings_();
   uart_port_t uart_num_{UART_NUM_MAX};
   uart_config_t get_config_();
@@ -91,8 +82,7 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   };
   Framing framing_() const { return {this->baud_rate_, this->data_bits_, this->stop_bits_, this->parity_}; }
   void set_framing_(const Framing &framing);
-  // Recorded after every configuration the driver accepted; a failed live
-  // reconfiguration rolls back to it. baud_rate 0 means none yet.
+  // Last framing the driver accepted; baud_rate 0 means none yet.
   Framing last_good_framing_{};
 
   bool has_peek_{false};

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -58,13 +58,16 @@ class IDFUARTComponent final : public UARTComponent, public Component {
    * the driver survive and the ring buffers are kept, but both hardware FIFOs are
    * flushed: a frame in flight reaches the peer truncated and bytes not yet out of the
    * RX FIFO are dropped. No lock is taken: quiesce writers first if that matters.
-   * rx_full_threshold is not rescaled; call set_rx_full_threshold_ms() first if it
-   * should follow the new baud rate.
+   * rx_full_threshold is not rescaled (call set_rx_full_threshold_ms() first if it
+   * should follow the baud rate); a rollback restores the value from the last accepted
+   * configuration, undoing a standalone set_rx_full_threshold() made since. Without an
+   * installed driver this is a full load_settings(false) instead.
    *
    * @return ESP_OK once the new framing is live (a line-setting error after that only
    * logs). On rejection (unreachable baud rate) the previous framing is restored and
    * the driver's error returned; if the restore fails too the component is marked
-   * failed. ESP_ERR_INVALID_STATE if already failed.
+   * failed. ESP_ERR_INVALID_STATE if already failed; ESP_FAIL if the fallback
+   * load_settings() fails.
    */
   esp_err_t apply_settings_live();
 

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -55,8 +55,9 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   /**
    * Apply the current framing (baud rate, parity, data/stop bits) to the installed
    * driver in place, without the delete/reinstall of load_settings(). Tasks blocked in
-   * the driver survive; both hardware FIFOs are flushed, so a frame in flight reaches
-   * the peer truncated. No lock is taken: quiesce writers first if that matters.
+   * the driver survive and the ring buffers are kept, but both hardware FIFOs are
+   * flushed: a frame in flight reaches the peer truncated and bytes not yet out of the
+   * RX FIFO are dropped. No lock is taken: quiesce writers first if that matters.
    * rx_full_threshold is not rescaled; call set_rx_full_threshold_ms() first if it
    * should follow the new baud rate.
    *
@@ -81,8 +82,11 @@ class IDFUARTComponent final : public UARTComponent, public Component {
     uint8_t data_bits;
     uint8_t stop_bits;
     UARTParityOptions parity;
+    size_t rx_full_threshold;  // sized for the baud rate, so rolled back with it
   };
-  Framing framing_() const { return {this->baud_rate_, this->data_bits_, this->stop_bits_, this->parity_}; }
+  Framing framing_() const {
+    return {this->baud_rate_, this->data_bits_, this->stop_bits_, this->parity_, this->rx_full_threshold_};
+  }
   void set_framing_(const Framing &framing);
   // Last framing the driver accepted; baud_rate 0 means none yet.
   Framing last_good_framing_{};


### PR DESCRIPTION
# What does this implement/fix?

Split out of #11689 at review request so it can be reviewed and merged on its own; #11689 is stacked on top of it.

Adds `IDFUARTComponent::apply_settings_live()`, which applies the current framing settings (baud rate, parity, data bits, stop bits) to the already-installed ESP-IDF driver with `uart_param_config()` instead of the driver delete/reinstall that `load_settings()` performs. The driver ring buffers and any tasks blocked in `uart_read_bytes()`/`uart_write_bytes()` survive the change, which is what lets the upcoming `usb_uart` bridge follow a USB host's line coding while its worker tasks stay blocked on the driver.

Details:

- `uart_param_config()` internally resets line inversion, the RX full threshold, the RX timeout and the port mode, so those moved into a new `apply_line_settings_()` that both `load_settings()` and `apply_settings_live()` call after it. `load_settings()` keeps its original call order; the one behavioural difference is a second, idempotent `uart_set_line_inverse()` after `uart_set_pin()`. The first write is the load-bearing one (it sets the idle level before the pins are attached) and is commented as such.
- A failed live reconfiguration, which happens for baud rates the clock divider cannot reach, leaves the registers reset. `apply_settings_live()` restores the whole framing that last worked (baud rate, data bits, stop bits and parity, recorded after every configuration the driver accepted), so the getters keep describing the hardware, and marks the component failed only if that restore also fails.
- `apply_settings_live()` returns `esp_err_t`: `ESP_OK` once the requested framing is live, otherwise the driver's error after the previous framing (including the RX full threshold sized for it) has been restored, or `ESP_ERR_INVALID_STATE` on an already-failed component. Non-OK therefore always means the port did not move, which is the one thing a caller answering a remote line-coding request needs to know; a line-settings error after a successful reconfigure only logs.
- If the driver is not installed yet, `apply_settings_live()` falls back to `load_settings(false)`.
- Live reconfiguration flushes both hardware FIFOs, so up to a FIFO's worth of in-flight bytes is discarded per direction. That is inherent to `uart_param_config()` and documented on the method.

No configuration changes; `apply_settings_live()` is a new public C++ method with its contract, side effects and failure behaviour documented in the header.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration change. From a lambda, after adjusting settings:
#   id(my_uart).set_baud_rate(230400);
#   id(my_uart).apply_settings_live();
uart:
  - id: my_uart
    tx_pin: GPIO14
    rx_pin: GPIO13
    baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).


