### PR TITLE
[text_sensor] Use a user provided default constructor

### DIFF
--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -29,7 +29,8 @@ class TextSensor : public EntityBase {
  public:
   std::string state;
 
-  TextSensor() = default;
+  // User provided, not "= default": `new(p) TextSensor()` would zero-fill .bss that is already zero.
+  TextSensor() {}
   ~TextSensor() = default;
 
   /// Getter-syntax for .state.


### PR DESCRIPTION
# What does this implement/fix?

`TextSensor` declares `TextSensor() = default;`. Codegen constructs entities with `new(storage) Type()`, and with a defaulted constructor that is value initialization: the compiler zero fills the object before the constructor runs. The storage is a static byte array that is already zero, so the fill is a `memset` call at every plain `TextSensor` construction site in `setup()`, about 14 bytes of flash per site on ESP32 and a store loop on esp8266.

A user provided constructor makes `TextSensor()` run the constructor only. The data members are two `std::string` objects plus the `EntityBase` members, all of which construct themselves, so nothing relied on the fill. Subclasses are unaffected either way; value initialization is decided by the subclass's own constructor. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config with 7 plain `TextSensor` objects, against dev: `setup()` 16077 to 15993, `.flash.text` -88 bytes; RAM unchanged. The text_sensor test config constructs no plain `TextSensor`, so the memory bot shows +0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
