### PR TITLE
[core] Isolate contextvars per task in the coroutine runner

### DIFF
--- a/esphome/coroutine.py
+++ b/esphome/coroutine.py
@@ -45,6 +45,7 @@ the last `yield` expression defines what is returned.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Generator, Iterator
+import contextvars
 import enum
 import functools
 import heapq
@@ -277,14 +278,22 @@ class _Task:
         id_number: int,
         iterator: Iterator[None],
         original_function: Any,
+        context: contextvars.Context,
     ):
         self.priority = priority
         self.id_number = id_number
         self.iterator = iterator
         self.original_function = original_function
+        self.context = context
 
     def with_priority(self, priority: float) -> _Task:
-        return _Task(priority, self.id_number, self.iterator, self.original_function)
+        return _Task(
+            priority,
+            self.id_number,
+            self.iterator,
+            self.original_function,
+            self.context,
+        )
 
     @property
     def _cmp_tuple(self) -> tuple[float, int]:
@@ -321,7 +330,10 @@ class FakeEventLoop:
             coro = coroutine(func)
             gen = coro(*args, **kwargs)
         prio = getattr(coro, "priority", 0.0)
-        task = _Task(prio, self._task_counter, gen, func)
+        # Each task gets its own copy of the current context, isolating any
+        # contextvars it sets from other tasks the scheduler interleaves it with
+        # (mirrors what asyncio.Task does internally).
+        task = _Task(prio, self._task_counter, gen, func, contextvars.copy_context())
         self._task_counter += 1
         heapq.heappush(self._pending_tasks, task)
 
@@ -352,7 +364,7 @@ class FakeEventLoop:
             )
 
             try:
-                next(task.iterator)
+                task.context.run(next, task.iterator)
                 # Decrease priority over time, so that if this task is blocked
                 # due to a dependency others will clear the dependency
                 # This could be improved with a less naive approach

--- a/tests/unit_tests/test_coroutine.py
+++ b/tests/unit_tests/test_coroutine.py
@@ -1,5 +1,7 @@
 """Tests for the coroutine module."""
 
+import contextvars
+
 import pytest
 
 from esphome.coroutine import CoroPriority, FakeEventLoop, coroutine_with_priority
@@ -217,3 +219,47 @@ def test_custom_priority_between_enum_values() -> None:
 
     # Check execution order
     assert execution_order == ["core", "custom", "diagnostics"]
+
+
+def test_context_isolated_between_interleaved_tasks() -> None:
+    """Test that a contextvar set in one task does not leak into another task
+    that the scheduler interleaves with it."""
+    my_var: contextvars.ContextVar[str] = contextvars.ContextVar("my_var")
+    seen: dict[str, str] = {}
+
+    def task_a():
+        my_var.set("a")
+        yield  # suspend so task_b can run before task_a resumes
+        seen["a"] = my_var.get()
+
+    def task_b():
+        my_var.set("b")
+        yield
+        seen["b"] = my_var.get()
+
+    loop = FakeEventLoop()
+    loop.add_job(task_a)
+    loop.add_job(task_b)
+    loop.flush_tasks()
+
+    assert seen == {"a": "a", "b": "b"}
+
+
+def test_context_inherits_ambient_value_at_schedule_time() -> None:
+    """Test that a job sees whatever contextvar value was set before it was scheduled."""
+    my_var: contextvars.ContextVar[str] = contextvars.ContextVar("my_var")
+    token = my_var.set("ambient")
+    seen: dict[str, str] = {}
+
+    def task():
+        seen["value"] = my_var.get()
+        yield
+
+    try:
+        loop = FakeEventLoop()
+        loop.add_job(task)
+        loop.flush_tasks()
+    finally:
+        my_var.reset(token)
+
+    assert seen == {"value": "ambient"}

--- a/tests/unit_tests/test_coroutine.py
+++ b/tests/unit_tests/test_coroutine.py
@@ -222,8 +222,7 @@ def test_custom_priority_between_enum_values() -> None:
 
 
 def test_context_isolated_between_interleaved_tasks() -> None:
-    """Test that a contextvar set in one task does not leak into another task
-    that the scheduler interleaves with it."""
+    """Test that a contextvar set in one task does not leak into another task that the scheduler interleaves with it."""
     my_var: contextvars.ContextVar[str] = contextvars.ContextVar("my_var")
     seen: dict[str, str] = {}
 


### PR DESCRIPTION
# What does this implement/fix?

ESPHome's code generation coroutine runner (`esphome/coroutine.py`) is not a real event loop: `FakeEventLoop.flush_tasks()` steps each pending job's generator, interleaving jobs based on a priority queue so that dependencies between components resolve in a deterministic order.

This means that there is no support for proper `ContextVars` as is provided by `asyncio` - if one `to_code()` job were to set a `contextvars.ContextVar` and then suspend, the value could leak into an unrelated job the scheduler steps next, since they'd all be sharing one ambient context.

This PR gives each task its own copy of the context, taken at the point the job is scheduled, and steps it through `Context.run()`as used by `asyncio.Task` internally, so `contextvars` can be used safely in coroutine-based code generation.

It leaves the existing priority-based scheduling that guarantees deterministic `main.cpp` output for a given YAML config unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New developer-facing feature (adds functionality for component developers; no end-user configuration change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- N/A — internal implementation detail, no user-facing configuration change.

**Pull request in [developers.esphome.io](https://github.com/esphome/developers.esphome.io) with developer documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# No config.yaml changes — this is a pure Python code-generation internals change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK9pNvTG7wUS5dXpzsWQkq)_