### PR TITLE
[esp32_rmt_led_strip] Use a user provided default constructor for ESP32RMTLEDStripLightOutput

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -24,6 +24,9 @@ struct LedParams {
 
 class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
  public:
+  // User provided, not "= default": `new(p) ESP32RMTLEDStripLightOutput()` would zero-fill .bss that is already zero.
+  ESP32RMTLEDStripLightOutput() {}
+
   void setup() override;
   void write_state(light::LightState *state) override;
   float get_setup_priority() const override;
@@ -68,7 +71,7 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};
-  LedParams params_;
+  LedParams params_{};
   rmt_channel_handle_t channel_{nullptr};
   rmt_encoder_handle_t encoder_{nullptr};
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
@@ -77,8 +80,8 @@ class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
   rmt_symbol_word_t *rmt_buf_{nullptr};
 #endif
   uint32_t rmt_symbols_{48};
-  uint8_t pin_;
-  uint16_t num_leds_;
+  uint8_t pin_{0};
+  uint16_t num_leds_{0};
   bool use_dma_{false};
   bool use_psram_{false};
   bool invert_out_{false};


### PR DESCRIPTION
# What does this implement/fix?

`ESP32RMTLEDStripLightOutput` has no user provided default constructor, so codegen's `new(storage) ESP32RMTLEDStripLightOutput()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is a `memset` call of about 14 bytes per site on ESP32 and a store loop per site on esp8266.

This adds a user provided default constructor so only the constructors run. `params_`, `pin_` and `num_leds_` get `{}` initializers, the zero values the fill used to provide before codegen sets them. Every other member constructs itself or has an initializer. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
