### PR TITLE
[core] Use default initialization for placement new with no constructor arguments

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -717,12 +717,9 @@ async def to_code(config: ConfigType) -> None:
     cg.add_global(cg.RawExpression("using std::min"))
     cg.add_global(cg.RawExpression("using std::max"))
 
-    # Construct App via placement new — see application.cpp for storage details.
-    # No parentheses: Application has no user provided ctor, so `Application()`
-    # would zero-fill the whole object before the ctor runs. The storage is
-    # already zero.
+    # Construct App via placement new — see application.cpp for storage details
     cg.add_global(cg.RawStatement("#include <new>"))
-    cg.add(cg.RawExpression("new (&App) Application"))
+    cg.add(cg.RawExpression("new (&App) Application()"))
     name = config[CONF_NAME]
     friendly_name = config[CONF_FRIENDLY_NAME]
     name_add_mac_suffix = config[CONF_NAME_ADD_MAC_SUFFIX]

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -717,9 +717,12 @@ async def to_code(config: ConfigType) -> None:
     cg.add_global(cg.RawExpression("using std::min"))
     cg.add_global(cg.RawExpression("using std::max"))
 
-    # Construct App via placement new — see application.cpp for storage details
+    # Construct App via placement new — see application.cpp for storage details.
+    # No parentheses: Application has no user provided ctor, so `Application()`
+    # would zero-fill the whole object before the ctor runs. The storage is
+    # already zero.
     cg.add_global(cg.RawStatement("#include <new>"))
-    cg.add(cg.RawExpression("new (&App) Application()"))
+    cg.add(cg.RawExpression("new (&App) Application"))
     name = config[CONF_NAME]
     friendly_name = config[CONF_FRIENDLY_NAME]
     name_add_mac_suffix = config[CONF_NAME_ADD_MAC_SUFFIX]

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -642,9 +642,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
                 MockObj(f"reinterpret_cast<{pointer_type} *>({storage_name})"),
             )
         )
-        # `new(p) T()` is value initialization: with a defaulted default ctor it
-        # zero-fills the object at every site before the ctor runs. The storage
-        # is .bss and already zero, so emit `new(p) T` when there are no args.
+        # No parens without args: `T()` value-initializes, zero-filling .bss that is already zero.
         placement_new = RawExpression(f"new({id_.id}) {actual_type}")
         if call_expr.args.args:
             placement_new = CallExpression(placement_new, *call_expr.args)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -645,12 +645,9 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         # `new(p) T()` is value initialization: with a defaulted default ctor it
         # zero-fills the object at every site before the ctor runs. The storage
         # is .bss and already zero, so emit `new(p) T` when there are no args.
+        placement_new = RawExpression(f"new({id_.id}) {actual_type}")
         if call_expr.args.args:
-            placement_new = CallExpression(
-                f"new({id_.id}) {actual_type}", *call_expr.args
-            )
-        else:
-            placement_new = RawExpression(f"new({id_.id}) {actual_type}")
+            placement_new = CallExpression(placement_new, *call_expr.args)
         CORE.add(ExpressionStatement(placement_new))
     else:
         decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -642,7 +642,15 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
                 MockObj(f"reinterpret_cast<{pointer_type} *>({storage_name})"),
             )
         )
-        placement_new = CallExpression(f"new({id_.id}) {actual_type}", *call_expr.args)
+        # `new(p) T()` is value initialization: with a defaulted default ctor it
+        # zero-fills the object at every site before the ctor runs. The storage
+        # is .bss and already zero, so emit `new(p) T` when there are no args.
+        if call_expr.args.args:
+            placement_new = CallExpression(
+                f"new({id_.id}) {actual_type}", *call_expr.args
+            )
+        else:
+            placement_new = RawExpression(f"new({id_.id}) {actual_type}")
         CORE.add(ExpressionStatement(placement_new))
     else:
         decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)

--- a/tests/component_tests/button/test_button.py
+++ b/tests/component_tests/button/test_button.py
@@ -14,7 +14,7 @@ def test_button_is_setup(generate_main):
 
     # Then
     assert "static wake_on_lan::WakeOnLanButton *const" in main_cpp
-    assert ") wake_on_lan::WakeOnLanButton();" in main_cpp
+    assert ") wake_on_lan::WakeOnLanButton;" in main_cpp
     assert "App.register_button" in main_cpp
     assert "App.register_component" in main_cpp
 

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -19,7 +19,7 @@ def test_deep_sleep_setup(generate_main):
         "static deep_sleep::DeepSleepComponent *const deepsleep = reinterpret_cast<deep_sleep::DeepSleepComponent *>(deep_sleep__deepsleep__pstorage);"
         in main_cpp
     )
