### PR TITLE
[core] Use a user provided default constructor for Automation

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -609,7 +609,8 @@ template<typename... Ts> class Automation {
  public:
   /// Default constructor for use with TriggerForwarder (no Trigger object needed).
   // User provided, not "= default": `new(p) Automation()` would zero-fill .bss that is already zero.
-  Automation() {}
+  // constexpr and noexcept keep the rest of the implicit constructor's contract.
+  constexpr Automation() noexcept {}
   explicit Automation(Trigger<Ts...> *trigger) { trigger->set_automation_parent(this); }
 
   void add_action(Action<Ts...> *action) { this->actions_.add_action(action); }

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -608,7 +608,8 @@ template<typename... Ts> class ActionList {
 template<typename... Ts> class Automation {
  public:
   /// Default constructor for use with TriggerForwarder (no Trigger object needed).
-  Automation() = default;
+  // User provided, not "= default": `new(p) Automation()` would zero-fill .bss that is already zero.
+  Automation() {}
   explicit Automation(Trigger<Ts...> *trigger) { trigger->set_automation_parent(this); }
 
   void add_action(Action<Ts...> *action) { this->actions_.add_action(action); }


### PR DESCRIPTION
# What does this implement/fix?

`Automation<Ts...>` declares `Automation() = default;`, so codegen's `new(storage) Automation<>()` for every automation that uses a `TriggerForwarder` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is wasted code at every such site in `setup()`, a `memset` call of about 14 bytes per site on ESP32 and a store loop per site on esp8266. Every `on_...:` block without trigger arguments is one of these; the Apollo radar config has six, the Voice PE config fourteen.

A user provided constructor makes only the constructors run. The only member is an `ActionList` whose fields all have initializers, so nothing relied on the fill. The trigger taking constructor is unchanged. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** ESP32-S3 Apollo config, 6 sites, against dev: `setup()` 16077 to 16077, `.flash.text` +0; ESP32-C6 copy of the same config: `setup()` 27322 to 27322, +0. The compiler had already eliminated the 8 byte fill for this class as dead stores on both targets, so the constructor only guards against configs where it cannot; RAM unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
