### PR TITLE
[ld2412] Drop the unused gate index from GateThresholdNumber

### DIFF
--- a/esphome/components/ld2412/number/__init__.py
+++ b/esphome/components/ld2412/number/__init__.py
@@ -109,14 +109,14 @@ async def to_code(config: ConfigType) -> None:
     for x in range(14):
         if gate_conf := config.get(f"gate_{x}"):
             move_config = gate_conf[CONF_MOVE_THRESHOLD]
-            n = cg.new_Pvariable(move_config[CONF_ID], x)
+            n = cg.new_Pvariable(move_config[CONF_ID])
             await number.register_number(
                 n, move_config, min_value=0, max_value=100, step=1
             )
             await cg.register_parented(n, config[CONF_LD2412_ID])
             cg.add(LD2412_component.set_gate_move_threshold_number(x, n))
             still_config = gate_conf[CONF_STILL_THRESHOLD]
-            n = cg.new_Pvariable(still_config[CONF_ID], x)
+            n = cg.new_Pvariable(still_config[CONF_ID])
             await number.register_number(
                 n, still_config, min_value=0, max_value=100, step=1
             )

--- a/esphome/components/ld2412/number/gate_threshold_number.cpp
+++ b/esphome/components/ld2412/number/gate_threshold_number.cpp
@@ -2,8 +2,6 @@
 
 namespace esphome::ld2412 {
 
-GateThresholdNumber::GateThresholdNumber(uint8_t gate) : gate_(gate) {}
-
 void GateThresholdNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_gate_threshold();

--- a/esphome/components/ld2412/number/gate_threshold_number.h
+++ b/esphome/components/ld2412/number/gate_threshold_number.h
@@ -7,7 +7,8 @@ namespace esphome::ld2412 {
 
 class GateThresholdNumber final : public number::Number, public Parented<LD2412Component> {
  public:
-  GateThresholdNumber() = default;
+  // Not "= default": that makes new(p) T() zero-fill the object at every codegen site before the ctor runs.
+  GateThresholdNumber() {}
 
  protected:
   void control(float value) override;

--- a/esphome/components/ld2412/number/gate_threshold_number.h
+++ b/esphome/components/ld2412/number/gate_threshold_number.h
@@ -7,10 +7,9 @@ namespace esphome::ld2412 {
 
 class GateThresholdNumber final : public number::Number, public Parented<LD2412Component> {
  public:
-  GateThresholdNumber(uint8_t gate);
+  GateThresholdNumber() = default;
 
  protected:
-  uint8_t gate_;
   void control(float value) override;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

`GateThresholdNumber` stores the gate index it is constructed with, but nothing reads it; `control()` calls the hub's `set_gate_threshold()` which rebuilds the whole 14 gate command from its number arrays. The byte came along when the class was copied from ld2410, where the sensor protocol sets one gate per command and the index is needed. The LD2412 protocol never worked that way, so the member and the constructor argument have been dead since the component was added.

Removing them takes the object from 52 to 48 bytes, measured with the ESP32-S3 toolchain; a config with all 14 gates configured saves 112 bytes of static RAM. No behaviour change.

The replacement constructor is `GateThresholdNumber() {}` rather than `= default`. Codegen constructs entities with `new(storage) Type()`, and with a defaulted constructor that form zero fills the object at every construction site before the constructor runs; on the esp8266 test build that added a 48 byte fill loop at each of the 28 gate numbers, 512 bytes of flash. A user provided constructor avoids it, so the final result is 112 bytes less RAM and 32 bytes less flash than dev. The general fix for every class in the tree is in #19108, which emits `new(storage) Type` when there are no constructor arguments.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** esp8266 ld2412 test build: RAM -112 bytes, flash -32 bytes, confirmed by the memory bot.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