-    assert "new(deepsleep) deep_sleep::DeepSleepComponent();" in main_cpp
+    assert "new(deepsleep) deep_sleep::DeepSleepComponent;" in main_cpp
     assert "App.register_component_(deepsleep, " in main_cpp
 
 
@@ -49,7 +49,7 @@ def test_deep_sleep_on_wake_trigger(generate_main):
     """
     main_cpp = generate_main("tests/component_tests/deep_sleep/test_deep_sleep3.yaml")
 
-    assert "deep_sleep::WakeTrigger();" in main_cpp
+    assert "deep_sleep::WakeTrigger;" in main_cpp
     assert "Automation<deep_sleep::WakeupCause>" in main_cpp
 
 

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.py
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.py
@@ -22,7 +22,7 @@ def test_gpio_binary_sensor_basic_setup(
     main_cpp = generate_main("tests/component_tests/gpio/test_gpio_binary_sensor.yaml")
 
     assert "static gpio::GPIOBinarySensor *const" in main_cpp
-    assert ") gpio::GPIOBinarySensor();" in main_cpp
+    assert ") gpio::GPIOBinarySensor;" in main_cpp
     assert "App.register_binary_sensor" in main_cpp
     # set_use_interrupt(true) should NOT be generated (uses C++ default)
     assert "bs_gpio->set_use_interrupt(true);" not in main_cpp

--- a/tests/component_tests/ili9xxx/test_ili9xxx.py
+++ b/tests/component_tests/ili9xxx/test_ili9xxx.py
@@ -26,6 +26,6 @@ def test_ili9xxx_placement_new_uses_model_subclass(
     # Pointer is declared as the base type for polymorphism.
     assert "static ili9xxx::ILI9XXXDisplay *const tft_display" in main_cpp
     # Placement new runs the subclass constructor — this is the actual regression fix.
-    assert "new(tft_display) ili9xxx::ILI9XXXST7789V()" in main_cpp
+    assert "new(tft_display) ili9xxx::ILI9XXXST7789V;" in main_cpp
     # Base-class default constructor must NOT be used.
-    assert "new(tft_display) ili9xxx::ILI9XXXDisplay()" not in main_cpp
+    assert "new(tft_display) ili9xxx::ILI9XXXDisplay;" not in main_cpp

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -358,7 +358,7 @@ def test_native_generation(
 
     main_cpp = generate_main(component_fixture_path("native.yaml"))
     assert (
-        "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, 0, 0, 0, true, 1, 1>()"
+        "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, 0, 0, 0, true, 1, 1>;"
         in main_cpp
     )
     # A 10ms post-reset delay ({10, 255}) is prepended ahead of the model commands.
@@ -375,7 +375,7 @@ def test_lvgl_generation(
 
     main_cpp = generate_main(component_fixture_path("lvgl.yaml"))
     assert (
-        "mipi_spi::MipiSpi<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_SINGLE, 128, 160, 0, 0, 0, 0, 0, true>();"
+        "mipi_spi::MipiSpi<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_SINGLE, 128, 160, 0, 0, 0, 0, 0, true>;"
         in main_cpp
     )
     # A 10ms post-reset delay ({10, 255}) is prepended ahead of the model commands.

--- a/tests/component_tests/mipi_spi/test_padding_and_offsets.py
+++ b/tests/component_tests/mipi_spi/test_padding_and_offsets.py
@@ -314,7 +314,7 @@ class TestTemplateParameterPassing:
         #  FRACTION, ROUNDING)
         # The instantiation should include padding values (0, 0 for default)
         assert (
-            "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, 0, 0, 0, true, 1, 1>()"
+            "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, 0, 0, 0, true, 1, 1>;"
             in main_cpp
         ), (
             "Padding parameters (0, 0) should be in the MipiSpiBuffer template instantiation"

--- a/tests/component_tests/template/test_template_text.py
+++ b/tests/component_tests/template/test_template_text.py
@@ -30,10 +30,10 @@ def test_template_text_saver_uses_placement_new_with_templated_subclass(
         in main_cpp
     )
     # Placement new runs the templated subclass constructor.
-    assert "new(test_text_restore_value_saver) template_::TextSaver<10>()" in main_cpp
+    assert "new(test_text_restore_value_saver) template_::TextSaver<10>;" in main_cpp
     # Base-class default ctor must NOT be used.
     assert (
-        "new(test_text_restore_value_saver) template_::TemplateTextSaverBase()"
+        "new(test_text_restore_value_saver) template_::TemplateTextSaverBase;"
         not in main_cpp
     )
     # No heap `new TextSaver<...>()` left over — the pre-fix pattern.

--- a/tests/component_tests/text/test_text.py
+++ b/tests/component_tests/text/test_text.py
@@ -14,7 +14,7 @@ def test_text_is_setup(generate_main):
 
     # Then
     assert "static template_::TemplateText *const" in main_cpp
-    assert ") template_::TemplateText();" in main_cpp
+    assert ") template_::TemplateText;" in main_cpp
     assert "App.register_text" in main_cpp
 
 

--- a/tests/component_tests/text_sensor/test_text_sensor.py
+++ b/tests/component_tests/text_sensor/test_text_sensor.py
@@ -14,7 +14,7 @@ def test_text_sensor_is_setup(generate_main):
 
     # Then
     assert "static template_::TemplateTextSensor *const" in main_cpp
-    assert ") template_::TemplateTextSensor();" in main_cpp
+    assert ") template_::TemplateTextSensor;" in main_cpp
     assert "App.register_text_sensor" in main_cpp
 
 

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -790,3 +790,29 @@ async def test_templatable__lambda_with_std_string() -> None:
     result = await cg.templatable(lambda_obj, [], ct.std_string)
 
     assert isinstance(result, cg.LambdaExpression)
+
+
+class TestPvariablePlacementNew:
+    def _placement_new(self) -> str:
+        from esphome.core import CORE
+
+        return next(
+            str(stmt) for stmt in CORE.main_statements if str(stmt).startswith("new(")
+        )
+
+    def test_no_args_uses_default_initialization(self) -> None:
+        """`new(p) T` rather than `new(p) T()`: value initialization would zero-fill
+        storage that is already zero, costing a loop of flash at every site."""
+        id_ = cg.ID("my_id", is_declaration=True, type=ct.esphome_ns.class_("Foo"))
+        cg.new_Pvariable(id_)
+        assert self._placement_new() == "new(my_id) Foo;"
+
+    def test_with_args_calls_constructor(self) -> None:
+        id_ = cg.ID("my_id", is_declaration=True, type=ct.esphome_ns.class_("Foo"))
+        cg.new_Pvariable(id_, 1, 2)
+        assert self._placement_new() == "new(my_id) Foo(1, 2);"
+
+    def test_template_args_without_ctor_args(self) -> None:
+        id_ = cg.ID("my_id", is_declaration=True, type=ct.esphome_ns.class_("Foo"))
+        cg.new_Pvariable(id_, cg.TemplateArguments(ct.uint8))
+        assert self._placement_new() == "new(my_id) Foo<uint8_t>;"

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -4,6 +4,7 @@ import math
 import pytest
 
 from esphome import cpp_generator as cg, cpp_types as ct
+from esphome.core import CORE
 
 
 class TestExpressions:
@@ -794,8 +795,6 @@ async def test_templatable__lambda_with_std_string() -> None:
 
 class TestPvariablePlacementNew:
     def _placement_new(self) -> str:
-        from esphome.core import CORE
-
         return next(
             str(stmt) for stmt in CORE.main_statements if str(stmt).startswith("new(")
         )


### PR DESCRIPTION
# What does this implement/fix?

Codegen constructs every object with `new(storage) Type()`. With empty parentheses that is value initialization; when the class has a defaulted or implicit default constructor the compiler zero fills the whole object before the constructor chain runs. The storage is a `static` byte array in `.bss`, so it is already zero, and the constructor then writes every field again. The fill is emitted at every construction site in `setup()`: a store loop on the esp8266 toolchain, a `memset` call on ESP32.

This emits `new(storage) Type` when there are no constructor arguments, which is default initialization and skips the fill. Classes with a user provided constructor generate identical code either way; the only language level difference is that members without an initializer are no longer formally zeroed, which is already the case for every class with a user provided constructor, and the bytes are zero in practice because the storage is `.bss`.

Measured against dev:

| Build | `setup()` | Flash text |
|---|---|---|
| ld2412 test, esp8266-ard | 6416 -> 6272 | -144 bytes, 44 sites changed |
| Apollo R Pro 1 config, esp32-s3 idf | 16077 -> 15233 | -840 bytes, `memset` calls in `setup()` 99 -> 18 |
| Home Assistant Voice PE config, esp32-s3 idf | 16509 -> 15829 | -668 bytes, 149 sites changed |

Component tests that asserted the `Type();` form are updated, and unit tests cover the no argument, argument and template argument cases.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
