### PR TITLE
[light] Refactor addressable light buffer allocation.

### DIFF
--- a/esphome/components/adalight/adalight_light_effect.cpp
+++ b/esphome/components/adalight/adalight_light_effect.cpp
@@ -24,7 +24,7 @@ void AdalightLightEffect::stop() {
   AddressableLightEffect::stop();
 }
 
-unsigned int AdalightLightEffect::get_frame_size_(int led_count) const {
+size_t AdalightLightEffect::get_frame_size_(size_t led_count) const {
   // 3 bytes: Ada
   // 2 bytes: LED count
   // 1 byte: checksum
@@ -33,14 +33,15 @@ unsigned int AdalightLightEffect::get_frame_size_(int led_count) const {
 }
 
 void AdalightLightEffect::reset_frame_(light::AddressableLight &it) {
-  int buffer_capacity = get_frame_size_(it.size());
+  size_t buffer_capacity = get_frame_size_(it.buffer().size());
 
   frame_.clear();
   frame_.reserve(buffer_capacity);
 }
 
 void AdalightLightEffect::blank_all_leds_(light::AddressableLight &it) {
-  for (int led = it.size(); led-- > 0;) {
+  light::ESPColorBuffer &buffer = it.buffer();
+  for (int led = buffer.size(); led-- > 0;) {
     it[led].set(Color::BLACK);
   }
   it.schedule_show();
@@ -124,13 +125,14 @@ AdalightLightEffect::Frame AdalightLightEffect::parse_frame_(light::AddressableL
     return PARTIAL;
 
   // Apply lights
-  auto accepted_led_count = std::min<int>(led_count, it.size());
+  light::ESPColorBuffer &buffer = it.buffer();
+  auto accepted_led_count = std::min<size_t>(led_count, buffer.size());
   uint8_t *led_data = &frame_[6];
 
-  for (int led = 0; led < accepted_led_count; led++, led_data += 3) {
+  for (size_t led = 0; led < accepted_led_count; led++, led_data += 3) {
     auto white = std::min({led_data[0], led_data[1], led_data[2]});
 
-    it[led].set(Color(led_data[0], led_data[1], led_data[2], white));
+    buffer[led].set(Color(led_data[0], led_data[1], led_data[2], white));
   }
 
   it.schedule_show();

--- a/esphome/components/adalight/adalight_light_effect.cpp
+++ b/esphome/components/adalight/adalight_light_effect.cpp
@@ -41,9 +41,7 @@ void AdalightLightEffect::reset_frame_(light::AddressableLight &it) {
 
 void AdalightLightEffect::blank_all_leds_(light::AddressableLight &it) {
   light::ESPColorBuffer &buffer = it.buffer();
-  for (int led = buffer.size(); led-- > 0;) {
-    it[led].set(Color::BLACK);
-  }
+  buffer.all().set(Color::BLACK);
   it.schedule_show();
 }
 

--- a/esphome/components/adalight/adalight_light_effect.h
+++ b/esphome/components/adalight/adalight_light_effect.h
@@ -23,7 +23,7 @@ class AdalightLightEffect : public light::AddressableLightEffect, public uart::U
     CONSUMED,
   };
 
-  unsigned int get_frame_size_(int led_count) const;
+  size_t get_frame_size_(size_t led_count) const;
   void reset_frame_(light::AddressableLight &it);
   void blank_all_leds_(light::AddressableLight &it);
   Frame parse_frame_(light::AddressableLight &it);

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -127,7 +127,7 @@ void BekenSPILEDStripLightOutput::setup() {
     return;
   }
 
-  size_t dma_buffer_size = (this->buffer_->get_led_data_bytes() * 8) + (2 * 64);
+  size_t dma_buffer_size = (this->buffer_.get_led_data_bytes() * 8) + (2 * 64);
   this->dma_buf_ = allocator.allocate(dma_buffer_size);
   if (this->dma_buf_ == nullptr) {
     ESP_LOGE(TAG, "Cannot allocate DMA buffer!");
@@ -262,7 +262,7 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
 
   spi_data->tx_in_progress = true;
 
-  const size_t led_data_bytes = this->buffer_->get_led_data_bytes();
+  const size_t led_data_bytes = this->buffer_.get_led_data_bytes();
   size_t size = 0;
   uint8_t *psrc = this->buffer_.get_led_data();
   uint8_t *pdest = this->dma_buf_ + 64;

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -120,24 +120,14 @@ void spi_dma_tx_finish_callback(unsigned int param) {
 }
 
 void BekenSPILEDStripLightOutput::setup() {
-  size_t buffer_size = this->get_buffer_size_();
-  size_t dma_buffer_size = (buffer_size * 8) + (2 * 64);
-
   RAMAllocator<uint8_t> allocator;
-  this->buf_ = allocator.allocate(buffer_size);
-  if (this->buf_ == nullptr) {
-    ESP_LOGE(TAG, "Cannot allocate LED buffer!");
+  if (!this->buffer_.allocate_and_setup(&allocator)) {
+    ESP_LOGE(TAG, "Cannot allocate color buffer");
     this->mark_failed();
     return;
   }
 
-  this->effect_data_ = allocator.allocate(this->num_leds_);
-  if (this->effect_data_ == nullptr) {
-    ESP_LOGE(TAG, "Cannot allocate effect data!");
-    this->mark_failed();
-    return;
-  }
-
+  size_t dma_buffer_size = (this->buffer_->get_led_data_bytes() * 8) + (2 * 64);
   this->dma_buf_ = allocator.allocate(dma_buffer_size);
   if (this->dma_buf_ == nullptr) {
     ESP_LOGE(TAG, "Cannot allocate DMA buffer!");
@@ -145,8 +135,6 @@ void BekenSPILEDStripLightOutput::setup() {
     return;
   }
 
-  memset(this->buf_, 0, buffer_size);
-  memset(this->effect_data_, 0, this->num_leds_);
   memset(this->dma_buf_, 0, dma_buffer_size);
 
   uint32_t value = PCLK_POSI_SPI;
@@ -245,6 +233,9 @@ void BekenSPILEDStripLightOutput::set_led_params(uint8_t bit0, uint8_t bit1, uin
 }
 
 void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   // protect from refreshing too often
   uint32_t now = micros();
   if (this->max_refresh_rate_.has_value() && *this->max_refresh_rate_ != 0 &&
@@ -257,12 +248,6 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
   this->mark_shown_();
 
   ESP_LOGVV(TAG, "Writing RGB values to bus");
-
-  if (spi_data == nullptr) {
-    ESP_LOGE(TAG, "SPI not initialized");
-    this->status_set_warning();
-    return;
-  }
 
   if (!spi_data->first_run && !xSemaphoreTake(spi_data->dma_tx_semaphore, 10 / portTICK_PERIOD_MS)) {
     ESP_LOGE(TAG, "Timed out waiting for semaphore");
@@ -277,14 +262,14 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
 
   spi_data->tx_in_progress = true;
 
-  size_t buffer_size = this->get_buffer_size_();
+  const size_t led_data_bytes = this->buffer_->get_led_data_bytes();
   size_t size = 0;
-  uint8_t *psrc = this->buf_;
+  uint8_t *psrc = this->buffer_.get_led_data();
   uint8_t *pdest = this->dma_buf_ + 64;
   // The 64 byte padding is a workaround for a SPI DMA bug where the
   // output doesn't exactly start at the beginning of dma_buf_
 
-  while (size < buffer_size) {
+  while (size < led_data_bytes) {
     uint8_t b = *psrc;
     for (int i = 0; i < 8; i++) {
       *pdest++ = b & (1 << (7 - i)) ? this->bit1_ : this->bit0_;
@@ -299,17 +284,6 @@ void BekenSPILEDStripLightOutput::write_state(light::LightState *state) {
   this->status_clear_warning();
 }
 
-light::ESPColorView BekenSPILEDStripLightOutput::get_view_internal(int32_t index) const {
-  const light::ChannelColors &colors = this->channel_colors_;
-  uint8_t *led = this->buf_ + (index * colors.bytes_per_led());
-  return {led + colors.r,
-          led + colors.g,
-          led + colors.b,
-          colors.has_white() ? led + colors.w : nullptr,
-          &this->effect_data_[index],
-          &this->correction_};
-}
-
 void BekenSPILEDStripLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Beken SPI LED Strip:\n"
@@ -320,7 +294,8 @@ void BekenSPILEDStripLightOutput::dump_config() {
                 "  Channel colors: %s\n"
                 "  Max refresh rate: %" PRIu32 "\n"
                 "  Number of LEDs: %u",
-                this->channel_colors_.to_string(channel_colors), this->max_refresh_rate_.value_or(0), this->num_leds_);
+                this->buffer_.layout().channel_colors.to_string(channel_colors), this->max_refresh_rate_.value_or(0),
+                this->buffer().size());
 }
 
 float BekenSPILEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -295,7 +295,7 @@ void BekenSPILEDStripLightOutput::dump_config() {
                 "  Max refresh rate: %" PRIu32 "\n"
                 "  Number of LEDs: %u",
                 this->buffer_.layout().channel_colors.to_string(channel_colors), this->max_refresh_rate_.value_or(0),
-                this->buffer().size());
+                this->buffer_.size());
 }
 
 float BekenSPILEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/beken_spi_led_strip/led_strip.h
+++ b/esphome/components/beken_spi_led_strip/led_strip.h
@@ -42,7 +42,7 @@ class BekenSPILEDStripLightOutput final : public light::AddressableLight {
   void dump_config() override;
 
  protected:
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
 
   uint8_t *dma_buf_{nullptr};
 

--- a/esphome/components/beken_spi_led_strip/led_strip.h
+++ b/esphome/components/beken_spi_led_strip/led_strip.h
@@ -33,8 +33,6 @@ class BekenSPILEDStripLightOutput final : public light::AddressableLight {
   }
 
   void set_pin(uint8_t pin) { this->pin_ = pin; }
-  void set_num_leds(uint16_t num_leds) { this->num_leds_ = num_leds; }
-  void set_channel_colors(light::ChannelColors channel_colors) { this->channel_colors_ = channel_colors; }
 
   /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
   void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }

--- a/esphome/components/beken_spi_led_strip/led_strip.h
+++ b/esphome/components/beken_spi_led_strip/led_strip.h
@@ -13,14 +13,18 @@ namespace esphome::beken_spi_led_strip {
 
 class BekenSPILEDStripLightOutput final : public light::AddressableLight {
  public:
+  BekenSPILEDStripLightOutput(size_t num_leds, light::ChannelColors channel_colors)
+      : buffer_(num_leds, {.channel_colors = channel_colors}, &this->correction_) {}
+
+  light::ESPColorBuffer &buffer() override { return this->buffer_; }
+
   void setup() override;
   void write_state(light::LightState *state) override;
   float get_setup_priority() const override;
 
-  int32_t size() const override { return this->num_leds_; }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
-    if (this->channel_colors_.has_white()) {
+    if (this->buffer_.layout().channel_colors.has_white()) {
       traits.set_supported_color_modes({light::ColorMode::RGB_WHITE, light::ColorMode::WHITE});
     } else {
       traits.set_supported_color_modes({light::ColorMode::RGB});
@@ -37,29 +41,18 @@ class BekenSPILEDStripLightOutput final : public light::AddressableLight {
 
   void set_led_params(uint8_t bit0, uint8_t bit1, uint32_t spi_frequency);
 
-  void clear_effect_data() override {
-    for (int i = 0; i < this->size(); i++)
-      this->effect_data_[i] = 0;
-  }
-
   void dump_config() override;
 
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override;
+  light::InterleavedColorBuffer buffer_;
 
-  size_t get_buffer_size_() const { return this->num_leds_ * this->channel_colors_.bytes_per_led(); }
-
-  uint8_t *buf_{nullptr};
-  uint8_t *effect_data_{nullptr};
   uint8_t *dma_buf_{nullptr};
 
   uint8_t pin_;
-  uint16_t num_leds_;
 
   uint32_t spi_frequency_{6666666};
   uint8_t bit0_{0xE0};
   uint8_t bit1_{0xFC};
-  light::ChannelColors channel_colors_{0, 1, 2, light::ChannelColors::NO_WHITE};
 
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};

--- a/esphome/components/beken_spi_led_strip/light.py
+++ b/esphome/components/beken_spi_led_strip/light.py
@@ -104,11 +104,15 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config: ConfigType) -> None:
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    var = cg.new_Pvariable(
+        config[CONF_OUTPUT_ID],
+        config[CONF_NUM_LEDS],
+        light.channel_colors_struct(config[CONF_CHANNEL_COLORS]),
+    )
     await light.register_light(var, config)
     await cg.register_component(var, config)
 
-    cg.add(var.set_num_leds(config[CONF_NUM_LEDS]))
+    cg.add(var.set_num_leds())
     cg.add(var.set_pin(config[CONF_PIN]))
 
     if CONF_MAX_REFRESH_RATE in config:
@@ -121,8 +125,4 @@ async def to_code(config: ConfigType) -> None:
             chipset.bit1,
             chipset.spi_frequency,
         )
-    )
-
-    cg.add(
-        var.set_channel_colors(light.channel_colors_struct(config[CONF_CHANNEL_COLORS]))
     )

--- a/esphome/components/beken_spi_led_strip/light.py
+++ b/esphome/components/beken_spi_led_strip/light.py
@@ -112,7 +112,6 @@ async def to_code(config: ConfigType) -> None:
     await light.register_light(var, config)
     await cg.register_component(var, config)
 
-    cg.add(var.set_num_leds())
     cg.add(var.set_pin(config[CONF_PIN]))
 
     if CONF_MAX_REFRESH_RATE in config:

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -51,11 +51,13 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
   if (universe < first_universe_ || universe > get_last_universe())
     return false;
 
+  light::ESPColorBuffer &buffer = it->buffer();
   int32_t output_offset = (universe - first_universe_) * get_lights_per_universe();
   // limit amount of lights per universe and received
   // packet.count is the number of DMX bytes including start code; divide by channels to get the number of lights
   int lights_in_packet = (packet.count > 0) ? (packet.count - 1) / channels_ : 0;
-  int output_end = std::min({it->size(), output_offset + get_lights_per_universe(), output_offset + lights_in_packet});
+  int output_end =
+      std::min({buffer.size(), output_offset + get_lights_per_universe(), output_offset + lights_in_packet});
   auto *input_data = packet.values + 1;
 
   auto effect_name = get_name();
@@ -65,23 +67,20 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
   switch (channels_) {
     case E131_MONO:
       for (; output_offset < output_end; output_offset++, input_data++) {
-        auto output = (*it)[output_offset];
-        output.set(Color(input_data[0], input_data[0], input_data[0], input_data[0]));
+        buffer[output_offset].set(Color(input_data[0], input_data[0], input_data[0], input_data[0]));
       }
       break;
 
     case E131_RGB:
       for (; output_offset < output_end; output_offset++, input_data += 3) {
-        auto output = (*it)[output_offset];
-        output.set(
+        buffer[output_offset].set(
             Color(input_data[0], input_data[1], input_data[2], (input_data[0] + input_data[1] + input_data[2]) / 3));
       }
       break;
 
     case E131_RGBW:
       for (; output_offset < output_end; output_offset++, input_data += 4) {
-        auto output = (*it)[output_offset];
-        output.set(Color(input_data[0], input_data[1], input_data[2], input_data[3]));
+        buffer[output_offset].set(Color(input_data[0], input_data[1], input_data[2], input_data[3]));
       }
       break;
   }

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -21,7 +21,7 @@ int E131AddressableLightEffect::get_last_universe() const { return first_univers
 int E131AddressableLightEffect::get_universe_count() const {
   // Round up to lights_per_universe
   auto lights = get_lights_per_universe();
-  return (get_addressable_()->size() + lights - 1) / lights;
+  return (get_addressable_()->buffer().size() + lights - 1) / lights;
 }
 
 void E131AddressableLightEffect::start() {
@@ -57,7 +57,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
   // packet.count is the number of DMX bytes including start code; divide by channels to get the number of lights
   int lights_in_packet = (packet.count > 0) ? (packet.count - 1) / channels_ : 0;
   int output_end =
-      std::min({buffer.size(), output_offset + get_lights_per_universe(), output_offset + lights_in_packet});
+      std::min({int32_t(buffer.size()), output_offset + get_lights_per_universe(), output_offset + lights_in_packet});
   auto *input_data = packet.values + 1;
 
   auto effect_name = get_name();

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -63,32 +63,21 @@ static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size
 #endif
 
 void ESP32RMTLEDStripLightOutput::setup() {
-  size_t buffer_size = this->get_buffer_size_();
-
   RAMAllocator<uint8_t> allocator(this->use_psram_ ? 0 : RAMAllocator<uint8_t>::ALLOC_INTERNAL);
-  this->buf_ = allocator.allocate(buffer_size);
-  if (this->buf_ == nullptr) {
-    ESP_LOGE(TAG, "Cannot allocate LED buffer!");
-    this->mark_failed();
-    return;
-  }
-  memset(this->buf_, 0, buffer_size);
-
-  this->effect_data_ = allocator.allocate(this->num_leds_);
-  if (this->effect_data_ == nullptr) {
-    ESP_LOGE(TAG, "Cannot allocate effect data!");
+  if (!this->buffer_.allocate_and_setup(&allocator)) {
+    ESP_LOGE(TAG, "Cannot allocate color buffer");
     this->mark_failed();
     return;
   }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
   // copy of the led buffer
-  this->rmt_buf_ = allocator.allocate(buffer_size);
+  this->rmt_buf_ = allocator.allocate(this->buffer_.get_led_data_bytes());
 #else
   RAMAllocator<rmt_symbol_word_t> rmt_allocator(this->use_psram_ ? 0 : RAMAllocator<rmt_symbol_word_t>::ALLOC_INTERNAL);
 
   // 8 bits per byte, 1 rmt_symbol_word_t per bit + 1 rmt_symbol_word_t for reset
-  this->rmt_buf_ = rmt_allocator.allocate(buffer_size * 8 + 1);
+  this->rmt_buf_ = rmt_allocator.allocate(this->buffer_.get_led_data_bytes() * 8 + 1);
 #endif
 
   rmt_tx_channel_config_t channel;
@@ -157,6 +146,9 @@ void ESP32RMTLEDStripLightOutput::set_led_params(uint32_t bit0_high, uint32_t bi
 }
 
 void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   // protect from refreshing too often
   uint32_t now = micros();
   auto rate = this->max_refresh_rate_.value_or(0);
@@ -178,16 +170,15 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
   }
   delayMicroseconds(50);
 
+  const size_t led_data_bytes = this->buffer_.get_led_data_bytes();
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
-  memcpy(this->rmt_buf_, this->buf_, this->get_buffer_size_());
+  memcpy(this->rmt_buf_, this->buffer_.get_led_data(), led_data_bytes);
 #else
-  size_t buffer_size = this->get_buffer_size_();
-
   size_t size = 0;
   size_t len = 0;
-  uint8_t *psrc = this->buf_;
+  uint8_t *psrc = this->buffer_.get_led_data();
   rmt_symbol_word_t *pdest = this->rmt_buf_;
-  while (size < buffer_size) {
+  while (size < pixel_data_size) {
     uint8_t b = *psrc;
     for (int i = 0; i < 8; i++) {
       pdest->val = b & (1 << (7 - i)) ? this->params_.bit1.val : this->params_.bit0.val;
@@ -208,7 +199,7 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
   rmt_transmit_config_t config;
   memset(&config, 0, sizeof(config));
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
-  error = rmt_transmit(this->channel_, this->encoder_, this->rmt_buf_, this->get_buffer_size_(), &config);
+  error = rmt_transmit(this->channel_, this->encoder_, this->rmt_buf_, led_data_bytes, &config);
 #else
   error = rmt_transmit(this->channel_, this->encoder_, this->rmt_buf_, len * sizeof(rmt_symbol_word_t), &config);
 #endif
@@ -218,17 +209,6 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
     return;
   }
   this->status_clear_warning();
-}
-
-light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index) const {
-  const light::ChannelColors &colors = this->channel_colors_;
-  uint8_t *led = this->buf_ + (index * colors.bytes_per_led());
-  return {led + colors.r,
-          led + colors.g,
-          led + colors.b,
-          colors.has_white() ? led + colors.w : nullptr,
-          &this->effect_data_[index],
-          &this->correction_};
 }
 
 void ESP32RMTLEDStripLightOutput::dump_config() {
@@ -242,7 +222,8 @@ void ESP32RMTLEDStripLightOutput::dump_config() {
                 "  Channel colors: %s\n"
                 "  Max refresh rate: %" PRIu32 "\n"
                 "  Number of LEDs: %u",
-                this->channel_colors_.to_string(channel_colors), this->max_refresh_rate_.value_or(0), this->num_leds_);
+                this->buffer_.layout().channel_colors.to_string(channel_colors), this->max_refresh_rate_.value_or(0),
+                this->buffer_.size());
 }
 
 float ESP32RMTLEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -24,14 +24,18 @@ struct LedParams {
 
 class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
  public:
+  ESP32RMTLEDStripLightOutput(size_t num_leds, light::ChannelColors channel_colors)
+      : buffer_(num_leds, {.channel_colors = channel_colors}, &this->correction_) {}
+
+  light::ESPColorBuffer &buffer() override { return this->buffer_; }
+
   void setup() override;
   void write_state(light::LightState *state) override;
   float get_setup_priority() const override;
 
-  int32_t size() const override { return this->num_leds_; }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
-    if (this->channel_colors_.has_white()) {
+    if (this->buffer_.layout().channel_colors.has_white()) {
       traits.set_supported_color_modes({light::ColorMode::RGB_WHITE, light::ColorMode::WHITE});
     } else {
       traits.set_supported_color_modes({light::ColorMode::RGB});
@@ -41,8 +45,6 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
 
   void set_pin(uint8_t pin) { this->pin_ = pin; }
   void set_inverted(bool inverted) { this->invert_out_ = inverted; }
-  void set_num_leds(uint16_t num_leds) { this->num_leds_ = num_leds; }
-  void set_channel_colors(light::ChannelColors channel_colors) { this->channel_colors_ = channel_colors; }
   void set_use_dma(bool use_dma) { this->use_dma_ = use_dma; }
   void set_use_psram(bool use_psram) { this->use_psram_ = use_psram; }
 
@@ -54,20 +56,11 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
 
   void set_rmt_symbols(uint32_t rmt_symbols) { this->rmt_symbols_ = rmt_symbols; }
 
-  void clear_effect_data() override {
-    for (int i = 0; i < this->size(); i++)
-      this->effect_data_[i] = 0;
-  }
-
   void dump_config() override;
 
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override;
+  light::InterleavedColorBuffer buffer_;
 
-  size_t get_buffer_size_() const { return this->num_leds_ * this->channel_colors_.bytes_per_led(); }
-
-  uint8_t *buf_{nullptr};
-  uint8_t *effect_data_{nullptr};
   LedParams params_;
   rmt_channel_handle_t channel_{nullptr};
   rmt_encoder_handle_t encoder_{nullptr};
@@ -78,12 +71,9 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
 #endif
   uint32_t rmt_symbols_{48};
   uint8_t pin_;
-  uint16_t num_leds_;
   bool use_dma_{false};
   bool use_psram_{false};
   bool invert_out_{false};
-
-  light::ChannelColors channel_colors_{0, 1, 2, light::ChannelColors::NO_WHITE};
 
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -59,7 +59,7 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
   void dump_config() override;
 
  protected:
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
 
   LedParams params_;
   rmt_channel_handle_t channel_{nullptr};

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -128,11 +128,14 @@ async def to_code(config: ConfigType) -> None:
     # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
     include_builtin_idf_component("esp_driver_rmt")
 
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    var = cg.new_Pvariable(
+        config[CONF_OUTPUT_ID],
+        config[CONF_NUM_LEDS],
+        light.channel_colors_struct(config[CONF_CHANNEL_COLORS]),
+    )
     await light.register_light(var, config)
     await cg.register_component(var, config)
 
-    cg.add(var.set_num_leds(config[CONF_NUM_LEDS]))
     cg.add(var.set_pin(config[CONF_PIN][CONF_NUMBER]))
     if config[CONF_PIN][CONF_INVERTED]:
         cg.add(var.set_inverted(True))
@@ -164,9 +167,6 @@ async def to_code(config: ConfigType) -> None:
             )
         )
 
-    cg.add(
-        var.set_channel_colors(light.channel_colors_struct(config[CONF_CHANNEL_COLORS]))
-    )
     cg.add(var.set_use_psram(config[CONF_USE_PSRAM]))
     cg.add(var.set_rmt_symbols(config[CONF_RMT_SYMBOLS]))
     if CONF_USE_DMA in config:

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -39,12 +39,10 @@ BASE_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
 async def new_fastled_light(
     config: ConfigType, controller_template_args: cg.TemplateArguments
 ) -> MockObj:
-    var = cg.new_Pvariable(
-        config[CONF_OUTPUT_ID],
-        config[CONF_NUM_LEDS],
-        FastLEDLightOutput.make_controller(controller_template_args),
-    )
+    var = cg.new_Pvariable(config[CONF_OUTPUT_ID], config[CONF_NUM_LEDS])
     await cg.register_component(var, config)
+
+    cg.add(var.set_controller(controller_template_args))
 
     if CONF_MAX_REFRESH_RATE in config:
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -36,8 +36,14 @@ BASE_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def new_fastled_light(config: ConfigType) -> MockObj:
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+async def new_fastled_light(
+    config: ConfigType, controller_template_args: cg.TemplateArguments
+) -> MockObj:
+    var = cg.new_Pvariable(
+        config[CONF_OUTPUT_ID],
+        config[CONF_NUM_LEDS],
+        FastLEDLightOutput.make_controller(controller_template_args),
+    )
     await cg.register_component(var, config)
 
     if CONF_MAX_REFRESH_RATE in config:

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -17,7 +17,7 @@ void FastLEDLightOutput::setup() {
 void FastLEDLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "FastLED light:\n"
-                "  Num LEDs: %u\n"
+                "  Number of LEDs: %u\n"
                 "  Max refresh rate: %" PRIu32,
                 this->num_leds_, this->max_refresh_rate_.value_or(0));
 }

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -9,8 +9,7 @@ static const char *const TAG = "fastled";
 
 void FastLEDLightOutput::setup() {
   this->controller_->init();
-  this->controller_->setLeds(this->leds_, this->num_leds_);
-  this->effect_data_ = new uint8_t[this->num_leds_];  // NOLINT
+  this->controller_->setLeds(this->led_data_, this->num_leds_);
   if (!this->max_refresh_rate_.has_value()) {
     this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
   }
@@ -23,6 +22,9 @@ void FastLEDLightOutput::dump_config() {
                 this->num_leds_, this->max_refresh_rate_.value_or(0));
 }
 void FastLEDLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   // protect from refreshing too often
   uint32_t now = micros();
   uint32_t max_rate = this->max_refresh_rate_.value_or(0);

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -210,9 +210,9 @@ class FastLEDLightOutput final : public light::AddressableLight, protected light
     return true;
   }
 
-  void clear_effect_data() override { clear_effect_data_internal_(this->effect_data_, this->num_leds_); }
+  void clear_effect_data() override { clear_effect_data_internal(this->effect_data_, this->num_leds_); }
 
-  light::ESPColorView get_color_view_(size_t index) override {
+  light::ESPColorView get_color_view(size_t index) override {
     return light::ESPColorView{&this->led_data_[index].r,  &this->led_data_[index].g,
                                &this->led_data_[index].b,  nullptr,
                                &this->effect_data_[index], &this->correction_};

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -17,189 +17,174 @@
 
 namespace esphome::fastled_base {
 
-class FastLEDLightOutput final : public light::AddressableLight {
+class FastLEDLightOutput final : public light::AddressableLight, protected light::ESPColorBuffer {
  public:
+  FastLEDLightOutput(size_t num_leds, CLEDController *controller)
+      : ESPColorBuffer(num_leds),
+        controller_(controller),
+        led_data_(new CRGB[num_leds]{CRGB::Black}),
+        effect_data_(new uint8_t[num_leds]{0}) {}
+
+  light::ESPColorBuffer &buffer() override { return *this; }
+
   /// Only for custom effects: Get the internal controller.
   CLEDController *get_controller() const { return this->controller_; }
-
-  inline int32_t size() const override { return this->num_leds_; }
 
   /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
   void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
 
-  /// Add some LEDS, can only be called once.
-  CLEDController &add_leds(CLEDController *controller, int num_leds) {
-    this->controller_ = controller;
-    this->num_leds_ = num_leds;
-    this->leds_ = new CRGB[num_leds];  // NOLINT
-
-    for (int i = 0; i < this->num_leds_; i++)
-      this->leds_[i] = CRGB::Black;
-
-    return *this->controller_;
-  }
-
   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER, uint32_t SPI_DATA_RATE>
-  CLEDController &add_leds(int num_leds) {
+  static CLEDController *make_controller() {
     switch (CHIPSET) {
       case LPD8806: {
         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case WS2801: {
         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case WS2803: {
         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case SM16716: {
         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case P9813: {
         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case DOTSTAR:
       case APA102: {
         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case SK9822: {
         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
     }
   }
 
-  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> CLEDController &add_leds(int num_leds) {
+  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *make_controller() {
     switch (CHIPSET) {
       case LPD8806: {
         static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case WS2801: {
         static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case WS2803: {
         static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case SM16716: {
         static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case P9813: {
         static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case DOTSTAR:
       case APA102: {
         static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case SK9822: {
         static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
     }
   }
 
   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER>
-  CLEDController &add_leds(int num_leds) {
+  static CLEDController *make_controller() {
     switch (CHIPSET) {
       case LPD8806: {
         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case WS2801: {
         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case WS2803: {
         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case SM16716: {
         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case P9813: {
         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case DOTSTAR:
       case APA102: {
         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
       case SK9822: {
         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return add_leds(&controller, num_leds);
+        return &controller;
       }
     }
   }
 
   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
-  CLEDController &add_leds(int num_leds) {
+  static CLEDController *make_controller() {
     static CHIPSET<DATA_PIN, RGB_ORDER> controller;
-    return add_leds(&controller, num_leds);
+    return &controller;
   }
 
   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
-  CLEDController &add_leds(int num_leds) {
+  static CLEDController *make_controller() {
     static CHIPSET<DATA_PIN, RGB> controller;
-    return add_leds(&controller, num_leds);
+    return &controller;
   }
 
-  template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> CLEDController &add_leds(int num_leds) {
+  template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> static CLEDController *make_controller() {
     static CHIPSET<DATA_PIN> controller;
-    return add_leds(&controller, num_leds);
+    return &controller;
   }
 
-  template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
+  template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> static CLEDController *make_controller() {
     static CHIPSET<RGB_ORDER> controller;
-    return add_leds(&controller, num_leds);
+    return &controller;
   }
 
-  template<template<EOrder RGB_ORDER> class CHIPSET> CLEDController &add_leds(int num_leds) {
+  template<template<EOrder RGB_ORDER> class CHIPSET> static CLEDController *make_controller() {
     static CHIPSET<RGB> controller;
-    return add_leds(&controller, num_leds);
+    return &controller;
   }
 
 #ifdef FASTLED_HAS_BLOCKLESS
-  template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> CLEDController &add_leds(int num_leds) {
+  template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> static CLEDController *make_controller() {
     switch (CHIPSET) {
 #ifdef PORTA_FIRST_PIN
       case WS2811_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>(),
-            num_leds);
+        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>();
       case WS2811_400_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>(),
-            num_leds);
+        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>();
       case WS2813_PORTA:
-        return add_leds(new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640),
-                                                           RGB_ORDER, 0, false, 300>(),
-                        num_leds);
+        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER, 0,
+                                                  false, 300>();
       case TM1803_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>(),
-            num_leds);
+        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>();
       case UCS1903_PORTA:
-        return add_leds(
-            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>(),
-            num_leds);
+        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>();
 #endif
     }
   }
 
-  template<EBlockChipsets CHIPSET, int NUM_LANES> CLEDController &add_leds(int num_leds) {
-    return add_leds<CHIPSET, NUM_LANES, GRB>(num_leds);
+  template<EBlockChipsets CHIPSET, int NUM_LANES> static CLEDController *make_controller() {
+    return make_controller<CHIPSET, NUM_LANES, GRB>();
   }
 #endif
 
@@ -215,21 +200,28 @@ class FastLEDLightOutput final : public light::AddressableLight {
   void write_state(light::LightState *state) override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  void clear_effect_data() override {
-    for (int i = 0; i < this->size(); i++)
-      this->effect_data_[i] = 0;
-  }
-
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override {
-    return {&this->leds_[index].r,      &this->leds_[index].g, &this->leds_[index].b, nullptr,
-            &this->effect_data_[index], &this->correction_};
+  bool is_all_black() const override {
+    for (size_t i = 0; i < this->num_leds_; i++) {
+      if (this->led_data_[i].r != 0 || this->led_data_[i].g != 0 || this->led_data_[i].b != 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
-  CLEDController *controller_{nullptr};
-  CRGB *leds_{nullptr};
-  uint8_t *effect_data_{nullptr};
-  int num_leds_{0};
+  void clear_effect_data() override { clear_effect_data_internal_(this->effect_data_, this->num_leds_); }
+
+  light::ESPColorView get_color_view_(size_t index) override {
+    return light::ESPColorView{&this->led_data_[index].r,  &this->led_data_[index].g,
+                               &this->led_data_[index].b,  nullptr,
+                               &this->effect_data_[index], &this->correction_};
+  }
+
+  CLEDController *const controller_;
+  CRGB *const led_data_;
+  uint8_t *const effect_data_;
+
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};
 };

--- a/esphome/components/fastled_base/fastled_light.h
+++ b/esphome/components/fastled_base/fastled_light.h
@@ -19,11 +19,8 @@ namespace esphome::fastled_base {
 
 class FastLEDLightOutput final : public light::AddressableLight, protected light::ESPColorBuffer {
  public:
-  FastLEDLightOutput(size_t num_leds, CLEDController *controller)
-      : ESPColorBuffer(num_leds),
-        controller_(controller),
-        led_data_(new CRGB[num_leds]{CRGB::Black}),
-        effect_data_(new uint8_t[num_leds]{0}) {}
+  FastLEDLightOutput(size_t num_leds)
+      : ESPColorBuffer(num_leds), led_data_(new CRGB[num_leds]{CRGB::Black}), effect_data_(new uint8_t[num_leds]{0}) {}
 
   light::ESPColorBuffer &buffer() override { return *this; }
 
@@ -34,157 +31,185 @@ class FastLEDLightOutput final : public light::AddressableLight, protected light
   void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
 
   template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER, uint32_t SPI_DATA_RATE>
-  static CLEDController *make_controller() {
+  void set_controller() {
     switch (CHIPSET) {
       case LPD8806: {
         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case WS2801: {
         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case WS2803: {
         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case SM16716: {
         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case P9813: {
         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case DOTSTAR:
       case APA102: {
         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case SK9822: {
         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER, SPI_DATA_RATE> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
     }
   }
 
-  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> static CLEDController *make_controller() {
+  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN> void set_controller() {
     switch (CHIPSET) {
       case LPD8806: {
         static LPD8806Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case WS2801: {
         static WS2801Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case WS2803: {
         static WS2803Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case SM16716: {
         static SM16716Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case P9813: {
         static P9813Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case DOTSTAR:
       case APA102: {
         static APA102Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case SK9822: {
         static SK9822Controller<DATA_PIN, CLOCK_PIN> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
     }
   }
 
-  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER>
-  static CLEDController *make_controller() {
+  template<ESPIChipsets CHIPSET, uint8_t DATA_PIN, uint8_t CLOCK_PIN, EOrder RGB_ORDER> void set_controller() {
     switch (CHIPSET) {
       case LPD8806: {
         static LPD8806Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case WS2801: {
         static WS2801Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case WS2803: {
         static WS2803Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case SM16716: {
         static SM16716Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case P9813: {
         static P9813Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case DOTSTAR:
       case APA102: {
         static APA102Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
       case SK9822: {
         static SK9822Controller<DATA_PIN, CLOCK_PIN, RGB_ORDER> controller;
-        return &controller;
+        this->controller_ = &controller;
+        return;
       }
     }
   }
 
   template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN, EOrder RGB_ORDER>
-  static CLEDController *make_controller() {
+  void set_controller() {
     static CHIPSET<DATA_PIN, RGB_ORDER> controller;
-    return &controller;
+    this->controller_ = &controller;
   }
 
-  template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN>
-  static CLEDController *make_controller() {
+  template<template<uint8_t DATA_PIN, EOrder RGB_ORDER> class CHIPSET, uint8_t DATA_PIN> void set_controller() {
     static CHIPSET<DATA_PIN, RGB> controller;
-    return &controller;
+    this->controller_ = &controller;
   }
 
-  template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> static CLEDController *make_controller() {
+  template<template<uint8_t DATA_PIN> class CHIPSET, uint8_t DATA_PIN> void set_controller() {
     static CHIPSET<DATA_PIN> controller;
-    return &controller;
+    this->controller_ = &controller;
   }
 
-  template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> static CLEDController *make_controller() {
+  template<template<EOrder RGB_ORDER> class CHIPSET, EOrder RGB_ORDER> void set_controller() {
     static CHIPSET<RGB_ORDER> controller;
-    return &controller;
+    this->controller_ = &controller;
   }
 
-  template<template<EOrder RGB_ORDER> class CHIPSET> static CLEDController *make_controller() {
+  template<template<EOrder RGB_ORDER> class CHIPSET> void set_controller() {
     static CHIPSET<RGB> controller;
-    return &controller;
+    this->controller_ = &controller;
   }
 
 #ifdef FASTLED_HAS_BLOCKLESS
-  template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> static CLEDController *make_controller() {
+  template<EBlockChipsets CHIPSET, int NUM_LANES, EOrder RGB_ORDER> void set_controller() {
     switch (CHIPSET) {
 #ifdef PORTA_FIRST_PIN
       case WS2811_PORTA:
-        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>();
+        this->controller_ =
+            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER>();
+        return;
       case WS2811_400_PORTA:
-        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>();
+        this->controller_ =
+            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(800), NS(800), NS(900), RGB_ORDER>();
+        return;
       case WS2813_PORTA:
-        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640), RGB_ORDER, 0,
-                                                  false, 300>();
+        this->controller_ = new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(320), NS(320), NS(640),
+                                                               RGB_ORDER, 0, false, 300>();
+        return;
       case TM1803_PORTA:
-        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>();
+        this->controller_ =
+            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(700), NS(1100), NS(700), RGB_ORDER>();
+        return;
       case UCS1903_PORTA:
-        return new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>();
+        this->controller_ =
+            new InlineBlockClocklessController<NUM_LANES, PORTA_FIRST_PIN, NS(500), NS(1500), NS(500), RGB_ORDER>();
+        return;
 #endif
     }
   }
 
-  template<EBlockChipsets CHIPSET, int NUM_LANES> static CLEDController *make_controller() {
-    return make_controller<CHIPSET, NUM_LANES, GRB>();
+  template<EBlockChipsets CHIPSET, int NUM_LANES> void set_controller() {
+    this->set_controller<CHIPSET, NUM_LANES, GRB>();
   }
 #endif
 
@@ -218,9 +243,10 @@ class FastLEDLightOutput final : public light::AddressableLight, protected light
                                &this->effect_data_[index], &this->correction_};
   }
 
-  CLEDController *const controller_;
   CRGB *const led_data_;
   uint8_t *const effect_data_;
+
+  CLEDController *controller_{nullptr};
 
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -2,13 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import fastled_base
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_CHIPSET,
-    CONF_NUM_LEDS,
-    CONF_PIN,
-    CONF_RGB_ORDER,
-    Framework,
-)
+from esphome.const import CONF_CHIPSET, CONF_PIN, CONF_RGB_ORDER, Framework
 from esphome.types import ConfigType
 
 AUTO_LOAD = ["fastled_base"]
@@ -75,12 +69,10 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config: ConfigType) -> None:
-    var = await fastled_base.new_fastled_light(config)
-
     rgb_order = None
     if CONF_RGB_ORDER in config:
         rgb_order = cg.RawExpression(config[CONF_RGB_ORDER])
-    template_args = cg.TemplateArguments(
+    controller_template_args = cg.TemplateArguments(
         cg.RawExpression(config[CONF_CHIPSET]), config[CONF_PIN], rgb_order
     )
-    cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))
+    await fastled_base.new_fastled_light(config, controller_template_args)

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -7,7 +7,6 @@ from esphome.const import (
     CONF_CLOCK_PIN,
     CONF_DATA_PIN,
     CONF_DATA_RATE,
-    CONF_NUM_LEDS,
     CONF_RGB_ORDER,
     Framework,
 )
@@ -54,8 +53,6 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config: ConfigType) -> None:
-    var = await fastled_base.new_fastled_light(config)
-
     rgb_order = cg.RawExpression(config.get(CONF_RGB_ORDER, "RGB"))
     data_rate = None
 
@@ -66,11 +63,11 @@ async def to_code(config: ConfigType) -> None:
         else:
             data_rate_mhz = int(data_rate_khz / 1000)
             data_rate = cg.RawExpression(f"DATA_RATE_MHZ({data_rate_mhz})")
-    template_args = cg.TemplateArguments(
+    controller_template_args = cg.TemplateArguments(
         cg.RawExpression(config[CONF_CHIPSET]),
         config[CONF_DATA_PIN],
         config[CONF_CLOCK_PIN],
         rgb_order,
         data_rate,
     )
-    cg.add(var.add_leds(template_args, config[CONF_NUM_LEDS]))
+    await fastled_base.new_fastled_light(config, controller_template_args)

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -12,8 +12,9 @@ void AddressableLight::call_setup() {
   this->set_interval(5000, [this]() {
     const char *name = this->state_parent_ == nullptr ? "" : this->state_parent_->get_name().c_str();
     ESP_LOGVV(TAG, "Addressable Light '%s' (effect_active=%s)", name, YESNO(this->effect_active_));
-    for (int i = 0; i < this->size(); i++) {
-      auto color = this->get(i);
+    ESPColorBuffer &buffer = this->buffer();
+    for (int i = 0; i < buffer.size(); i++) {
+      auto color = buffer[i];
       ESP_LOGVV(TAG, "  [%2d] Color: R=%3u G=%3u B=%3u W=%3u", i, color.get_red_raw(), color.get_green_raw(),
                 color.get_blue_raw(), color.get_white_raw());
     }
@@ -43,7 +44,7 @@ void AddressableLight::update_state(LightState *state) {
     return;
 
   // don't use LightState helper, gamma correction+brightness is handled by ESPColorView
-  this->all() = color_from_light_color_values(val);
+  this->buffer().all() = color_from_light_color_values(val);
   this->schedule_show();
 }
 
@@ -111,11 +112,12 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
     // round to stored 0, freezing progress).
     if (!this->uniform_start_scanned_) {
       this->uniform_start_scanned_ = true;
-      if (this->light_.size() > 0) {
-        Color first = this->light_[0].get();
+      ESPColorBuffer &buffer = this->light_.buffer();
+      if (buffer.size() > 0) {
+        Color first = buffer[0].get();
         bool uniform = true;
-        for (int32_t i = 1; i < this->light_.size(); i++) {
-          if (this->light_[i].get() != first) {
+        for (int32_t i = 1; i < buffer.size(); i++) {
+          if (buffer[i].get() != first) {
             uniform = false;
             break;
           }
@@ -142,13 +144,13 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
       uint8_t g = subtract_scaled_difference(this->target_color_.green, start.green, remaining);
       uint8_t b = subtract_scaled_difference(this->target_color_.blue, start.blue, remaining);
       uint8_t w = subtract_scaled_difference(this->target_color_.white, start.white, remaining);
-      for (auto led : this->light_) {
+      for (auto led : this->light_.buffer()) {
         led.set_rgbw(r, g, b, w);
       }
     } else {
       int32_t scale =
           int32_t(256.f * std::max((1.f - smoothed_progress) / (1.f - this->last_transition_progress_), 0.f));
-      for (auto led : this->light_) {
+      for (auto led : this->light_.buffer()) {
         led.set_rgbw(subtract_scaled_difference(this->target_color_.red, led.get_red(), scale),
                      subtract_scaled_difference(this->target_color_.green, led.get_green(), scale),
                      subtract_scaled_difference(this->target_color_.blue, led.get_blue(), scale),

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esp_color_buffer.h"
 #include "esp_color_correction.h"
 #include "esp_color_view.h"
 #include "esp_range_view.h"
@@ -27,36 +28,39 @@ class AddressableLightState final : public LightState {
 
 class AddressableLight : public LightOutput, public Component {
  public:
-  virtual int32_t size() const = 0;
-  ESPColorView operator[](int32_t index) const { return this->get_view_internal(interpret_index(index, this->size())); }
-  ESPColorView get(int32_t index) { return this->get_view_internal(interpret_index(index, this->size())); }
-  virtual void clear_effect_data() = 0;
-  ESPRangeView range(int32_t from, int32_t to) {
-    from = interpret_index(from, this->size());
-    to = interpret_index(to, this->size());
-    return ESPRangeView(this, from, to);
-  }
-  ESPRangeView all() { return ESPRangeView(this, 0, this->size()); }
-  ESPRangeIterator begin() { return this->all().begin(); }
-  ESPRangeIterator end() { return this->all().end(); }
-  void shift_left(int32_t amnt) {
-    if (amnt < 0) {
-      this->shift_right(-amnt);
-      return;
-    }
-    if (amnt > this->size())
-      amnt = this->size();
-    this->range(0, -amnt) = this->range(amnt, this->size());
-  }
-  void shift_right(int32_t amnt) {
-    if (amnt < 0) {
-      this->shift_left(-amnt);
-      return;
-    }
-    if (amnt > this->size())
-      amnt = this->size();
-    this->range(amnt, this->size()) = this->range(0, -amnt);
-  }
+  /// Get the pixel data and effect data for this addressable light.
+  virtual ESPColorBuffer &buffer();
+
+  ESPDEPRECATED("Use buffer().size() instead. Will be removed in 2027.4.0.", "2026.10.0")
+  int32_t size() { return this->buffer().size(); }
+
+  ESPDEPRECATED("Use buffer()[index] instead. Will be removed in 2027.4.0.", "2026.10.0")
+  ESPColorView operator[](int32_t index) { return this->buffer()[index]; }
+
+  ESPDEPRECATED("Use buffer().get(index) instead. Will be removed in 2027.4.0.", "2026.10.0")
+  ESPColorView get(int32_t index) { return this->buffer().get(index); }
+
+  ESPDEPRECATED("Use buffer().clear_effect_data() instead. Will be removed in 2027.4.0.", "2026.10.0")
+  void clear_effect_data() { this->buffer().clear_effect_data(); }
+
+  ESPDEPRECATED("Use buffer().range(from, to) instead. Will be removed in 2027.4.0.", "2026.10.0")
+  ESPRangeView range(int32_t from, int32_t to) { return this->buffer().range(from, to); }
+
+  ESPDEPRECATED("Use buffer().all() instead. Will be removed in 2027.4.0.", "2026.10.0")
+  ESPRangeView all() { return this->buffer().all(); }
+
+  ESPDEPRECATED("Use buffer().begin() instead. Will be removed in 2027.4.0.", "2026.10.0")
+  ESPRangeIterator begin() { return this->buffer().begin(); }
+
+  ESPDEPRECATED("Use buffer().end() instead. Will be removed in 2027.4.0.", "2026.10.0")
+  ESPRangeIterator end() { return this->buffer().end(); }
+
+  ESPDEPRECATED("Use buffer().shift_left(amount) instead. Will be removed in 2027.4.0.", "2026.10.0")
+  void shift_left(int32_t amount) { this->buffer().shift_left(amount); }
+
+  ESPDEPRECATED("Use buffer().shift_right(amount) instead. Will be removed in 2027.4.0.", "2026.10.0")
+  void shift_right(int32_t amount) { this->buffer().shift_right(amount); }
+
   // Indicates whether an effect that directly updates the output buffer is active to prevent overwriting
   bool is_effect_active() const { return this->effect_active_; }
   void set_effect_active(bool effect_active) { this->effect_active_ = effect_active; }
@@ -72,7 +76,11 @@ class AddressableLight : public LightOutput, public Component {
     this->state_parent_ = state;
   }
   void update_state(LightState *state) override;
-  void schedule_show() { this->state_parent_->schedule_write_(); }
+  void schedule_show() {
+    if (this->state_parent_ != nullptr) {
+      this->state_parent_->schedule_write_();
+    }
+  }
 
 #ifdef USE_POWER_SUPPLY
   void set_power_supply(power_supply::PowerSupply *power_supply) { this->power_.set_parent(power_supply); }
@@ -85,16 +93,13 @@ class AddressableLight : public LightOutput, public Component {
 
   void mark_shown_() {
 #ifdef USE_POWER_SUPPLY
-    for (const auto &c : *this) {
-      if (c.get_red_raw() > 0 || c.get_green_raw() > 0 || c.get_blue_raw() > 0 || c.get_white_raw() > 0) {
-        this->power_.request();
-        return;
-      }
+    if (!this->buffer().is_all_black()) {
+      this->power_.request();
+    } else {
+      this->power_.unrequest();
     }
-    this->power_.unrequest();
 #endif
   }
-  virtual ESPColorView get_view_internal(int32_t index) const = 0;
 
   ESPColorCorrection correction_{};
   LightState *state_parent_{nullptr};

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -29,7 +29,7 @@ class AddressableLightState final : public LightState {
 class AddressableLight : public LightOutput, public Component {
  public:
   /// Get the pixel data and effect data for this addressable light.
-  virtual ESPColorBuffer &buffer();
+  virtual ESPColorBuffer &buffer() = 0;
 
   ESPDEPRECATED("Use buffer().size() instead. Will be removed in 2027.4.0.", "2026.10.0")
   int32_t size() { return this->buffer().size(); }

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -31,8 +31,9 @@ class AddressableLightEffect : public LightEffect {
  public:
   explicit AddressableLightEffect(const char *name) : LightEffect(name) {}
   void start_internal() override {
-    this->get_addressable_()->set_effect_active(true);
-    this->get_addressable_()->clear_effect_data();
+    auto addressable = this->get_addressable_();
+    addressable->set_effect_active(true);
+    addressable->buffer().clear_effect_data();
     this->start();
   }
   void stop() override { this->get_addressable_()->set_effect_active(false); }
@@ -86,7 +87,7 @@ class AddressableRainbowLightEffect : public AddressableLightEffect {
     hsv.saturation = 240;
     uint16_t hue = (millis() * this->speed_) % 0xFFFF;
     const uint16_t add = 0xFFFF / this->width_;
-    for (auto var : it) {
+    for (auto var : it.buffer()) {
       hsv.hue = hue >> 8;
       var = hsv;
       hue += add;
@@ -119,10 +120,11 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
     if (now - this->last_add_ < this->add_led_interval_)
       return;
     this->last_add_ = now;
+    ESPColorBuffer &buffer = it.buffer();
     if (this->reverse_) {
-      it.shift_left(1);
+      buffer.shift_left(1);
     } else {
-      it.shift_right(1);
+      buffer.shift_right(1);
     }
     const AddressableColorWipeEffectColor &color = this->colors_[this->at_color_];
     Color esp_color = Color(color.r, color.g, color.b, color.w);
@@ -134,9 +136,9 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
       esp_color = esp_color.gradient(next_esp_color, gradient);
     }
     if (this->reverse_) {
-      it[-1] = esp_color;
+      buffer[-1] = esp_color;
     } else {
-      it[0] = esp_color;
+      buffer[0] = esp_color;
     }
     if (++this->leds_added_ >= color.num_leds) {
       this->leds_added_ = 0;
@@ -171,9 +173,10 @@ class AddressableScanEffect : public AddressableLightEffect {
     if (now - this->last_move_ < this->move_interval_)
       return;
 
-    const auto num_leds = static_cast<uint32_t>(it.size());
+    ESPColorBuffer &buffer = it.buffer();
+    const uint32_t num_leds = buffer.size();
     if (this->scan_width_ >= num_leds) {
-      it.all() = current_color;
+      buffer.all() = current_color;
       it.schedule_show();
       this->last_move_ = now;
       return;
@@ -197,9 +200,9 @@ class AddressableScanEffect : public AddressableLightEffect {
     }
     this->last_move_ = now;
 
-    it.all() = Color::BLACK;
+    buffer.all() = Color::BLACK;
     for (uint32_t i = 0; i < this->scan_width_; i++) {
-      it[this->at_led_ + i] = current_color;
+      buffer[this->at_led_ + i] = current_color;
     }
 
     it.schedule_show();
@@ -224,7 +227,8 @@ class AddressableTwinkleEffect : public AddressableLightEffect {
       pos_add = pos_add32;
       this->last_progress_ += pos_add32 * this->progress_interval_;
     }
-    for (auto view : addressable) {
+    ESPColorBuffer &buffer = addressable.buffer();
+    for (auto view : buffer) {
       if (view.get_effect_data() != 0) {
         const uint8_t sine = half_sin8(view.get_effect_data());
         view = current_color * sine;
@@ -239,10 +243,10 @@ class AddressableTwinkleEffect : public AddressableLightEffect {
       }
     }
     while (random_float() < this->twinkle_probability_) {
-      const size_t pos = random_uint32() % addressable.size();
-      if (addressable[pos].get_effect_data() != 0)
+      auto view = buffer[random_uint32() % buffer.size()];
+      if (view.get_effect_data() != 0)
         continue;
-      addressable[pos].set_effect_data(1);
+      view.set_effect_data(1);
     }
     addressable.schedule_show();
   }
@@ -266,7 +270,8 @@ class AddressableRandomTwinkleEffect : public AddressableLightEffect {
       this->last_progress_ = now;
     }
     uint8_t subsine = ((8 * (now - this->last_progress_)) / this->progress_interval_) & 0b111;
-    for (auto view : it) {
+    ESPColorBuffer &buffer = it.buffer();
+    for (auto view : buffer) {
       if (view.get_effect_data() != 0) {
         const uint8_t x = (view.get_effect_data() >> 3) & 0b11111;
         const uint8_t color = view.get_effect_data() & 0b111;
@@ -287,11 +292,11 @@ class AddressableRandomTwinkleEffect : public AddressableLightEffect {
       }
     }
     while (random_float() < this->twinkle_probability_) {
-      const size_t pos = random_uint32() % it.size();
-      if (it[pos].get_effect_data() != 0)
+      auto view = buffer[random_uint32() % buffer.size()];
+      if (view.get_effect_data() != 0)
         continue;
       const uint8_t color = random_uint32() & 0b111;
-      it[pos].set_effect_data(0b1000 | color);
+      view.set_effect_data(0b1000 | color);
     }
     it.schedule_show();
   }
@@ -309,7 +314,7 @@ class AddressableFireworksEffect : public AddressableLightEffect {
   explicit AddressableFireworksEffect(const char *name) : AddressableLightEffect(name) {}
   void start() override {
     auto &it = *this->get_addressable_();
-    it.all() = Color::BLACK;
+    it.buffer().all() = Color::BLACK;
   }
   void apply(AddressableLight &it, const Color &current_color) override {
     const uint32_t now = millis();
@@ -318,26 +323,27 @@ class AddressableFireworksEffect : public AddressableLightEffect {
     this->last_update_ = now;
     // "invert" the fade out parameter so that higher values make fade out faster
     const uint8_t fade_out_mult = 255u - this->fade_out_rate_;
-    for (auto view : it) {
+    ESPColorBuffer &buffer = it.buffer();
+    for (auto view : buffer) {
       Color target = view.get() * fade_out_mult;
       if (target.r < 64)
         target *= 170;
       view = target;
     }
-    if (it.size() < 2)
+    if (buffer.size() < 2)
       return;
-    int last = it.size() - 1;
-    it[0].set(it[0].get() + (it[1].get() * 128));
+    int last = buffer.size() - 1;
+    buffer[0].set(buffer[0].get() + (buffer[1].get() * 128));
     for (int i = 1; i < last; i++) {
-      it[i] = (it[i - 1].get() * 64) + it[i].get() + (it[i + 1].get() * 64);
+      buffer[i] = (buffer[i - 1].get() * 64) + buffer[i].get() + (buffer[i + 1].get() * 64);
     }
-    it[last] = it[last].get() + (it[last - 1].get() * 128);
+    buffer[last] = buffer[last].get() + (buffer[last - 1].get() * 128);
     if (random_float() < this->spark_probability_) {
-      const size_t pos = random_uint32() % it.size();
+      auto view = buffer[random_uint32() % buffer.size()];
       if (this->use_random_color_) {
-        it[pos] = Color::random_color();
+        view = Color::random_color();
       } else {
-        it[pos] = current_color;
+        view = current_color;
       }
     }
     it.schedule_show();
@@ -367,7 +373,8 @@ class AddressableFlickerEffect : public AddressableLightEffect {
 
     this->last_update_ = now;
     uint32_t rng_state = random_uint32();
-    for (auto var : it) {
+    ESPColorBuffer &buffer = it.buffer();
+    for (auto var : buffer) {
       rng_state = (rng_state * 0x9E3779B9) + 0x9E37;
       const uint8_t flicker = (rng_state & 0xFF) % intensity;
       // scale down by random factor

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -31,7 +31,7 @@ class AddressableLightEffect : public LightEffect {
  public:
   explicit AddressableLightEffect(const char *name) : LightEffect(name) {}
   void start_internal() override {
-    auto addressable = this->get_addressable_();
+    auto *addressable = this->get_addressable_();
     addressable->set_effect_active(true);
     addressable->buffer().clear_effect_data();
     this->start();

--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -112,7 +112,7 @@ class AddressableLightWrapper : public light::AddressableLight {
 
  protected:
   light::LightState *light_state_;
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
   uint8_t led_data_[4]{};
   uint8_t effect_data_[1]{};
   ColorMode color_mode_{ColorMode::UNKNOWN};

--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -7,11 +7,13 @@ namespace esphome::light {
 
 class AddressableLightWrapper : public light::AddressableLight {
  public:
-  explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {}
+  explicit AddressableLightWrapper(light::LightState *light_state)
+      : light_state_(light_state),
+        buffer_(1, {.channel_colors = {.r = 0, .g = 1, .b = 2, .w = 3}}, &this->correction_) {
+    this->buffer_.setup(this->led_data_, this->effect_data_);
+  }
 
-  int32_t size() const override { return 1; }
-
-  void clear_effect_data() override { this->wrapper_state_[4] = 0; }
+  ESPColorBuffer &buffer() override { return this->buffer_; }
 
   light::LightTraits get_traits() override {
     LightTraits traits;
@@ -74,10 +76,10 @@ class AddressableLightWrapper : public light::AddressableLight {
       return;
     }
 
-    float r = this->light_state_->gamma_uncorrect_lut(this->wrapper_state_[0] / 255.0f);
-    float g = this->light_state_->gamma_uncorrect_lut(this->wrapper_state_[1] / 255.0f);
-    float b = this->light_state_->gamma_uncorrect_lut(this->wrapper_state_[2] / 255.0f);
-    float w = this->light_state_->gamma_uncorrect_lut(this->wrapper_state_[3] / 255.0f);
+    float r = this->light_state_->gamma_uncorrect_lut(this->led_data_[0] / 255.0f);
+    float g = this->light_state_->gamma_uncorrect_lut(this->led_data_[1] / 255.0f);
+    float b = this->light_state_->gamma_uncorrect_lut(this->led_data_[2] / 255.0f);
+    float w = this->light_state_->gamma_uncorrect_lut(this->led_data_[3] / 255.0f);
 
     auto call = this->light_state_->make_call();
 
@@ -109,13 +111,10 @@ class AddressableLightWrapper : public light::AddressableLight {
   }
 
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override {
-    return {&this->wrapper_state_[0], &this->wrapper_state_[1], &this->wrapper_state_[2],
-            &this->wrapper_state_[3], &this->wrapper_state_[4], &this->correction_};
-  }
-
   light::LightState *light_state_;
-  mutable uint8_t wrapper_state_[5]{};
+  light::InterleavedColorBuffer buffer_;
+  uint8_t led_data_[4]{};
+  uint8_t effect_data_[1]{};
   ColorMode color_mode_{ColorMode::UNKNOWN};
 };
 

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -230,17 +230,18 @@ template<typename... Ts> class AddressableSet final : public Action<Ts...> {
 
   void play(const Ts &...x) override {
     auto *out = (AddressableLight *) this->parent_->get_output();
-    int32_t range_from = interpret_index(this->range_from_.value_or(x..., 0), out->size());
-    if (range_from < 0 || range_from >= out->size())
+    ESPColorBuffer &buffer = out->buffer();
+    int32_t range_from = interpret_index(this->range_from_.value_or(x..., 0), buffer.size());
+    if (range_from < 0 || range_from >= buffer.size())
       range_from = 0;
 
-    int32_t range_to = interpret_index(this->range_to_.value_or(x..., out->size() - 1) + 1, out->size());
-    if (range_to < 0 || range_to >= out->size())
-      range_to = out->size();
+    int32_t range_to = interpret_index(this->range_to_.value_or(x..., buffer.size() - 1) + 1, buffer.size());
+    if (range_to < 0 || range_to >= buffer.size())
+      range_to = buffer.size();
 
     uint8_t color_brightness =
         to_uint8_scale(this->color_brightness_.value_or(x..., this->parent_->remote_values.get_color_brightness()));
-    auto range = out->range(range_from, range_to);
+    auto range = buffer.range(range_from, range_to);
     if (this->red_.has_value())
       range.set_red(esp_scale8(to_uint8_compat(this->red_.value(x...), "red"), color_brightness));
     if (this->green_.has_value())

--- a/esphome/components/light/channel_colors.h
+++ b/esphome/components/light/channel_colors.h
@@ -18,22 +18,28 @@ struct ChannelColors {
   uint8_t b;
   uint8_t w;
 
-  bool has_white() const { return this->w != NO_WHITE; }
-
-  uint8_t bytes_per_led() const { return this->has_white() ? 4 : 3; }
+  constexpr bool has_white() const { return this->w != NO_WHITE; }
 
   /// Write the order back out as text, e.g. "GRBW".
   ///
   /// `buf` must have room for at least 5 characters. Returns `buf` so the result can be
   /// passed straight to a log call.
   const char *to_string(char *buf) const {
-    buf[this->r] = 'R';
-    buf[this->g] = 'G';
-    buf[this->b] = 'B';
-    if (this->has_white()) {
-      buf[this->w] = 'W';
+    unsigned fields = (1u << this->r) | (1u << this->g) | (1u << this->b) | (this->has_white() ? 1u << this->w : 0u);
+    if (fields == 0b111 || fields == 0b1111) {
+      buf[this->r] = 'R';
+      buf[this->g] = 'G';
+      buf[this->b] = 'B';
+      if (this->has_white()) {
+        buf[this->w] = 'W';
+        buf[4] = '\0';
+      } else {
+        buf[3] = '\0';
+      }
+    } else {
+      buf[0] = '?';
+      buf[1] = '\0';
     }
-    buf[this->bytes_per_led()] = '\0';
     return buf;
   }
 };

--- a/esphome/components/light/esp_color_buffer.cpp
+++ b/esphome/components/light/esp_color_buffer.cpp
@@ -38,20 +38,20 @@ void InterleavedColorBuffer::setup(uint8_t *led_data, uint8_t *effect_data) {
 
 bool InterleavedColorBuffer::is_all_black() const {
   return this->led_data_after_leading_bytes_ == nullptr ||
-         is_all_black_internal_(this->led_data_after_leading_bytes_, this->num_leds_, this->layout_.channel_colors,
-                                this->layout_.bytes_per_led);
+         is_all_black_internal(this->led_data_after_leading_bytes_, this->num_leds_, this->layout_.channel_colors,
+                               this->layout_.bytes_per_led);
 }
 
 void InterleavedColorBuffer::clear_effect_data() {
   if (this->effect_data_ != nullptr) {
-    clear_effect_data_internal_(this->effect_data_, this->num_leds_);
+    clear_effect_data_internal(this->effect_data_, this->num_leds_);
   }
 }
 
-ESPColorView InterleavedColorBuffer::get_color_view_(size_t index) {
+ESPColorView InterleavedColorBuffer::get_color_view(size_t index) {
   if (this->led_data_after_leading_bytes_ != nullptr) {  // implies effect_data_ is also not null
-    return get_color_view_internal_(index, this->led_data_after_leading_bytes_, this->effect_data_,
-                                    this->layout_.channel_colors, this->layout_.bytes_per_led, this->color_correction_);
+    return get_color_view_internal(index, this->led_data_after_leading_bytes_, this->effect_data_,
+                                   this->layout_.channel_colors, this->layout_.bytes_per_led, this->color_correction_);
   }
   return ESPColorView{this->color_correction_};
 }

--- a/esphome/components/light/esp_color_buffer.cpp
+++ b/esphome/components/light/esp_color_buffer.cpp
@@ -1,0 +1,59 @@
+#include "esp_color_buffer.h"
+
+namespace esphome::light {
+
+void ESPColorBuffer::shift_left(int32_t amount) {
+  const int32_t size = this->size();
+  if (amount > 0) {
+    if (amount >= size)
+      return;
+    this->range(0, size - amount) = this->range(amount, size);
+  } else {
+    amount = -amount;
+    if (amount >= size)
+      return;
+    this->range(amount, size) = this->range(0, size - amount);
+  }
+}
+
+bool InterleavedColorBuffer::allocate_and_setup(RAMAllocator<uint8_t> *allocator) {
+  uint8_t *led_data = allocator->allocate(this->get_led_data_bytes());
+  if (led_data != nullptr) {
+    uint8_t *effect_data = allocator->allocate(this->num_leds_);
+    if (effect_data != nullptr) {
+      this->setup(led_data, effect_data);
+      return true;
+    }
+    allocator->deallocate(led_data, this->get_led_data_bytes());
+  }
+  return false;
+}
+
+void InterleavedColorBuffer::setup(uint8_t *led_data, uint8_t *effect_data) {
+  memset(led_data, 0, this->get_led_data_bytes());
+  memset(effect_data, 0, this->num_leds_);
+  this->led_data_after_leading_bytes_ = led_data + this->layout_.leading_bytes;
+  this->effect_data_ = effect_data;
+}
+
+bool InterleavedColorBuffer::is_all_black() const {
+  return this->led_data_after_leading_bytes_ == nullptr ||
+         is_all_black_internal_(this->led_data_after_leading_bytes_, this->num_leds_, this->layout_.channel_colors,
+                                this->layout_.bytes_per_led);
+}
+
+void InterleavedColorBuffer::clear_effect_data() {
+  if (this->effect_data_ != nullptr) {
+    clear_effect_data_internal_(this->effect_data_, this->num_leds_);
+  }
+}
+
+ESPColorView InterleavedColorBuffer::get_color_view_(size_t index) {
+  if (this->led_data_after_leading_bytes_ != nullptr) {  // implies effect_data_ is also not null
+    return get_color_view_internal_(index, this->led_data_after_leading_bytes_, this->effect_data_,
+                                    this->layout_.channel_colors, this->layout_.bytes_per_led, this->color_correction_);
+  }
+  return ESPColorView{this->color_correction_};
+}
+
+}  // namespace esphome::light

--- a/esphome/components/light/esp_color_buffer.cpp
+++ b/esphome/components/light/esp_color_buffer.cpp
@@ -16,7 +16,7 @@ void ESPColorBuffer::shift_left(int32_t amount) {
   }
 }
 
-bool InterleavedColorBuffer::allocate_and_setup(RAMAllocator<uint8_t> *allocator) {
+bool PackedColorBuffer::allocate_and_setup(RAMAllocator<uint8_t> *allocator) {
   uint8_t *led_data = allocator->allocate(this->get_led_data_bytes());
   if (led_data != nullptr) {
     uint8_t *effect_data = allocator->allocate(this->num_leds_);
@@ -29,26 +29,26 @@ bool InterleavedColorBuffer::allocate_and_setup(RAMAllocator<uint8_t> *allocator
   return false;
 }
 
-void InterleavedColorBuffer::setup(uint8_t *led_data, uint8_t *effect_data) {
+void PackedColorBuffer::setup(uint8_t *led_data, uint8_t *effect_data) {
   memset(led_data, 0, this->get_led_data_bytes());
   memset(effect_data, 0, this->num_leds_);
   this->led_data_after_leading_bytes_ = led_data + this->layout_.leading_bytes;
   this->effect_data_ = effect_data;
 }
 
-bool InterleavedColorBuffer::is_all_black() const {
+bool PackedColorBuffer::is_all_black() const {
   return this->led_data_after_leading_bytes_ == nullptr ||
          is_all_black_internal(this->led_data_after_leading_bytes_, this->num_leds_, this->layout_.channel_colors,
                                this->layout_.bytes_per_led);
 }
 
-void InterleavedColorBuffer::clear_effect_data() {
+void PackedColorBuffer::clear_effect_data() {
   if (this->effect_data_ != nullptr) {
     clear_effect_data_internal(this->effect_data_, this->num_leds_);
   }
 }
 
-ESPColorView InterleavedColorBuffer::get_color_view(size_t index) {
+ESPColorView PackedColorBuffer::get_color_view(size_t index) {
   if (this->led_data_after_leading_bytes_ != nullptr) {  // implies effect_data_ is also not null
     return get_color_view_internal(index, this->led_data_after_leading_bytes_, this->effect_data_,
                                    this->layout_.channel_colors, this->layout_.bytes_per_led, this->color_correction_);

--- a/esphome/components/light/esp_color_buffer.h
+++ b/esphome/components/light/esp_color_buffer.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "channel_colors.h"
+#include "esp_color_correction.h"
+#include "esp_color_view.h"
+#include "esp_range_view.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::light {
+
+class ESPColorBuffer {
+ public:
+  ESPColorBuffer(size_t num_leds) : num_leds_(num_leds) {}
+
+  /// Get the number of LEDs in the buffer.
+  size_t size() const { return this->num_leds_; }
+
+  /// Get a color view of the LED at an index between -(size - 1) and (size - 1) inclusively.
+  /// Use a negative index to access LEDs from the end of the buffer.
+  ESPColorView operator[](int32_t index) {
+    return this->get_color_view_(size_t(interpret_index(index, this->num_leds_)));
+  }
+
+  /// Get a color view of the LED at an index between -(size - 1) and (size - 1) inclusively.
+  /// Use a negative index to access LEDs from the end of the buffer.
+  ESPColorView get(int32_t index) { return (*this)[index]; }
+
+  /// Get a range view over the LEDs at indices between -(size - 1) and (size - 1) inclusively.
+  /// Use a negative index to access LEDs from the end of the buffer.
+  ESPRangeView range(int32_t from, int32_t to) {
+    from = interpret_index(from, this->num_leds_);
+    to = interpret_index(to, this->num_leds_);
+    return ESPRangeView(this, from, to);
+  }
+
+  /// Get a range view over all LEDs in the buffer.
+  ESPRangeView all() { return ESPRangeView(this, 0, this->num_leds_); }
+
+  ESPRangeIterator begin() { return this->all().begin(); }
+
+  ESPRangeIterator end() { return this->all().end(); }
+
+  /// Shift all LED color to the left by the specified number of positions.
+  void shift_left(int32_t amount);
+
+  /// Shift all LED colors to the right by the specified number of positions.
+  void shift_right(int32_t amount) { this->shift_left(-amount); }
+
+  /// Returns true if all LEDs have a zero raw color value.
+  virtual bool is_all_black() const = 0;
+
+  /// Set the light effect data associated with all LEDs in the buffer to zero.
+  virtual void clear_effect_data() = 0;
+
+ protected:
+  virtual ESPColorView get_color_view_(size_t index) = 0;
+
+  inline static bool is_all_black_internal_(uint8_t *led_data, size_t num_leds, const ChannelColors &channel_colors,
+                                            size_t bytes_per_led) {
+    for (size_t i = 0; i < num_leds; i++, led_data += bytes_per_led) {
+      if (led_data[channel_colors.r] != 0 || led_data[channel_colors.g] != 0 || led_data[channel_colors.b] != 0 ||
+          (channel_colors.has_white() && led_data[channel_colors.w] != 0)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  inline static void clear_effect_data_internal_(uint8_t *effect_data, size_t num_leds) {
+    memset(effect_data, 0, num_leds);
+  }
+
+  inline static ESPColorView get_color_view_internal_(size_t index, uint8_t *led_data, uint8_t *effect_data,
+                                                      const ChannelColors &channel_colors, size_t bytes_per_led,
+                                                      const ESPColorCorrection *color_correction) {
+    led_data += index * bytes_per_led;
+    return ESPColorView{&led_data[channel_colors.r], &led_data[channel_colors.g],
+                        &led_data[channel_colors.b], channel_colors.has_white() ? &led_data[channel_colors.w] : nullptr,
+                        &effect_data[index],         color_correction};
+  }
+
+  const size_t num_leds_;
+};
+
+struct InterleavedColorBufferLayout {
+  ChannelColors channel_colors{};
+  uint8_t bytes_per_led{uint8_t(channel_colors.has_white() ? 4 : 3)};
+  uint8_t leading_bytes{0};
+  uint8_t trailing_bytes{0};
+};
+
+class InterleavedColorBuffer final : public ESPColorBuffer {
+ public:
+  InterleavedColorBuffer(size_t num_leds, InterleavedColorBufferLayout layout,
+                         const ESPColorCorrection *color_correction)
+      : ESPColorBuffer(num_leds), layout_(layout), color_correction_(color_correction) {}
+
+  const InterleavedColorBufferLayout &layout() const { return this->layout_; }
+
+  bool allocate_and_setup(RAMAllocator<uint8_t> *allocator);
+  void setup(uint8_t *led_data, uint8_t *effect_data);
+
+  bool is_all_black() const override;
+
+  void clear_effect_data() override;
+
+  uint8_t *get_led_data() { return this->led_data_after_leading_bytes_ - this->layout_.leading_bytes; }
+
+  size_t get_led_data_bytes() const {
+    return this->layout_.leading_bytes + this->num_leds_ * this->layout_.bytes_per_led + this->layout_.trailing_bytes;
+  }
+
+ protected:
+  ESPColorView get_color_view_(size_t index) override;
+
+  const InterleavedColorBufferLayout layout_;
+  const ESPColorCorrection *const color_correction_;
+  uint8_t *led_data_after_leading_bytes_{nullptr};
+  uint8_t *effect_data_{nullptr};
+};
+
+}  // namespace esphome::light

--- a/esphome/components/light/esp_color_buffer.h
+++ b/esphome/components/light/esp_color_buffer.h
@@ -10,7 +10,7 @@ namespace esphome::light {
 
 class ESPColorBuffer {
  public:
-  ESPColorBuffer(size_t num_leds) : num_leds_(num_leds) {}
+  explicit ESPColorBuffer(size_t num_leds) : num_leds_(num_leds) {}
 
   /// Get the number of LEDs in the buffer.
   size_t size() const { return this->num_leds_; }
@@ -82,20 +82,19 @@ class ESPColorBuffer {
   const size_t num_leds_;
 };
 
-struct InterleavedColorBufferLayout {
+struct PackedColorBufferLayout {
   ChannelColors channel_colors{};
   uint8_t bytes_per_led{uint8_t(channel_colors.has_white() ? 4 : 3)};
   uint8_t leading_bytes{0};
   uint8_t trailing_bytes{0};
 };
 
-class InterleavedColorBuffer final : public ESPColorBuffer {
+class PackedColorBuffer final : public ESPColorBuffer {
  public:
-  InterleavedColorBuffer(size_t num_leds, InterleavedColorBufferLayout layout,
-                         const ESPColorCorrection *color_correction)
+  PackedColorBuffer(size_t num_leds, PackedColorBufferLayout layout, const ESPColorCorrection *color_correction)
       : ESPColorBuffer(num_leds), layout_(layout), color_correction_(color_correction) {}
 
-  const InterleavedColorBufferLayout &layout() const { return this->layout_; }
+  const PackedColorBufferLayout &layout() const { return this->layout_; }
 
   bool allocate_and_setup(RAMAllocator<uint8_t> *allocator);
   void setup(uint8_t *led_data, uint8_t *effect_data);
@@ -114,7 +113,7 @@ class InterleavedColorBuffer final : public ESPColorBuffer {
  protected:
   ESPColorView get_color_view(size_t index) override;
 
-  const InterleavedColorBufferLayout layout_;
+  const PackedColorBufferLayout layout_;
   const ESPColorCorrection *const color_correction_;
   uint8_t *led_data_after_leading_bytes_{nullptr};
   uint8_t *effect_data_{nullptr};

--- a/esphome/components/light/esp_color_buffer.h
+++ b/esphome/components/light/esp_color_buffer.h
@@ -18,7 +18,7 @@ class ESPColorBuffer {
   /// Get a color view of the LED at an index between -(size - 1) and (size - 1) inclusively.
   /// Use a negative index to access LEDs from the end of the buffer.
   ESPColorView operator[](int32_t index) {
-    return this->get_color_view_(size_t(interpret_index(index, this->num_leds_)));
+    return this->get_color_view(size_t(interpret_index(index, this->num_leds_)));
   }
 
   /// Get a color view of the LED at an index between -(size - 1) and (size - 1) inclusively.
@@ -53,10 +53,10 @@ class ESPColorBuffer {
   virtual void clear_effect_data() = 0;
 
  protected:
-  virtual ESPColorView get_color_view_(size_t index) = 0;
+  virtual ESPColorView get_color_view(size_t index) = 0;
 
-  inline static bool is_all_black_internal_(uint8_t *led_data, size_t num_leds, const ChannelColors &channel_colors,
-                                            size_t bytes_per_led) {
+  inline static bool is_all_black_internal(const uint8_t *led_data, size_t num_leds,
+                                           const ChannelColors &channel_colors, size_t bytes_per_led) {
     for (size_t i = 0; i < num_leds; i++, led_data += bytes_per_led) {
       if (led_data[channel_colors.r] != 0 || led_data[channel_colors.g] != 0 || led_data[channel_colors.b] != 0 ||
           (channel_colors.has_white() && led_data[channel_colors.w] != 0)) {
@@ -66,13 +66,13 @@ class ESPColorBuffer {
     return true;
   }
 
-  inline static void clear_effect_data_internal_(uint8_t *effect_data, size_t num_leds) {
+  inline static void clear_effect_data_internal(uint8_t *effect_data, size_t num_leds) {
     memset(effect_data, 0, num_leds);
   }
 
-  inline static ESPColorView get_color_view_internal_(size_t index, uint8_t *led_data, uint8_t *effect_data,
-                                                      const ChannelColors &channel_colors, size_t bytes_per_led,
-                                                      const ESPColorCorrection *color_correction) {
+  inline static ESPColorView get_color_view_internal(size_t index, uint8_t *led_data, uint8_t *effect_data,
+                                                     const ChannelColors &channel_colors, size_t bytes_per_led,
+                                                     const ESPColorCorrection *color_correction) {
     led_data += index * bytes_per_led;
     return ESPColorView{&led_data[channel_colors.r], &led_data[channel_colors.g],
                         &led_data[channel_colors.b], channel_colors.has_white() ? &led_data[channel_colors.w] : nullptr,
@@ -105,13 +105,14 @@ class InterleavedColorBuffer final : public ESPColorBuffer {
   void clear_effect_data() override;
 
   uint8_t *get_led_data() { return this->led_data_after_leading_bytes_ - this->layout_.leading_bytes; }
+  const uint8_t *get_led_data() const { return this->led_data_after_leading_bytes_ - this->layout_.leading_bytes; }
 
   size_t get_led_data_bytes() const {
     return this->layout_.leading_bytes + this->num_leds_ * this->layout_.bytes_per_led + this->layout_.trailing_bytes;
   }
 
  protected:
-  ESPColorView get_color_view_(size_t index) override;
+  ESPColorView get_color_view(size_t index) override;
 
   const InterleavedColorBufferLayout layout_;
   const ESPColorCorrection *const color_correction_;

--- a/esphome/components/light/esp_color_view.h
+++ b/esphome/components/light/esp_color_view.h
@@ -34,7 +34,7 @@ class ESPColorSettable {
   }
 };
 
-class ESPColorView : public ESPColorSettable {
+class ESPColorView final : public ESPColorSettable {
  public:
   ESPColorView(uint8_t *red, uint8_t *green, uint8_t *blue, uint8_t *white, uint8_t *effect_data,
                const ESPColorCorrection *color_correction)
@@ -43,6 +43,13 @@ class ESPColorView : public ESPColorSettable {
         blue_(blue),
         white_(white),
         effect_data_(effect_data),
+        color_correction_(color_correction) {}
+  ESPColorView(const ESPColorCorrection *color_correction)
+      : red_(nullptr),
+        green_(nullptr),
+        blue_(nullptr),
+        white_(nullptr),
+        effect_data_(nullptr),
         color_correction_(color_correction) {}
   ESPColorView &operator=(const Color &rhs) {
     this->set(rhs);
@@ -53,9 +60,21 @@ class ESPColorView : public ESPColorSettable {
     return *this;
   }
   void set(const Color &color) override { this->set_rgbw(color.r, color.g, color.b, color.w); }
-  void set_red(uint8_t red) override { *this->red_ = this->color_correction_->color_correct_red(red); }
-  void set_green(uint8_t green) override { *this->green_ = this->color_correction_->color_correct_green(green); }
-  void set_blue(uint8_t blue) override { *this->blue_ = this->color_correction_->color_correct_blue(blue); }
+  void set_red(uint8_t red) override {
+    if (this->red_ == nullptr)
+      return;
+    *this->red_ = this->color_correction_->color_correct_red(red);
+  }
+  void set_green(uint8_t green) override {
+    if (this->green_ == nullptr)
+      return;
+    *this->green_ = this->color_correction_->color_correct_green(green);
+  }
+  void set_blue(uint8_t blue) override {
+    if (this->blue_ == nullptr)
+      return;
+    *this->blue_ = this->color_correction_->color_correct_blue(blue);
+  }
   void set_white(uint8_t white) override {
     if (this->white_ == nullptr)
       return;
@@ -71,12 +90,36 @@ class ESPColorView : public ESPColorSettable {
   void lighten(uint8_t delta) override { this->set(this->get().lighten(delta)); }
   void darken(uint8_t delta) override { this->set(this->get().darken(delta)); }
   Color get() const { return Color(this->get_red(), this->get_green(), this->get_blue(), this->get_white()); }
-  uint8_t get_red() const { return this->color_correction_->color_uncorrect_red(*this->red_); }
-  uint8_t get_red_raw() const { return *this->red_; }
-  uint8_t get_green() const { return this->color_correction_->color_uncorrect_green(*this->green_); }
-  uint8_t get_green_raw() const { return *this->green_; }
-  uint8_t get_blue() const { return this->color_correction_->color_uncorrect_blue(*this->blue_); }
-  uint8_t get_blue_raw() const { return *this->blue_; }
+  uint8_t get_red() const {
+    if (this->red_ == nullptr)
+      return 0;
+    return this->color_correction_->color_uncorrect_red(*this->red_);
+  }
+  uint8_t get_red_raw() const {
+    if (this->red_ == nullptr)
+      return 0;
+    return *this->red_;
+  }
+  uint8_t get_green() const {
+    if (this->green_ == nullptr)
+      return 0;
+    return this->color_correction_->color_uncorrect_green(*this->green_);
+  }
+  uint8_t get_green_raw() const {
+    if (this->green_ == nullptr)
+      return 0;
+    return *this->green_;
+  }
+  uint8_t get_blue() const {
+    if (this->blue_ == nullptr)
+      return 0;
+    return this->color_correction_->color_uncorrect_blue(*this->blue_);
+  }
+  uint8_t get_blue_raw() const {
+    if (this->blue_ == nullptr)
+      return 0;
+    return *this->blue_;
+  }
   uint8_t get_white() const {
     if (this->white_ == nullptr)
       return 0;

--- a/esphome/components/light/esp_range_view.cpp
+++ b/esphome/components/light/esp_range_view.cpp
@@ -1,5 +1,5 @@
 #include "esp_range_view.h"
-#include "addressable_light.h"
+#include "esp_color_buffer.h"
 
 namespace esphome::light {
 

--- a/esphome/components/light/esp_range_view.h
+++ b/esphome/components/light/esp_range_view.h
@@ -7,7 +7,7 @@ namespace esphome::light {
 
 int32_t interpret_index(int32_t index, int32_t size);
 
-class AddressableLight;
+class ESPColorBuffer;
 class ESPRangeIterator;
 
 /**
@@ -15,7 +15,7 @@ class ESPRangeIterator;
  */
 class ESPRangeView : public ESPColorSettable {
  public:
-  ESPRangeView(AddressableLight *parent, int32_t begin, int32_t end)
+  ESPRangeView(ESPColorBuffer *parent, int32_t begin, int32_t end)
       : parent_(parent), begin_(begin), end_(end < begin ? begin : end) {}
   ESPRangeView(const ESPRangeView &) = default;
 
@@ -54,7 +54,7 @@ class ESPRangeView : public ESPColorSettable {
  protected:
   friend ESPRangeIterator;
 
-  AddressableLight *parent_;
+  ESPColorBuffer *parent_;
   int32_t begin_;
   int32_t end_;
 };

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.cpp
@@ -8,36 +8,24 @@ static const char *const TAG = "m5stack_8angle.light";
 
 void M5Stack8AngleLightOutput::setup() {
   RAMAllocator<uint8_t> allocator;
-  this->buf_ = allocator.allocate(M5STACK_8ANGLE_NUM_LEDS * M5STACK_8ANGLE_BYTES_PER_LED);
-  if (this->buf_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate buffer of size %u", M5STACK_8ANGLE_NUM_LEDS * M5STACK_8ANGLE_BYTES_PER_LED);
+  if (!this->buffer_.allocate_and_setup(&allocator)) {
+    ESP_LOGE(TAG, "Cannot allocate color buffer");
     this->mark_failed();
     return;
-  };
-  memset(this->buf_, 0xFF, M5STACK_8ANGLE_NUM_LEDS * M5STACK_8ANGLE_BYTES_PER_LED);
-
-  this->effect_data_ = allocator.allocate(M5STACK_8ANGLE_NUM_LEDS);
-  if (this->effect_data_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate effect data of size %u", M5STACK_8ANGLE_NUM_LEDS);
-    this->mark_failed();
-    return;
-  };
-  memset(this->effect_data_, 0x00, M5STACK_8ANGLE_NUM_LEDS);
+  }
+  memset(this->buffer_.get_led_data(), 0xFF, M5STACK_8ANGLE_NUM_LEDS * M5STACK_8ANGLE_BYTES_PER_LED);
 }
 
 void M5Stack8AngleLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   for (int i = 0; i < M5STACK_8ANGLE_NUM_LEDS;
        i++) {  // write one LED at a time, otherwise the message will be truncated
     this->parent_->write_register(M5STACK_8ANGLE_REGISTER_RGB_24B + i * M5STACK_8ANGLE_BYTES_PER_LED,
-                                  this->buf_ + i * M5STACK_8ANGLE_BYTES_PER_LED, M5STACK_8ANGLE_BYTES_PER_LED);
+                                  this->buffer_.get_led_data() + i * M5STACK_8ANGLE_BYTES_PER_LED,
+                                  M5STACK_8ANGLE_BYTES_PER_LED);
   }
-}
-
-light::ESPColorView M5Stack8AngleLightOutput::get_view_internal(int32_t index) const {
-  size_t pos = index * M5STACK_8ANGLE_BYTES_PER_LED;
-  // red, green, blue, white, effect_data, color_correction
-  return {this->buf_ + pos, this->buf_ + pos + 1,       this->buf_ + pos + 2,
-          nullptr,          this->effect_data_ + index, &this->correction_};
 }
 
 }  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
@@ -12,24 +12,25 @@ static const uint8_t M5STACK_8ANGLE_BYTES_PER_LED = 4;
 
 class M5Stack8AngleLightOutput final : public light::AddressableLight, public Parented<M5Stack8AngleComponent> {
  public:
+  M5Stack8AngleLightOutput()
+      : buffer_(M5STACK_8ANGLE_NUM_LEDS,
+                {.channel_colors = {.r = 0, .g = 1, .b = 2}, .bytes_per_led = M5STACK_8ANGLE_BYTES_PER_LED},
+                &this->correction_) {}
+
+  light::ESPColorBuffer &buffer() override { return this->buffer_; }
+
   void setup() override;
 
   void write_state(light::LightState *state) override;
 
-  int32_t size() const override { return M5STACK_8ANGLE_NUM_LEDS; }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::RGB});
     return traits;
   };
 
-  void clear_effect_data() override { memset(this->effect_data_, 0x00, M5STACK_8ANGLE_NUM_LEDS); };
-
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override;
-
-  uint8_t *buf_{nullptr};
-  uint8_t *effect_data_{nullptr};
+  light::InterleavedColorBuffer buffer_;
 };
 
 }  // namespace esphome::m5stack_8angle

--- a/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
+++ b/esphome/components/m5stack_8angle/light/m5stack_8angle_light.h
@@ -30,7 +30,7 @@ class M5Stack8AngleLightOutput final : public light::AddressableLight, public Pa
   };
 
  protected:
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
 };
 
 }  // namespace esphome::m5stack_8angle

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -239,21 +239,17 @@ async def to_code(config):
         out_type = NeoPixelRGBWLightOutput.template(method_template)
     else:
         out_type = NeoPixelRGBLightOutput.template(method_template)
-    rhs = out_type.new()
+    num_leds = config[CONF_NUM_LEDS]
+    pixel_order = getattr(ESPNeoPixelOrder, config[CONF_TYPE])
+    if CONF_PIN in config:
+        rhs = out_type.new(num_leds, pixel_order, config[CONF_PIN])
+    else:
+        rhs = out_type.new(
+            num_leds, pixel_order, config[CONF_CLOCK_PIN], config[CONF_DATA_PIN]
+        )
     var = cg.Pvariable(config[CONF_OUTPUT_ID], rhs, out_type)
     await light.register_light(var, config)
     await cg.register_component(var, config)
-
-    if CONF_PIN in config:
-        cg.add(var.add_leds(config[CONF_NUM_LEDS], config[CONF_PIN]))
-    else:
-        cg.add(
-            var.add_leds(
-                config[CONF_NUM_LEDS], config[CONF_CLOCK_PIN], config[CONF_DATA_PIN]
-            )
-        )
-
-    cg.add(var.set_pixel_order(getattr(ESPNeoPixelOrder, config[CONF_TYPE])))
 
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
     # Version Listed Here: https://registry.platformio.org/libraries/makuna/NeoPixelBus/versions

--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -109,7 +109,7 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight, protected lig
 };
 
 template<typename T_METHOD, typename T_COLOR_FEATURE = NeoRgbFeature>
-class NeoPixelRGBLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, false> {
+class NeoPixelRGBLightOutput final : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, false> {
  public:
   NeoPixelRGBLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
       : NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, false>(num_leds, order, pin) {}
@@ -125,7 +125,7 @@ class NeoPixelRGBLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COL
 };
 
 template<typename T_METHOD, typename T_COLOR_FEATURE = NeoRgbwFeature>
-class NeoPixelRGBWLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, true> {
+class NeoPixelRGBWLightOutput final : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, true> {
  public:
   NeoPixelRGBWLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
       : NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, true>(num_leds, order, pin) {}

--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -47,16 +47,6 @@ enum class ESPNeoPixelOrder {
   RWBG = 0b00111001,
 };
 
-constexpr light::ChannelColors to_channel_colors(ESPNeoPixelOrder order, bool has_white) {
-  uint8_t u_order = static_cast<uint8_t>(order);
-  return {
-      .r = (u_order >> 6) & 0b11,
-      .g = (u_order >> 4) & 0b11,
-      .b = (u_order >> 2) & 0b11,
-      .w = has_white ? (u_order >> 0) & 0b11 : light::ChannelColors::NO_WHITE,
-  };
-}
-
 template<typename T_METHOD, typename T_COLOR_FEATURE, bool HAS_WHITE>
 class NeoPixelBusLightOutputBase : public light::AddressableLight, protected light::ESPColorBuffer {
  public:
@@ -85,36 +75,47 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight, protected lig
  protected:
   using Controller = NeoPixelBus<T_COLOR_FEATURE, T_METHOD>;
 
+  static constexpr light::ChannelColors to_channel_colors(ESPNeoPixelOrder order) {
+    uint8_t u_order = static_cast<uint8_t>(order);
+    return {
+        .r = uint8_t((u_order >> 6) & 0b11),
+        .g = uint8_t((u_order >> 4) & 0b11),
+        .b = uint8_t((u_order >> 2) & 0b11),
+        .w = HAS_WHITE ? uint8_t((u_order >> 0) & 0b11) : light::ChannelColors::NO_WHITE,
+    };
+  }
+
   NeoPixelBusLightOutputBase(Controller *controller, ESPNeoPixelOrder order)
       : ESPColorBuffer(controller->PixelCount()),
         controller_(controller),
         effect_data_(new uint8_t[controller->PixelCount()]{0}),
-        channel_colors_(to_channel_colors(order)) {}
+        channel_colors_(NeoPixelBusLightOutputBase::to_channel_colors(order)) {}
 
   bool is_all_black() const override {
-    return is_all_black_internal(this->controller_->Pixels(), this->num_leds, this->channel_colors_, HAS_WHITE ? 4 : 3);
+    return is_all_black_internal(this->controller_->Pixels(), this->num_leds_, this->channel_colors_,
+                                 HAS_WHITE ? 4 : 3);
   }
 
   void clear_effect_data() override { clear_effect_data_internal(this->effect_data_, this->num_leds_); }
 
   light::ESPColorView get_color_view(size_t index) override {
-    return get_color_view_internal(index, this->controller_->Pixels(), this->effect_data_, this->channel_colors,
-                                   HAS_WHITE ? 4 : 3, this->correction_);
+    return get_color_view_internal(index, this->controller_->Pixels(), this->effect_data_, this->channel_colors_,
+                                   HAS_WHITE ? 4 : 3, &this->correction_);
   }
 
   Controller *const controller_;
   uint8_t *const effect_data_;
-  ChannelColors const channel_colors_;
+  light::ChannelColors const channel_colors_;
 };
 
 template<typename T_METHOD, typename T_COLOR_FEATURE = NeoRgbFeature>
-class NeoPixelRGBLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE> {
+class NeoPixelRGBLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, false> {
  public:
   NeoPixelRGBLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
-      : NeoPixelBusLightOutputBase(num_leds, order, pin) {}
+      : NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, false>(num_leds, order, pin) {}
 
   NeoPixelRGBLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin_clock, uint8_t pin_data)
-      : NeoPixelBusLightOutputBase(num_leds, order, pin_clock, pin_data) {}
+      : NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, false>(num_leds, order, pin_clock, pin_data) {}
 
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
@@ -124,13 +125,13 @@ class NeoPixelRGBLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COL
 };
 
 template<typename T_METHOD, typename T_COLOR_FEATURE = NeoRgbwFeature>
-class NeoPixelRGBWLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE> {
+class NeoPixelRGBWLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, true> {
  public:
   NeoPixelRGBWLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
-      : NeoPixelBusLightOutputBase(num_leds, order, pin) {}
+      : NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, true>(num_leds, order, pin) {}
 
   NeoPixelRGBWLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin_clock, uint8_t pin_data)
-      : NeoPixelBusLightOutputBase(num_leds, order, pin_clock, pin_data) {}
+      : NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE, true>(num_leds, order, pin_clock, pin_data) {}
 
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();

--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -92,15 +92,14 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight, protected lig
         channel_colors_(to_channel_colors(order)) {}
 
   bool is_all_black() const override {
-    return is_all_black_internal_(this->controller_->Pixels(), this->num_leds, this->channel_colors_,
-                                  HAS_WHITE ? 4 : 3);
+    return is_all_black_internal(this->controller_->Pixels(), this->num_leds, this->channel_colors_, HAS_WHITE ? 4 : 3);
   }
 
-  void clear_effect_data() override { clear_effect_data_internal_(this->effect_data_, this->num_leds_); }
+  void clear_effect_data() override { clear_effect_data_internal(this->effect_data_, this->num_leds_); }
 
-  light::ESPColorView get_color_view_(size_t index) override {
-    return get_color_view_internal_(index, this->controller_->Pixels(), this->effect_data_, this->channel_colors,
-                                    HAS_WHITE ? 4 : 3, this->correction_);
+  light::ESPColorView get_color_view(size_t index) override {
+    return get_color_view_internal(index, this->controller_->Pixels(), this->effect_data_, this->channel_colors,
+                                   HAS_WHITE ? 4 : 3, this->correction_);
   }
 
   Controller *const controller_;

--- a/esphome/components/neopixelbus/neopixelbus_light.h
+++ b/esphome/components/neopixelbus/neopixelbus_light.h
@@ -6,6 +6,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/macros.h"
+#include "esphome/components/light/channel_colors.h"
 #include "esphome/components/light/light_output.h"
 #include "esphome/components/light/addressable_light.h"
 
@@ -46,39 +47,31 @@ enum class ESPNeoPixelOrder {
   RWBG = 0b00111001,
 };
 
-template<typename T_METHOD, typename T_COLOR_FEATURE>
-class NeoPixelBusLightOutputBase : public light::AddressableLight {
+constexpr light::ChannelColors to_channel_colors(ESPNeoPixelOrder order, bool has_white) {
+  uint8_t u_order = static_cast<uint8_t>(order);
+  return {
+      .r = (u_order >> 6) & 0b11,
+      .g = (u_order >> 4) & 0b11,
+      .b = (u_order >> 2) & 0b11,
+      .w = has_white ? (u_order >> 0) & 0b11 : light::ChannelColors::NO_WHITE,
+  };
+}
+
+template<typename T_METHOD, typename T_COLOR_FEATURE, bool HAS_WHITE>
+class NeoPixelBusLightOutputBase : public light::AddressableLight, protected light::ESPColorBuffer {
  public:
+  NeoPixelBusLightOutputBase(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
+      : NeoPixelBusLightOutputBase(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(num_leds, pin), order) {}
+
+  NeoPixelBusLightOutputBase(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin_clock, uint8_t pin_data)
+      : NeoPixelBusLightOutputBase(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(num_leds, pin_clock, pin_data), order) {}
+
+  light::ESPColorBuffer &buffer() override { return *this; }
+
   NeoPixelBus<T_COLOR_FEATURE, T_METHOD> *get_controller() const { return this->controller_; }
 
-  void clear_effect_data() override {
-    for (int i = 0; i < this->size(); i++)
-      this->effect_data_[i] = 0;
-  }
-
-  /// Add some LEDS, can only be called once.
-  void add_leds(uint16_t count_pixels, uint8_t pin) {
-    this->add_leds(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(count_pixels, pin));
-  }
-  void add_leds(uint16_t count_pixels, uint8_t pin_clock, uint8_t pin_data) {
-    this->add_leds(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(count_pixels, pin_clock, pin_data));
-  }
-  void add_leds(uint16_t count_pixels) { this->add_leds(new NeoPixelBus<T_COLOR_FEATURE, T_METHOD>(count_pixels)); }
-  void add_leds(NeoPixelBus<T_COLOR_FEATURE, T_METHOD> *controller) {
-    this->controller_ = controller;
-    // controller gets initialised in setup() - avoid calling twice (crashes with RMT)
-    // this->controller_->Begin();
-  }
-
   // ========== INTERNAL METHODS ==========
-  void setup() override {
-    for (int i = 0; i < this->size(); i++) {
-      (*this)[i] = Color(0, 0, 0, 0);
-    }
-
-    this->effect_data_ = new uint8_t[this->size()];  // NOLINT
-    this->controller_->Begin();
-  }
+  void setup() override { this->controller_->Begin(); }
 
   void write_state(light::LightState *state) override {
     this->mark_shown_();
@@ -89,53 +82,61 @@ class NeoPixelBusLightOutputBase : public light::AddressableLight {
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  int32_t size() const override { return this->controller_->PixelCount(); }
+ protected:
+  using Controller = NeoPixelBus<T_COLOR_FEATURE, T_METHOD>;
 
-  void set_pixel_order(ESPNeoPixelOrder order) {
-    uint8_t u_order = static_cast<uint8_t>(order);
-    this->rgb_offsets_[0] = (u_order >> 6) & 0b11;
-    this->rgb_offsets_[1] = (u_order >> 4) & 0b11;
-    this->rgb_offsets_[2] = (u_order >> 2) & 0b11;
-    this->rgb_offsets_[3] = (u_order >> 0) & 0b11;
+  NeoPixelBusLightOutputBase(Controller *controller, ESPNeoPixelOrder order)
+      : ESPColorBuffer(controller->PixelCount()),
+        controller_(controller),
+        effect_data_(new uint8_t[controller->PixelCount()]{0}),
+        channel_colors_(to_channel_colors(order)) {}
+
+  bool is_all_black() const override {
+    return is_all_black_internal_(this->controller_->Pixels(), this->num_leds, this->channel_colors_,
+                                  HAS_WHITE ? 4 : 3);
   }
 
- protected:
-  NeoPixelBus<T_COLOR_FEATURE, T_METHOD> *controller_{nullptr};
-  uint8_t *effect_data_{nullptr};
-  uint8_t rgb_offsets_[4]{0, 1, 2, 3};
+  void clear_effect_data() override { clear_effect_data_internal_(this->effect_data_, this->num_leds_); }
+
+  light::ESPColorView get_color_view_(size_t index) override {
+    return get_color_view_internal_(index, this->controller_->Pixels(), this->effect_data_, this->channel_colors,
+                                    HAS_WHITE ? 4 : 3, this->correction_);
+  }
+
+  Controller *const controller_;
+  uint8_t *const effect_data_;
+  ChannelColors const channel_colors_;
 };
 
 template<typename T_METHOD, typename T_COLOR_FEATURE = NeoRgbFeature>
 class NeoPixelRGBLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE> {
  public:
+  NeoPixelRGBLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
+      : NeoPixelBusLightOutputBase(num_leds, order, pin) {}
+
+  NeoPixelRGBLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin_clock, uint8_t pin_data)
+      : NeoPixelBusLightOutputBase(num_leds, order, pin_clock, pin_data) {}
+
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::RGB});
     return traits;
-  }
-
- protected:
-  light::ESPColorView get_view_internal(int32_t index) const override {  // NOLINT
-    uint8_t *base = this->controller_->Pixels() + 3ULL * index;
-    return light::ESPColorView(base + this->rgb_offsets_[0], base + this->rgb_offsets_[1], base + this->rgb_offsets_[2],
-                               nullptr, this->effect_data_ + index, &this->correction_);
   }
 };
 
 template<typename T_METHOD, typename T_COLOR_FEATURE = NeoRgbwFeature>
 class NeoPixelRGBWLightOutput : public NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE> {
  public:
+  NeoPixelRGBWLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin)
+      : NeoPixelBusLightOutputBase(num_leds, order, pin) {}
+
+  NeoPixelRGBWLightOutput(size_t num_leds, ESPNeoPixelOrder order, uint8_t pin_clock, uint8_t pin_data)
+      : NeoPixelBusLightOutputBase(num_leds, order, pin_clock, pin_data) {}
+
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::RGB_WHITE});
     return traits;
-  }
-
- protected:
-  light::ESPColorView get_view_internal(int32_t index) const override {  // NOLINT
-    uint8_t *base = this->controller_->Pixels() + 4ULL * index;
-    return light::ESPColorView(base + this->rgb_offsets_[0], base + this->rgb_offsets_[1], base + this->rgb_offsets_[2],
-                               base + this->rgb_offsets_[3], this->effect_data_ + index, &this->correction_);
   }
 };
 

--- a/esphome/components/partition/light_partition.h
+++ b/esphome/components/partition/light_partition.h
@@ -10,24 +10,24 @@ namespace esphome::partition {
 
 class AddressableSegment {
  public:
-  AddressableSegment(light::LightState *src, int32_t src_offset, int32_t size, bool reversed)
+  AddressableSegment(light::LightState *src, size_t src_offset, size_t size, bool reversed)
       : src_(static_cast<light::AddressableLight *>(src->get_output())),
         src_offset_(src_offset),
         size_(size),
         reversed_(reversed) {}
 
   light::AddressableLight *get_src() const { return this->src_; }
-  int32_t get_src_offset() const { return this->src_offset_; }
-  int32_t get_size() const { return this->size_; }
-  int32_t get_dst_offset() const { return this->dst_offset_; }
-  void set_dst_offset(int32_t dst_offset) { this->dst_offset_ = dst_offset; }
+  size_t get_src_offset() const { return this->src_offset_; }
+  size_t get_size() const { return this->size_; }
+  size_t get_dst_offset() const { return this->dst_offset_; }
+  void set_dst_offset(size_t dst_offset) { this->dst_offset_ = dst_offset; }
   bool is_reversed() const { return this->reversed_; }
 
  protected:
   light::AddressableLight *src_;
-  int32_t src_offset_;
-  int32_t size_;
-  int32_t dst_offset_;
+  size_t src_offset_;
+  size_t size_;
+  size_t dst_offset_;
   bool reversed_;
 };
 
@@ -62,12 +62,12 @@ class PartitionLightOutput final : public light::AddressableLight, protected lig
   }
 
   light::ESPColorView get_color_view(size_t index) override {
-    uint32_t lo = 0;
-    uint32_t hi = this->segments_.size() - 1;
+    size_t lo = 0;
+    size_t hi = this->segments_.size() - 1;
     while (lo < hi) {
-      uint32_t mid = (lo + hi) / 2;
-      int32_t begin = this->segments_[mid].get_dst_offset();
-      int32_t end = begin + this->segments_[mid].get_size();
+      size_t mid = (lo + hi) / 2;
+      size_t begin = this->segments_[mid].get_dst_offset();
+      size_t end = begin + this->segments_[mid].get_size();
       if (index < begin) {
         hi = mid - 1;
       } else if (index >= end) {
@@ -78,9 +78,9 @@ class PartitionLightOutput final : public light::AddressableLight, protected lig
     }
     auto &seg = this->segments_[lo];
     // offset within the segment
-    int32_t seg_off = index - seg.get_dst_offset();
+    size_t seg_off = index - seg.get_dst_offset();
     // offset within the src
-    int32_t src_off;
+    size_t src_off;
     if (seg.is_reversed()) {
       src_off = seg.get_src_offset() + seg.get_size() - seg_off - 1;
     } else {

--- a/esphome/components/partition/light_partition.h
+++ b/esphome/components/partition/light_partition.h
@@ -31,24 +31,12 @@ class AddressableSegment {
   bool reversed_;
 };
 
-class PartitionLightOutput final : public light::AddressableLight {
+class PartitionLightOutput final : public light::AddressableLight, protected light::ESPColorBuffer {
  public:
-  explicit PartitionLightOutput(std::vector<AddressableSegment> segments) : segments_(std::move(segments)) {
-    int32_t off = 0;
-    for (auto &seg : this->segments_) {
-      seg.set_dst_offset(off);
-      off += seg.get_size();
-    }
-  }
-  int32_t size() const override {
-    auto &last_seg = this->segments_[this->segments_.size() - 1];
-    return last_seg.get_dst_offset() + last_seg.get_size();
-  }
-  void clear_effect_data() override {
-    for (auto &seg : this->segments_) {
-      seg.get_src()->clear_effect_data();
-    }
-  }
+  explicit PartitionLightOutput(std::vector<AddressableSegment> segments)
+      : ESPColorBuffer(set_segment_dst_offsets(&segments)), segments_(std::move(segments)) {}
+
+  light::ESPColorBuffer &buffer() override { return *this; }
   light::LightTraits get_traits() override { return this->segments_[0].get_src()->get_traits(); }
   void write_state(light::LightState *state) override {
     for (auto seg : this->segments_) {
@@ -58,7 +46,22 @@ class PartitionLightOutput final : public light::AddressableLight {
   }
 
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override {
+  bool is_all_black() const override {
+    for (auto &seg : this->segments_) {
+      if (!seg.get_src()->buffer().is_all_black()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void clear_effect_data() override {
+    for (auto &seg : this->segments_) {
+      seg.get_src()->buffer().clear_effect_data();
+    }
+  }
+
+  light::ESPColorView get_color_view(size_t index) override {
     uint32_t lo = 0;
     uint32_t hi = this->segments_.size() - 1;
     while (lo < hi) {
@@ -84,12 +87,22 @@ class PartitionLightOutput final : public light::AddressableLight {
       src_off = seg.get_src_offset() + seg_off;
     }
 
-    auto view = (*seg.get_src())[src_off];
+    auto view = seg.get_src()->buffer()[src_off];
     view.raw_set_color_correction(&this->correction_);
     return view;
   }
 
   std::vector<AddressableSegment> segments_;
+
+ private:
+  static int32_t set_segment_dst_offsets(std::vector<AddressableSegment> *segments) {
+    int32_t off = 0;
+    for (auto &seg : *segments) {
+      seg.set_dst_offset(off);
+      off += seg.get_size();
+    }
+    return off;
+  }
 };
 
 }  // namespace esphome::partition

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -28,19 +28,9 @@ void RP2040PIOLEDStripLightOutput::dma_write_complete_handler() {
 }
 
 void RP2040PIOLEDStripLightOutput::setup() {
-  size_t buffer_size = this->get_buffer_size_();
-
   RAMAllocator<uint8_t> allocator;
-  this->buf_ = allocator.allocate(buffer_size);
-  if (this->buf_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate buffer of size %u", buffer_size);
-    this->mark_failed();
-    return;
-  }
-
-  this->effect_data_ = allocator.allocate(this->num_leds_);
-  if (this->effect_data_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate effect data of size %u", this->num_leds_);
+  if (!this->buffer_.allocate_and_setup(&allocator)) {
+    ESP_LOGE(TAG, "Cannot allocate color buffer");
     this->mark_failed();
     return;
   }
@@ -107,10 +97,10 @@ void RP2040PIOLEDStripLightOutput::setup() {
                           pio_get_dreq(this->pio_, this->sm_, true));  // set the DREQ to the state machine's TX FIFO
 
   dma_channel_configure(this->dma_chan_, &this->dma_config_,
-                        &this->pio_->txf[this->sm_],  // write to the state machine's TX FIFO
-                        this->buf_,                   // read from memory
-                        this->get_buffer_size_(),     // number of bytes to transfer
-                        false                         // don't start yet
+                        &this->pio_->txf[this->sm_],         // write to the state machine's TX FIFO
+                        this->buffer_.get_led_data(),        // read from memory
+                        this->buffer_.get_led_data_bytes(),  // number of bytes to transfer
+                        false                                // don't start yet
   );
 
   // Initialize the semaphore for this DMA channel
@@ -124,32 +114,15 @@ void RP2040PIOLEDStripLightOutput::setup() {
 }
 
 void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
+  if (!this->is_ready()) {
+    return;
+  }
   ESP_LOGVV(TAG, "Writing state");
-
-  if (this->is_failed()) {
-    ESP_LOGW(TAG, "Light is in failed state, not writing state.");
-    return;
-  }
-
-  if (this->buf_ == nullptr) {
-    ESP_LOGW(TAG, "Buffer is null, not writing state.");
-    return;
-  }
 
   // the bits are already in the correct order for the pio program so we can just copy the buffer using DMA
   sem_acquire_blocking(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem[this->dma_chan_]);
-  dma_channel_transfer_from_buffer_now(this->dma_chan_, this->buf_, this->get_buffer_size_());
-}
-
-light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t index) const {
-  const light::ChannelColors &colors = this->channel_colors_;
-  uint8_t *led = this->buf_ + (index * colors.bytes_per_led());
-  return {led + colors.r,
-          led + colors.g,
-          led + colors.b,
-          colors.has_white() ? led + colors.w : nullptr,
-          &this->effect_data_[index],
-          &this->correction_};
+  dma_channel_transfer_from_buffer_now(this->dma_chan_, this->buffer_.get_led_data(),
+                                       this->buffer_.get_led_data_bytes());
 }
 
 void RP2040PIOLEDStripLightOutput::dump_config() {
@@ -160,7 +133,8 @@ void RP2040PIOLEDStripLightOutput::dump_config() {
                 "  Number of LEDs: %d\n"
                 "  Channel colors: %s\n"
                 "  Max Refresh Rate: %f Hz",
-                this->pin_, this->num_leds_, this->channel_colors_.to_string(channel_colors), this->max_refresh_rate_);
+                this->pin_, this->num_leds_, this->buffer_.layout().channel_colors.to_string(channel_colors),
+                this->max_refresh_rate_);
 }
 
 float RP2040PIOLEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -133,7 +133,7 @@ void RP2040PIOLEDStripLightOutput::dump_config() {
                 "  Number of LEDs: %d\n"
                 "  Channel colors: %s\n"
                 "  Max Refresh Rate: %f Hz",
-                this->pin_, this->num_leds_, this->buffer_.layout().channel_colors.to_string(channel_colors),
+                this->pin_, this->buffer_.size(), this->buffer_.layout().channel_colors.to_string(channel_colors),
                 this->max_refresh_rate_);
 }
 

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -130,7 +130,7 @@ void RP2040PIOLEDStripLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "RP2040 PIO LED Strip Light Output:\n"
                 "  Pin: GPIO%d\n"
-                "  Number of LEDs: %d\n"
+                "  Number of LEDs: %u\n"
                 "  Channel colors: %s\n"
                 "  Max Refresh Rate: %f Hz",
                 this->pin_, this->buffer_.size(), this->buffer_.layout().channel_colors.to_string(channel_colors),

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -32,21 +32,23 @@ using init_fn = void (*)(PIO pio, uint sm, uint offset, uint pin, float freq);
 
 class RP2040PIOLEDStripLightOutput final : public light::AddressableLight {
  public:
+  RP2040PIOLEDStripLightOutput(size_t num_leds, light::ChannelColors channel_colors)
+      : buffer_(num_leds, {.channel_colors = channel_colors}, &this->correction_) {}
+
+  light::ESPColorBuffer &buffer() override { return this->buffer_; }
+
   void setup() override;
   void write_state(light::LightState *state) override;
   float get_setup_priority() const override;
 
-  int32_t size() const override { return this->num_leds_; }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
-    this->channel_colors_.has_white()
+    this->buffer_.layout().channel_colors.has_white()
         ? traits.set_supported_color_modes({light::ColorMode::RGB_WHITE, light::ColorMode::WHITE})
         : traits.set_supported_color_modes({light::ColorMode::RGB});
     return traits;
   }
   void set_pin(uint8_t pin) { this->pin_ = pin; }
-  void set_num_leds(uint32_t num_leds) { this->num_leds_ = num_leds; }
-  void set_channel_colors(light::ChannelColors channel_colors) { this->channel_colors_ = channel_colors; }
 
   void set_max_refresh_rate(float interval_us) { this->max_refresh_rate_ = interval_us; }
 
@@ -55,33 +57,21 @@ class RP2040PIOLEDStripLightOutput final : public light::AddressableLight {
   void set_init_function(init_fn init) { this->init_ = init; }
 
   void set_chipset(Chipset chipset) { this->chipset_ = chipset; };
-  void clear_effect_data() override {
-    for (int i = 0; i < this->size(); i++) {
-      this->effect_data_[i] = 0;
-    }
-  }
 
   void dump_config() override;
 
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override;
-
-  size_t get_buffer_size_() const { return this->num_leds_ * this->channel_colors_.bytes_per_led(); }
-
   static void dma_write_complete_handler();
 
-  uint8_t *buf_{nullptr};
-  uint8_t *effect_data_{nullptr};
+  light::InterleavedColorBuffer buffer_;
 
   uint8_t pin_;
-  uint32_t num_leds_;
 
   pio_hw_t *pio_;
   uint sm_;
   uint dma_chan_;
   dma_channel_config dma_config_;
 
-  light::ChannelColors channel_colors_{0, 1, 2, light::ChannelColors::NO_WHITE};
   Chipset chipset_{CHIPSET_CUSTOM};
 
   uint32_t last_refresh_{0};

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -63,7 +63,7 @@ class RP2040PIOLEDStripLightOutput final : public light::AddressableLight {
  protected:
   static void dma_write_complete_handler();
 
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
 
   uint8_t pin_;
 

--- a/esphome/components/rp2040_pio_led_strip/light.py
+++ b/esphome/components/rp2040_pio_led_strip/light.py
@@ -222,17 +222,16 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config: ConfigType) -> None:
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    var = cg.new_Pvariable(
+        config[CONF_OUTPUT_ID],
+        config[CONF_NUM_LEDS],
+        light.channel_colors_struct(config[CONF_CHANNEL_COLORS]),
+    )
     id = config[CONF_ID].id
     await light.register_light(var, config)
     await cg.register_component(var, config)
 
-    cg.add(var.set_num_leds(config[CONF_NUM_LEDS]))
     cg.add(var.set_pin(config[CONF_PIN]))
-
-    cg.add(
-        var.set_channel_colors(light.channel_colors_struct(config[CONF_CHANNEL_COLORS]))
-    )
 
     cg.add(var.set_pio(config[CONF_PIO]))
     cg.add(var.set_program(cg.RawExpression(f"&rp2040_pio_led_strip_{id}_program")))

--- a/esphome/components/spi_led_strip/spi_led_strip.cpp
+++ b/esphome/components/spi_led_strip/spi_led_strip.cpp
@@ -3,29 +3,14 @@
 
 namespace esphome::spi_led_strip {
 
-SpiLedStrip::SpiLedStrip(uint16_t num_leds) {
-  this->num_leds_ = num_leds;
-  RAMAllocator<uint8_t> allocator;
-  this->buffer_size_ = num_leds * 4 + 8;
-  this->buf_ = allocator.allocate(this->buffer_size_);
-  if (this->buf_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate buffer of size %u", this->buffer_size_);
-    return;
-  }
-
-  this->effect_data_ = allocator.allocate(num_leds);
-  if (this->effect_data_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate effect data of size %u", num_leds);
-    return;
-  }
-  memset(this->buf_, 0xFF, this->buffer_size_);
-  memset(this->buf_, 0, 4);
-}
 void SpiLedStrip::setup() {
-  if (this->effect_data_ == nullptr || this->buf_ == nullptr) {
+  RAMAllocator<uint8_t> allocator;
+  if (!this->buffer_.allocate_and_setup(&allocator)) {
+    ESP_LOGE(TAG, "Cannot allocate color buffer");
     this->mark_failed();
     return;
   }
+  memset(this->buffer_.get_led_data() + 4, 0xFF, this->buffer_.get_led_data_bytes() - 4);
   this->spi_setup();
 }
 light::LightTraits SpiLedStrip::get_traits() {
@@ -37,7 +22,7 @@ void SpiLedStrip::dump_config() {
   esph_log_config(TAG,
                   "SPI LED Strip:\n"
                   "  LEDs: %d",
-                  this->num_leds_);
+                  this->buffer_.size());
   if (this->data_rate_ >= spi::DATA_RATE_1MHZ) {
     esph_log_config(TAG, "  Data rate: %uMHz", (unsigned) (this->data_rate_ / 1000000));
   } else {
@@ -45,23 +30,19 @@ void SpiLedStrip::dump_config() {
   }
 }
 void SpiLedStrip::write_state(light::LightState *state) {
-  if (this->is_failed())
+  if (!this->is_ready()) {
     return;
+  }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   {
     char strbuf[49];  // format_hex_pretty_size(16) = 48, fits 16 bytes
-    size_t len = std::min(this->buffer_size_, (size_t) 16);
-    format_hex_pretty_to(strbuf, sizeof(strbuf), this->buf_, len, ' ');
+    size_t len = std::min(this->buffer_.get_led_data_bytes(), (size_t) 16);
+    format_hex_pretty_to(strbuf, sizeof(strbuf), this->buffer_.get_led_data(), len, ' ');
     esph_log_v(TAG, "write_state: buf = %s", strbuf);
   }
 #endif
   this->enable();
-  this->write_array(this->buf_, this->buffer_size_);
+  this->write_array(this->buffer_.get_led_data(), this->buffer_.get_led_data_bytes());
   this->disable();
-}
-light::ESPColorView SpiLedStrip::get_view_internal(int32_t index) const {
-  size_t pos = index * 4 + 5;
-  return {this->buf_ + pos + 2,       this->buf_ + pos + 1, this->buf_ + pos + 0, nullptr,
-          this->effect_data_ + index, &this->correction_};
 }
 }  // namespace esphome::spi_led_strip

--- a/esphome/components/spi_led_strip/spi_led_strip.cpp
+++ b/esphome/components/spi_led_strip/spi_led_strip.cpp
@@ -21,7 +21,7 @@ light::LightTraits SpiLedStrip::get_traits() {
 void SpiLedStrip::dump_config() {
   esph_log_config(TAG,
                   "SPI LED Strip:\n"
-                  "  LEDs: %d",
+                  "  Number of LEDs: %u",
                   this->buffer_.size());
   if (this->data_rate_ >= spi::DATA_RATE_1MHZ) {
     esph_log_config(TAG, "  Data rate: %uMHz", (unsigned) (this->data_rate_ / 1000000));

--- a/esphome/components/spi_led_strip/spi_led_strip.h
+++ b/esphome/components/spi_led_strip/spi_led_strip.h
@@ -12,11 +12,18 @@ class SpiLedStrip final : public light::AddressableLight,
                           public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
                                                 spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
  public:
-  SpiLedStrip(uint16_t num_leds);
+  SpiLedStrip(size_t num_leds, light::ChannelColors channel_colors)
+      : buffer_(num_leds,
+                {.channel_colors = {.r = 3, .g = 2, .b = 1, .w = light::ChannelColors::NO_WHITE},
+                 .bytes_per_led = 4,
+                 .leading_bytes = 4,
+                 .trailing_bytes = 4},
+                &this->correction_) {}
+
+  light::ESPColorBuffer &buffer() override { return this->buffer_; }
+
   void setup() override;
   float get_setup_priority() const override { return setup_priority::IO; }
-
-  int32_t size() const override { return this->num_leds_; }
 
   light::LightTraits get_traits() override;
 
@@ -24,15 +31,8 @@ class SpiLedStrip final : public light::AddressableLight,
 
   void write_state(light::LightState *state) override;
 
-  void clear_effect_data() override { memset(this->effect_data_, 0, this->num_leds_ * sizeof(this->effect_data_[0])); }
-
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override;
-
-  size_t buffer_size_{};
-  uint8_t *effect_data_{nullptr};
-  uint8_t *buf_{nullptr};
-  uint16_t num_leds_;
+  light::InterleavedColorBuffer buffer_;
 };
 
 }  // namespace esphome::spi_led_strip

--- a/esphome/components/spi_led_strip/spi_led_strip.h
+++ b/esphome/components/spi_led_strip/spi_led_strip.h
@@ -12,7 +12,7 @@ class SpiLedStrip final : public light::AddressableLight,
                           public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
                                                 spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
  public:
-  SpiLedStrip(size_t num_leds, light::ChannelColors channel_colors)
+  SpiLedStrip(size_t num_leds)
       : buffer_(num_leds,
                 {.channel_colors = {.r = 3, .g = 2, .b = 1, .w = light::ChannelColors::NO_WHITE},
                  .bytes_per_led = 4,

--- a/esphome/components/spi_led_strip/spi_led_strip.h
+++ b/esphome/components/spi_led_strip/spi_led_strip.h
@@ -12,7 +12,7 @@ class SpiLedStrip final : public light::AddressableLight,
                           public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_HIGH,
                                                 spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
  public:
-  SpiLedStrip(size_t num_leds)
+  explicit SpiLedStrip(size_t num_leds)
       : buffer_(num_leds,
                 {.channel_colors = {.r = 3, .g = 2, .b = 1, .w = light::ChannelColors::NO_WHITE},
                  .bytes_per_led = 4,
@@ -32,7 +32,7 @@ class SpiLedStrip final : public light::AddressableLight,
   void write_state(light::LightState *state) override;
 
  protected:
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
 };
 
 }  // namespace esphome::spi_led_strip

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -50,9 +50,7 @@ void WLEDLightEffect::stop() {
 }
 
 void WLEDLightEffect::blank_all_leds_(light::AddressableLight &it) {
-  for (int led = it.size(); led-- > 0;) {
-    it[led].set(Color::BLACK);
-  }
+  it.buffer().all().set(Color::BLACK);
   it.schedule_show();
 }
 
@@ -177,9 +175,7 @@ bool WLEDLightEffect::parse_notifier_frame_(light::AddressableLight &it, const u
   uint8_t b = esp_scale8(payload[3], bri);
   uint8_t w = esp_scale8(payload[8], bri);
 
-  for (auto &&led : it) {
-    led.set(Color(r, g, b, w));
-  }
+  it.buffer().all().set(Color(r, g, b, w));
 
   return true;
 }
@@ -190,8 +186,9 @@ bool WLEDLightEffect::parse_warls_frame_(light::AddressableLight &it, const uint
     return false;
   }
 
-  auto count = size / 4;
-  auto max_leds = it.size();
+  light::ESPColorBuffer &buffer = it.buffer();
+  size_t count = size / 4;
+  size_t max_leds = buffer.size();
 
   for (; count > 0; count--, payload += 4) {
     uint8_t led = payload[0];
@@ -200,7 +197,7 @@ bool WLEDLightEffect::parse_warls_frame_(light::AddressableLight &it, const uint
     uint8_t b = payload[3];
 
     if (led < max_leds) {
-      it[led].set(Color(r, g, b));
+      buffer[led].set(Color(r, g, b));
     }
   }
 
@@ -213,17 +210,14 @@ bool WLEDLightEffect::parse_drgb_frame_(light::AddressableLight &it, const uint8
     return false;
   }
 
-  auto count = size / 3;
-  auto max_leds = it.size();
+  light::ESPColorBuffer &buffer = it.buffer();
+  auto count = std::min<size_t>(size / 3, buffer.size());
 
-  for (uint16_t led = 0; led < count; ++led, payload += 3) {
+  for (size_t led = 0; led < count; ++led, payload += 3) {
     uint8_t r = payload[0];
     uint8_t g = payload[1];
     uint8_t b = payload[2];
-
-    if (led < max_leds) {
-      it[led].set(Color(r, g, b));
-    }
+    buffer[led].set(Color(r, g, b));
   }
 
   return true;
@@ -235,18 +229,15 @@ bool WLEDLightEffect::parse_drgbw_frame_(light::AddressableLight &it, const uint
     return false;
   }
 
-  auto count = size / 4;
-  auto max_leds = it.size();
+  light::ESPColorBuffer &buffer = it.buffer();
+  auto count = std::min<size_t>(size / 4, buffer.size());
 
   for (uint16_t led = 0; led < count; ++led, payload += 4) {
     uint8_t r = payload[0];
     uint8_t g = payload[1];
     uint8_t b = payload[2];
     uint8_t w = payload[3];
-
-    if (led < max_leds) {
-      it[led].set(Color(r, g, b, w));
-    }
+    buffer[led].set(Color(r, g, b, w));
   }
 
   return true;
@@ -258,7 +249,7 @@ bool WLEDLightEffect::parse_dnrgb_frame_(light::AddressableLight &it, const uint
     return false;
   }
 
-  uint16_t led = (uint16_t(payload[0]) << 8) + payload[1];
+  size_t led = (uint16_t(payload[0]) << 8) + payload[1];
   payload += 2;
   size -= 2;
 
@@ -267,17 +258,14 @@ bool WLEDLightEffect::parse_dnrgb_frame_(light::AddressableLight &it, const uint
     return false;
   }
 
-  auto count = size / 3;
-  auto max_leds = it.size();
+  light::ESPColorBuffer &buffer = it.buffer();
+  auto end = std::min<size_t>(led + size / 3, buffer.size());
 
-  for (; count > 0; count--, payload += 3, led++) {
+  for (; led < end; led++, payload += 3) {
     uint8_t r = payload[0];
     uint8_t g = payload[1];
     uint8_t b = payload[2];
-
-    if (led < max_leds) {
-      it[led].set(Color(r, g, b));
-    }
+    buffer[led].set(Color(r, g, b));
   }
 
   return true;

--- a/tests/components/adalight/test.esp8266-ard.yaml
+++ b/tests/components/adalight/test.esp8266-ard.yaml
@@ -1,0 +1,22 @@
+logger:
+  baud_rate: 0
+
+uart:
+  rx_buffer_size: 1024
+  baud_rate: 115200
+  rx_pin: 1
+  tx_pin: 0
+
+adalight:
+
+light:
+  - platform: neopixelbus
+    id: addr
+    name: Neopixelbus Light
+    method: esp8266_uart
+    num_leds: 5
+    pin: 2
+    type: GRBW
+    variant: SK6812
+    effects:
+      - adalight:

--- a/tests/components/adalight/test.esp8266-ard.yaml
+++ b/tests/components/adalight/test.esp8266-ard.yaml
@@ -11,7 +11,7 @@ adalight:
 
 light:
   - platform: neopixelbus
-    id: addr
+    id: adalight_light
     name: Neopixelbus Light
     method: esp8266_uart
     num_leds: 5

--- a/tests/components/fastled_clockless/common.yaml
+++ b/tests/components/fastled_clockless/common.yaml
@@ -53,7 +53,7 @@ light:
           name: Test For Custom Lambda Effect
           lambda: |-
             if (initial_run) {
-              it[0] = current_color;
+              it.buffer()[0] = current_color;
             }
       - automation:
           name: Custom Effect

--- a/tests/components/fastled_spi/common.yaml
+++ b/tests/components/fastled_spi/common.yaml
@@ -53,7 +53,7 @@ light:
           name: Test For Custom Lambda Effect
           lambda: |-
             if (initial_run) {
-              it[0] = current_color;
+              it.buffer()[0] = current_color;
             }
       - automation:
           name: Custom Effect

--- a/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
@@ -37,7 +37,7 @@ class MockAddressableLight : public light::AddressableLight {
   uint8_t get_raw_white(uint16_t index) const { return this->buffer_.get_led_data()[index * 4 + 3]; }
 
  protected:
-  light::InterleavedColorBuffer buffer_;
+  light::PackedColorBuffer buffer_;
 };
 
 }  // namespace esphome::mock_addressable_light

--- a/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
@@ -15,15 +15,14 @@ namespace esphome::mock_addressable_light {
 class MockAddressableLight : public light::AddressableLight {
  public:
   explicit MockAddressableLight(uint16_t num_leds)
-      : num_leds_(num_leds), buf_(new uint8_t[num_leds * 4]()), effect_data_(new uint8_t[num_leds]()) {}
+      : buffer_(num_leds, {.channel_colors = {.r = 0, .g = 1, .b = 2, .w = 3}}, &this->correction_) {
+    RAMAllocator<uint8_t> allocator;
+    buffer_.allocate_and_setup(&allocator);
+  }
 
+  light::ESPColorBuffer &buffer() override { return buffer_; }
   void setup() override {}
   void write_state(light::LightState *state) override {}
-  int32_t size() const override { return this->num_leds_; }
-  void clear_effect_data() override {
-    for (uint16_t i = 0; i < this->num_leds_; i++)
-      this->effect_data_[i] = 0;
-  }
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::RGB});
@@ -32,21 +31,13 @@ class MockAddressableLight : public light::AddressableLight {
 
   // Accessors for tests: return the raw stored byte (post gamma correction),
   // which is what actual LED hardware would receive.
-  uint8_t get_raw_red(uint16_t index) const { return this->buf_[index * 4 + 0]; }
-  uint8_t get_raw_green(uint16_t index) const { return this->buf_[index * 4 + 1]; }
-  uint8_t get_raw_blue(uint16_t index) const { return this->buf_[index * 4 + 2]; }
-  uint8_t get_raw_white(uint16_t index) const { return this->buf_[index * 4 + 3]; }
+  uint8_t get_raw_red(uint16_t index) const { return this->buffer_.get_led_data()[index * 4 + 0]; }
+  uint8_t get_raw_green(uint16_t index) const { return this->buffer_.get_led_data()[index * 4 + 1]; }
+  uint8_t get_raw_blue(uint16_t index) const { return this->buffer_.get_led_data()[index * 4 + 2]; }
+  uint8_t get_raw_white(uint16_t index) const { return this->buffer_.get_led_data()[index * 4 + 3]; }
 
  protected:
-  light::ESPColorView get_view_internal(int32_t index) const override {
-    size_t pos = index * 4;
-    return {this->buf_.get() + pos + 0, this->buf_.get() + pos + 1,       this->buf_.get() + pos + 2,
-            this->buf_.get() + pos + 3, this->effect_data_.get() + index, &this->correction_};
-  }
-
-  uint16_t num_leds_;
-  std::unique_ptr<uint8_t[]> buf_;
-  std::unique_ptr<uint8_t[]> effect_data_;
+  light::InterleavedColorBuffer buffer_;
 };
 
 }  // namespace esphome::mock_addressable_light


### PR DESCRIPTION
# What does this implement/fix?

- Harden components against failures in setup (used to crash).
- Ensure component is ready in write_state() and remove redundant checks.
- Handle case where ESPColorView points nowhere.
- Migrate buffer access API to ESPColorBuffer class for reuse.
- Deprecate old API on AccessibleLight and delegate to buffer instead.
- Make ESPColorView final to allow setters to be devirtualized.
- Optimize is_all_black() test because it's called on every frame.
- Move initialization logic to component constructor wherever possible.
- Update every addressable light output and effect component accordingly.
- Streamline buffer access in effects.
- Delete unused code in a few places.
- Rectify the assortment of types used to refer to the number of LEDs and to internally index LEDs within the buffer, use size_t to prevent confusion of signedness wherever possible.  Note that the buffer API still accepts int32_t indices and translates them as before.

This change implements the alternative I discussed in https://github.com/esphome/esphome/pull/19081.  It cleans up a lot of cruft and should make it easier to continue evolving the API.

Currently marked as draft to give the build bots some time to run all of the tests.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [X] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- TODO: esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- TODO: esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [X] RP2040/RP2350
- [X] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
