### PR TITLE
[binary_sensor] Use a user provided default constructor

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -32,7 +32,8 @@ void log_binary_sensor(const char *tag, const char *prefix, const char *type, Bi
  */
 class BinarySensor : public StatefulEntityBase<bool> {
  public:
-  explicit BinarySensor() = default;
+  // User provided, not "= default": `new(p) BinarySensor()` would zero-fill .bss that is already zero.
+  explicit BinarySensor() {}
 
   const bool &get_state() const override { return this->state; }
   void set_trigger_on_initial_state(bool value) { this->trigger_on_initial_state_ = value; }


### PR DESCRIPTION
# What does this implement/fix?

`BinarySensor` declares `explicit BinarySensor() = default;`. Codegen constructs entities with `new(storage) Type()`, and with a defaulted constructor that is value initialization: the compiler zero fills the object before the constructor runs. The storage is a static byte array that is already zero, so the fill is a `memset` call at every plain `BinarySensor` construction site in `setup()`.

**Why this base class is different from the abstract ones.** `BinarySensor` has no pure virtual methods; publishing is driven from outside by the owning component, so there is nothing a subclass must implement. Hub components that only report a state therefore instantiate it directly: `binary_sensor_schema()` without a `class_` defaults to `binary_sensor::BinarySensor`, and `new_binary_sensor()` constructs exactly that type. The ld2450 and ld2412 platforms alone put seven of these in the Apollo firmware:

```cpp
new(ld2450_presence) binary_sensor::BinarySensor();
new(ld2412_moving_target) binary_sensor::BinarySensor();
```

That is unlike `Number`, `Button`, `Switch` or `Fan`, which are abstract, are never the constructed type, and whose own constructor therefore decides nothing about the fill. Subclasses such as `GPIOBinarySensor` are unaffected by this PR either way; their own constructor decides for them.

A user provided constructor makes `BinarySensor()` run the constructor only. Every data member, including the `StatefulEntityBase` and `EntityBase` ones, has an initializer, so nothing relied on the fill. Subclasses are unaffected either way; value initialization is decided by the subclass's own constructor.

Measured on an ESP32-S3 IDF config with 7 plain binary sensors, against dev: `setup()` 16077 to 15989 bytes, `.flash.text` -92 bytes, `memset` calls in `setup()` 99 to 92. RAM unchanged.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config with 7 plain `BinarySensor` objects, against dev: `setup()` 16077 to 15989, `.flash.text` -92 bytes, `memset` calls in `setup()` 99 to 92; RAM unchanged. The memory bot shows +0 because the binary_sensor test config uses platform subclasses and constructs no plain `BinarySensor`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
