### PR TITLE
[core] Construct App without value initialization

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -528,7 +528,7 @@ class Application {
 
   // 1-byte members (grouped together to minimize padding)
   uint8_t app_state_{0};
-  bool name_add_mac_suffix_;
+  bool name_add_mac_suffix_{false};
   bool in_loop_{false};
   volatile bool has_pending_enable_loop_requests_{false};
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -717,9 +717,10 @@ async def to_code(config: ConfigType) -> None:
     cg.add_global(cg.RawExpression("using std::min"))
     cg.add_global(cg.RawExpression("using std::max"))
 
-    # Construct App via placement new — see application.cpp for storage details
+    # Construct App via placement new — see application.cpp for storage details.
+    # No parens: `Application()` would zero-fill storage that is already zero.
     cg.add_global(cg.RawStatement("#include <new>"))
-    cg.add(cg.RawExpression("new (&App) Application()"))
+    cg.add(cg.RawExpression("new (&App) Application"))
     name = config[CONF_NAME]
     friendly_name = config[CONF_FRIENDLY_NAME]
     name_add_mac_suffix = config[CONF_NAME_ADD_MAC_SUFFIX]

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -175,6 +175,27 @@ async def test_core_area_recorded_at_config_load(
     assert CORE.area == expected_area
 
 
+@pytest.mark.asyncio
+async def test_app_is_default_initialized(
+    yaml_file: Callable[[str], Path],
+) -> None:
+    """App is constructed with `new (&App) Application`, no parentheses.
+
+    `Application()` would value-initialize and memset the whole object into
+    storage that is already zero."""
+    result = load_config_from_fixture(yaml_file, "valid_area_device.yaml", FIXTURES_DIR)
+    assert result is not None
+
+    with patch("esphome.core.config.cg") as mock_cg:
+        mock_cg.RawStatement.side_effect = lambda *args, **kwargs: MagicMock()
+        mock_cg.RawExpression.side_effect = lambda *args, **kwargs: MagicMock()
+        await config.to_code(result[CONF_ESPHOME])
+
+    raw_expressions = [c.args[0] for c in mock_cg.RawExpression.call_args_list]
+    assert "new (&App) Application" in raw_expressions
+    assert "new (&App) Application()" not in raw_expressions
+
+
 def test_config_load_without_area_clears_stale_core_area(
     yaml_file: Callable[[str], Path],
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The generated `setup()` constructs the global with `new (&App) Application()`. `Application` has no user provided constructor, so the empty parentheses are value initialization: the compiler zero fills all 1264 bytes of the object before running the constructor, which then initialises every member again. The storage is a static byte array that is already zero, so the fill is a wasted `memset` at every boot and a few bytes of flash.

This drops the parentheses, which is default initialization and skips the fill. `name_add_mac_suffix_` was the only member without an initializer; it now has one, so every member is initialized without relying on the storage being zero. A unit test pins the emitted expression.

Flash analysis, ESP32-S3 IDF config (Apollo R Pro 1) against dev:

| Section | dev | PR | Change |
|---|---|---|---|
| `setup()` | 16077 | 16065 | -12 bytes |
| `.flash.text` | 541908 | 541888 | -20 bytes |
| `.flash.rodata`, `.dram0.data`, `.dram0.bss` | | | unchanged |
| `memset` calls in `setup()` | 99 | 98 | the 1264 byte App fill |

The flash saving is the one call site; the runtime saving is a 1264 byte memset removed from every boot. The remaining `memset` calls in `setup()` are member initializers on `std::array` and `StaticVector` fields; the StaticVector ones are addressed in #19110.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config against dev: `setup()` 16077 to 16065, `.flash.text` -20 bytes, one 1264 byte `memset` gone from every boot; RAM unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
