### PR TITLE
[http_request] Use a user provided default constructor for HttpRequestUpdate

### DIFF
--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -15,6 +15,9 @@ namespace esphome::http_request {
 
 class HttpRequestUpdate final : public update::UpdateEntity, public PollingComponent, public ota::OTAStateListener {
  public:
+  // User provided, not "= default": `new(p) HttpRequestUpdate()` would zero-fill .bss that is already zero.
+  HttpRequestUpdate() {}
+
   void setup() override;
   void update() override;
 
@@ -31,8 +34,8 @@ class HttpRequestUpdate final : public update::UpdateEntity, public PollingCompo
   void on_ota_state(ota::OTAState state, float progress, uint8_t error) override;
 
  protected:
-  HttpRequestComponent *request_parent_;
-  OtaHttpRequestComponent *ota_parent_;
+  HttpRequestComponent *request_parent_{nullptr};
+  OtaHttpRequestComponent *ota_parent_{nullptr};
   std::string source_url_;
 
   static void update_task(void *params);


### PR DESCRIPTION
# What does this implement/fix?

`HttpRequestUpdate` has no user provided default constructor, so codegen's `new(storage) HttpRequestUpdate()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is a `memset` call of about 14 bytes per site on ESP32 and a store loop per site on esp8266.

This adds a user provided default constructor so only the constructors run. The two parent pointers get `{nullptr}` initializers; codegen sets both before `setup()`. `UpdateInfo::progress` gets its initializer in #19121 and everything else constructs itself. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config against dev: `setup()` 16077 to 16077, `.flash.text` +0 bytes; RAM unchanged. The fill was already eliminated by the compiler here; the constructor keeps the class safe for configs where it is not.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
