### PR TITLE
[core][lvgl] Migrate codegen helpers from LVGL to core code

### DIFF
--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -14,7 +14,7 @@ from esphome.const import (
     CONF_TIMEOUT,
 )
 from esphome.core import Lambda
-from esphome.cpp_generator import TemplateArguments, get_variable
+from esphome.cpp_generator import StaticCastExpression, TemplateArguments, get_variable
 from esphome.cpp_types import nullptr
 
 from .defines import (
@@ -30,7 +30,6 @@ from .defines import (
     CONF_SHOW_SNOW,
     CONF_TOP_LAYER,
     PARTS,
-    StaticCastExpression,
     add_warning,
     get_focused_widgets,
     get_options,

--- a/esphome/components/lvgl/defines.py
+++ b/esphome/components/lvgl/defines.py
@@ -10,12 +10,7 @@ from typing import Any
 from esphome import codegen as cg, config_validation as cv
 from esphome.const import CONF_ITEMS
 from esphome.core import CORE, ID, Lambda
-from esphome.cpp_generator import (
-    CallExpression,
-    LambdaExpression,
-    MockObj,
-    MockObjClass,
-)
+from esphome.cpp_generator import MockObj, StaticCastExpression, call_lambda
 from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
 from esphome.types import Expression, SafeExpType
 
@@ -157,17 +152,6 @@ def get_refreshed_widgets() -> set:
     return _get_data(KEY_REFRESHED_WIDGETS, set())
 
 
-class StaticCastExpression(Expression):
-    __slots__ = ("type", "exp")
-
-    def __init__(self, type: Any, exp: SafeExpType):
-        self.type = str(type)
-        self.exp = cg.safe_exp(exp)
-
-    def __str__(self):
-        return f"static_cast<{self.type}>({self.exp})"
-
-
 def add_define(macro: str, value="1"):
     lv_defines = get_defines()
     value = str(value)
@@ -190,31 +174,6 @@ def literal(arg) -> MockObj:
 
 def addr(arg) -> MockObj:
     return MockObj(f"&{arg}")
-
-
-def call_lambda(lamb: LambdaExpression) -> Expression:
-    """
-    Given a lambda, either reduce to a simple expression or call it, possibly with parameters
-    from the surrounding context
-    :param lamb:
-    :return:
-    """
-    expr = lamb.content.strip()
-    if expr.startswith("return") and expr.endswith(";"):
-        # Convert a lambda returning a simple expression to just that expression
-        expr = cg.RawExpression(expr[6:-1].strip())
-        # Don't cast if the return type is a class
-        if isinstance(lamb.return_type, MockObjClass):
-            return expr
-        return StaticCastExpression(lamb.return_type, expr)
-    # If lambda has parameters, call it with their names
-    # Parameter names come from hardcoded component code (like "x", "it", "event")
-    # not from user input, so they're safe to use directly
-    if lamb.parameters and lamb.parameters.parameters:
-        return CallExpression(
-            lamb, *[MockObj(x.id) for x in lamb.parameters.parameters]
-        )
-    return CallExpression(lamb)
 
 
 class LValidator:

--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -16,7 +16,7 @@ from esphome.const import (
     CONF_VALUE,
 )
 from esphome.core import CORE, ID, Lambda
-from esphome.cpp_generator import MockObj
+from esphome.cpp_generator import MockObj, StaticCastExpression, call_lambda
 from esphome.cpp_types import ESPTime, int32, uint32
 from esphome.helpers import cpp_string_escape
 from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
@@ -33,9 +33,7 @@ from .defines import (
     LV_FONTS,
     LValidator,
     LvConstant,
-    StaticCastExpression,
     add_lv_use,
-    call_lambda,
     get_esphome_fonts_used,
     get_lv_fonts_used,
     get_lv_images_used,

--- a/esphome/components/lvgl/widgets/__init__.py
+++ b/esphome/components/lvgl/widgets/__init__.py
@@ -16,7 +16,7 @@ from esphome.const import (
 )
 from esphome.core import ID, EsphomeError, TimePeriod
 from esphome.coroutine import FakeAwaitable
-from esphome.cpp_generator import MockObj
+from esphome.cpp_generator import MockObj, call_lambda
 from esphome.schema_extractors import EnableSchemaExtraction
 from esphome.types import Expression
 
@@ -42,7 +42,6 @@ from ..defines import (
     STATES,
     LValidator,
     add_lv_use,
-    call_lambda,
     get_styles_used,
     get_theme_widget_map,
     get_widget_map,

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -1211,7 +1211,7 @@ def call_lambda(lamb: LambdaExpression) -> Expression:
     # Developer error if this is called with a lambda that doesn't have a return type
     assert lamb.return_type is not None, "Lambda must have a return type to be called"
     expr = lamb.content.strip()
-    if expr.match(r"^return\b") and expr.endswith(";"):
+    if re.match(r"^return\b", expr) and expr.endswith(";"):
         # Convert a lambda returning a simple expression to just that expression
         expr = RawExpression(expr[6:-1].strip())
         # Don't cast if the return type is a class

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -1203,12 +1203,15 @@ class StaticCastExpression(Expression):
 def call_lambda(lamb: LambdaExpression) -> Expression:
     """
     Given a lambda, either reduce to a simple expression or call it, possibly with parameters
-    from the surrounding context
+    from the surrounding context.
+    This is for use only with value-returning lambdas, used in places where the value of a lambda call is needed.
     :param lamb: The LambdaExpression to call or reduce
     :return: An Expression representing the result of calling the lambda or reducing it to a simple expression
     """
+    # Developer error if this is called with a lambda that doesn't have a return type
+    assert lamb.return_type is not None, "Lambda must have a return type to be called"
     expr = lamb.content.strip()
-    if expr.startswith("return") and expr.endswith(";"):
+    if expr.match(r"^return\b") and expr.endswith(";"):
         # Convert a lambda returning a simple expression to just that expression
         expr = RawExpression(expr[6:-1].strip())
         # Don't cast if the return type is a class

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -1187,3 +1187,39 @@ class MockObjClass(MockObj):
 
     def __repr__(self):
         return f"MockObjClass<{str(self.base)}, parents={self._parents}>"
+
+
+class StaticCastExpression(Expression):
+    __slots__ = ("type", "exp")
+
+    def __init__(self, type: Any, exp: SafeExpType):
+        self.type = str(type)
+        self.exp = safe_exp(exp)
+
+    def __str__(self):
+        return f"static_cast<{self.type}>({self.exp})"
+
+
+def call_lambda(lamb: LambdaExpression) -> Expression:
+    """
+    Given a lambda, either reduce to a simple expression or call it, possibly with parameters
+    from the surrounding context
+    :param lamb: The LambdaExpression to call or reduce
+    :return: An Expression representing the result of calling the lambda or reducing it to a simple expression
+    """
+    expr = lamb.content.strip()
+    if expr.startswith("return") and expr.endswith(";"):
+        # Convert a lambda returning a simple expression to just that expression
+        expr = RawExpression(expr[6:-1].strip())
+        # Don't cast if the return type is a class
+        if isinstance(lamb.return_type, MockObjClass):
+            return expr
+        return StaticCastExpression(lamb.return_type, expr)
+    # If lambda has parameters, call it with their names
+    # Parameter names come from hardcoded component code (like "x", "it", "event")
+    # not from user input, so they're safe to use directly
+    if lamb.parameters and lamb.parameters.parameters:
+        return CallExpression(
+            lamb, *[MockObj(x.id) for x in lamb.parameters.parameters]
+        )
+    return CallExpression(lamb)

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -85,6 +85,15 @@ class TestCallExpression:
         assert actual == 'my_function<int32_t, float>(1, "2", false)'
 
 
+class TestStaticCastExpression:
+    def test_str(self):
+        target = cg.StaticCastExpression(ct.bool_, 42)
+
+        actual = str(target)
+
+        assert actual == "static_cast<bool>(42)"
+
+
 class TestStructInitializer:
     def test_str(self):
         target = cg.StructInitializer(
@@ -227,6 +236,55 @@ class TestLambdaExpression:
         assert actual == (
             "[captured_var](int32_t x) -> int32_t {\n  return captured_var + x;\n}"
         )
+
+
+class TestCallLambda:
+    """Tests for the call_lambda() function."""
+
+    def test_call_lambda__return_expression_casts_to_return_type(self):
+        """A lambda body that is just a return statement reduces to the
+        expression, cast to the lambda's return type."""
+        lamb = cg.LambdaExpression(("return foo + 1;",), (), "", ct.bool_)
+
+        result = cg.call_lambda(lamb)
+
+        assert isinstance(result, cg.StaticCastExpression)
+        assert str(result) == "static_cast<bool>(foo + 1)"
+
+    def test_call_lambda__return_expression_with_class_return_type_no_cast(self):
+        """A class return type is not cast, since static_cast doesn't apply
+        to arbitrary class types."""
+        mock_class = cg.MockObjClass("foo::Bar", parents=())
+        lamb = cg.LambdaExpression(("return get_bar();",), (), "", mock_class)
+
+        result = cg.call_lambda(lamb)
+
+        assert isinstance(result, cg.RawExpression)
+        assert str(result) == "get_bar()"
+
+    def test_call_lambda__no_return_with_parameters_calls_with_names(self):
+        """A multi-statement lambda with parameters is called with the
+        parameter names as arguments."""
+        lamb = cg.LambdaExpression(
+            ("do_something(x, y);",), ((int, "x"), (float, "y")), "="
+        )
+
+        result = cg.call_lambda(lamb)
+
+        assert isinstance(result, cg.CallExpression)
+        assert str(result) == (
+            "[=](int32_t x, float y) {\n  do_something(x, y);\n}(x, y)"
+        )
+
+    def test_call_lambda__no_return_no_parameters_calls_with_no_args(self):
+        """A multi-statement lambda without parameters is called with no
+        arguments."""
+        lamb = cg.LambdaExpression(("do_something();",), (), "")
+
+        result = cg.call_lambda(lamb)
+
+        assert isinstance(result, cg.CallExpression)
+        assert str(result) == "[]() {\n  do_something();\n}()"
 
 
 class TestLiterals:

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -266,25 +266,46 @@ class TestCallLambda:
         """A multi-statement lambda with parameters is called with the
         parameter names as arguments."""
         lamb = cg.LambdaExpression(
-            ("do_something(x, y);",), ((int, "x"), (float, "y")), "="
+            ("do_something(x, y);",), ((int, "x"), (float, "y")), "=", ct.bool_
         )
 
         result = cg.call_lambda(lamb)
 
         assert isinstance(result, cg.CallExpression)
         assert str(result) == (
-            "[=](int32_t x, float y) {\n  do_something(x, y);\n}(x, y)"
+            "[=](int32_t x, float y) -> bool {\n  do_something(x, y);\n}(x, y)"
         )
 
-    def test_call_lambda__no_return_no_parameters_calls_with_no_args(self):
-        """A multi-statement lambda without parameters is called with no
-        arguments."""
-        lamb = cg.LambdaExpression(("do_something();",), (), "")
+    def test_call_lambda__no_return_type_raises(self):
+        """Calling a lambda with no declared return type is a developer
+        error: call_lambda is only for value-returning lambdas."""
+        lamb = cg.LambdaExpression(("do_something();",), (), "=")
+
+        with pytest.raises(AssertionError):
+            cg.call_lambda(lamb)
+
+    def test_call_lambda__identifier_starting_with_return_is_not_a_return_statement(
+        self,
+    ):
+        """A body that merely starts with the substring "return" (e.g. a call
+        to a function named returnValue()) must not be mistaken for a return
+        statement -- the match requires a word boundary after "return"."""
+        lamb = cg.LambdaExpression(("returnValue();",), (), "=", ct.bool_)
 
         result = cg.call_lambda(lamb)
 
         assert isinstance(result, cg.CallExpression)
-        assert str(result) == "[]() {\n  do_something();\n}()"
+        assert str(result) == "[=]() -> bool {\n  returnValue();\n}()"
+
+    def test_call_lambda__no_return_no_parameters_calls_with_no_args(self):
+        """A multi-statement lambda without parameters is called with no
+        arguments."""
+        lamb = cg.LambdaExpression(("do_something();",), (), "", ct.bool_)
+
+        result = cg.call_lambda(lamb)
+
+        assert isinstance(result, cg.CallExpression)
+        assert str(result) == "[]() -> bool {\n  do_something();\n}()"
 
 
 class TestLiterals:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The lvgl component had a python class `StaticCastExpression` representing a C++ static cast expression, and a helper to evaluate a lambda, reducing simple `return` statements to inline expressions where possible.

These items have applicability beyond LVGL, so this PR moves them to the core cpp_generator.py module.

Needed for a bug fix in #18997 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
