### PR TITLE
[esp32_hosted] Keep the update manifest URL as a pointer to the literal

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -169,7 +169,7 @@ void Esp32HostedUpdate::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Mode: HTTP\n"
                 "  Source URL: %s",
-                this->source_url_.c_str());
+                this->get_source_url().c_str());
 #else
   ESP_LOGCONFIG(TAG,
                 "  Mode: Embedded\n"
@@ -213,9 +213,9 @@ void Esp32HostedUpdate::check() {
 bool Esp32HostedUpdate::fetch_manifest_() {
   ESP_LOGD(TAG, "Fetching manifest");
 
-  auto container = this->http_request_parent_->get(this->source_url_);
+  auto container = this->http_request_parent_->get(this->get_source_url());
   if (container == nullptr || container->status_code != 200) {
-    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this->source_url_.c_str());
+    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this->get_source_url().c_str());
     this->status_set_error(LOG_STR("Failed to fetch manifest"));
     return false;
   }

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -169,7 +169,7 @@ void Esp32HostedUpdate::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Mode: HTTP\n"
                 "  Source URL: %s",
-                this->get_source_url().c_str());
+                this->source_url_);
 #else
   ESP_LOGCONFIG(TAG,
                 "  Mode: Embedded\n"
@@ -213,9 +213,9 @@ void Esp32HostedUpdate::check() {
 bool Esp32HostedUpdate::fetch_manifest_() {
   ESP_LOGD(TAG, "Fetching manifest");
 
-  auto container = this->http_request_parent_->get(this->get_source_url());
+  auto container = this->http_request_parent_->get(this->source_url_);
   if (container == nullptr || container->status_code != 200) {
-    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this->get_source_url().c_str());
+    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this->source_url_);
     this->status_set_error(LOG_STR("Failed to fetch manifest"));
     return false;
   }

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.h
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.h
@@ -3,7 +3,6 @@
 #if defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32P4)
 
 #include "esphome/core/component.h"
-#include "esphome/core/string_ref.h"
 #include "esphome/components/update/update_entity.h"
 #include <array>
 #include <string>
@@ -27,7 +26,6 @@ class Esp32HostedUpdate final : public update::UpdateEntity, public PollingCompo
 #ifdef USE_ESP32_HOSTED_HTTP_UPDATE
   // HTTP mode setters
   void set_source_url(const char *url) { this->source_url_ = url; }
-  StringRef get_source_url() const { return StringRef(this->source_url_); }
   void set_http_request_parent(http_request::HttpRequestComponent *parent) { this->http_request_parent_ = parent; }
 #else
   // Embedded mode setters
@@ -40,6 +38,7 @@ class Esp32HostedUpdate final : public update::UpdateEntity, public PollingCompo
 #ifdef USE_ESP32_HOSTED_HTTP_UPDATE
   // HTTP mode members
   http_request::HttpRequestComponent *http_request_parent_{nullptr};
+  const char *source_url_{nullptr};  // literal from codegen
   std::string firmware_url_;
 
   // HTTP mode helpers
@@ -56,9 +55,6 @@ class Esp32HostedUpdate final : public update::UpdateEntity, public PollingCompo
 #endif
 
   std::array<uint8_t, 32> firmware_sha256_{};
-
- private:
-  const char *source_url_{nullptr};  // literal from codegen
 };
 
 }  // namespace esphome::esp32_hosted

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.h
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.h
@@ -3,6 +3,7 @@
 #if defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32P4)
 
 #include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
 #include "esphome/components/update/update_entity.h"
 #include <array>
 #include <string>
@@ -25,7 +26,8 @@ class Esp32HostedUpdate final : public update::UpdateEntity, public PollingCompo
 
 #ifdef USE_ESP32_HOSTED_HTTP_UPDATE
   // HTTP mode setters
-  void set_source_url(const std::string &url) { this->source_url_ = url; }
+  void set_source_url(const char *url) { this->source_url_ = url; }
+  StringRef get_source_url() const { return StringRef(this->source_url_); }
   void set_http_request_parent(http_request::HttpRequestComponent *parent) { this->http_request_parent_ = parent; }
 #else
   // Embedded mode setters
@@ -38,7 +40,6 @@ class Esp32HostedUpdate final : public update::UpdateEntity, public PollingCompo
 #ifdef USE_ESP32_HOSTED_HTTP_UPDATE
   // HTTP mode members
   http_request::HttpRequestComponent *http_request_parent_{nullptr};
-  std::string source_url_;
   std::string firmware_url_;
 
   // HTTP mode helpers
@@ -55,6 +56,9 @@ class Esp32HostedUpdate final : public update::UpdateEntity, public PollingCompo
 #endif
 
   std::array<uint8_t, 32> firmware_sha256_{};
+
+ private:
+  const char *source_url_{nullptr};  // literal from codegen
 };
 
 }  // namespace esphome::esp32_hosted


### PR DESCRIPTION
# What does this implement/fix?

The `esp32_hosted` update platform kept its manifest URL, a literal from code generation, in a `std::string`: 24 B for the object plus a heap copy of the URL, on top of the literal already in flash. The setter now takes `const char *` and stores the pointer next to the other HTTP mode members, the same way `select` stores its options. The two log lines pass the pointer directly, and the manifest fetch builds a short lived `std::string` for `get()` once per check, which is a fair trade for dropping the permanent copy. This is the same change as the `http_request` update platform in its own pull request.

Measured by hand on the esp32-p4-idf http test config against dev, since this component has no base test config for the CI memory report: 206 B less flash and 16 B less RAM. The embedded test config is byte for byte unchanged.

Compiled for the ESP32-P4 IDF `esp32_hosted` fixture, which carries the update entity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#<esphome.io PR number goes here>

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- esphome/developers.esphome.io#<developers.esphome.io PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
update:
  - platform: esp32_hosted
    name: Firmware
    source: https://example.com/firmware/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

