### PR TITLE
[remote_receiver] Wake the main loop when the RMT callback stores a frame

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -34,10 +34,10 @@ static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_r
   event_buffer->received_symbols = event->received_symbols;
   const bool stored = next_write != buffer_write;
   store->buffer_write = next_write;
-  // a stored frame is decoded on the next loop pass instead of waiting out the loop interval;
-  // filtered noise and dropped frames leave nothing to read
+  // a stored frame is decoded, and a failed re-arm reported, on the next loop pass instead of
+  // waiting out the loop interval; filtered noise and dropped frames leave nothing to read
   BaseType_t task_woken = pdFALSE;
-  if (stored)
+  if (stored || store->error != ESP_OK)
     wake_loop_isrsafe(&task_woken);
   return task_woken != pdFALSE;
 }

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -1,4 +1,5 @@
 #include "remote_receiver.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -31,7 +32,10 @@ static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_r
   event_buffer->num_symbols = event->num_symbols;
   event_buffer->received_symbols = event->received_symbols;
   store->buffer_write = next_write;
-  return false;
+  // decode on the next loop pass instead of waiting out the loop interval
+  BaseType_t task_woken = pdFALSE;
+  Application::wake_loop_isrsafe(&task_woken);
+  return task_woken == pdTRUE;
 }
 
 void RemoteReceiverComponent::setup() {

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -14,24 +14,25 @@ static const char *const TAG = "remote_receiver";
 
 static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_rx_done_event_data_t *event, void *arg) {
   RemoteReceiverComponentStore *store = (RemoteReceiverComponentStore *) arg;
-  rmt_rx_done_event_data_t *event_buffer = (rmt_rx_done_event_data_t *) (store->buffer + store->buffer_write);
+  const uint32_t buffer_write = store->buffer_write;
+  rmt_rx_done_event_data_t *event_buffer = (rmt_rx_done_event_data_t *) (store->buffer + buffer_write);
   uint32_t event_size = sizeof(rmt_rx_done_event_data_t);
-  uint32_t next_write = store->buffer_write + event_size + event->num_symbols * sizeof(rmt_symbol_word_t);
+  uint32_t next_write = buffer_write + event_size + event->num_symbols * sizeof(rmt_symbol_word_t);
   if (next_write + event_size + store->receive_size > store->buffer_size) {
     next_write = 0;
   }
   if (store->buffer_read - next_write < event_size + store->receive_size) {
-    next_write = store->buffer_write;
+    next_write = buffer_write;
     store->overflow = true;
   }
   if (event->num_symbols <= store->filter_symbols) {
-    next_write = store->buffer_write;
+    next_write = buffer_write;
   }
   store->error =
       rmt_receive(channel, (uint8_t *) store->buffer + next_write + event_size, store->receive_size, &store->config);
   event_buffer->num_symbols = event->num_symbols;
   event_buffer->received_symbols = event->received_symbols;
-  const bool stored = next_write != store->buffer_write;
+  const bool stored = next_write != buffer_write;
   store->buffer_write = next_write;
   // a stored frame is decoded on the next loop pass instead of waiting out the loop interval;
   // filtered noise and dropped frames leave nothing to read

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -1,6 +1,6 @@
 #include "remote_receiver.h"
-#include "esphome/core/application.h"
 #include "esphome/core/log.h"
+#include "esphome/core/wake.h"
 
 #ifdef USE_ESP32
 #include <soc/soc_caps.h>
@@ -31,11 +31,14 @@ static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_r
       rmt_receive(channel, (uint8_t *) store->buffer + next_write + event_size, store->receive_size, &store->config);
   event_buffer->num_symbols = event->num_symbols;
   event_buffer->received_symbols = event->received_symbols;
+  const bool stored = next_write != store->buffer_write;
   store->buffer_write = next_write;
-  // decode on the next loop pass instead of waiting out the loop interval
+  // a stored frame is decoded on the next loop pass instead of waiting out the loop interval;
+  // filtered noise and dropped frames leave nothing to read
   BaseType_t task_woken = pdFALSE;
-  Application::wake_loop_isrsafe(&task_woken);
-  return task_woken == pdTRUE;
+  if (stored)
+    wake_loop_isrsafe(&task_woken);
+  return task_woken != pdFALSE;
 }
 
 void RemoteReceiverComponent::setup() {


### PR DESCRIPTION
# What does this implement/fix?

On the ESP32 RMT path the receive callback stored a frame in the ring and returned, and nothing told the main loop about it. The frame waited for the next scheduled loop pass, up to a loop interval and longer while the loop slept at a raised interval, and the ring filled with everything that arrived meanwhile.

The callback now notifies the loop task from the interrupt the same way the ESP-IDF UART driver does, and returns the task woken flag so the driver performs the yield. Decoding and the `on_` triggers run on the very next pass, and the ring drains as soon as a frame lands, so its slots only accumulate while the loop is genuinely stalled. The wake is skipped for frames the callback discards (noise under `filter_symbols`, overflow drops), since those leave nothing to read.

Tested on an Athom ESP32 RF/IR remote with dev plus esphome/esphome#19100 and esphome/esphome#19086 merged: four bursts of 10 raw RF frames each completed 10 of 10, the receiver decoded 339 to 349 rc_switch frames per burst (349 before this change), and no buffer overflow was logged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_receiver:
  - pin: GPIO4
    dump: nec
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
