### PR TITLE
[i2s_audio][router] Loop thread controls all state changes

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -53,6 +53,13 @@ void I2SAudioSpeakerBase::dump_config() {
 void I2SAudioSpeakerBase::loop() {
   uint32_t event_group_bits = xEventGroupGetBits(this->event_group_);
 
+  // A stop that arrives while stopped cancels any start that has not been processed yet
+  constexpr uint32_t stop_bits = SpeakerEventGroupBits::COMMAND_STOP | SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY;
+  if ((event_group_bits & stop_bits) && (this->state_ == speaker::STATE_STOPPED)) {
+    xEventGroupClearBits(this->event_group_, stop_bits | SpeakerEventGroupBits::COMMAND_START);
+    event_group_bits &= ~(stop_bits | SpeakerEventGroupBits::COMMAND_START);
+  }
+
   if ((event_group_bits & SpeakerEventGroupBits::COMMAND_START) && (this->state_ == speaker::STATE_STOPPED)) {
     this->state_ = speaker::STATE_STARTING;
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
@@ -249,9 +256,8 @@ void I2SAudioSpeakerBase::finish() { this->stop_(true); }
 void I2SAudioSpeakerBase::stop_(bool wait_on_empty) {
   if (this->is_failed())
     return;
-  if (this->state_ == speaker::STATE_STOPPED)
-    return;
 
+  // Always set the bit, even when stopped, so loop() can cancel a start that is still pending
   if (wait_on_empty) {
     xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY);
   } else {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -239,8 +239,6 @@ void I2SAudioSpeakerBase::start() {
   if ((this->state_ == speaker::STATE_STARTING) || (this->state_ == speaker::STATE_RUNNING))
     return;
 
-  // Mark STARTING immediately to avoid transient STOPPED observations before loop() processes COMMAND_START.
-  this->state_ = speaker::STATE_STARTING;
   xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_START);
 }
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -254,7 +254,7 @@ void I2SAudioSpeakerBase::stop() { this->stop_(false); }
 void I2SAudioSpeakerBase::finish() { this->stop_(true); }
 
 void I2SAudioSpeakerBase::stop_(bool wait_on_empty) {
-  if (this->is_failed())
+  if (!this->is_ready() || this->is_failed())
     return;
 
   // Always set the bit, even when stopped, so loop() can cancel a start that is still pending

--- a/esphome/components/router/speaker/router_speaker.cpp
+++ b/esphome/components/router/speaker/router_speaker.cpp
@@ -2,6 +2,8 @@
 
 #ifdef USE_ESP32
 
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 #include "esp_timer.h"
@@ -11,6 +13,9 @@
 namespace esphome::router {
 
 static const char *const TAG = "router.speaker";
+
+// Maximum time to wait for the active output to report running after start() before giving up
+static const uint32_t STATE_TRANSITION_TIMEOUT_MS = 5000;
 
 static inline uint32_t atomic_subtract_clamped(std::atomic<uint32_t> &var, uint32_t amount) {
   uint32_t current = var.load(std::memory_order_acquire);
@@ -72,6 +77,7 @@ void Router::loop() {
 
       this->apply_cached_state_to_active_();
       this->state_ = speaker::STATE_STARTING;
+      this->state_start_ms_ = App.get_loop_component_start_time();
       active->start();
     }
     return;
@@ -86,10 +92,17 @@ void Router::loop() {
   // set_audio_stream_info() and never reaches the output on its own; if the format
   // changed while stopped, only start()'s apply_cached_state_to_active_() pushes it
   // down before the output's play()-side auto-start locks in the stale format.
-  if (active->is_stopped()) {
+  // While STARTING, ignore a transient stopped report as speaker running state
+  // is set asynchronously from start(). Timeout if the speaker never transitions.
+  if (this->state_ == speaker::STATE_STARTING) {
+    if (active->is_running()) {
+      this->state_ = speaker::STATE_RUNNING;
+    } else if ((App.get_loop_component_start_time() - this->state_start_ms_) > STATE_TRANSITION_TIMEOUT_MS) {
+      ESP_LOGW(TAG, "Active output did not start; giving up");
+      this->state_ = speaker::STATE_STOPPED;
+    }
+  } else if (active->is_stopped()) {
     this->state_ = speaker::STATE_STOPPED;
-  } else if (this->state_ == speaker::STATE_STARTING && active->is_running()) {
-    this->state_ = speaker::STATE_RUNNING;
   }
 }
 
@@ -133,6 +146,8 @@ void Router::start() {
   this->frames_in_pipeline_.store(0, std::memory_order_release);
   this->apply_cached_state_to_active_();
   this->state_ = speaker::STATE_STARTING;
+  // May run on a producer task, so the cached loop timestamp is not usable here
+  this->state_start_ms_ = millis();
   this->get_active_output()->start();
 }
 

--- a/esphome/components/router/speaker/router_speaker.h
+++ b/esphome/components/router/speaker/router_speaker.h
@@ -59,6 +59,9 @@ class Router final : public Component, public speaker::Speaker {
   // frames_in_pipeline_.
   std::atomic<uint32_t> frames_in_pipeline_{0};
 
+  // Set when entering STATE_STARTING; used to time out a start the output never acts on
+  uint32_t state_start_ms_{0};
+
   bool cached_pause_{false};
 
   void apply_cached_state_to_active_();


### PR DESCRIPTION
# What does this implement/fix?

Makes the main loop the only place the i2s audio speaker's state changes, and lets a stop request cancel a start that the loop has not processed yet.

`start` can be called by other threads. It previously set the speaker state to starting directly, bypassing the event group's thread safety. This PR removes that write, so `start` only sets the `COMMAND_START` bit and the loop drives the transition. The downside is a temporary flap where the speaker reports it is not running immediately after a `start` call, but this doesn't seem to affect the audio pipeline as all components just try again on the next loop iteration when they call `play` again.

#19027 exposed this as a problem, as the `COMMAND_START` bit wasn't ever being cleared since the main loop only clears it when it drives the speaker state change from stopped to starting. Since the `COMMAND_START` bit was always set, the speaker would always immediately restart. The speaker_source media player would then get wedged, as it requires the speaker to be in the stopped state before starting a new source.

With the state change deferred, a stop or finish that arrives before the loop processes a pending start would previously return early because the speaker still reported stopped, leaving the start to go ahead with nothing to play. `stop` and `finish` now always set their command bit, and the loop cancels a pending start when it sees a stop bit while stopped. This matches the stop over start precedence the mixer and resampler speakers already use. A start that arrives while the task is winding down is unaffected, since #19027 preserves it after the stop bits are cleared along with everything else.

The direct state change was originally introduced when SPDIF support was added. I have tested this PR with a media player -> mixer speaker -> router speaker -> spdif speaker path, and it didn't have any problems with sendspin and regular audio_http components, so the original change doesn't seem necessary for typical use.

This PR also modifies the router component to fix a preexisting issue where it latches to the stopped state if the output speaker doesn't report the running state immediately. In practice this wasn't a big issue, because almost all audio components will just call start again when it retries sending audio. The resampler speaker uses the timeout approach added here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):** not applicable

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: i2s_spdif_speaker
    dac_type: external
    i2s_audio_id: i2s_spdif_bus
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    bits_per_sample: 16bit
    spdif_mode: true
    channel: stereo
    use_apll: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
