### PR TITLE
[remote_receiver] [remote_transmitter] Keep the RMT setup error message as a pointer to the literal

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -83,20 +83,14 @@ class RemoteReceiverComponent final : public remote_base::RemoteReceiverBase,
  protected:
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED
   void decode_rmt_(rmt_symbol_word_t *item, size_t item_count);
+  // log the failed RMT call and mark the component failed
+  void fail_(esp_err_t error, const LogString *reason);
   rmt_channel_handle_t channel_{NULL};
   uint32_t filter_symbols_{0};
   uint32_t receive_symbols_{0};
   bool with_dma_{false};
   uint32_t carrier_frequency_{0};
   uint8_t carrier_duty_percent_{100};
-  // every RMT failure records the code and the reason together
-  void fail_(esp_err_t error, const char *where) {
-    this->error_code_ = error;
-    this->error_string_ = where;
-    this->mark_failed();
-  }
-  esp_err_t error_code_{ESP_OK};
-  const char *error_string_{""};
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ESP32)

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -89,8 +89,14 @@ class RemoteReceiverComponent final : public remote_base::RemoteReceiverBase,
   bool with_dma_{false};
   uint32_t carrier_frequency_{0};
   uint8_t carrier_duty_percent_{100};
+  // every RMT failure records the code and the reason together
+  void fail_(esp_err_t error, const char *where) {
+    this->error_code_ = error;
+    this->error_string_ = where;
+    this->mark_failed();
+  }
   esp_err_t error_code_{ESP_OK};
-  const char *error_string_{nullptr};
+  const char *error_string_{""};
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ESP32)

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -90,7 +90,7 @@ class RemoteReceiverComponent final : public remote_base::RemoteReceiverBase,
   uint32_t carrier_frequency_{0};
   uint8_t carrier_duty_percent_{100};
   esp_err_t error_code_{ESP_OK};
