### PR TITLE
[http_request] Keep the update manifest URL as a pointer to the literal

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -1,5 +1,7 @@
 #include "http_request_update.h"
 
+#include <cstring>
+
 #include "esphome/core/application.h"
 #include "esphome/core/version.h"
 
@@ -91,10 +93,10 @@ void HttpRequestUpdate::update_task(void *params) {
   auto *result = new TaskResult();
   auto *info = &result->info;
 
-  auto container = this_update->request_parent_->get(this_update->source_url_);
+  auto container = this_update->request_parent_->get(this_update->get_source_url());
 
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
-    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->source_url_.c_str());
+    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->get_source_url().c_str());
     if (container != nullptr)
       container->end();
     result->error_str = LOG_STR("Failed to fetch manifest");
@@ -174,7 +176,7 @@ void HttpRequestUpdate::update_task(void *params) {
     allocator.deallocate(data, content_length);
 
     if (!valid) {
-      ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_.c_str());
+      ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->get_source_url().c_str());
       result->error_str = LOG_STR("Failed to parse manifest JSON");
       goto defer;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
@@ -182,12 +184,14 @@ void HttpRequestUpdate::update_task(void *params) {
     // Merge source_url_ and firmware_url
     if (!info->firmware_url.empty() && info->firmware_url.find("http") == std::string::npos) {
       std::string path = info->firmware_url;
+      const StringRef source = this_update->get_source_url();
       if (path[0] == '/') {
-        std::string domain = this_update->source_url_.substr(0, this_update->source_url_.find('/', 8));
-        info->firmware_url = domain + path;
+        // scheme and host, up to the first slash after "https://"
+        info->firmware_url = source.substr(0, source.find('/', 8)) + path;
       } else {
-        std::string domain = this_update->source_url_.substr(0, this_update->source_url_.rfind('/') + 1);
-        info->firmware_url = domain + path;
+        // directory of the manifest, up to and including its last slash
+        const char *dir_end = strrchr(source.c_str(), '/');
+        info->firmware_url = source.substr(0, dir_end != nullptr ? dir_end - source.c_str() + 1 : 0) + path;
       }
     }
 

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -183,16 +183,19 @@ void HttpRequestUpdate::update_task(void *params) {
 
     // Merge source_url_ and firmware_url
     if (!info->firmware_url.empty() && info->firmware_url.find("http") == std::string::npos) {
-      std::string path = info->firmware_url;
-      const StringRef source = this_update->get_source_url();
-      if (path[0] == '/') {
+      const char *source = this_update->source_url_;
+      const size_t source_len = strlen(source);
+      size_t prefix_len;
+      if (info->firmware_url[0] == '/') {
         // scheme and host, up to the first slash after "https://"
-        info->firmware_url = source.substr(0, source.find('/', 8)) + path;
+        const char *host_end = source_len > 8 ? strchr(source + 8, '/') : nullptr;
+        prefix_len = host_end != nullptr ? host_end - source : source_len;
       } else {
         // directory of the manifest, up to and including its last slash
-        const char *dir_end = strrchr(source.c_str(), '/');
-        info->firmware_url = source.substr(0, dir_end != nullptr ? dir_end - source.c_str() + 1 : 0) + path;
+        const char *dir_end = strrchr(source, '/');
+        prefix_len = dir_end != nullptr ? dir_end - source + 1 : 0;
       }
+      info->firmware_url.insert(0, source, prefix_len);
     }
 
 #ifdef ESPHOME_PROJECT_VERSION

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -93,10 +93,10 @@ void HttpRequestUpdate::update_task(void *params) {
   auto *result = new TaskResult();
   auto *info = &result->info;
 
-  auto container = this_update->request_parent_->get(this_update->get_source_url());
+  auto container = this_update->request_parent_->get(this_update->source_url_);
 
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
-    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->get_source_url().c_str());
+    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->source_url_);
     if (container != nullptr)
       container->end();
     result->error_str = LOG_STR("Failed to fetch manifest");
@@ -176,7 +176,7 @@ void HttpRequestUpdate::update_task(void *params) {
     allocator.deallocate(data, content_length);
 
     if (!valid) {
-      ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->get_source_url().c_str());
+      ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_);
       result->error_str = LOG_STR("Failed to parse manifest JSON");
       goto defer;  // NOLINT(cppcoreguidelines-avoid-goto)
     }

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
 #include "esphome/core/helpers.h"
 
 #include "esphome/components/http_request/http_request.h"
@@ -21,7 +22,8 @@ class HttpRequestUpdate final : public update::UpdateEntity, public PollingCompo
   void perform(bool force) override;
   void check() override { this->update(); }
 
-  void set_source_url(const std::string &source_url) { this->source_url_ = source_url; }
+  void set_source_url(const char *source_url) { this->source_url_ = source_url; }
+  StringRef get_source_url() const { return StringRef(this->source_url_); }
 
   void set_request_parent(HttpRequestComponent *request_parent) { this->request_parent_ = request_parent; }
   void set_ota_parent(OtaHttpRequestComponent *ota_parent) { this->ota_parent_ = ota_parent; }
@@ -33,13 +35,15 @@ class HttpRequestUpdate final : public update::UpdateEntity, public PollingCompo
  protected:
   HttpRequestComponent *request_parent_;
   OtaHttpRequestComponent *ota_parent_;
-  std::string source_url_;
 
   static void update_task(void *params);
 #ifdef USE_ESP32
   TaskHandle_t update_task_handle_{nullptr};
 #endif
   uint8_t initial_check_remaining_{0};
+
+ private:
+  const char *source_url_{nullptr};  // literal from codegen
 };
 
 }  // namespace esphome::http_request

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/core/string_ref.h"
 #include "esphome/core/helpers.h"
 
 #include "esphome/components/http_request/http_request.h"
@@ -23,7 +22,6 @@ class HttpRequestUpdate final : public update::UpdateEntity, public PollingCompo
   void check() override { this->update(); }
 
   void set_source_url(const char *source_url) { this->source_url_ = source_url; }
-  StringRef get_source_url() const { return StringRef(this->source_url_); }
 
   void set_request_parent(HttpRequestComponent *request_parent) { this->request_parent_ = request_parent; }
   void set_ota_parent(OtaHttpRequestComponent *ota_parent) { this->ota_parent_ = ota_parent; }


### PR DESCRIPTION
# What does this implement/fix?

The `http_request` update platform kept its manifest URL, a literal from code generation, in a `std::string`: 24 B for the object plus a heap copy of the URL per entity, on top of the literal already in flash. The setter now takes `const char *` and stores the pointer in a private member, the same way `select` stores its options. The two log lines pass the pointer directly, and the manifest fetch builds a short lived `std::string` for `get()` once per check, which is a fair trade for dropping the permanent copy; the firmware URL merge finds the prefix length with `strchr` and `strrchr` and inserts it in place, so the two temporary strings the old code built are gone. On the esp32-c6-idf test build this is 176 B less flash and 16 B less RAM than dev.

Two update entities on an Athom ESP32 remote each dropped an 80 character heap copy plus the string object. Compiled for the ESP32 IDF `http_request` fixture, which carries an update entity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
update:
  - platform: http_request
    name: Firmware
    source: https://example.com/firmware/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

