### PR TITLE
[icm20689] Add ICM-20689 6-axis accelerometer/gyroscope (SPI)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -266,6 +266,7 @@ esphome/components/i2s_audio/* @jesserockz
 esphome/components/i2s_audio/microphone/* @jesserockz
 esphome/components/i2s_audio/speaker/* @jesserockz @kahrendt
 esphome/components/iaqcore/* @yozik04
+esphome/components/icm20689/* @lboue
 esphome/components/ili9xxx/* @clydebarrow @nielsnl68
 esphome/components/improv_base/* @esphome/core
 esphome/components/improv_serial/* @esphome/core

--- a/esphome/components/icm20689/__init__.py
+++ b/esphome/components/icm20689/__init__.py
@@ -1,0 +1,12 @@
+import esphome.codegen as cg
+from esphome.components import spi
+from esphome.components.motion import MotionComponent
+
+CODEOWNERS = ["@lboue"]
+
+CONF_ICM20689_ID = "icm20689_id"
+#  C++ namespace / class
+icm20689_ns = cg.esphome_ns.namespace("icm20689")
+ICM20689Component = icm20689_ns.class_(
+    "ICM20689Component", MotionComponent, spi.SPIDevice
+)

--- a/esphome/components/icm20689/icm20689.cpp
+++ b/esphome/components/icm20689/icm20689.cpp
@@ -1,0 +1,106 @@
+#include "icm20689.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome::icm20689 {
+
+static const char *const TAG = "icm20689";
+
+void ICM20689Component::write_register_(uint8_t reg, uint8_t value) {
+  this->enable();
+  this->write_byte(reg & 0x7F);
+  this->write_byte(value);
+  this->disable();
+}
+
+void ICM20689Component::read_registers_(uint8_t reg, uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(reg | ICM20689_READ_BIT);
+  this->read_array(data, len);
+  this->disable();
+}
+
+void ICM20689Component::setup() {
+  MotionComponent::setup();
+
+  this->spi_setup();
+
+  this->enable();
+  this->write_byte(ICM20689_REG_WHO_AM_I | ICM20689_READ_BIT);
+  uint8_t who_am_i = this->transfer_byte(0x00);
+  this->disable();
+  if (who_am_i != ICM20689_WHO_AM_I_VALUE) {
+    ESP_LOGE(TAG, "Unexpected WHO_AM_I 0x%02X (expected 0x%02X) -- check wiring/CS", who_am_i, ICM20689_WHO_AM_I_VALUE);
+    this->mark_failed();
+    return;
+  }
+
+  // Clear SLEEP, auto-select clock source (falls back to the internal oscillator if
+  // the gyro PLL isn't ready yet).
+  this->write_register_(ICM20689_REG_PWR_MGMT_1, 0x01);
+  delay(50);  // NOLINT -- one-time settle time after waking from sleep, only runs in setup()
+  this->write_register_(ICM20689_REG_ACCEL_CONFIG, this->accel_range_ << 3);
+  this->write_register_(ICM20689_REG_GYRO_CONFIG, this->gyro_range_ << 3);
+}
+
+void ICM20689Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "ICM20689 IMU:");
+  LOG_PIN("  CS Pin: ", this->cs_);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+    return;
+  }
+
+  static constexpr const char *const ACCEL_RANGE_STRS[] = {"±2g", "±4g", "±8g", "±16g"};
+  static constexpr const char *const GYRO_RANGE_STRS[] = {"±250°/s", "±500°/s", "±1000°/s", "±2000°/s"};
+
+  ESP_LOGCONFIG(TAG, "  Accel range: %s", ACCEL_RANGE_STRS[this->accel_range_]);
+  ESP_LOGCONFIG(TAG, "  Gyro  range: %s", GYRO_RANGE_STRS[this->gyro_range_]);
+  MotionComponent::dump_config();
+}
+
+bool ICM20689Component::update_data(motion::MotionData &data) {
+  if (this->is_failed())
+    return false;
+
+  uint8_t raw_data[14];
+  this->read_registers_(ICM20689_REG_ACCEL_XOUT_H, raw_data, sizeof(raw_data));
+
+  auto to_int16 = [](uint8_t hi, uint8_t lo) -> int16_t { return static_cast<int16_t>((hi << 8) | lo); };
+
+  // Scale factor: LSB/g depends on range -- full-scale = range_g * 2^15 lsb.
+  static constexpr float ACCEL_SCALE[] = {
+      2.0f / 32768.0f,
+      4.0f / 32768.0f,
+      8.0f / 32768.0f,
+      16.0f / 32768.0f,
+  };
+  float accel_scale = ACCEL_SCALE[this->accel_range_];
+
+  data.acceleration[motion::X_AXIS] = to_int16(raw_data[0], raw_data[1]) * accel_scale;
+  data.acceleration[motion::Y_AXIS] = to_int16(raw_data[2], raw_data[3]) * accel_scale;
+  data.acceleration[motion::Z_AXIS] = to_int16(raw_data[4], raw_data[5]) * accel_scale;
+
+  // Scale factor: LSB/(deg/s) depends on range -- full-scale = range_dps * 2^15 lsb.
+  static constexpr float GYRO_SCALE[] = {
+      250.0f / 32768.0f,
+      500.0f / 32768.0f,
+      1000.0f / 32768.0f,
+      2000.0f / 32768.0f,
+  };
+  float gyro_scale = GYRO_SCALE[this->gyro_range_];
+
+  data.angular_rate[motion::X_AXIS] = to_int16(raw_data[8], raw_data[9]) * gyro_scale;
+  data.angular_rate[motion::Y_AXIS] = to_int16(raw_data[10], raw_data[11]) * gyro_scale;
+  data.angular_rate[motion::Z_AXIS] = to_int16(raw_data[12], raw_data[13]) * gyro_scale;
+
+  if (!this->temperature_callback_.empty()) {
+    // Datasheet formula: degC = raw / 326.8 + 25.
+    float temperature = to_int16(raw_data[6], raw_data[7]) / 326.8f + 25.0f;
+    this->temperature_callback_.call(temperature);
+  }
+
+  return true;
+}
+
+}  // namespace esphome::icm20689

--- a/esphome/components/icm20689/icm20689.h
+++ b/esphome/components/icm20689/icm20689.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "esphome/components/motion/motion_component.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/spi/spi.h"
+#include <functional>
+
+namespace esphome::icm20689 {
+
+//  Register map (public datasheet, fixed-function silicon)
+static const uint8_t ICM20689_REG_WHO_AM_I = 0x75;
+static const uint8_t ICM20689_REG_PWR_MGMT_1 = 0x6B;
+static const uint8_t ICM20689_REG_GYRO_CONFIG = 0x1B;
+static const uint8_t ICM20689_REG_ACCEL_CONFIG = 0x1C;
+static const uint8_t ICM20689_REG_ACCEL_XOUT_H = 0x3B;  // 14 bytes: accel(6) + temp(2) + gyro(6)
+static const uint8_t ICM20689_REG_TEMP_OUT_H = 0x41;
+static const uint8_t ICM20689_READ_BIT = 0x80;
+static const uint8_t ICM20689_WHO_AM_I_VALUE = 0x98;
+
+//  Accelerometer range options -- FS_SEL bits [4:3] of ACCEL_CONFIG
+enum ICM20689AccelRange : uint8_t {
+  ICM20689_ACCEL_RANGE_2G = 0x00,
+  ICM20689_ACCEL_RANGE_4G = 0x01,
+  ICM20689_ACCEL_RANGE_8G = 0x02,
+  ICM20689_ACCEL_RANGE_16G = 0x03,
+};
+
+//  Gyroscope range options -- FS_SEL bits [4:3] of GYRO_CONFIG
+enum ICM20689GyroRange : uint8_t {
+  ICM20689_GYRO_RANGE_250 = 0x00,
+  ICM20689_GYRO_RANGE_500 = 0x01,
+  ICM20689_GYRO_RANGE_1000 = 0x02,
+  ICM20689_GYRO_RANGE_2000 = 0x03,
+};
+
+// Main component class
+class ICM20689Component final : public motion::MotionComponent,
+                                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                      spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
+ public:
+  // Lifecycle
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  // Configuration setters
+  void set_accel_range(ICM20689AccelRange r) { this->accel_range_ = r; }
+  void set_gyro_range(ICM20689GyroRange r) { this->gyro_range_ = r; }
+  template<typename F> void add_temperature_listener(F &&cb) { this->temperature_callback_.add(std::forward<F>(cb)); }
+
+ protected:
+  bool update_data(motion::MotionData &data) override;
+
+  void write_register_(uint8_t reg, uint8_t value);
+  // Reads len bytes starting at reg into data, in one CS-low transaction.
+  void read_registers_(uint8_t reg, uint8_t *data, size_t len);
+
+  // Config
+  ICM20689AccelRange accel_range_{ICM20689_ACCEL_RANGE_2G};
+  ICM20689GyroRange gyro_range_{ICM20689_GYRO_RANGE_250};
+
+  LazyCallbackManager<void(float)> temperature_callback_{};
+};
+
+}  // namespace esphome::icm20689

--- a/esphome/components/icm20689/motion.py
+++ b/esphome/components/icm20689/motion.py
@@ -1,0 +1,56 @@
+import esphome.codegen as cg
+from esphome.components import spi
+from esphome.components.const import CONF_ACCELEROMETER_RANGE, CONF_GYROSCOPE_RANGE
+from esphome.components.motion import motion_schema, new_motion_component
+import esphome.config_validation as cv
+from esphome.types import ConfigType
+
+from . import ICM20689Component, icm20689_ns
+
+DEPENDENCIES = ["spi"]
+
+#  Enum proxies (must match the C++ enum values exactly)
+ICM20689AccelRange = icm20689_ns.enum("ICM20689AccelRange")
+ACCEL_RANGE_OPTIONS = {
+    "2G": ICM20689AccelRange.ICM20689_ACCEL_RANGE_2G,
+    "4G": ICM20689AccelRange.ICM20689_ACCEL_RANGE_4G,
+    "8G": ICM20689AccelRange.ICM20689_ACCEL_RANGE_8G,
+    "16G": ICM20689AccelRange.ICM20689_ACCEL_RANGE_16G,
+}
+
+ICM20689GyroRange = icm20689_ns.enum("ICM20689GyroRange")
+GYRO_RANGE_OPTIONS = {
+    "250DPS": ICM20689GyroRange.ICM20689_GYRO_RANGE_250,
+    "500DPS": ICM20689GyroRange.ICM20689_GYRO_RANGE_500,
+    "1000DPS": ICM20689GyroRange.ICM20689_GYRO_RANGE_1000,
+    "2000DPS": ICM20689GyroRange.ICM20689_GYRO_RANGE_2000,
+}
+
+#  Top-level CONFIG_SCHEMA
+CONFIG_SCHEMA = (
+    motion_schema(ICM20689Component, has_accel=True, has_gyro=True)
+    .extend(
+        {
+            cv.Optional(CONF_ACCELEROMETER_RANGE, default="2G"): cv.enum(
+                ACCEL_RANGE_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_GYROSCOPE_RANGE, default="250DPS"): cv.enum(
+                GYRO_RANGE_OPTIONS, upper=True
+            ),
+        }
+    )
+    .extend(
+        spi.spi_device_schema(
+            cs_pin_required=True, default_mode="MODE0", default_data_rate="1MHz"
+        )
+    )
+)
+
+
+#  Code generation
+async def to_code(config: ConfigType) -> None:
+    var = await new_motion_component(config)
+    await spi.register_spi_device(var, config)
+
+    cg.add(var.set_accel_range(config[CONF_ACCELEROMETER_RANGE]))
+    cg.add(var.set_gyro_range(config[CONF_GYROSCOPE_RANGE]))

--- a/esphome/components/icm20689/sensor.py
+++ b/esphome/components/icm20689/sensor.py
@@ -1,0 +1,42 @@
+#  YAML config keys
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_TEMPERATURE,
+    CONF_TYPE,
+    DEVICE_CLASS_TEMPERATURE,
+    ICON_THERMOMETER,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+)
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
+
+from . import CONF_ICM20689_ID, ICM20689Component
+
+AUTO_LOAD = ["icm20689"]
+
+CONFIG_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    icon=ICON_THERMOMETER,
+    accuracy_decimals=2,
+    state_class=STATE_CLASS_MEASUREMENT,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+).extend(
+    {
+        cv.Optional(CONF_TYPE): cv.one_of(CONF_TEMPERATURE),
+        cv.GenerateID(CONF_ICM20689_ID): cv.use_id(ICM20689Component),
+    }
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = await sensor.new_sensor(config)
+    parent = await cg.get_variable(config[CONF_ICM20689_ID])
+    data = MockObj("data")
+    value_lambda = await cg.process_lambda(
+        var.publish_state(data),
+        [(cg.float_, str(data))],
+    )
+    cg.add(parent.add_temperature_listener(value_lambda))

--- a/tests/components/icm20689/common.yaml
+++ b/tests/components/icm20689/common.yaml
@@ -1,0 +1,73 @@
+sensor:
+  - platform: icm20689
+    type: temperature
+    name: "ICM20689 Temperature"
+
+  - platform: motion
+    motion_id: icm20689_motion
+    type: acceleration_x
+    name: "ICM20689 Accel X"
+    accuracy_decimals: 4
+    filters:
+      - sliding_window_moving_average:
+          window_size: 4
+          send_every: 1
+  - platform: motion
+    motion_id: icm20689_motion
+    type: acceleration_y
+    name: "ICM20689 Accel Y"
+    accuracy_decimals: 4
+  - platform: motion
+    motion_id: icm20689_motion
+    type: acceleration_z
+    name: "ICM20689 Accel Z"
+    accuracy_decimals: 4
+
+    # Gyroscope axes (unit: °/s)
+  - platform: motion
+    motion_id: icm20689_motion
+    type: gyroscope_x
+    name: "ICM20689 Gyro X"
+  - platform: motion
+    motion_id: icm20689_motion
+    type: gyroscope_y
+    name: "ICM20689 Gyro Y"
+  - platform: motion
+    motion_id: icm20689_motion
+    type: gyroscope_z
+    name: "ICM20689 Gyro Z"
+
+  - platform: motion
+    motion_id: icm20689_motion
+    type: angular_rate_x
+    name: "ICM20689 Angular Rate X"
+  - platform: motion
+    motion_id: icm20689_motion
+    type: angular_rate_y
+    name: "ICM20689 Angular Rate Y"
+  - platform: motion
+    motion_id: icm20689_motion
+    type: angular_rate_z
+    name: "ICM20689 Angular Rate Z"
+
+  - platform: motion
+    motion_id: icm20689_motion
+    type: pitch
+    name: "ICM20689 Pitch"
+  - platform: motion
+    motion_id: icm20689_motion
+    type: roll
+    name: "ICM20689 Roll"
+
+motion:
+  - platform: icm20689
+    id: icm20689_motion
+    cs_pin: GPIO5
+    # Accelerometer full-scale range: 2G | 4G | 8G | 16G
+    accelerometer_range: 4G
+    # Gyroscope full-scale range: 250DPS | 500DPS | 1000DPS | 2000DPS
+    gyroscope_range: 500DPS
+    axis_map:
+      x: y
+      y: x
+      z: -z

--- a/tests/components/icm20689/test.esp32-idf.yaml
+++ b/tests/components/icm20689/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `icm20689` component for the TDK InvenSense ICM-20689 6-axis accelerometer/gyroscope, wired via SPI. It plugs into the shared `motion` component (`esphome/components/motion`), so axis remapping (`axis_map`/`transform_matrix`), NVS-persisted calibration, and pitch/roll derivation all come for free -- no extra code needed here.

Structured closely after the existing `bmi270` component (same `motion.py`/`sensor.py` split, same accelerometer/gyroscope range enum pattern), swapped to the generic `spi.SPIDevice` transport since this chip is wired via SPI (not I2C) on the hardware this was developed against.

**Verified on real hardware**: 

- Silicon Labs xG27-DK2602A dev kit (EFR32BG27), via a downstream `platform: zephyr` integration -- not one of this repo's own supported platforms, so I can't check a box below for it, but the actual chip and register-level logic is identical regardless of MCU, since it only uses the generic `spi.SPIDevice` transport (no platform-specific code anywhere in this component). 
- `WHO_AM_I` reads `0x98` as expected, and accel/gyro/temperature values track real physical movement (tested by shaking the board) and settle to a plausible ~1G on the Z axis at rest. 
- Config validation and a full compile were also run against `tests/components/icm20689/test.esp32-idf.yaml` in this repo (see Test Environment below).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Not applicable -- no existing tracking issue.

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable): https://github.com/esphome/esphome.io/pull/7373

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- Not applicable.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] EFR32BG27

## Example entry for `config.yaml`:

```yaml
spi:
  - id: spi_bus
    clk_pin: GPIO18
    mosi_pin: GPIO23
    miso_pin: GPIO19

motion:
  - platform: icm20689
    id: imu
    cs_pin: GPIO5
    accelerometer_range: 4G
    gyroscope_range: 500DPS

sensor:
  - platform: motion
    type: acceleration_x
    name: "Accel X"
  - platform: motion
    type: acceleration_y
    name: "Accel Y"
  - platform: motion
    type: acceleration_z
    name: "Accel Z"
  - platform: motion
    type: gyroscope_x
    name: "Gyro X"
  - platform: motion
    type: gyroscope_y
    name: "Gyro Y"
  - platform: motion
    type: gyroscope_z
    name: "Gyro Z"
  - platform: icm20689
    type: temperature
    name: "IMU Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

---

**Note on local lint:** the git `pylint`/`ci-custom` pre-commit hooks fail locally with an unrelated environment error (`python` not resolving in the hook's `language: system` context outside the activated venv) -- this commit was made with `--no-verify`. Every hook (`ruff`, `flake8`, `clang-format`, `pylint`, `ci-custom`) passes cleanly when run manually via `prek run --files ...` with the venv active.
