### PR TITLE
[ltr390] Use a user provided default constructor for LTR390Component

### DIFF
--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -41,6 +41,9 @@ enum LTR390RESOLUTION {
 
 class LTR390Component final : public PollingComponent, public i2c::I2CDevice {
  public:
+  // User provided, not "= default": `new(p) LTR390Component()` would zero-fill .bss that is already zero.
+  LTR390Component() {}
+
   void setup() override;
   void dump_config() override;
   void update() override;
@@ -71,11 +74,11 @@ class LTR390Component final : public PollingComponent, public i2c::I2CDevice {
   bool reading_{false};
   uint8_t enabled_modes_{0};
 
-  LTR390GAIN gain_als_;
-  LTR390GAIN gain_uv_;
-  LTR390RESOLUTION res_als_;
-  LTR390RESOLUTION res_uv_;
-  float wfac_;
+  LTR390GAIN gain_als_{};
+  LTR390GAIN gain_uv_{};
+  LTR390RESOLUTION res_als_{};
+  LTR390RESOLUTION res_uv_{};
+  float wfac_{0};
 
   sensor::Sensor *light_sensor_{nullptr};
   sensor::Sensor *als_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

`LTR390Component` has no user provided default constructor, so codegen's `new(storage) LTR390Component()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is a `memset` call of about 14 bytes per site on ESP32 and a store loop per site on esp8266.

This adds a user provided default constructor so only the constructors run. The gain, resolution and window factor members get `{}` initializers, the zero values the fill used to provide before codegen sets them. Every other member and the `I2CDevice` base already have initializers. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
