### PR TITLE
[remote_receiver] Size the RMT ring buffer from receive symbols by default

### DIFF
--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -112,9 +112,10 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.Required(CONF_PIN): cv.All(pins.internal_gpio_input_pin_schema),
             cv.Optional(CONF_DUMP, default=[]): remote_base.validate_dumpers,
             cv.Optional(CONF_TOLERANCE, default="25%"): validate_tolerance,
+            # RMT targets size the ring from receive_symbols unless set, see setup()
             cv.SplitDefault(
                 CONF_BUFFER_SIZE,
-                esp32="10000b",
+                esp32=cv.UNDEFINED,
                 esp32_c2="1000b",
                 esp32_c61="1000b",
                 esp8266="1000b",
@@ -233,7 +234,8 @@ async def to_code(config: ConfigType) -> None:
             config[CONF_TOLERANCE][CONF_VALUE], config[CONF_TOLERANCE][CONF_TYPE]
         )
     )
-    cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))
+    if (buffer_size := config.get(CONF_BUFFER_SIZE)) is not None:
+        cg.add(var.set_buffer_size(buffer_size))
     cg.add(var.set_filter_us(config[CONF_FILTER]))
     cg.add(var.set_idle_us(config[CONF_IDLE]))
 

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -125,7 +125,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
                 ln882x="1000b",
                 rtl87xx="1000b",
                 rp2="1000b",
