### PR TITLE
[bluetooth_proxy] Add an advertisement filter hook

### DIFF
--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -395,6 +395,19 @@ async def _to_code_ble_hub(config: ConfigType) -> None:
     await _connections_to_code(var, config)
 
 
+def enable_advertisement_filter() -> None:
+    """Compile the advertisement filter hook into bluetooth_proxy.
+
+    Call this from an external filtering component's to_code(); it is the
+    supported way to turn the hook on. The underlying define is an
+    implementation detail and may be renamed, so do not emit it directly.
+
+    Without it the slot, its member and the branch on the advertisement path are
+    all compiled out, and a proxy that installs no filter is unaffected.
+    """
+    cg.add_define("USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER")
+
+
 async def to_code(config: ConfigType) -> None:
     if CORE.is_esp32:
         await _to_code_esp32(config)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -94,6 +94,15 @@ void BluetoothProxy::on_raw_advertisement_(const ble_device_base::RawAdvertiseme
   if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr)
     return;
 
+#ifdef USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
+  // Ask the filter before the packet is queued, so a dropped advertisement never
+  // reaches the batch or the network.
+  if (this->advertisement_filter_.is_set() && !this->advertisement_filter_.should_forward(raw)) {
+    ESP_LOGVV(TAG, "Filtered packet from %012" PRIX64, raw.address);
+    return;
+  }
+#endif
+
   auto &adv = this->response_.advertisements[this->response_.advertisements_len];
   adv.address = raw.address;
   adv.rssi = raw.rssi;

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -110,10 +110,11 @@ static_assert(PendingReply{}.empty());
 ///     return static_cast<MyFilter *>(self)->should_forward(adv);
 ///   }});
 ///
