### PR TITLE
[datetime] Initialize the date and time entity fields

### DIFF
--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -31,10 +31,6 @@ struct DateEntityRestoreState {
 } __attribute__((packed));
 
 class DateEntity : public DateTimeBase {
- public:
-  // User provided, not "= default": `new(p) DateEntity()` would zero-fill .bss that is already zero.
-  DateEntity() {}
-
  protected:
   uint16_t year_{0};
   uint8_t month_{0};

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -31,10 +31,14 @@ struct DateEntityRestoreState {
 } __attribute__((packed));
 
 class DateEntity : public DateTimeBase {
+ public:
+  // User provided, not "= default": `new(p) DateEntity()` would zero-fill .bss that is already zero.
+  DateEntity() {}
+
  protected:
-  uint16_t year_;
-  uint8_t month_;
-  uint8_t day_;
+  uint16_t year_{0};
+  uint8_t month_{0};
+  uint8_t day_{0};
 
  public:
   void publish_state();

--- a/esphome/components/datetime/datetime_base.h
+++ b/esphome/components/datetime/datetime_base.h
@@ -27,7 +27,7 @@ class DateTimeBase : public EntityBase {
   LazyCallbackManager<void()> state_callback_;
 
 #ifdef USE_TIME
-  time::RealTimeClock *rtc_;
+  time::RealTimeClock *rtc_{nullptr};
 #endif
 };
 

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -34,13 +34,17 @@ struct DateTimeEntityRestoreState {
 } __attribute__((packed));
 
 class DateTimeEntity : public DateTimeBase {
+ public:
+  // User provided, not "= default": `new(p) DateTimeEntity()` would zero-fill .bss that is already zero.
+  DateTimeEntity() {}
+
  protected:
-  uint16_t year_;
-  uint8_t month_;
-  uint8_t day_;
-  uint8_t hour_;
-  uint8_t minute_;
-  uint8_t second_;
+  uint16_t year_{0};
+  uint8_t month_{0};
+  uint8_t day_{0};
+  uint8_t hour_{0};
+  uint8_t minute_{0};
+  uint8_t second_{0};
 
  public:
   void publish_state();

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -34,10 +34,6 @@ struct DateTimeEntityRestoreState {
 } __attribute__((packed));
 
 class DateTimeEntity : public DateTimeBase {
- public:
-  // User provided, not "= default": `new(p) DateTimeEntity()` would zero-fill .bss that is already zero.
-  DateTimeEntity() {}
-
  protected:
   uint16_t year_{0};
   uint8_t month_{0};

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -32,10 +32,6 @@ struct TimeEntityRestoreState {
 } __attribute__((packed));
 
 class TimeEntity : public DateTimeBase {
- public:
-  // User provided, not "= default": `new(p) TimeEntity()` would zero-fill .bss that is already zero.
-  TimeEntity() {}
-
  protected:
   uint8_t hour_{0};
   uint8_t minute_{0};

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -32,10 +32,14 @@ struct TimeEntityRestoreState {
 } __attribute__((packed));
 
 class TimeEntity : public DateTimeBase {
+ public:
+  // User provided, not "= default": `new(p) TimeEntity()` would zero-fill .bss that is already zero.
+  TimeEntity() {}
+
  protected:
-  uint8_t hour_;
-  uint8_t minute_;
-  uint8_t second_;
+  uint8_t hour_{0};
+  uint8_t minute_{0};
+  uint8_t second_{0};
 
  public:
   void publish_state();


### PR DESCRIPTION
# What does this implement/fix?

The year, month, day, hour, minute and second fields of `DateEntity`, `TimeEntity` and `DateTimeEntity`, and `DateTimeBase::rtc_`, have no initializer. They are zero today only because codegen value initializes every entity with `new(storage) Type()`, which zero fills the object before the constructors run. A concrete platform that switches to a user provided constructor to skip that fill would leave them indeterminate.

`{0}` and `{nullptr}` initializers keep the same values. The three entities share `DateTimeBase`, so they are in one PR. Cost is one store per field per derived constructor.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** Memory bot on the datetime test build: +0 bytes, no platform is constructed there. On the esp8266 template test build, which has three template datetime entities, the initializers cost +80 bytes against dev (`setup()` 8226 to 8310); the stacked #19133 and #19134 recover 48 of that, and the template date conversion measured no change, so the chain is net +32 bytes on that build.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
