### PR TITLE
[esp32] Use a user provided default constructor for ESP32InternalGPIOPin

### DIFF
--- a/esphome/components/esp32/gpio.h
+++ b/esphome/components/esp32/gpio.h
@@ -12,6 +12,9 @@ static_assert(GPIO_DRIVE_CAP_MAX <= 4, "gpio_drive_cap_t has too many values for
 
 class ESP32InternalGPIOPin final : public InternalGPIOPin {
  public:
+  // User provided, not "= default": `new(p) ESP32InternalGPIOPin()` would zero-fill .bss that is already zero.
+  ESP32InternalGPIOPin() {}
+
   void set_pin(gpio_num_t pin) { this->pin_ = static_cast<uint8_t>(pin); }
   void set_inverted(bool inverted) { this->pin_flags_.inverted = inverted; }
   void set_drive_strength(gpio_drive_cap_t drive_strength) {
@@ -39,7 +42,7 @@ class ESP32InternalGPIOPin final : public InternalGPIOPin {
   // - 3 bytes for members below
   // - 1 byte padding for alignment
   // - 4 bytes for vtable pointer
-  uint8_t pin_;          // GPIO pin number (0-255, actual max ~54 on ESP32)
+  uint8_t pin_{0};       // GPIO pin number (0-255, actual max ~54 on ESP32)
   gpio::Flags flags_{};  // GPIO flags (1 byte)
   struct PinFlags {
     uint8_t inverted : 1;        // Invert pin logic (1 bit)


### PR DESCRIPTION
# What does this implement/fix?

`ESP32InternalGPIOPin` has no user provided default constructor, so codegen's `new(storage) ESP32InternalGPIOPin()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is wasted code at every pin object in `setup()`, a `memset` call of about 14 bytes per site on ESP32. Every GPIO pin on every ESP32 config is one of these; a small config has half a dozen, a remote control config has six, the Apollo radar config seven.

This adds a user provided default constructor so only the constructors run, and gives `pin_` a `{0}` initializer, the value the fill used to provide before codegen calls `set_pin`. `flags_` and the `InternalGPIOPin` base already have initializers. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
