### PR TITLE
[esp32] Redefine __FILE__ to the basename so assert paths stay out of RAM

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2609,6 +2609,11 @@ async def to_code(config):
     # NVS finds stored preferences by key, so preference key migration is possible
     cg.add_define("USE_PREFERENCE_KEY_LOOKUP")
     cg.add_build_flag("-Wl,-z,noexecstack")
+    # assert(), HAL_ASSERT and ESP_ERROR_CHECK bake __FILE__ into rodata, and
+    # IDF's noflash placement puts the flash driver's copies in DRAM. The
+    # basename keeps the panic output useful at a fraction of the size.
+    cg.add_build_flag("-D__FILE__=__FILE_NAME__")
+    cg.add_build_flag("-Wno-builtin-macro-redefined")
     # Deferred so KEY_COMPONENTS is fully populated -- see the coroutine.
     CORE.add_job(_finalize_arduino_aware_flags)
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2612,8 +2612,10 @@ async def to_code(config):
     # assert(), HAL_ASSERT and ESP_ERROR_CHECK bake __FILE__ into rodata, and
     # IDF's noflash placement puts the flash driver's copies in DRAM. The
     # basename keeps the panic output useful at a fraction of the size.
-    cg.add_build_flag("-D__FILE__=__FILE_NAME__")
-    cg.add_build_flag("-Wno-builtin-macro-redefined")
+    # __FILE_NAME__ is a GCC 12 builtin; IDF 5.0 still ships GCC 11.2.
+    if idf_version() >= cv.Version(5, 1, 0):
+        cg.add_build_flag("-D__FILE__=__FILE_NAME__")
+        cg.add_build_flag("-Wno-builtin-macro-redefined")
     # Deferred so KEY_COMPONENTS is fully populated -- see the coroutine.
     CORE.add_job(_finalize_arduino_aware_flags)
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])

--- a/tests/component_tests/esp32/config/file_macro_idf_5_0.yaml
+++ b/tests/component_tests/esp32/config/file_macro_idf_5_0.yaml
@@ -1,0 +1,8 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    version: 5.0.6

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -659,18 +659,24 @@ def test_platformio_arduino_enables_reproducible_build(
 
 
 @pytest.mark.parametrize(
-    "config_file", ["reproducible_build.yaml", "reproducible_build_arduino.yaml"]
+    ("config_file", "expected"),
+    [
+        ("reproducible_build.yaml", True),
+        ("reproducible_build_arduino.yaml", True),
+        ("file_macro_idf_5_0.yaml", False),
+    ],
 )
 def test_file_macro_is_basename_only(
     generate_main: Callable[[str | Path], str],
     component_config_path: Callable[[str], Path],
     config_file: str,
+    expected: bool,
 ) -> None:
-    """__FILE__ is redefined to the basename so assert paths stay out of RAM."""
+    """__FILE__ becomes the basename on GCC 12 toolchains; IDF 5.0 (GCC 11) is skipped."""
     generate_main(component_config_path(config_file))
 
-    assert "-D__FILE__=__FILE_NAME__" in CORE.build_flags
-    assert "-Wno-builtin-macro-redefined" in CORE.build_flags
+    assert ("-D__FILE__=__FILE_NAME__" in CORE.build_flags) is expected
+    assert ("-Wno-builtin-macro-redefined" in CORE.build_flags) is expected
 
 
 def test_native_idf_enables_reproducible_build(

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -658,6 +658,21 @@ def test_platformio_arduino_enables_reproducible_build(
     assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True
 
 
+@pytest.mark.parametrize(
+    "config_file", ["reproducible_build.yaml", "reproducible_build_arduino.yaml"]
+)
+def test_file_macro_is_basename_only(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+    config_file: str,
+) -> None:
+    """__FILE__ is redefined to the basename so assert paths stay out of RAM."""
+    generate_main(component_config_path(config_file))
+
+    assert "-D__FILE__=__FILE_NAME__" in CORE.build_flags
+    assert "-Wno-builtin-macro-redefined" in CORE.build_flags
+
+
 def test_native_idf_enables_reproducible_build(
     component_config_path: Callable[[str], Path],
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`assert()`, `HAL_ASSERT` and `ESP_ERROR_CHECK` in ESP-IDF store `__FILE__` as a string; IDF's `-fmacro-prefix-map` only trims the checkout prefix, so every failing check keeps a string like `/IDF/components/hal/esp32/include/hal/clk_tree_ll.h`. IDF's own `__FILENAME__` trick only offsets the pointer, the full literal is still emitted. The flash driver, MMU, cache and panic code are placed with the `noflash` scheme, so their copies end up in `.dram0.data`.

This passes `-D__FILE__=__FILE_NAME__` and `-Wno-builtin-macro-redefined` as project wide compile options on esp32, which is the flag combination GCC documents for redefining `__FILE__`. The literal becomes the basename, the assert checks and the line, function and expression in the panic output are unchanged; only the directory part disappears from the message.

Measured on an ESP32 IDF config, `.dram0.data` drops 327 bytes and `.flash.rodata` drops 2931 bytes. `__FILE_NAME__` needs GCC 12 or newer, which every supported ESP32 toolchain ships.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
