### PR TITLE
[template] Use a user provided default constructor for TemplateButton

### DIFF
--- a/esphome/components/template/button/template_button.h
+++ b/esphome/components/template/button/template_button.h
@@ -6,7 +6,8 @@ namespace esphome::template_ {
 
 class TemplateButton final : public button::Button {
  public:
-  // Implements the abstract `press_action` but the `on_press` trigger already handles the press.
+  // User provided, not "= default": `new(p) TemplateButton()` would zero-fill .bss that is already zero.
+  TemplateButton() {}  // Implements the abstract `press_action` but the `on_press` trigger already handles the press.
   void press_action() override{};
 };
 

--- a/esphome/components/template/button/template_button.h
+++ b/esphome/components/template/button/template_button.h
@@ -7,7 +7,9 @@ namespace esphome::template_ {
 class TemplateButton final : public button::Button {
  public:
   // User provided, not "= default": `new(p) TemplateButton()` would zero-fill .bss that is already zero.
-  TemplateButton() {}  // Implements the abstract `press_action` but the `on_press` trigger already handles the press.
+  TemplateButton() {}
+
+  // Implements the abstract `press_action` but the `on_press` trigger already handles the press.
   void press_action() override{};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

`TemplateButton` has no user provided default constructor, so codegen's `new(storage) TemplateButton()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is wasted code at every `TemplateButton` in `setup()`, about 14 bytes of flash per site on ESP32 and a store loop per site on esp8266.

This adds a user provided default constructor so only the constructors run. It has no data members of its own; `Button` holds only a `LazyCallbackManager` with an initializer and every `EntityBase` member has one, so nothing relied on the fill. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** esp8266 template test build (1 template button) against dev: `setup()` 8226 to 8218, -8 bytes, and `.text` 387851 to 387835, -16 bytes once the following function moves; the memory bot reports the same -8 in `setup` with total flash unchanged because alignment padding absorbs it in this one button config. The per site saving scales with the number of template buttons.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
