### PR TITLE
[select] Use a user provided default constructor

### DIFF
--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -30,7 +30,8 @@ class Select : public EntityBase {
  public:
   SelectTraits traits;
 
-  Select() = default;
+  // User provided, not "= default": `new(p) Select()` would zero-fill .bss that is already zero.
+  Select() {}
   ~Select() = default;
 
   void publish_state(const std::string &state) { this->publish_state(state.c_str()); }


### PR DESCRIPTION
# What does this implement/fix?

`Select` declares `Select() = default;`. Codegen constructs entities with `new(storage) Type()`, and with a defaulted constructor that is value initialization: the compiler zero fills the object before the constructor runs. The storage is a static byte array that is already zero, so the fill is wasted code at every plain `Select` construction site in `setup()`, about 14 bytes of flash per site on ESP32 and a store loop on esp8266.

A user provided constructor makes `Select()` run the constructor only. `traits` holds a `FixedVector` whose members have initializers, `active_index_` is initialized, and the `EntityBase` members are too, so nothing relied on the fill. Subclasses are unaffected either way. Same change as #19111 for `BinarySensor`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