-  std::string error_string_;
+  const char *error_string_{nullptr};
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_LIBRETINY) || defined(USE_RP2) || defined(USE_ESP32)

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -36,7 +36,7 @@ static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_r
 }
 
 void RemoteReceiverComponent::fail_(esp_err_t error, const LogString *reason) {
-  ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(error), LOG_STR_ARG(reason));
+  ESP_LOGE(TAG, "RMT driver failed: %s", esp_err_to_name(error));
   this->mark_failed(reason);
 }
 

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -141,8 +141,7 @@ void RemoteReceiverComponent::dump_config() {
       this->carrier_frequency_, this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
   LOG_PIN("  Pin: ", this->pin_);
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),
-             this->error_string_.c_str());
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_);
   }
 }
 

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -47,13 +47,7 @@ void RemoteReceiverComponent::setup() {
   channel.flags.with_dma = this->with_dma_;
   esp_err_t error = rmt_new_rx_channel(&channel, &this->channel_);
   if (error != ESP_OK) {
-    this->error_code_ = error;
-    if (error == ESP_ERR_NOT_FOUND) {
-      this->error_string_ = "out of RMT symbol memory";
-    } else {
-      this->error_string_ = "in rmt_new_rx_channel";
-    }
-    this->mark_failed();
+    this->fail_(error, error == ESP_ERR_NOT_FOUND ? "out of RMT symbol memory" : "in rmt_new_rx_channel");
     return;
   }
   if (this->pin_->get_flags() & gpio::FLAG_PULLUP) {
@@ -63,9 +57,7 @@ void RemoteReceiverComponent::setup() {
   }
   error = rmt_enable(this->channel_);
   if (error != ESP_OK) {
-    this->error_code_ = error;
-    this->error_string_ = "in rmt_enable";
-    this->mark_failed();
+    this->fail_(error, "in rmt_enable");
     return;
   }
 
@@ -77,9 +69,7 @@ void RemoteReceiverComponent::setup() {
     carrier.flags.polarity_active_low = this->pin_->is_inverted();
     error = rmt_apply_carrier(this->channel_, &carrier);
     if (error != ESP_OK) {
-      this->error_code_ = error;
-      this->error_string_ = "in rmt_apply_carrier";
-      this->mark_failed();
+      this->fail_(error, "in rmt_apply_carrier");
       return;
     }
   }
@@ -89,9 +79,7 @@ void RemoteReceiverComponent::setup() {
   callbacks.on_recv_done = rmt_callback;
   error = rmt_rx_register_event_callbacks(this->channel_, &callbacks, &this->store_);
   if (error != ESP_OK) {
-    this->error_code_ = error;
-    this->error_string_ = "in rmt_rx_register_event_callbacks";
-    this->mark_failed();
+    this->fail_(error, "in rmt_rx_register_event_callbacks");
     return;
   }
 
@@ -114,9 +102,7 @@ void RemoteReceiverComponent::setup() {
   error = rmt_receive(this->channel_, (uint8_t *) this->store_.buffer + event_size, this->store_.receive_size,
                       &this->store_.config);
   if (error != ESP_OK) {
-    this->error_code_ = error;
-    this->error_string_ = "in rmt_receive";
-    this->mark_failed();
+    this->fail_(error, "in rmt_receive");
     return;
   }
 }
@@ -148,9 +134,7 @@ void RemoteReceiverComponent::dump_config() {
 void RemoteReceiverComponent::loop() {
   if (this->store_.error != ESP_OK) {
     ESP_LOGE(TAG, "Receive error");
-    this->error_code_ = this->store_.error;
-    this->error_string_ = "in rmt_callback";
-    this->mark_failed();
+    this->fail_(this->store_.error, "in rmt_callback");
   }
   if (this->store_.overflow) {
     ESP_LOGW(TAG, "Buffer overflow");

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -35,6 +35,11 @@ static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_r
   return false;
 }
 
+void RemoteReceiverComponent::fail_(esp_err_t error, const LogString *reason) {
+  ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(error), LOG_STR_ARG(reason));
+  this->mark_failed(reason);
+}
+
 void RemoteReceiverComponent::setup() {
   rmt_rx_channel_config_t channel;
   memset(&channel, 0, sizeof(channel));
@@ -47,7 +52,8 @@ void RemoteReceiverComponent::setup() {
   channel.flags.with_dma = this->with_dma_;
   esp_err_t error = rmt_new_rx_channel(&channel, &this->channel_);
   if (error != ESP_OK) {
-    this->fail_(error, error == ESP_ERR_NOT_FOUND ? "out of RMT symbol memory" : "in rmt_new_rx_channel");
+    this->fail_(error,
+                error == ESP_ERR_NOT_FOUND ? LOG_STR("out of RMT symbol memory") : LOG_STR("in rmt_new_rx_channel"));
     return;
   }
   if (this->pin_->get_flags() & gpio::FLAG_PULLUP) {
@@ -57,7 +63,7 @@ void RemoteReceiverComponent::setup() {
   }
   error = rmt_enable(this->channel_);
   if (error != ESP_OK) {
-    this->fail_(error, "in rmt_enable");
+    this->fail_(error, LOG_STR("in rmt_enable"));
     return;
   }
 
@@ -69,7 +75,7 @@ void RemoteReceiverComponent::setup() {
     carrier.flags.polarity_active_low = this->pin_->is_inverted();
     error = rmt_apply_carrier(this->channel_, &carrier);
     if (error != ESP_OK) {
-      this->fail_(error, "in rmt_apply_carrier");
+      this->fail_(error, LOG_STR("in rmt_apply_carrier"));
       return;
     }
   }
@@ -79,7 +85,7 @@ void RemoteReceiverComponent::setup() {
   callbacks.on_recv_done = rmt_callback;
   error = rmt_rx_register_event_callbacks(this->channel_, &callbacks, &this->store_);
   if (error != ESP_OK) {
-    this->fail_(error, "in rmt_rx_register_event_callbacks");
+    this->fail_(error, LOG_STR("in rmt_rx_register_event_callbacks"));
     return;
   }
 
@@ -102,7 +108,7 @@ void RemoteReceiverComponent::setup() {
   error = rmt_receive(this->channel_, (uint8_t *) this->store_.buffer + event_size, this->store_.receive_size,
                       &this->store_.config);
   if (error != ESP_OK) {
-    this->fail_(error, "in rmt_receive");
+    this->fail_(error, LOG_STR("in rmt_receive"));
     return;
   }
 }
@@ -126,15 +132,11 @@ void RemoteReceiverComponent::dump_config() {
       (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? LOG_STR_LITERAL(" us") : LOG_STR_LITERAL("%"),
       this->carrier_frequency_, this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
   LOG_PIN("  Pin: ", this->pin_);
-  if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_);
-  }
 }
 
 void RemoteReceiverComponent::loop() {
   if (this->store_.error != ESP_OK) {
-    ESP_LOGE(TAG, "Receive error");
-    this->fail_(this->store_.error, "in rmt_callback");
+    this->fail_(this->store_.error, LOG_STR("in rmt_callback"));
   }
   if (this->store_.overflow) {
     ESP_LOGW(TAG, "Buffer overflow");

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -156,8 +156,14 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   bool eot_level_{false};
   rmt_channel_handle_t channel_{NULL};
   rmt_encoder_handle_t encoder_{NULL};
+  // every RMT failure records the code and the reason together
+  void fail_(esp_err_t error, const char *where) {
+    this->error_code_ = error;
+    this->error_string_ = where;
+    this->mark_failed();
+  }
   esp_err_t error_code_{ESP_OK};
-  const char *error_string_{nullptr};
+  const char *error_string_{""};
   bool inverted_{false};
   bool non_blocking_{false};
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -141,6 +141,8 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
 #endif
 
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED
+  // log the failed RMT call and mark the component failed
+  void fail_(esp_err_t error, const LogString *reason);
   void configure_rmt_();
   void wait_for_rmt_();
 
@@ -156,14 +158,6 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   bool eot_level_{false};
   rmt_channel_handle_t channel_{NULL};
   rmt_encoder_handle_t encoder_{NULL};
-  // every RMT failure records the code and the reason together
-  void fail_(esp_err_t error, const char *where) {
-    this->error_code_ = error;
-    this->error_string_ = where;
-    this->mark_failed();
-  }
-  esp_err_t error_code_{ESP_OK};
-  const char *error_string_{""};
   bool inverted_{false};
   bool non_blocking_{false};
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -157,7 +157,7 @@ class RemoteTransmitterComponent final : public remote_base::RemoteTransmitterBa
   rmt_channel_handle_t channel_{NULL};
   rmt_encoder_handle_t encoder_{NULL};
   esp_err_t error_code_{ESP_OK};
-  std::string error_string_;
+  const char *error_string_{nullptr};
   bool inverted_{false};
   bool non_blocking_{false};
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
@@ -69,8 +69,7 @@ void RemoteTransmitterComponent::dump_config() {
   }
 
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),
-             this->error_string_.c_str());
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_);
   }
 }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
@@ -128,13 +128,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
 #endif
     error = rmt_new_tx_channel(&channel, &this->channel_);
     if (error != ESP_OK) {
-      this->error_code_ = error;
-      if (error == ESP_ERR_NOT_FOUND) {
-        this->error_string_ = "out of RMT symbol memory";
-      } else {
-        this->error_string_ = "in rmt_new_tx_channel";
-      }
-      this->mark_failed();
+      this->fail_(error, error == ESP_ERR_NOT_FOUND ? "out of RMT symbol memory" : "in rmt_new_tx_channel");
       return;
     }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
@@ -158,9 +152,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
     encoder.min_chunk_size = 1;
     error = rmt_new_simple_encoder(&encoder, &this->encoder_);
     if (error != ESP_OK) {
-      this->error_code_ = error;
-      this->error_string_ = "in rmt_new_simple_encoder";
-      this->mark_failed();
+      this->fail_(error, "in rmt_new_simple_encoder");
       return;
     }
 #else
@@ -168,18 +160,14 @@ void RemoteTransmitterComponent::configure_rmt_() {
     memset(&encoder, 0, sizeof(encoder));
     error = rmt_new_copy_encoder(&encoder, &this->encoder_);
     if (error != ESP_OK) {
-      this->error_code_ = error;
-      this->error_string_ = "in rmt_new_copy_encoder";
-      this->mark_failed();
+      this->fail_(error, "in rmt_new_copy_encoder");
       return;
     }
 #endif
 
     error = rmt_enable(this->channel_);
     if (error != ESP_OK) {
-      this->error_code_ = error;
-      this->error_string_ = "in rmt_enable";
-      this->mark_failed();
+      this->fail_(error, "in rmt_enable");
       return;
     }
     this->digital_write(open_drain || this->inverted_);
@@ -198,9 +186,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
     error = rmt_apply_carrier(this->channel_, &carrier);
   }
   if (error != ESP_OK) {
-    this->error_code_ = error;
-    this->error_string_ = "in rmt_apply_carrier";
-    this->mark_failed();
+    this->fail_(error, "in rmt_apply_carrier");
     return;
   }
 }

--- a/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
@@ -52,7 +52,7 @@ static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size
 #endif
 
 void RemoteTransmitterComponent::fail_(esp_err_t error, const LogString *reason) {
-  ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(error), LOG_STR_ARG(reason));
+  ESP_LOGE(TAG, "RMT driver failed: %s", esp_err_to_name(error));
   this->mark_failed(reason);
 }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
@@ -51,6 +51,11 @@ static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size
 }
 #endif
 
+void RemoteTransmitterComponent::fail_(esp_err_t error, const LogString *reason) {
+  ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(error), LOG_STR_ARG(reason));
+  this->mark_failed(reason);
+}
+
 void RemoteTransmitterComponent::setup() {
   this->inverted_ = this->pin_->is_inverted();
   this->configure_rmt_();
@@ -66,10 +71,6 @@ void RemoteTransmitterComponent::dump_config() {
 
   if (this->current_carrier_frequency_ != 0 && this->carrier_duty_percent_ != 100) {
     ESP_LOGCONFIG(TAG, "    Carrier Duty: %u%%", this->carrier_duty_percent_);
-  }
-
-  if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_);
   }
 }
 
