### PR TITLE
[scd4x] Use a user provided default constructor for SCD4XComponent

### DIFF
--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -24,6 +24,9 @@ enum MeasurementMode : uint8_t {
 
 class SCD4XComponent final : public PollingComponent, public sensirion_common::SensirionI2CDevice {
  public:
+  // User provided, not "= default": `new(p) SCD4XComponent()` would zero-fill .bss that is already zero.
+  SCD4XComponent() {}
+
   void setup() override;
   void dump_config() override;
   void update() override;
@@ -49,12 +52,12 @@ class SCD4XComponent final : public PollingComponent, public sensirion_common::S
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   sensor::Sensor *ambient_pressure_source_{nullptr};  // used for compensation
-  float temperature_offset_;
+  float temperature_offset_{0};
   uint16_t altitude_compensation_{0};
   uint16_t ambient_pressure_{0};  // Per datasheet, valid values are 700 to 1200 hPa; 0 is a valid sentinel value
   bool initialized_{false};
   bool enable_asc_{false};
-  ErrorCode error_code_;
+  ErrorCode error_code_{};
   MeasurementMode measurement_mode_{PERIODIC};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

`SCD4XComponent` has no user provided default constructor, so codegen's `new(storage) SCD4XComponent()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is a `memset` call of about 14 bytes per site on ESP32 and a store loop per site on esp8266.

This adds a user provided default constructor so only the constructors run. `temperature_offset_` and `error_code_` get `{}` initializers, the zero values the fill used to provide before codegen sets them. Every other member and the `I2CDevice` base already have initializers. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