-/// Returning false drops the advertisement. Define
-/// USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER from the external component's
-/// codegen (cg.add_define) to compile the hook in; without it there is no slot,
-/// no branch on the hot path, and no cost.
+/// Returning false drops the advertisement. Call
+/// bluetooth_proxy.enable_advertisement_filter() from the external component's
+/// codegen to compile the hook in; without it there is no slot, no branch on the
+/// hot path, and no cost. The define behind that function is an implementation
+/// detail - external components should not emit it themselves.
 struct AdvertisementFilter {
   void *instance{nullptr};
   bool (*fn)(void *instance, const ble_device_base::RawAdvertisement &adv){nullptr};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -119,9 +119,7 @@ struct AdvertisementFilter {
   bool (*fn)(void *instance, const ble_device_base::RawAdvertisement &adv){nullptr};
   /// A default-constructed slot is "no filter"; the proxy guards on this.
   bool is_set() const { return this->fn != nullptr; }
-  bool should_forward(const ble_device_base::RawAdvertisement &adv) const {
-    return this->fn(this->instance, adv);
-  }
+  bool should_forward(const ble_device_base::RawAdvertisement &adv) const { return this->fn(this->instance, adv); }
 };
 #endif  // USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -97,6 +97,34 @@ static_assert(pending_reply_round_trips(0xABCD112233445566ULL, 0x000011223344556
 static_assert(PendingReply{}.empty());
 #endif
 
+#ifdef USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
+/// Predicate slot letting an external component drop advertisements before they
+/// are queued for the API, instead of forwarding every packet the radio hears.
+///
+/// Same shape as ble_device_base::RawAdvertisementCallback: a POD slot with no
+/// allocation and a single subscriber. The filter runs on the advertisement hot
+/// path, so it must be cheap and must not block.
+///
+/// Usage from an external component:
+///   proxy->set_advertisement_filter({this, [](void *self, const ble_device_base::RawAdvertisement &adv) {
+///     return static_cast<MyFilter *>(self)->should_forward(adv);
+///   }});
+///
+/// Returning false drops the advertisement. Define
+/// USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER from the external component's
+/// codegen (cg.add_define) to compile the hook in; without it there is no slot,
+/// no branch on the hot path, and no cost.
+struct AdvertisementFilter {
+  void *instance{nullptr};
+  bool (*fn)(void *instance, const ble_device_base::RawAdvertisement &adv){nullptr};
+  /// A default-constructed slot is "no filter"; the proxy guards on this.
+  bool is_set() const { return this->fn != nullptr; }
+  bool should_forward(const ble_device_base::RawAdvertisement &adv) const {
+    return this->fn(this->instance, adv);
+  }
+};
+#endif  // USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
+
 class BluetoothProxy final : public Component {
 #ifdef USE_BLUETOOTH_PROXY_CONNECTIONS
   // Allow the connection to update connections_free_response_
@@ -161,6 +189,12 @@ class BluetoothProxy final : public Component {
 
   void set_active(bool active) { this->active_ = active; }
   bool has_active() { return this->active_; }
+
+#ifdef USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
+  /// Install the advertisement filter. One subscriber; a later call replaces an
+  /// earlier one.
+  void set_advertisement_filter(AdvertisementFilter filter) { this->advertisement_filter_ = filter; }
+#endif
 
   uint32_t get_legacy_version() const {
     if (!this->active_) {
@@ -329,6 +363,10 @@ class BluetoothProxy final : public Component {
   // Group 3: 4-byte types; paired with hub_ so the 8-aligned messages below
   // start on an even word, closing two alignment holes.
   uint32_t last_advertisement_flush_time_{0};
+
+#ifdef USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
+  AdvertisementFilter advertisement_filter_{};
+#endif
 
   // BLE advertisement batching
   api::BluetoothLERawAdvertisementsResponse response_;

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -329,6 +329,9 @@
 #else
 #define BLUETOOTH_PROXY_MAX_CONNECTIONS 0
 #endif
+// Hook for an external filtering component; declared here so static analysis
+// parses the slot and its call site.
+#define USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER
 #define BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE 16
 #endif
 

--- a/tests/component_tests/bluetooth_proxy/test_advertisement_filter.py
+++ b/tests/component_tests/bluetooth_proxy/test_advertisement_filter.py
@@ -1,0 +1,17 @@
+"""The codegen hook external filtering components use to turn on the filter slot."""
+
+from unittest.mock import patch
+
+from esphome.components import bluetooth_proxy
+
+
+def test_enable_advertisement_filter_emits_define() -> None:
+    """The function is the supported API; the define behind it may be renamed.
+
+    External components must call this rather than emitting the define, so that
+    the define stays an implementation detail core is free to change.
+    """
+    with patch("esphome.codegen.add_define") as add_define:
+        bluetooth_proxy.enable_advertisement_filter()
+
+    add_define.assert_called_once_with("USE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER")

--- a/tests/components/bluetooth_proxy/test-advertisement-filter.esp32-s3-idf.yaml
+++ b/tests/components/bluetooth_proxy/test-advertisement-filter.esp32-s3-idf.yaml
@@ -1,0 +1,18 @@
+# Compiles the advertisement filter hook, which is otherwise gated out.
+#
+# The define is normally emitted by an external component's codegen
+# (cg.add_define). Forcing it here gives CI coverage of the gated code path -
+# the slot, the member and the call site in on_raw_advertisement_() - without
+# needing an external component in-tree. The other bluetooth_proxy tests leave
+# it unset and so cover the ungated build.
+<<: !include common.yaml
+
+esphome:
+  platformio_options:
+    build_flags:
+      - "-DUSE_BLUETOOTH_PROXY_ADVERTISEMENT_FILTER"
+
+esp32_ble_tracker:
+
+bluetooth_proxy:
+  active: true

--- a/tests/components/bluetooth_proxy/test-advertisement-filter.esp32-s3-idf.yaml
+++ b/tests/components/bluetooth_proxy/test-advertisement-filter.esp32-s3-idf.yaml
@@ -1,7 +1,9 @@
 # Compiles the advertisement filter hook, which is otherwise gated out.
 #
-# The define is normally emitted by an external component's codegen
-# (cg.add_define). Forcing it here gives CI coverage of the gated code path -
+# The define is normally emitted by bluetooth_proxy.enable_advertisement_filter(),
+# which is what external components call. Forcing it directly here is core
+# testing its own gate, not the supported external API - there is no external
+# component in-tree to call that function. It gives CI coverage of the gated path -
 # the slot, the member and the call site in on_raw_advertisement_() - without
 # needing an external component in-tree. The other bluetooth_proxy tests leave
 # it unset and so cover the ungated build.


### PR DESCRIPTION
# What does this implement/fix?

Adds a predicate slot an external component can install to drop advertisements before they are queued for the API. Filtering policy stays out of core; only the hook and its ifdefs are maintained here.

```cpp
proxy->set_advertisement_filter({this, [](void *self, const ble_device_base::RawAdvertisement &adv) {
  return static_cast<MyFilter *>(self)->should_forward(adv);
}});
```

Turned on from the external component's codegen:

```python
bluetooth_proxy.enable_advertisement_filter()
```

Off by default, gated on an ifdef. ESP32-S3/IDF, same config:

| | image |
|---|---|
| stock `dev` | 1,084,995 |
| this branch, no filter | 1,084,995 |
| with an external filter installed | 1,085,207 |

Follow-up to #19219, per review there. Motivation: ~60% of forwarded advertisements are unusable noise in a 60+ proxy install (6,197 dropped vs 3,991 forwarded per minute on one node).

Written with AI assistance.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to #19219

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — no end-user configuration change.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A — closed esphome/developers.esphome.io#178 per review; the header comment covers it.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No user-facing configuration. Enabled from an external component's codegen:
#   bluetooth_proxy.enable_advertisement_filter()
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