@@ -128,7 +129,8 @@ void RemoteTransmitterComponent::configure_rmt_() {
 #endif
     error = rmt_new_tx_channel(&channel, &this->channel_);
     if (error != ESP_OK) {
-      this->fail_(error, error == ESP_ERR_NOT_FOUND ? "out of RMT symbol memory" : "in rmt_new_tx_channel");
+      this->fail_(error,
+                  error == ESP_ERR_NOT_FOUND ? LOG_STR("out of RMT symbol memory") : LOG_STR("in rmt_new_tx_channel"));
       return;
     }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
@@ -152,7 +154,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
     encoder.min_chunk_size = 1;
     error = rmt_new_simple_encoder(&encoder, &this->encoder_);
     if (error != ESP_OK) {
-      this->fail_(error, "in rmt_new_simple_encoder");
+      this->fail_(error, LOG_STR("in rmt_new_simple_encoder"));
       return;
     }
 #else
@@ -160,14 +162,14 @@ void RemoteTransmitterComponent::configure_rmt_() {
     memset(&encoder, 0, sizeof(encoder));
     error = rmt_new_copy_encoder(&encoder, &this->encoder_);
     if (error != ESP_OK) {
-      this->fail_(error, "in rmt_new_copy_encoder");
+      this->fail_(error, LOG_STR("in rmt_new_copy_encoder"));
       return;
     }
 #endif
 
     error = rmt_enable(this->channel_);
     if (error != ESP_OK) {
-      this->fail_(error, "in rmt_enable");
+      this->fail_(error, LOG_STR("in rmt_enable"));
       return;
     }
     this->digital_write(open_drain || this->inverted_);
@@ -186,7 +188,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
     error = rmt_apply_carrier(this->channel_, &carrier);
   }
   if (error != ESP_OK) {
-    this->fail_(error, "in rmt_apply_carrier");
+    this->fail_(error, LOG_STR("in rmt_apply_carrier"));
     return;
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

The RMT receiver and transmitter kept the reason a driver call failed in a `std::string`, plus the error code, so `dump_config` could print them. Every reason is a string literal, and core already stores a `LogString` reason for a failed component and prints it after `dump_config`. Both fields are gone: the failure site logs the error name and the reason once and hands the reason to `mark_failed()`, so the usual `is marked FAILED` line now carries it instead of `unspecified`. That is 28 B per instance back; on a device with two receivers and two transmitters, 112 B of RAM.

The eleven failure sites that set the code, set the reason and called `mark_failed()` as three statements now call one `fail_()` helper on each class, so the log line and the failed state cannot come apart. The receiver's separate `Receive error` line is folded into the same message.

Compiled for the ESP32 IDF receiver and transmitter fixtures; the field only exists on the RMT path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_receiver:
  - pin: GPIO4
    dump: nec
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

