### PR TITLE
[alarm_control_panel] Initialize the state members

### DIFF
--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -21,6 +21,9 @@ enum AlarmControlPanelFeature : uint8_t {
 
 class AlarmControlPanel : public EntityBase {
  public:
+  // User provided, not "= default": `new(p) AlarmControlPanel()` would zero-fill .bss that is already zero.
+  AlarmControlPanel() {}
+
   /** Make a AlarmControlPanelCall
    *
    */
@@ -138,11 +141,11 @@ class AlarmControlPanel : public EntityBase {
   // in order to store last panel state in flash
   ESPPreferenceObject pref_;
   // current state
-  AlarmControlPanelState current_state_;
+  AlarmControlPanelState current_state_{ACP_STATE_DISARMED};
   // the desired (or previous) state
-  AlarmControlPanelState desired_state_;
+  AlarmControlPanelState desired_state_{ACP_STATE_DISARMED};
   // last time the state was updated
-  uint32_t last_update_;
+  uint32_t last_update_{0};
   // the call control function
   virtual void control(const AlarmControlPanelCall &call) = 0;
   // state callback - passes the new state to listeners

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -21,9 +21,6 @@ enum AlarmControlPanelFeature : uint8_t {
 
 class AlarmControlPanel : public EntityBase {
  public:
-  // User provided, not "= default": `new(p) AlarmControlPanel()` would zero-fill .bss that is already zero.
-  AlarmControlPanel() {}
-
   /** Make a AlarmControlPanelCall
    *
    */


### PR DESCRIPTION
# What does this implement/fix?

`AlarmControlPanel::current_state_`, `desired_state_` and `last_update_` have no initializer. They are zero today only because codegen value initializes every entity with `new(storage) Type()`, which zero fills the object before the constructors run. A concrete panel platform that switches to a user provided constructor to skip that fill would leave them indeterminate, and `current_state_` is read on the first `publish_state`.

`ACP_STATE_DISARMED` is 0 and `last_update_{0}` matches, so the values are unchanged. Cost is one store per field per derived constructor.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** esp8266 template test build with one template alarm panel, against dev: `setup()` 8226 to 8226, flash 387851 to 387851, +0 bytes. Memory bot on the alarm_control_panel test: +0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
