### PR TITLE
[pca9554] Use a user provided default constructor for PCA9554GPIOPin

### DIFF
--- a/esphome/components/pca9554/pca9554.h
+++ b/esphome/components/pca9554/pca9554.h
@@ -55,6 +55,9 @@ class PCA9554Component final : public Component,
 /// Helper class to expose a PCA9554 pin as an internal input GPIO pin.
 class PCA9554GPIOPin final : public GPIOPin {
  public:
+  // User provided, not "= default": `new(p) PCA9554GPIOPin()` would zero-fill .bss that is already zero.
+  PCA9554GPIOPin() {}
+
   void setup() override;
   void pin_mode(gpio::Flags flags) override;
   bool digital_read() override;
@@ -69,10 +72,10 @@ class PCA9554GPIOPin final : public GPIOPin {
   gpio::Flags get_flags() const override { return this->flags_; }
 
  protected:
-  PCA9554Component *parent_;
-  uint8_t pin_;
-  bool inverted_;
-  gpio::Flags flags_;
+  PCA9554Component *parent_{nullptr};
+  uint8_t pin_{0};
+  bool inverted_{false};
+  gpio::Flags flags_{};
 };
 
 }  // namespace esphome::pca9554


### PR DESCRIPTION
# What does this implement/fix?

`PCA9554GPIOPin` has no user provided default constructor, so codegen's `new(storage) PCA9554GPIOPin()` is value initialization: the compiler zero fills the object before the constructors run. The storage is a static byte array that is already zero, so the fill is a `memset` call of about 14 bytes at every expander pin in `setup()`, and an expander config has one object per used pin; the config measured below has three.

This adds a user provided default constructor so only the constructors run, and gives `parent_`, `pin_`, `inverted_` and `flags_` initializers with the zero values the fill used to provide; codegen sets all four immediately after construction. Same change as #19207 for the PCF8574 pin.

**Why this is not fixed in codegen.** #19108 tried emitting `new(storage) Type` for every class, so no class would be value initialized. That is only correct when every member of the constructed class, including inherited ones, has an initializer or is written before it is read. Several classes rely on the zero that value initialization provides, `daly_bms::DalyBmsComponent::trigger_next_` for example, and `cppcoreguidelines-pro-type-member-init` is disabled in `.clang-tidy`, so nothing enforces it. The per class change is that audit: the constructor is only made user provided after every member has been checked, which is done above for this class. Classes without a user provided constructor keep the value initialization and its zero fill.

**Measured.** drivewaygate config (ESP32-S3, three PCA9554 pins), against dev: `setup()` 3150 to 3130, `.flash.text` -20 bytes, `memset` calls in `setup()` 35 to 32; RAM unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
