### PR TITLE
[text] Initialize the TextTraits length limits

### DIFF
--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -20,9 +20,6 @@ namespace esphome::text {
  */
 class Text : public EntityBase {
  public:
-  // User provided, not "= default": `new(p) Text()` would zero-fill .bss that is already zero.
-  Text() {}
-
   std::string state;
   TextTraits traits;
 

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -20,6 +20,9 @@ namespace esphome::text {
  */
 class Text : public EntityBase {
  public:
+  // User provided, not "= default": `new(p) Text()` would zero-fill .bss that is already zero.
+  Text() {}
+
   std::string state;
   TextTraits traits;
 

--- a/esphome/components/text/text_traits.h
+++ b/esphome/components/text/text_traits.h
@@ -30,8 +30,8 @@ class TextTraits {
   TextMode get_mode() const { return this->mode_; }
 
  protected:
-  int min_length_;
-  int max_length_;
+  int min_length_{0};
+  int max_length_{0};
   const char *pattern_{""};
   TextMode mode_{TEXT_MODE_TEXT};
 };


### PR DESCRIPTION
# What does this implement/fix?

`TextTraits::min_length_` and `max_length_` have no initializer. They are zero today only because codegen value initializes every entity with `new(storage) Type()`, which zero fills the object before the constructors run. A concrete text platform that switches to a user provided constructor to skip that fill would leave them indeterminate until codegen calls the setters.

`{0}` initializers keep the same values. Cost is one store each per derived constructor; the memory bot measures +16 bytes on the component test build, which a converted platform gets back per construction site.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** Memory bot on the text test build: +16 bytes flash, two zero stores per derived constructor. This is the cost of the audit; a converted text platform recovers about 14 bytes per construction site.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
