### PR TITLE
[adalight] Add a component build test.

### DIFF
--- a/tests/components/adalight/test.esp8266-ard.yaml
+++ b/tests/components/adalight/test.esp8266-ard.yaml
@@ -1,0 +1,22 @@
+logger:
+  baud_rate: 0
+
+uart:
+  rx_buffer_size: 1024
+  baud_rate: 115200
+  rx_pin: 1
+  tx_pin: 0
+
+adalight:
+
+light:
+  - platform: neopixelbus
+    id: addr
+    name: Neopixelbus Light
+    method: esp8266_uart
+    num_leds: 5
+    pin: 2
+    type: GRBW
+    variant: SK6812
+    effects:
+      - adalight:

--- a/tests/components/adalight/test.esp8266-ard.yaml
+++ b/tests/components/adalight/test.esp8266-ard.yaml
@@ -11,7 +11,7 @@ adalight:
 
 light:
   - platform: neopixelbus
-    id: addr
+    id: adalight_light
     name: Neopixelbus Light
     method: esp8266_uart
     num_leds: 5


### PR DESCRIPTION
# What does this implement/fix?

There was no build test for the `adalight` component.  Now there is one.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

N/A

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
logger:
  baud_rate: 0

uart:
  rx_buffer_size: 1024
  baud_rate: 115200
  rx_pin: 1
  tx_pin: 0

adalight:

light:
  - platform: neopixelbus
    id: addr
    name: Neopixelbus Light
    method: esp8266_uart
    num_leds: 5
    pin: 2
    type: GRBW
    variant: SK6812
    effects:
      - adalight:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