-            ): cv.validate_bytes,
+            ): cv.All(cv.validate_bytes, cv.int_range(min=64)),
             cv.Optional(CONF_FILTER, default="50us"): cv.All(
                 cv.positive_time_period_microseconds,
                 cv.Range(max=TimePeriod(microseconds=4294967295)),

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -115,8 +115,11 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.SplitDefault(
                 CONF_BUFFER_SIZE,
                 esp32=cv.UNDEFINED,
-                esp32_c2="1000b",
-                esp32_c61="1000b",
+                # the pulse ring needs a size; only RMT targets size themselves in setup()
+                **{
+                    f"esp32_{variant.removeprefix('ESP32').lower()}": "1000b"
+                    for variant in esp32_rmt.VARIANTS_NO_RMT
+                },
                 esp8266="1000b",
                 bk72xx="1000b",
                 ln882x="1000b",

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -112,7 +112,6 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.Required(CONF_PIN): cv.All(pins.internal_gpio_input_pin_schema),
             cv.Optional(CONF_DUMP, default=[]): remote_base.validate_dumpers,
             cv.Optional(CONF_TOLERANCE, default="25%"): validate_tolerance,
-            # RMT targets size the ring from receive_symbols unless set, see setup()
             cv.SplitDefault(
                 CONF_BUFFER_SIZE,
                 esp32=cv.UNDEFINED,
@@ -234,8 +233,8 @@ async def to_code(config: ConfigType) -> None:
             config[CONF_TOLERANCE][CONF_VALUE], config[CONF_TOLERANCE][CONF_TYPE]
         )
     )
-    if (buffer_size := config.get(CONF_BUFFER_SIZE)) is not None:
-        cg.add(var.set_buffer_size(buffer_size))
+    if CONF_BUFFER_SIZE in config:
+        cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))
     cg.add(var.set_filter_us(config[CONF_FILTER]))
     cg.add(var.set_idle_us(config[CONF_IDLE]))
 

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -47,7 +47,7 @@ struct RemoteReceiverComponentStore {
   /// The position last read from
   volatile uint32_t buffer_read{0};
   bool overflow{false};
-  uint32_t buffer_size{1000};
+  uint32_t buffer_size{0};
   uint32_t receive_size{0};
   uint32_t filter_symbols{0};
   esp_err_t error{ESP_OK};

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -101,7 +101,7 @@ class RemoteReceiverComponent final : public remote_base::RemoteReceiverBase,
   HighFrequencyLoopRequester high_freq_;
 #endif
 
-  uint32_t buffer_size_{};
+  uint32_t buffer_size_{};  // 0 on RMT targets: sized from receive_symbols in setup()
   uint32_t filter_us_{10};
   uint32_t idle_us_{10000};
 };

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -122,22 +122,23 @@ void RemoteReceiverComponent::setup() {
 }
 
 void RemoteReceiverComponent::dump_config() {
-  ESP_LOGCONFIG(TAG,
-                "Remote Receiver:\n"
-                "  Clock resolution: %" PRIu32 " hz\n"
-                "  RMT symbols: %" PRIu32 "\n"
-                "  Filter symbols: %" PRIu32 "\n"
-                "  Receive symbols: %" PRIu32 "\n"
-                "  Buffer size: %" PRIu32 " bytes\n"
-                "  Tolerance: %" PRIu32 "%s\n"
-                "  Carrier frequency: %" PRIu32 " hz\n"
-                "  Carrier duty: %u%%\n"
-                "  Filter out pulses shorter than: %" PRIu32 " us\n"
-                "  Signal is done after %" PRIu32 " us of no changes",
-                this->clock_resolution_, this->rmt_symbols_, this->filter_symbols_, this->receive_symbols_,
-                this->store_.buffer_size, this->tolerance_,
-                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->carrier_frequency_,
-                this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
+  ESP_LOGCONFIG(
+      TAG,
+      "Remote Receiver:\n"
+      "  Clock resolution: %" PRIu32 " hz\n"
+      "  RMT symbols: %" PRIu32 "\n"
+      "  Filter symbols: %" PRIu32 "\n"
+      "  Receive symbols: %" PRIu32 "\n"
+      "  Buffer size: %" PRIu32 " bytes\n"
+      "  Tolerance: %" PRIu32 "%s\n"
+      "  Carrier frequency: %" PRIu32 " hz\n"
+      "  Carrier duty: %u%%\n"
+      "  Filter out pulses shorter than: %" PRIu32 " us\n"
+      "  Signal is done after %" PRIu32 " us of no changes",
+      this->clock_resolution_, this->rmt_symbols_, this->filter_symbols_, this->receive_symbols_,
+      this->store_.buffer_size, this->tolerance_,
+      (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? LOG_STR_LITERAL(" us") : LOG_STR_LITERAL("%"),
+      this->carrier_frequency_, this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
   LOG_PIN("  Pin: ", this->pin_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -10,6 +10,7 @@
 namespace esphome::remote_receiver {
 
 static const char *const TAG = "remote_receiver";
+static constexpr uint32_t DEFAULT_BUFFER_SLOTS = 4;
 
 static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_rx_done_event_data_t *event, void *arg) {
   RemoteReceiverComponentStore *store = (RemoteReceiverComponentStore *) arg;
@@ -104,7 +105,11 @@ void RemoteReceiverComponent::setup() {
   this->store_.config.signal_range_max_ns = this->idle_us_ * 1000;
   this->store_.filter_symbols = this->filter_symbols_;
   this->store_.receive_size = this->receive_symbols_ * sizeof(rmt_symbol_word_t);
-  this->store_.buffer_size = std::max((event_size + this->store_.receive_size) * 2, this->buffer_size_);
+  // one slot per pending rmt_receive; two are the floor (one filling while one is decoded), and
+  // the default of four covers a few frames queued across a stalled loop pass
+  const uint32_t slot_size = event_size + this->store_.receive_size;
+  this->store_.buffer_size =
+      this->buffer_size_ != 0 ? std::max(slot_size * 2, this->buffer_size_) : slot_size * DEFAULT_BUFFER_SLOTS;
   this->store_.buffer = new uint8_t[this->store_.buffer_size];
   error = rmt_receive(this->channel_, (uint8_t *) this->store_.buffer + event_size, this->store_.receive_size,
                       &this->store_.config);
@@ -123,14 +128,16 @@ void RemoteReceiverComponent::dump_config() {
                 "  RMT symbols: %" PRIu32 "\n"
                 "  Filter symbols: %" PRIu32 "\n"
                 "  Receive symbols: %" PRIu32 "\n"
+                "  Buffer size: %" PRIu32 " bytes\n"
                 "  Tolerance: %" PRIu32 "%s\n"
                 "  Carrier frequency: %" PRIu32 " hz\n"
                 "  Carrier duty: %u%%\n"
                 "  Filter out pulses shorter than: %" PRIu32 " us\n"
                 "  Signal is done after %" PRIu32 " us of no changes",
                 this->clock_resolution_, this->rmt_symbols_, this->filter_symbols_, this->receive_symbols_,
-                this->tolerance_, (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%",
-                this->carrier_frequency_, this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
+                this->store_.buffer_size, this->tolerance_,
+                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->carrier_frequency_,
+                this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
   LOG_PIN("  Pin: ", this->pin_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),

--- a/tests/component_tests/remote_receiver/config/receiver_buffer_size.yaml
+++ b/tests/component_tests/remote_receiver/config/receiver_buffer_size.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+remote_receiver:
+  - id: rcvr
+    pin: GPIO4
+    buffer_size: 2kb

--- a/tests/component_tests/remote_receiver/config/receiver_esp32_c2.yaml
+++ b/tests/component_tests/remote_receiver/config/receiver_esp32_c2.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32-c2-devkitm-1
+  variant: esp32c2
+  framework:
+    type: esp-idf
+
+remote_receiver:
+  - id: rcvr
+    pin: GPIO4

--- a/tests/component_tests/remote_receiver/config/receiver_esp8266.yaml
+++ b/tests/component_tests/remote_receiver/config/receiver_esp8266.yaml
@@ -1,0 +1,9 @@
+esphome:
+  name: test
+
+esp8266:
+  board: d1_mini
+
+remote_receiver:
+  - id: rcvr
+    pin: GPIO4

--- a/tests/component_tests/remote_receiver/test_buffer_size.py
+++ b/tests/component_tests/remote_receiver/test_buffer_size.py
@@ -1,0 +1,20 @@
+"""The RMT ring buffer is sized from receive_symbols unless buffer_size is set."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+
+def test_rmt_default_leaves_buffer_size_to_setup(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    main_cpp = generate_main(component_config_path("receiver_bare.yaml"))
+    assert "set_buffer_size" not in main_cpp
+
+
+def test_explicit_buffer_size_is_passed_through(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    main_cpp = generate_main(component_config_path("receiver_buffer_size.yaml"))
+    assert "rcvr->set_buffer_size(2000);" in main_cpp

--- a/tests/component_tests/remote_receiver/test_buffer_size.py
+++ b/tests/component_tests/remote_receiver/test_buffer_size.py
@@ -1,4 +1,4 @@
-"""An explicit buffer_size still reaches the RMT receiver."""
+"""buffer_size reaches the receiver when set, and always on the pulse ring targets."""
 
 from collections.abc import Callable
 from pathlib import Path
@@ -10,3 +10,11 @@ def test_explicit_buffer_size_is_passed_through(
 ) -> None:
     main_cpp = generate_main(component_config_path("receiver_buffer_size.yaml"))
     assert "rcvr->set_buffer_size(2000);" in main_cpp
+
+
+def test_pulse_ring_target_keeps_a_default(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    main_cpp = generate_main(component_config_path("receiver_esp8266.yaml"))
+    assert "rcvr->set_buffer_size(1000);" in main_cpp

--- a/tests/component_tests/remote_receiver/test_buffer_size.py
+++ b/tests/component_tests/remote_receiver/test_buffer_size.py
@@ -18,3 +18,11 @@ def test_pulse_ring_target_keeps_a_default(
 ) -> None:
     main_cpp = generate_main(component_config_path("receiver_esp8266.yaml"))
     assert "rcvr->set_buffer_size(1000);" in main_cpp
+
+
+def test_esp32_variant_without_rmt_keeps_a_default(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    main_cpp = generate_main(component_config_path("receiver_esp32_c2.yaml"))
+    assert "rcvr->set_buffer_size(1000);" in main_cpp

--- a/tests/component_tests/remote_receiver/test_buffer_size.py
+++ b/tests/component_tests/remote_receiver/test_buffer_size.py
@@ -1,15 +1,7 @@
-"""The RMT ring buffer is sized from receive_symbols unless buffer_size is set."""
+"""An explicit buffer_size still reaches the RMT receiver."""
 
 from collections.abc import Callable
 from pathlib import Path
-
-
-def test_rmt_default_leaves_buffer_size_to_setup(
-    generate_main: Callable[[str | Path], str],
-    component_config_path: Callable[[str], Path],
-) -> None:
-    main_cpp = generate_main(component_config_path("receiver_bare.yaml"))
-    assert "set_buffer_size" not in main_cpp
 
 
 def test_explicit_buffer_size_is_passed_through(

--- a/tests/component_tests/remote_receiver/test_slot_counts.py
+++ b/tests/component_tests/remote_receiver/test_slot_counts.py
@@ -27,7 +27,9 @@ def test_bare_receiver_emits_no_counts(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
 ) -> None:
-    generate_main(component_config_path("receiver_bare.yaml"))
+    main_cpp = generate_main(component_config_path("receiver_bare.yaml"))
+    # the RMT ring is sized in setup() unless buffer_size is set
+    assert "set_buffer_size" not in main_cpp
     assert get_define_value("REMOTE_BASE_DUMPER_COUNT") is None
     assert get_define_value("REMOTE_BASE_LISTENER_COUNT") is None
 


### PR DESCRIPTION
# What does this implement/fix?

The ESP32 default of `buffer_size: 10kb` per receiver dates from the legacy RMT driver, where the number was the size of the driver's own item ring. The current driver hands the component one event per pending `rmt_receive`, each up to `receive_symbols` x 4 B plus a 16 B header, and the ring only has to hold a few of those between two loop passes. 10 KB is 12 slots at the default 192 symbols, so most of it was never used.

Without an explicit `buffer_size` the ring is now four slots derived from `receive_symbols`, 3136 B at the defaults, and it grows with `receive_symbols` instead of silently losing slots when that is raised. An explicit `buffer_size` still overrides it down to the two slot floor, and `dump_config` prints the size in use. The existing "Buffer overflow" warning tells anyone who needs more.

Measured on an Athom ESP32 RF/IR remote with two receivers at the defaults: free heap went from 66.3 KiB to 81.3 KiB. The CI memory report cannot show this since the ring is allocated in `setup()`. With the four slot ring the receiver still decoded 339 to 349 rc_switch frames per burst of 10 transmits (349 before) with no overflow logged.

The esphome.io page is updated in the linked docs PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#7367

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_receiver:
  - pin: GPIO4
    dump: nec
    # optional, the default is four slots of receive_symbols
    buffer_size: 2kb
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
