### PR TITLE
[button] Use a user provided default constructor

### DIFF
--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -24,6 +24,9 @@ void log_button(const char *tag, const char *prefix, const char *type, Button *o
  */
 class Button : public EntityBase {
  public:
+  // User provided, not "= default": `new(p) Button()` would zero-fill .bss that is already zero.
+  Button() {}
+
   /** Press this button. This is called by the front-end.
    *
    * For implementing buttons, please override press_action.


### PR DESCRIPTION
# What does this implement/fix?

`Button` declares no constructor, so `new(storage) Button()` from codegen is value initialization: the compiler zero fills the object before the implicit constructor runs. The storage is a static byte array that is already zero, so the fill is wasted code at every plain `Button` construction site in `setup()`, about 14 bytes of flash per site on ESP32 and a store loop on esp8266.

This adds a user provided default constructor so `Button()` runs the constructor only. `Button` has no data members of its own and the `EntityBase` members have initializers, so nothing relied on the fill. Subclasses are unaffected either way. Same change as #19111 for `BinarySensor`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
