### PR TITLE
[uart] Use a user provided default constructor for IDFUARTComponent

### DIFF
--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
@@ -47,9 +47,6 @@ class GPIOBinarySensorStore {
 
 class GPIOBinarySensor final : public binary_sensor::BinarySensor, public Component {
  public:
-  // User provided, not "= default": `new(p) GPIOBinarySensor()` would zero-fill .bss that is already zero.
-  GPIOBinarySensor() {}
-
   // No destructor needed: ESPHome components are created at boot and live forever.
   // Interrupts are only detached on reboot when memory is cleared anyway.
 
@@ -73,7 +70,7 @@ class GPIOBinarySensor final : public binary_sensor::BinarySensor, public Compon
   void loop() override;
 
  protected:
-  GPIOPin *pin_{nullptr};
+  GPIOPin *pin_;
   GPIOBinarySensorStore store_;
 };
 

--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
@@ -47,6 +47,9 @@ class GPIOBinarySensorStore {
 
 class GPIOBinarySensor final : public binary_sensor::BinarySensor, public Component {
  public:
+  // User provided, not "= default": `new(p) GPIOBinarySensor()` would zero-fill .bss that is already zero.
+  GPIOBinarySensor() {}
+
   // No destructor needed: ESPHome components are created at boot and live forever.
   // Interrupts are only detached on reboot when memory is cleared anyway.
 
@@ -70,7 +73,7 @@ class GPIOBinarySensor final : public binary_sensor::BinarySensor, public Compon
   void loop() override;
 
  protected:
-  GPIOPin *pin_;
+  GPIOPin *pin_{nullptr};
   GPIOBinarySensorStore store_;
 };
 

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -18,6 +18,8 @@ namespace esphome::uart {
 /// peek byte state (has_peek_/peek_byte_) is not synchronized.
 class IDFUARTComponent final : public UARTComponent, public Component {
  public:
+  // User provided, not "= default": `new(p) IDFUARTComponent()` would zero-fill .bss that is already zero.
+  IDFUARTComponent() {}
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::BUS; }
@@ -96,7 +98,7 @@ class IDFUARTComponent final : public UARTComponent, public Component {
   Framing last_good_framing_{};
 
   bool has_peek_{false};
-  uint8_t peek_byte_;
+  uint8_t peek_byte_{0};
   uint32_t flush_timeout_ms_{0};  ///< 0 means wait indefinitely (portMAX_DELAY).
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX


### PR DESCRIPTION
# What does this implement/fix?

`IDFUARTComponent` has no user provided default constructor, so codegen's `new(storage) IDFUARTComponent()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is wasted code at every `IDFUARTComponent` in `setup()`, a `memset` call of about 14 bytes per site on ESP32 and a store loop per site on esp8266.

This adds a user provided default constructor so only the constructors run. `peek_byte_` gets a `{0}` initializer; it is only read when `has_peek_` is set. Every other member here and in `UARTComponent` already has one. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config against dev: `setup()` 16077 to 16053, `.flash.text` -36 bytes; RAM unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
