### PR TITLE
[esp8266_pwm] Use a user provided default constructor for ESP8266PWM

### DIFF
--- a/esphome/components/esp8266_pwm/esp8266_pwm.h
+++ b/esphome/components/esp8266_pwm/esp8266_pwm.h
@@ -11,6 +11,9 @@ namespace esphome::esp8266_pwm {
 
 class ESP8266PWM final : public output::FloatOutput, public Component {
  public:
+  // User provided, not "= default": `new(p) ESP8266PWM()` would zero-fill .bss that is already zero.
+  ESP8266PWM() {}
+
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_frequency(float frequency) { this->frequency_ = frequency; }
   /// Dynamically update frequency
@@ -28,7 +31,7 @@ class ESP8266PWM final : public output::FloatOutput, public Component {
  protected:
   void write_state(float state) override;
 
-  InternalGPIOPin *pin_;
+  InternalGPIOPin *pin_{nullptr};
   float frequency_{1000.0};
   /// Cache last output level for dynamic frequency updating
   float last_output_{0.0};


### PR DESCRIPTION
# What does this implement/fix?

`ESP8266PWM` has no user provided default constructor, so codegen's `new(storage) ESP8266PWM()` is value initialization: the compiler zero fills the object before the constructors run. On the esp8266 toolchain that is a 40 byte store loop at every PWM output in `setup()`; an RGBCT bulb has five of them. The storage is a static byte array that is already zero, so the loop is wasted code.

This adds a user provided default constructor so only the constructors run, and gives `pin_` a `{nullptr}` initializer, the value the fill used to provide before codegen calls `set_pin`. The other members already have initializers. Same change as #19111 for `BinarySensor`.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** esp8266 build of the Athom RGBCT bulb config, 5 PWM outputs, against dev: `setup()` 3750 to 3578, `.text` 457565 to 457405, -160 bytes; the five 40 byte store loops are gone from `setup()`; RAM unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
