### PR TITLE
[update] Initialize UpdateInfo::progress

### DIFF
--- a/esphome/components/update/update_entity.h
+++ b/esphome/components/update/update_entity.h
@@ -16,7 +16,7 @@ struct UpdateInfo {
   std::string firmware_url;
   std::string md5;
   bool has_progress{false};
-  float progress;
+  float progress{0};
 };
 
 enum UpdateState : uint8_t {
@@ -30,6 +30,9 @@ const LogString *update_state_to_string(UpdateState state);
 
 class UpdateEntity : public EntityBase {
  public:
+  // User provided, not "= default": `new(p) UpdateEntity()` would zero-fill .bss that is already zero.
+  UpdateEntity() {}
+
   void publish_state();
 
   void perform() { this->perform(false); }

--- a/esphome/components/update/update_entity.h
+++ b/esphome/components/update/update_entity.h
@@ -30,9 +30,6 @@ const LogString *update_state_to_string(UpdateState state);
 
 class UpdateEntity : public EntityBase {
  public:
-  // User provided, not "= default": `new(p) UpdateEntity()` would zero-fill .bss that is already zero.
-  UpdateEntity() {}
-
   void publish_state();
 
   void perform() { this->perform(false); }


### PR DESCRIPTION
# What does this implement/fix?

`UpdateInfo::progress` has no initializer. It is zero today only because codegen value initializes every entity with `new(storage) Type()`, which zero fills the object before the constructors run. A concrete update platform that switches to a user provided constructor to skip that fill would leave it indeterminate, and `progress` is published whenever `has_progress` is set.

`progress{0}` keeps the same value. Every other member is a `std::string`, a `unique_ptr` or already initialized. Cost is one store per derived constructor.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** esp8266 update test build, against dev: `setup()` 1390 to 1390, flash 470183 to 470183, +0 bytes. Memory bot agrees, +0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
