### PR TITLE
[lvgl] Fix crash when using lvgl.list.add

### DIFF
--- a/esphome/components/lvgl/widgets/lv_list.py
+++ b/esphome/components/lvgl/widgets/lv_list.py
@@ -61,6 +61,7 @@ from . import (
     collect_parts,
     get_widgets,
     set_obj_properties,
+    wait_for_widgets,
 )
 from .buttonmatrix import CONF_BUTTONMATRIX
 from .canvas import CONF_CANVAS
@@ -227,6 +228,7 @@ LIST_ID_SCHEMA = cv.Schema({cv.Required(CONF_ID): cv.use_id(lv_list_t)})
 )
 async def list_add_text_to_code(config, action_id, template_arg, args):
     widgets = await get_widgets(config)
+    await _wait_list_triggers_completed()
 
     async def do_add_text(w: Widget):
         text = await lv_text.process(config[CONF_TEXT])
@@ -370,6 +372,7 @@ async def list_add_to_code(config, action_id, template_arg, args):
     _register_lv_uses(w_type_name, w_conf)
     _register_dynamic_widget_style_uses(w_conf)
     widgets = await get_widgets(config)
+    await _wait_list_triggers_completed()
 
     async def do_add(w: Widget):
         index = None
@@ -416,6 +419,7 @@ async def _build_dynamic_widget(
                 lv.obj_move_to_index(w.obj, index)
             await _fire_on_add(list_id, list_obj, w.obj)
 
+    await wait_for_widgets()
     if widget_type.is_compound():
         with LocalVariable(
             var_name, widget_type.w_type, widget_type.w_type.new()
@@ -503,6 +507,7 @@ LIST_REMOVE_SCHEMA = LIST_ID_SCHEMA.extend(
 )
 async def list_remove_to_code(config, action_id, template_arg, args):
     widgets = await get_widgets(config)
+    await _wait_list_triggers_completed()
 
     async def do_remove(w: Widget):
         index = await lv_int.process(config[CONF_INDEX])
@@ -536,6 +541,7 @@ async def list_remove_to_code(config, action_id, template_arg, args):
 )
 async def list_clear_to_code(config, action_id, template_arg, args):
     widgets = await get_widgets(config)
+    await _wait_list_triggers_completed()
 
     async def do_clear(w: Widget):
         await _wait_list_triggers_completed()

--- a/esphome/components/lvgl/widgets/lv_list.py
+++ b/esphome/components/lvgl/widgets/lv_list.py
@@ -61,7 +61,6 @@ from . import (
     collect_parts,
     get_widgets,
     set_obj_properties,
-    wait_for_widgets,
 )
 from .buttonmatrix import CONF_BUTTONMATRIX
 from .canvas import CONF_CANVAS
@@ -419,7 +418,6 @@ async def _build_dynamic_widget(
                 lv.obj_move_to_index(w.obj, index)
             await _fire_on_add(list_id, list_obj, w.obj)
 
-    await wait_for_widgets()
     if widget_type.is_compound():
         with LocalVariable(
             var_name, widget_type.w_type, widget_type.w_type.new()

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -30,6 +30,18 @@ binary_sensor:
     widget: button_button
     state: pressed
 
+globals:
+  - id: counter
+    type: int
+
+script:
+  - id: add_row
+    then:
+      - lvgl.list.add:
+          id: test_list_id
+          label:
+            text: row
+
 lvgl:
   id: lvgl_id
   rotation: 90
@@ -1291,7 +1303,7 @@ lvgl:
               then:
                 - logger.log:
                     format: "table selected row %u col %u"
-                    args: [row, column]
+                    args: [(unsigned)row, (unsigned)column]
             on_click:
               then:
                 - lvgl.table.cell.update:
@@ -1347,10 +1359,12 @@ lvgl:
               - logger.log:
                   format: "list entry added at %d"
                   args: [list_index]
+              - lambda: "id(counter)++;"
             on_remove:
               - logger.log:
                   format: "list entry removed at %d"
                   args: [list_index]
+              - lambda: "id(counter)--;"
             on_click:
               - lvgl.list.add_text:
                   id: test_list_id


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When using `lvgl.list.add` and friends, a coroutine switch at the wrong time results in the CodeContext being reset and a build-time crash.

If the ESPHome coroutine runner supported contextvars like the native Python asyncio, this could be managed by making CodeContext a contextvar, so its value would be saved and restored around a coroutine context switch, but this isn't currently possible.

The work-around is similar to other LVGL constructs - using await to delay code generation until all required pieces are in place.

Also fix a warning from the lvgl build-test config where `%u` was used to format a `uint32_t` value.

 ## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #19123


**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
globals:
  - id: counter
    type: int

script:
  - id: add_row
    then:
      - lvgl.list.add:
          id: my_list
          label:
            text: row

lvgl:
  widgets:
    - list:
        id: my_list
        on_add:
          - lambda: "id(counter)++;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
