### PR TITLE
[core] Give StaticVector a user provided default constructor

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -239,7 +239,7 @@ template<typename T, size_t N> class StaticVector {
  public:
   // User provided, not "= default": otherwise `StaticVector<...> x_{}` members
   // value-initialize and memset data_, defeating the comment above.
-  StaticVector() {}
+  StaticVector() noexcept {}
 
   // Iterator range constructor
   template<typename InputIt> StaticVector(InputIt first, InputIt last) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -239,7 +239,7 @@ template<typename T, size_t N> class StaticVector {
  public:
   // User provided, not "= default": otherwise `StaticVector<...> x_{}` members
   // value-initialize and memset data_, defeating the comment above.
-  StaticVector() noexcept {}
+  constexpr StaticVector() noexcept {}
 
   // Iterator range constructor
   template<typename InputIt> StaticVector(InputIt first, InputIt last) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -237,8 +237,9 @@ template<typename T, size_t N> class StaticVector {
   size_t count_{0};
 
  public:
-  // Default constructor
-  StaticVector() = default;
+  // User provided, not "= default": otherwise `StaticVector<...> x_{}` members
+  // value-initialize and memset data_, defeating the comment above.
+  StaticVector() {}
 
   // Iterator range constructor
   template<typename InputIt> StaticVector(InputIt first, InputIt last) {


### PR DESCRIPTION
# What does this implement/fix?

`StaticVector` documents that `data_` is intentionally not value initialized to avoid a memset, but its default constructor is `= default`. Any member declared as `StaticVector<...> x_{}` is therefore value initialized, and the compiler zero fills `data_` anyway. `Application` declares eight such members, one per entity type plus the component list, so every boot memsets about 1.1 KB of storage that is already zero and never read past `count_`.

A user provided constructor makes `x_{}` run the constructor only, which sets `count_` and nothing else. Measured on an ESP32-S3 config against dev: `setup()` 16077 to 15973 bytes, `.flash.text` -108 bytes, `memset` calls in `setup()` 99 to 91. RAM sections are unchanged.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config against dev: `setup()` 16077 to 15973, `.flash.text` -108 bytes, `memset` calls in `setup()` 99 to 91; RAM unchanged. Memory bot: -36 bytes flash on the component test.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
