### PR TITLE
[it8951] Draw directly into controller image RAM when there is no writer

### DIFF
--- a/esphome/components/it8951/display.py
+++ b/esphome/components/it8951/display.py
@@ -3,6 +3,7 @@ ESPHome configuration for the IT8951 e-paper controller.
 """
 
 from collections.abc import Callable
+import logging
 from typing import Any
 
 from esphome import automation, core, pins
@@ -40,6 +41,8 @@ from esphome.core import ID
 from esphome.cpp_generator import MockObj, RawExpression, TemplateArgsType
 from esphome.final_validate import full_config
 from esphome.types import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["split_buffer"]
 DEPENDENCIES = ["spi"]
@@ -392,21 +395,29 @@ def _final_validate(config: ConfigType) -> None:
             [CONF_TRANSFORM, CONF_SWAP_XY],
         )
 
-    # Direct draw writes into the controller's image memory as LVGL flushes. If
-    # LVGL renders while a waveform is in flight, it overwrites the image the
-    # panel is still drawing from. LVGL's update_when_display_idle withholds
-    # rendering until the display reports idle, and drives the refresh once the
-    # render completes, which closes both directions of that race.
+    # Direct draw writes into the controller's image memory as LVGL flushes, so a
+    # render started while a waveform is in flight overwrites the image the panel
+    # is still drawing from; the driver logs and drops such a flush.
+    #
+    # 'update_when_display_idle' avoids it by withholding rendering until the
+    # display reports idle. It is not required, because it also presents at every
+    # render end with the display's default mode, which rules out both choosing a
+    # waveform per update and composing a frame ahead of time; a config that
+    # instead renders explicitly can gate on is_idle() itself and keep that
+    # control. Warn rather than fail, since neither shape is detectable here.
     display_id = config[CONF_ID]
     for lvgl_config in global_config.get(LVGL_DOMAIN, []):
         if display_id not in lvgl_config.get(lv_defines.CONF_DISPLAYS, []):
             continue
         if not lvgl_config.get(lv_defines.CONF_UPDATE_WHEN_DISPLAY_IDLE):
-            raise cv.Invalid(
-                f"The lvgl component driving '{display_id}' must set "
-                "'update_when_display_idle: true'. Without a framebuffer, LVGL "
-                "would write into the controller's image memory while the panel "
-                "is still refreshing from it."
+            _LOGGER.warning(
+                "Display '%s' has no framebuffer, so LVGL writes straight into the "
+                "controller's image memory. Either set 'update_when_display_idle: "
+                "true' on the lvgl component, or make sure anything calling "
+                "lv_refr_now() waits for id(%s).is_idle() first — otherwise a "
+                "render landing mid-waveform is dropped.",
+                display_id,
+                display_id,
             )
 
 

--- a/esphome/components/it8951/display.py
+++ b/esphome/components/it8951/display.py
@@ -68,6 +68,7 @@ IT8951DirectDisplay = it8951_ns.class_("IT8951DirectDisplay", IT8951Display)
 IT8951UpdateAction = it8951_ns.class_("IT8951UpdateAction", automation.Action)
 IT8951PauseAction = it8951_ns.class_("IT8951PauseAction", automation.Action)
 IT8951ResumeAction = it8951_ns.class_("IT8951ResumeAction", automation.Action)
+IT8951RefreshAction = it8951_ns.class_("IT8951RefreshAction", automation.Action)
 
 # Hardware waveform modes exposed to YAML. Strings are mapped to the C++
 # UpdateMode enum so the runtime can store the mode as a uint16_t rather
@@ -538,6 +539,31 @@ async def it8951_pause_action_to_code(
     synchronous=True,
 )
 async def it8951_resume_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    display_var = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, display_var)
+    if mode := config.get(CONF_MODE):
+        mode = await cg.templatable(mode, args, UpdateMode)
+        cg.add(var.set_mode(mode))
+    return var
+
+
+@automation.register_action(
+    "it8951.refresh",
+    IT8951RefreshAction,
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(IT8951Display),
+            cv.Optional(CONF_MODE): cv.templatable(update_mode),
+        }
+    ),
+    synchronous=True,
+)
+async def it8951_refresh_action_to_code(
     config: ConfigType,
     action_id: ID,
     template_arg: cg.TemplateArguments,

--- a/esphome/components/it8951/display.py
+++ b/esphome/components/it8951/display.py
@@ -354,11 +354,14 @@ def _customise_schema(config: ConfigType) -> ConfigType:
         # Report the configured rotation so LVGL can detect (and reject) a
         # rotation set in the display config instead of the LVGL config.
         rotation=model_config.get(CONF_ROTATION, 0),
-        # The IT8951 snaps partial display refreshes to a 32-pixel X boundary
-        # (see prepare_update_region_), so have LVGL round its redraw areas to
-        # 32px too — this keeps flush rectangles aligned with what the panel
-        # actually refreshes and avoids redundant re-rounding/over-draw.
-        draw_rounding=32,
+        # What the hardware actually requires of a LOAD is a 4-pixel boundary in
+        # 4bpp, or 16 for the 8bpp-packed monochrome trick. The 32-pixel X snap
+        # that partial REFRESH needs is applied separately in
+        # prepare_update_region_ and only on X, so asking LVGL for 32 here would
+        # round both axes and inflate every redraw: a one-pixel text change would
+        # become 32x32 of converted pixels. 16 satisfies both pixel formats and
+        # survives mirroring (see _final_validate).
+        draw_rounding=16,
     )
 
     return model_config
@@ -388,7 +391,26 @@ def _final_validate(config: ConfigType) -> None:
     if _has_writer(config):
         return
 
+    # Mirroring maps a rectangle to width - x - w, so the panel width has to be a
+    # multiple of the load alignment for a LVGL-aligned rectangle to stay aligned.
+    # Every model preset satisfies this; a generic model with hand-entered
+    # dimensions need not, and would otherwise drop every flush at runtime.
     transform = config.get(CONF_TRANSFORM)
+    mirrored = transform is not None and (
+        transform.get(CONF_MIRROR_X) or transform.get(CONF_MIRROR_Y)
+    )
+    if mirrored:
+        model = IT8951Model.models[config[CONF_MODEL]]
+        width, _ = model.get_dimensions(config)
+        align = 4 if config[CONF_GRAYSCALE] else 16
+        if width % align:
+            raise cv.Invalid(
+                f"Width {width} must be a multiple of {align} to use 'transform' "
+                f"without a framebuffer. Remove the mirror, pick a width that is a "
+                f"multiple of {align}, or add a 'lambda:' to use the buffered driver.",
+                [CONF_DIMENSIONS],
+            )
+
     if transform is not None and transform.get(CONF_SWAP_XY):
         raise cv.Invalid(
             "'swap_xy' is not supported without a framebuffer. Rotate in the LVGL "

--- a/esphome/components/it8951/display.py
+++ b/esphome/components/it8951/display.py
@@ -61,6 +61,7 @@ VCOM_REGISTER_OPTIONS = (VCOM_REGISTER_DEFAULT, VCOM_REGISTER_ALT)
 
 it8951_ns = cg.esphome_ns.namespace("it8951")
 IT8951Display = it8951_ns.class_("IT8951Display", display.Display, spi.SPIDevice)
+IT8951DirectDisplay = it8951_ns.class_("IT8951DirectDisplay", IT8951Display)
 IT8951UpdateAction = it8951_ns.class_("IT8951UpdateAction", automation.Action)
 
 # Hardware waveform modes exposed to YAML. Strings are mapped to the C++
@@ -184,6 +185,19 @@ DIMENSION_SCHEMA = cv.Schema(
         cv.Required(CONF_HEIGHT): cv.int_,
     }
 )
+
+
+def _has_writer(config: ConfigType) -> bool:
+    """True when a writer draws into this display pixel-by-pixel.
+
+    A lambda, pages or the test card all call draw_pixel_at in arbitrary order,
+    which cannot be streamed to the controller as it happens, so those configs
+    need the buffered class. Everything else (i.e. LVGL, which pushes whole
+    rectangles) can be drawn directly into controller RAM.
+    """
+    return any(
+        config.get(key) for key in (CONF_LAMBDA, CONF_PAGES, CONF_SHOW_TEST_CARD)
+    )
 
 
 def _model_pin_option(
@@ -315,18 +329,22 @@ def _customise_schema(config: ConfigType) -> ConfigType:
     model = IT8951Model.models[config[CONF_MODEL].upper()]
     width, height = model.get_dimensions(model_config)
 
+    has_writer = _has_writer(model_config)
     display.add_metadata(
         model_config[CONF_ID],
         width,
         height,
-        # Rotation is applied per-pixel in draw_pixel_at at no extra cost, so we
-        # advertise hardware rotation: LVGL routes its rotation to the driver via
-        # set_rotation rather than rotating the framebuffer in software.
-        has_hardware_rotation=True,
-        has_writer=any(
-            model_config.get(key)
-            for key in (CONF_LAMBDA, CONF_PAGES, CONF_SHOW_TEST_CARD)
-        ),
+        # With a framebuffer, rotation is applied per-pixel in draw_pixel_at at no
+        # extra cost, so we advertise hardware rotation and LVGL routes its
+        # rotation to the driver via set_rotation. The direct-draw variant has no
+        # framebuffer to rotate through — transposing a flush rectangle would need
+        # a chunk-sized scratch buffer, which is exactly what LVGL's own software
+        # (or ESP32-P4 PPA) rotation already provides — so it leaves rotation to
+        # LVGL. Where there is no writer and no LVGL, _final_validate turns on the
+        # test card, making this buffered again; nothing reads the flag in that
+        # case since only LVGL consults it.
+        has_hardware_rotation=has_writer,
+        has_writer=has_writer,
         # Report the configured rotation so LVGL can detect (and reject) a
         # rotation set in the display config instead of the LVGL config.
         rotation=model_config.get(CONF_ROTATION, 0),
@@ -350,7 +368,7 @@ def _final_validate(config: ConfigType) -> None:
     )
 
     global_config = full_config.get()
-    from esphome.components.lvgl import DOMAIN as LVGL_DOMAIN
+    from esphome.components.lvgl import DOMAIN as LVGL_DOMAIN, defines as lv_defines
 
     if CONF_LAMBDA not in config and CONF_PAGES not in config:
         if LVGL_DOMAIN in global_config:
@@ -358,6 +376,36 @@ def _final_validate(config: ConfigType) -> None:
                 config[CONF_UPDATE_INTERVAL] = update_interval("never")
         else:
             config[CONF_SHOW_TEST_CARD] = True
+
+    # Everything below applies only to the direct-draw variant, which is chosen
+    # (in to_code) exactly when nothing writes pixel-by-pixel.
+    if _has_writer(config):
+        return
+
+    transform = config.get(CONF_TRANSFORM)
+    if transform is not None and transform.get(CONF_SWAP_XY):
+        raise cv.Invalid(
+            "'swap_xy' is not supported without a framebuffer. Rotate in the LVGL "
+            "config instead, or add a 'lambda:' to use the buffered driver.",
+            [CONF_TRANSFORM, CONF_SWAP_XY],
+        )
+
+    # Direct draw writes into the controller's image memory as LVGL flushes. If
+    # LVGL renders while a waveform is in flight, it overwrites the image the
+    # panel is still drawing from. LVGL's update_when_display_idle withholds
+    # rendering until the display reports idle, and drives the refresh once the
+    # render completes, which closes both directions of that race.
+    display_id = config[CONF_ID]
+    for lvgl_config in global_config.get(LVGL_DOMAIN, []):
+        if display_id not in lvgl_config.get(lv_defines.CONF_DISPLAYS, []):
+            continue
+        if not lvgl_config.get(lv_defines.CONF_UPDATE_WHEN_DISPLAY_IDLE):
+            raise cv.Invalid(
+                f"The lvgl component driving '{display_id}' must set "
+                "'update_when_display_idle: true'. Without a framebuffer, LVGL "
+                "would write into the controller's image memory while the panel "
+                "is still refreshing from it."
+            )
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate
@@ -367,7 +415,12 @@ async def to_code(config: ConfigType) -> None:
     model = IT8951Model.models[config[CONF_MODEL]]
     width, height = model.get_dimensions(config)
 
-    var = cg.new_Pvariable(config[CONF_ID], model.name, width, height)
+    # No writer means every draw arrives as a rectangle (LVGL), which can be
+    # streamed straight into controller RAM instead of through a ~1.25 MiB
+    # framebuffer. See _has_writer.
+    var_id = config[CONF_ID]
+    var_id.type = IT8951Display if _has_writer(config) else IT8951DirectDisplay
+    var = cg.new_Pvariable(var_id, model.name, width, height)
     await display.register_display(var, config)
     await spi.register_spi_device(var, config, write_only=False)
 

--- a/esphome/components/it8951/display.py
+++ b/esphome/components/it8951/display.py
@@ -63,6 +63,8 @@ it8951_ns = cg.esphome_ns.namespace("it8951")
 IT8951Display = it8951_ns.class_("IT8951Display", display.Display, spi.SPIDevice)
 IT8951DirectDisplay = it8951_ns.class_("IT8951DirectDisplay", IT8951Display)
 IT8951UpdateAction = it8951_ns.class_("IT8951UpdateAction", automation.Action)
+IT8951PauseAction = it8951_ns.class_("IT8951PauseAction", automation.Action)
+IT8951ResumeAction = it8951_ns.class_("IT8951ResumeAction", automation.Action)
 
 # Hardware waveform modes exposed to YAML. Strings are mapped to the C++
 # UpdateMode enum so the runtime can store the mode as a uint16_t rather
@@ -484,6 +486,47 @@ async def to_code(config: ConfigType) -> None:
     synchronous=True,
 )
 async def it8951_update_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    display_var = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, display_var)
+    if mode := config.get(CONF_MODE):
+        mode = await cg.templatable(mode, args, UpdateMode)
+        cg.add(var.set_mode(mode))
+    return var
+
+
+@automation.register_action(
+    "it8951.pause",
+    IT8951PauseAction,
+    automation.maybe_simple_id({cv.Required(CONF_ID): cv.use_id(IT8951Display)}),
+    synchronous=True,
+)
+async def it8951_pause_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    display_var = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, display_var)
+
+
+@automation.register_action(
+    "it8951.resume",
+    IT8951ResumeAction,
+    automation.maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(IT8951Display),
+            cv.Optional(CONF_MODE): cv.templatable(update_mode),
+        }
+    ),
+    synchronous=True,
+)
+async def it8951_resume_action_to_code(
     config: ConfigType,
     action_id: ID,
     template_arg: cg.TemplateArguments,

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -1393,6 +1393,11 @@ void HOT IT8951DirectDisplay::draw_pixels_at(int x_start, int y_start, int w, in
   if (!this->prepare_direct_write_())
     return;
 
+  // Logging the rectangle LVGL asked for alongside the one finally presented
+  // (see prepare_update_region_) is how you tell an over-wide refresh caused by
+  // a parent-container invalidation from one caused by the 32-pixel X snap.
+  ESP_LOGV(TAG, "Flush %dx%d@%d,%d -> native %dx%d@%d,%d", w, h, x_start, y_start, clipped_w, clipped_h, cx, cy);
+
   const size_t line_stride = static_cast<size_t>(x_offset) + w + x_pad;
   this->write_area_(static_cast<uint16_t>(cx), static_cast<uint16_t>(cy), static_cast<uint16_t>(clipped_w),
                     static_cast<uint16_t>(clipped_h), ptr, order, bitness, big_endian, line_stride, x_offset, y_offset,

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -1215,12 +1215,14 @@ bool IT8951DirectDisplay::prepare_direct_write_() {
 
 void HOT IT8951DirectDisplay::pack_row_(uint16_t native_x, uint16_t native_y, uint16_t w, const uint8_t *ptr,
                                         ColorOrder order, ColorBitness bitness, bool big_endian, size_t source_index,
-                                        bool mirror_x) {
+                                        bool mirror_x, uint16_t source_w, uint16_t clip_left) {
   uint8_t *out = this->row_buf_.get();
   std::memset(out, 0, this->row_bytes_for_(w));
   for (uint16_t c = 0; c < w; c++) {
-    // Native column c reads back from source column (w-1-c) when mirrored in X.
-    const size_t src = source_index + (mirror_x ? static_cast<size_t>(w - 1 - c) : c);
+    // Column c of the clipped rectangle is column clip_left + c of the source
+    // rectangle, which in turn reads from the far end when mirrored in X.
+    const uint16_t column = static_cast<uint16_t>(clip_left + c);
+    const size_t src = source_index + (mirror_x ? static_cast<size_t>(source_w - 1 - column) : column);
     uint32_t color_value;
     switch (bitness) {
       case COLOR_BITNESS_565: {
@@ -1275,7 +1277,8 @@ void HOT IT8951DirectDisplay::pack_row_(uint16_t native_x, uint16_t native_y, ui
 
 void IT8951DirectDisplay::write_area_(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t *ptr,
                                       ColorOrder order, ColorBitness bitness, bool big_endian, size_t line_stride,
-                                      int x_offset, int y_offset, bool mirror_x, bool mirror_y) {
+                                      int x_offset, int y_offset, bool mirror_x, bool mirror_y, uint16_t source_w,
+                                      uint16_t source_h, uint16_t clip_left, uint16_t clip_top) {
   // Point the load at the image buffer, then open one LD_IMG_AREA for this
   // rectangle. Unlike the buffered path (one area per update) direct draw opens
   // one per flush, since each flush is an independent rectangle.
@@ -1310,10 +1313,13 @@ void IT8951DirectDisplay::write_area_(uint16_t x, uint16_t y, uint16_t w, uint16
   wait_for_hardware_ready(this->busy_pin_);
   for (uint16_t row = 0; row < h; row++) {
     App.feed_wdt();
-    // Native row `row` reads back from source row (h-1-row) when mirrored in Y.
-    const size_t source_row = mirror_y ? static_cast<size_t>(h - 1 - row) : row;
+    // Row `row` of the clipped rectangle is row clip_top + row of the source
+    // rectangle, which reads from the far end when mirrored in Y.
+    const uint16_t line = static_cast<uint16_t>(clip_top + row);
+    const size_t source_row = mirror_y ? static_cast<size_t>(source_h - 1 - line) : line;
     const size_t source_index = (static_cast<size_t>(y_offset) + source_row) * line_stride + x_offset;
-    this->pack_row_(x, static_cast<uint16_t>(y + row), w, ptr, order, bitness, big_endian, source_index, mirror_x);
+    this->pack_row_(x, static_cast<uint16_t>(y + row), w, ptr, order, bitness, big_endian, source_index, mirror_x,
+                    source_w, clip_left);
     this->write_array(this->row_buf_.get(), bytes_per_row);
   }
   this->disable();
@@ -1338,20 +1344,28 @@ void HOT IT8951DirectDisplay::draw_pixels_at(int x_start, int y_start, int w, in
   // exactly what LVGL's own rotation already provides.
   const int nx = mirror_x ? this->width_ - x_start - w : x_start;
   const int ny = mirror_y ? this->height_ - y_start - h : y_start;
-  if (nx < 0 || ny < 0 || nx + w > this->width_ || ny + h > this->height_) {
-    ESP_LOGW(TAG, "Flush rect (%d,%d %dx%d) lies outside the panel", x_start, y_start, w, h);
+
+  // LVGL rounds redraw areas up to draw_rounding, and neither panel dimension
+  // is a multiple of 32 (1872 = 58.5*32, 1404 = 43.875*32), so the last stripe
+  // of a redraw always overhangs. Clip it rather than dropping the flush; the
+  // buffered path gets the same effect from its per-pixel bounds test.
+  const int clip_left = std::max(0, -nx);
+  const int clip_top = std::max(0, -ny);
+  const int clipped_w = std::min(nx + w, static_cast<int>(this->width_)) - std::max(nx, 0);
+  const int clipped_h = std::min(ny + h, static_cast<int>(this->height_)) - std::max(ny, 0);
+  if (clipped_w <= 0 || clipped_h <= 0)
     return;
-  }
+  const int cx = nx + clip_left;
+  const int cy = ny + clip_top;
 
   // The controller loads on a 4-pixel boundary in 4bpp, or a 16-pixel boundary
-  // for the 8bpp-packed monochrome trick. LVGL rounds redraw areas to
-  // draw_rounding (32, see display.py), and mirroring a 32-aligned rectangle on
-  // a 16-aligned panel width leaves it 16-aligned, so this should never trip.
+  // for the 8bpp-packed monochrome trick. Both panel widths are multiples of
+  // 16, so clipping a 32-aligned rectangle against them leaves it 16-aligned.
   const uint16_t align = this->grayscale_ ? 4 : 16;
-  if ((nx % align) != 0 || (w % align) != 0) {
+  if ((cx % align) != 0 || (clipped_w % align) != 0) {
     if (!this->alignment_warned_) {
       this->alignment_warned_ = true;
-      ESP_LOGE(TAG, "Flush rect x=%d w=%d is not %u-pixel aligned; dropping", nx, w, align);
+      ESP_LOGE(TAG, "Flush rect x=%d w=%d is not %u-pixel aligned; dropping", cx, clipped_w, align);
     }
     return;
   }
@@ -1360,15 +1374,16 @@ void HOT IT8951DirectDisplay::draw_pixels_at(int x_start, int y_start, int w, in
     return;
 
   const size_t line_stride = static_cast<size_t>(x_offset) + w + x_pad;
-  this->write_area_(static_cast<uint16_t>(nx), static_cast<uint16_t>(ny), static_cast<uint16_t>(w),
-                    static_cast<uint16_t>(h), ptr, order, bitness, big_endian, line_stride, x_offset, y_offset,
-                    mirror_x, mirror_y);
+  this->write_area_(static_cast<uint16_t>(cx), static_cast<uint16_t>(cy), static_cast<uint16_t>(clipped_w),
+                    static_cast<uint16_t>(clipped_h), ptr, order, bitness, big_endian, line_stride, x_offset, y_offset,
+                    mirror_x, mirror_y, static_cast<uint16_t>(w), static_cast<uint16_t>(h),
+                    static_cast<uint16_t>(clip_left), static_cast<uint16_t>(clip_top));
 
   // Accumulate the region the next waveform has to present.
-  this->x_low_ = clamp_at_most(this->x_low_, nx);
-  this->x_high_ = clamp_at_least(this->x_high_, nx + w);
-  this->y_low_ = clamp_at_most(this->y_low_, ny);
-  this->y_high_ = clamp_at_least(this->y_high_, ny + h);
+  this->x_low_ = clamp_at_most(this->x_low_, cx);
+  this->x_high_ = clamp_at_least(this->x_high_, cx + clipped_w);
+  this->y_low_ = clamp_at_most(this->y_low_, cy);
+  this->y_high_ = clamp_at_least(this->y_high_, cy + clipped_h);
 }
 
 }  // namespace esphome::it8951

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -780,18 +780,28 @@ void IT8951Display::reset_dirty_region_() {
   this->y_high_ = 0;
 }
 
-void IT8951Display::set_refresh_paused(bool paused) {
-  if (paused == this->refresh_paused_)
+void IT8951Display::set_refresh_paused(bool paused, UpdateMode mode) {
+  if (paused) {
+    if (!this->refresh_paused_) {
+      this->refresh_paused_ = true;
+      ESP_LOGD(TAG, "Refresh paused");
+    }
     return;
-  this->refresh_paused_ = paused;
-  ESP_LOGD(TAG, "Refresh %s", paused ? "paused" : "resumed");
-  if (paused || !this->paused_present_pending_)
+  }
+  if (this->refresh_paused_) {
+    this->refresh_paused_ = false;
+    ESP_LOGD(TAG, "Refresh resumed");
+  }
+  if (!this->paused_present_pending_)
     return;
-  // Present what was composed while paused.
+  // Present what was composed while paused. An explicit mode replaces the one
+  // the swallowed request carried.
   this->paused_present_pending_ = false;
-  const UpdateMode mode = this->paused_mode_;
+  UpdateMode present = mode != UPDATE_MODE_NONE ? mode : this->paused_mode_;
   this->paused_mode_ = UPDATE_MODE_NONE;
-  this->start_update_(mode);
+  if (present == UPDATE_MODE_NONE)
+    present = UPDATE_MODE_GC16;
+  this->start_update_(present);
 }
 
 void IT8951Display::refresh_now(UpdateMode mode) {

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -1132,27 +1132,37 @@ void IT8951Display::dump_config() {
     strncpy(force_temperature, "(controller default)", sizeof(force_temperature));
     force_temperature[sizeof(force_temperature) - 1] = '\0';
   }
-  ESP_LOGCONFIG(
-      TAG,
-      "  Model preset: %s"
-      "\n  Dimensions: %dx%d"
-      "\n  Buffer: %u bytes"
-      "\n  Image buffer addr: 0x%04X%04X"
-      "\n  VCOM: %.02fV (set selector 0x%04X)"
-      "\n  Force temperature: %s"
-      "\n  Display command: %s"
-      "\n  Sleep when done: %s"
-      "\n  Full update every: %u"
-      "\n  Inverted colors: %s"
-      "\n  Pixel format: %s"
-      "\n  Reset duration: %" PRIu32 "ms",
-      this->name_ != nullptr ? this->name_ : LOG_STR_LITERAL("(unknown)"), this->get_width_internal(),
-      this->get_height_internal(), static_cast<unsigned>(this->buffer_length_), this->img_buf_addr_h_,
-      this->img_buf_addr_l_, static_cast<float>(this->vcom_) / 1000.0f, this->vcom_register_, force_temperature,
-      this->use_legacy_dpy_area_ ? LOG_STR_LITERAL("DPY_AREA (0x0034, legacy)")
-                                 : LOG_STR_LITERAL("DPY_BUF_AREA (0x0037)"),
-      YESNO(this->sleep_when_done_), this->full_update_every_, YESNO(this->invert_colors_),
-      this->grayscale_ ? LOG_STR_LITERAL("4bpp grayscale") : LOG_STR_LITERAL("1bpp monochrome"), this->reset_duration_);
+  // buffer_length_ is sized from the geometry in the constructor whether or not
+  // anything is allocated, so report what actually exists: the direct-draw
+  // variant streams into controller memory and has no framebuffer at all.
+  char framebuffer[24];
+  if (this->buffer_ != nullptr) {
+    snprintf(framebuffer, sizeof(framebuffer), "%u bytes", static_cast<unsigned>(this->buffer_length_));
+  } else {
+    strncpy(framebuffer, "none (direct draw)", sizeof(framebuffer));
+    framebuffer[sizeof(framebuffer) - 1] = '\0';
+  }
+  ESP_LOGCONFIG(TAG,
+                "  Model preset: %s"
+                "\n  Dimensions: %dx%d"
+                "\n  Framebuffer: %s"
+                "\n  Image buffer addr: 0x%04X%04X"
+                "\n  VCOM: %.02fV (set selector 0x%04X)"
+                "\n  Force temperature: %s"
+                "\n  Display command: %s"
+                "\n  Sleep when done: %s"
+                "\n  Full update every: %u"
+                "\n  Inverted colors: %s"
+                "\n  Pixel format: %s"
+                "\n  Reset duration: %" PRIu32 "ms",
+                this->name_ != nullptr ? this->name_ : LOG_STR_LITERAL("(unknown)"), this->get_width_internal(),
+                this->get_height_internal(), framebuffer, this->img_buf_addr_h_, this->img_buf_addr_l_,
+                static_cast<float>(this->vcom_) / 1000.0f, this->vcom_register_, force_temperature,
+                this->use_legacy_dpy_area_ ? LOG_STR_LITERAL("DPY_AREA (0x0034, legacy)")
+                                           : LOG_STR_LITERAL("DPY_BUF_AREA (0x0037)"),
+                YESNO(this->sleep_when_done_), this->full_update_every_, YESNO(this->invert_colors_),
+                this->grayscale_ ? LOG_STR_LITERAL("4bpp grayscale") : LOG_STR_LITERAL("1bpp monochrome"),
+                this->reset_duration_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_PIN("  CS Pin: ", this->cs_);

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -780,7 +780,47 @@ void IT8951Display::reset_dirty_region_() {
   this->y_high_ = 0;
 }
 
+void IT8951Display::set_refresh_paused(bool paused) {
+  if (paused == this->refresh_paused_)
+    return;
+  this->refresh_paused_ = paused;
+  ESP_LOGD(TAG, "Refresh %s", paused ? "paused" : "resumed");
+  if (paused || !this->paused_present_pending_)
+    return;
+  // Present what was composed while paused.
+  this->paused_present_pending_ = false;
+  const UpdateMode mode = this->paused_mode_;
+  this->paused_mode_ = UPDATE_MODE_NONE;
+  this->start_update_(mode);
+}
+
+void IT8951Display::refresh_now(UpdateMode mode) {
+  if (!this->initialised_)
+    return;
+  if (mode == UPDATE_MODE_NONE)
+    mode = UPDATE_MODE_GC16;
+  // Mark the whole panel dirty so prepare_update_region_ yields a full-screen
+  // area. Direct draw has nothing to transfer, so this is a waveform only; the
+  // buffered class re-streams its framebuffer, which is equally correct.
+  this->x_low_ = 0;
+  this->y_low_ = 0;
+  this->x_high_ = this->width_;
+  this->y_high_ = this->height_;
+  this->refresh_paused_ = false;
+  this->paused_present_pending_ = false;
+  this->paused_mode_ = UPDATE_MODE_NONE;
+  this->start_update_(mode);
+}
+
 void IT8951Display::start_update_(UpdateMode mode) {
+  if (this->refresh_paused_) {
+    // Remember the request; the dirty region keeps accumulating because we
+    // never reach prepare_update_region_, which is what resets it.
+    this->paused_present_pending_ = true;
+    this->paused_mode_ = mode;
+    ESP_LOGV(TAG, "Update deferred (refresh paused), mode=%u", static_cast<unsigned>(mode));
+    return;
+  }
   if (this->phase_ == Phase::IDLE && this->initialised_) {
     this->update_started_at_ = millis();
     this->active_mode_ = mode;

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -250,6 +250,11 @@ void IT8951Display::advance_phase_() {
       this->initialised_ = true;
       this->recovery_attempts_ = 0;
       ESP_LOGCONFIG(TAG, "IT8951 setup complete");
+      // Lets the direct-draw subclass queue its initial clear: controller image
+      // RAM holds whatever was in it at power-on, and there is no framebuffer
+      // to fill. Runs before the IDLE transition so the pending update it marks
+      // is picked up by the advance_phase_ below.
+      this->on_initialised_();
       this->set_phase_(Phase::IDLE);
       this->advance_phase_();
       break;
@@ -264,12 +269,20 @@ void IT8951Display::advance_phase_() {
         return;
       }
       this->active_mode_ = mode;
+      if (!this->needs_transfer_()) {
+        // Direct draw: the pixels were streamed into controller RAM as they
+        // were drawn, so go straight to the waveform.
+        this->set_phase_(Phase::UPDATE_REFRESH);
+        this->enqueue_update_refresh_();
+        break;
+      }
       this->set_phase_(Phase::UPDATE_TRANSFER);
       this->enqueue_update_transfer_();
       break;
     }
 
     case Phase::UPDATE_TRANSFER:
+      this->on_transfer_done_();
       this->set_phase_(Phase::UPDATE_REFRESH);
       this->enqueue_update_refresh_();
       break;
@@ -326,17 +339,23 @@ void IT8951Display::setup() {
   // init. LVGL (and other writers) can push pixels via draw_pixels_at as soon
   // as the component is set up — before init completes — and without a buffer
   // those writes would dereference a null pointer and crash.
+  //
+  // The direct-draw subclass has no framebuffer: it streams into controller RAM
+  // instead, and clears that RAM from on_initialised_() once the handshake is
+  // done. Its needs_transfer_() is false, so nothing reads buffer_.
   this->row_width_ = this->compute_row_width_();
-  this->buffer_length_ = static_cast<size_t>(this->row_width_) * static_cast<size_t>(this->height_);
-  RAMAllocator<uint8_t> allocator{};
-  this->buffer_ = allocator.allocate(this->buffer_length_);
-  if (this->buffer_ == nullptr) {
-    this->mark_failed(LOG_STR("Failed to allocate IT8951 framebuffer"));
-    return;
+  if (this->needs_transfer_()) {
+    this->buffer_length_ = static_cast<size_t>(this->row_width_) * static_cast<size_t>(this->height_);
+    RAMAllocator<uint8_t> allocator{};
+    this->buffer_ = allocator.allocate(this->buffer_length_);
+    if (this->buffer_ == nullptr) {
+      this->mark_failed(LOG_STR("Failed to allocate IT8951 framebuffer"));
+      return;
+    }
+    // The allocator does not zero memory; start blank (white) so undrawn regions
+    // (e.g. with auto_clear disabled) don't show garbage on the first update.
+    this->fill(Color::WHITE);
   }
-  // The allocator does not zero memory; start blank (white) so undrawn regions
-  // (e.g. with auto_clear disabled) don't show garbage on the first update.
-  this->fill(Color::WHITE);
 
   // Kick off async init via the queue. Reset pulse + boot delay + wake +
   // packed-write enable; everything blocking lives as DELAY_MS Ops gated by
@@ -403,18 +422,22 @@ void IT8951Display::enqueue_init_temp_() {
 
 // --- Update op enqueuers -----------------------------------------------------
 
-void IT8951Display::enqueue_update_transfer_() {
+void IT8951Display::enqueue_wake_if_asleep_() {
   // If the controller was put to sleep after the previous update, wake it
   // before touching the display engine. TCON_SLEEP gates off all clocks; a
   // register read (e.g. the LUTAFSR poll in UPDATE_REFRESH) returns a frozen
   // value while asleep, so without this the next update stalls forever in
   // op_check_lut_idle_(). SRAM/registers (packed-write mode, VCOM, LUT) are
   // retained across sleep, so SYS_RUN + a short settle is all that's needed.
-  if (this->asleep_) {
-    this->enqueue_(OpType::CMD, TCON_SYS_RUN);
-    this->enqueue_(OpType::DELAY_MS, 10);  // clocks settle after SYS_RUN
-    this->asleep_ = false;
-  }
+  if (!this->asleep_)
+    return;
+  this->enqueue_(OpType::CMD, TCON_SYS_RUN);
+  this->enqueue_(OpType::DELAY_MS, 10);  // clocks settle after SYS_RUN
+  this->asleep_ = false;
+}
+
+void IT8951Display::enqueue_update_transfer_() {
+  this->enqueue_wake_if_asleep_();
   this->transfer_row_ = 0;
   // Open a single LD_IMG_AREA load for the whole region. XFER_ROWS streams into
   // it across as many time-sliced passes as needed and emits the one matching
@@ -427,6 +450,9 @@ void IT8951Display::enqueue_update_transfer_() {
 
 void IT8951Display::enqueue_update_refresh_() {
   ESP_LOGV(TAG, "Enqueueing refresh ops: grayscale=%u", this->grayscale_);
+  // Direct draw reaches this phase without a transfer, which is where a
+  // sleeping controller would otherwise have been woken.
+  this->enqueue_wake_if_asleep_();
   // Poll LUT idle: CMD(REG_RD) → WRITE_W(LUTAFSR) → READ_WORD → CHECK_LUT_IDLE
   this->enqueue_(OpType::CMD, TCON_REG_RD);
   this->enqueue_(OpType::WRITE_W, LUTAFSR);
@@ -592,18 +618,15 @@ void IT8951Display::op_xfer_area_end_() { this->spi_cmd_(TCON_LD_IMG_END); }
 
 bool IT8951Display::op_xfer_rows_() {
   const uint32_t start_time = millis();
-  const uint16_t area_y = this->area_y_;
   const uint16_t area_h = this->area_h_;
 
-  // Bytes per source row, and the byte offset of area_x within a row, in the
-  // framebuffer's native packing. These match the per-row byte count the
-  // controller expects from op_xfer_area_args_: area_w/2 for 4bpp grayscale,
-  // area_w/8 for the 1bpp-packed monochrome trick. area_x / area_w are
-  // 16-pixel aligned (see prepare_update_region_), so both divisions are exact.
+  // Bytes per source row in the native packing. This matches the per-row byte
+  // count the controller expects from op_xfer_area_args_: area_w/2 for 4bpp
+  // grayscale, area_w/8 for the 1bpp-packed monochrome trick. area_x / area_w
+  // are 16-pixel aligned (see prepare_update_region_), so both divisions are
+  // exact.
   const uint16_t bytes_per_row =
       this->grayscale_ ? static_cast<uint16_t>(this->area_w_ >> 1) : static_cast<uint16_t>(this->area_w_ >> 3);
-  const uint16_t row_x_bytes =
-      this->grayscale_ ? static_cast<uint16_t>(this->area_x_ >> 1) : static_cast<uint16_t>(this->area_x_ >> 3);
 
   // Single CS write transaction — HW_RDY was confirmed high by the loop gate.
   this->enable();
@@ -614,8 +637,7 @@ bool IT8951Display::op_xfer_rows_() {
   // the buffer already holds the wire bytes — so stream it straight to SPI with
   // no per-pixel packing or temporary buffer.
   while (this->transfer_row_ < area_h) {
-    const uint32_t offset = (static_cast<uint32_t>(area_y) + this->transfer_row_) * this->row_width_ + row_x_bytes;
-    this->write_array(&this->buffer_[offset], bytes_per_row);
+    this->write_array(this->transfer_row_data_(this->transfer_row_), bytes_per_row);
     this->transfer_row_++;
     if (millis() - start_time >= MAX_TRANSFER_TIME_MS)
       break;
@@ -623,6 +645,13 @@ bool IT8951Display::op_xfer_rows_() {
 
   this->disable();
   return this->transfer_row_ >= area_h;
+}
+
+const uint8_t *IT8951Display::transfer_row_data_(uint16_t row) const {
+  const uint16_t row_x_bytes =
+      this->grayscale_ ? static_cast<uint16_t>(this->area_x_ >> 1) : static_cast<uint16_t>(this->area_x_ >> 3);
+  const uint32_t offset = (static_cast<uint32_t>(this->area_y_) + row) * this->row_width_ + row_x_bytes;
+  return &this->buffer_[offset];
 }
 
 void IT8951Display::op_dpy_buf_args_() {
@@ -1088,6 +1117,218 @@ void IT8951Display::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
+}
+
+// --- Direct-draw variant ------------------------------------------------------
+
+void IT8951DirectDisplay::setup() {
+  // One native-format row of the widest possible flush rectangle, plus a
+  // constant row for the whole-screen fill path. Both are a few hundred bytes
+  // rather than the ~1.25 MiB framebuffer the buffered class allocates.
+  const uint16_t max_row_bytes = this->row_bytes_for_(this->width_);
+  this->row_buf_ = std::make_unique<uint8_t[]>(max_row_bytes);
+  this->fill_row_ = std::make_unique<uint8_t[]>(max_row_bytes);
+  IT8951Display::setup();
+}
+
+void IT8951DirectDisplay::on_initialised_() {
+  // Controller image RAM holds whatever survived power-on and there is no
+  // framebuffer standing in for it, so clear it before the first waveform can
+  // present undrawn regions as garbage.
+  this->fill(Color::WHITE);
+}
+
+void IT8951DirectDisplay::fill(Color color) {
+  uint8_t packed = color_to_nibble(color);
+  if (this->invert_colors_)
+    packed = static_cast<uint8_t>(0x0F - packed);
+  const uint8_t fill_byte = this->grayscale_ ? static_cast<uint8_t>((packed << 4) | packed)
+                                             : static_cast<uint8_t>((packed <= 0x07) ? 0xFF : 0x00);
+  std::memset(this->fill_row_.get(), fill_byte, this->row_bytes_for_(this->width_));
+  // A fill covers the panel, so let the normal (time-sliced) transfer phase
+  // stream the constant row for every line rather than blocking here.
+  this->fill_pending_ = true;
+  this->x_low_ = 0;
+  this->y_low_ = 0;
+  this->x_high_ = this->width_;
+  this->y_high_ = this->height_;
+  this->update();
+}
+
+bool IT8951DirectDisplay::prepare_direct_write_() {
+  // Writing image RAM while the LUT engine is reading it corrupts the frame the
+  // panel is drawing. LVGL's update_when_display_idle option withholds
+  // rendering while the display is busy, which is the supported way to avoid
+  // this; the check here is a backstop for anything else that draws.
+  if (this->phase_ != Phase::IDLE) {
+    ESP_LOGW(TAG, "Dropping flush: controller busy in phase %u. Set 'update_when_display_idle: true' on lvgl.",
+             static_cast<unsigned>(this->phase_));
+    return false;
+  }
+  if (this->asleep_) {
+    this->spi_cmd_(TCON_SYS_RUN);
+    delay(10);  // clocks settle after SYS_RUN
+    this->asleep_ = false;
+  }
+  return true;
+}
+
+void HOT IT8951DirectDisplay::pack_row_(uint16_t native_x, uint16_t native_y, uint16_t w, const uint8_t *ptr,
+                                        ColorOrder order, ColorBitness bitness, bool big_endian, size_t source_index,
+                                        bool mirror_x) {
+  uint8_t *out = this->row_buf_.get();
+  std::memset(out, 0, this->row_bytes_for_(w));
+  for (uint16_t c = 0; c < w; c++) {
+    // Native column c reads back from source column (w-1-c) when mirrored in X.
+    const size_t src = source_index + (mirror_x ? static_cast<size_t>(w - 1 - c) : c);
+    uint32_t color_value;
+    switch (bitness) {
+      case COLOR_BITNESS_565: {
+        const size_t i = src * 2;
+        color_value = big_endian ? (static_cast<uint32_t>(ptr[i]) << 8) | ptr[i + 1]
+                                 : ptr[i] | (static_cast<uint32_t>(ptr[i + 1]) << 8);
+        break;
+      }
+      case COLOR_BITNESS_888: {
+        const size_t i = src * 3;
+        color_value =
+            big_endian ? (static_cast<uint32_t>(ptr[i]) << 16) | (static_cast<uint32_t>(ptr[i + 1]) << 8) | ptr[i + 2]
+                       : ptr[i] | (static_cast<uint32_t>(ptr[i + 1]) << 8) | (static_cast<uint32_t>(ptr[i + 2]) << 16);
+        break;
+      }
+      default:
+        color_value = ptr[src];
+        break;
+    }
+    const Color color = ColorUtil::to_color(color_value, order, bitness);
+    if (this->grayscale_) {
+      uint8_t nibble = color_to_nibble(color);
+      if (this->invert_colors_)
+        nibble = static_cast<uint8_t>(0x0F - nibble);
+      // native_x is 4-pixel aligned, so a pixel's nibble parity within the row
+      // buffer is just the parity of its column index.
+      const uint16_t index = static_cast<uint16_t>(c >> 1);
+      if (c & 1) {
+        out[index] = static_cast<uint8_t>((out[index] & 0xF0) | nibble);
+      } else {
+        out[index] = static_cast<uint8_t>((out[index] & 0x0F) | (nibble << 4));
+      }
+    } else {
+      // Rec.601 luma, matching write_pixel_native_.
+      auto lum = static_cast<uint16_t>(77u * color.r + 151u * color.g + 29u * color.b);
+      if (this->invert_colors_)
+        lum = static_cast<uint16_t>(65535u - lum);
+      // Threshold from absolute panel coordinates so the dither pattern stays
+      // continuous across flush-rectangle boundaries.
+      const uint16_t threshold =
+          this->dithering_ ? dither_threshold(static_cast<uint16_t>(native_x + c), native_y) : 32768;
+      if (lum < threshold) {
+        // 16-pixel groups; on the wire the high byte (pixels 8..15) precedes
+        // the low byte (pixels 0..7). See set_mono_pixel_.
+        const uint8_t sub = static_cast<uint8_t>(c & 0x0F);
+        const uint16_t byte_index = static_cast<uint16_t>((c >> 4) * 2u + (sub < 8u ? 1u : 0u));
+        out[byte_index] = static_cast<uint8_t>(out[byte_index] | (1u << (sub & 0x07)));
+      }
+    }
+  }
+}
+
+void IT8951DirectDisplay::write_area_(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t *ptr,
+                                      ColorOrder order, ColorBitness bitness, bool big_endian, size_t line_stride,
+                                      int x_offset, int y_offset, bool mirror_x, bool mirror_y) {
+  // Point the load at the image buffer, then open one LD_IMG_AREA for this
+  // rectangle. Unlike the buffered path (one area per update) direct draw opens
+  // one per flush, since each flush is an independent rectangle.
+  this->spi_cmd_(TCON_REG_WR);
+  this->spi_write_reg_(static_cast<uint16_t>(LISAR + 2), this->img_buf_addr_h_);
+  this->spi_cmd_(TCON_REG_WR);
+  this->spi_write_reg_(LISAR, this->img_buf_addr_l_);
+
+  uint16_t args[5];
+  if (this->grayscale_) {
+    args[0] = static_cast<uint16_t>((LDIMG_B_ENDIAN << 8) | (PIXEL_4BPP << 4));
+    args[1] = x;
+    args[2] = y;
+    args[3] = w;
+    args[4] = h;
+  } else {
+    // Monochrome uses the 8bpp-packed trick: x and width are in bytes.
+    args[0] = static_cast<uint16_t>((LDIMG_L_ENDIAN << 8) | (PIXEL_8BPP << 4));
+    args[1] = static_cast<uint16_t>(x / 8);
+    args[2] = y;
+    args[3] = static_cast<uint16_t>(w / 8);
+    args[4] = h;
+  }
+  this->spi_cmd_(TCON_LD_IMG_AREA);
+  this->spi_write_args_(args, 5);
+
+  const uint16_t bytes_per_row = this->row_bytes_for_(w);
+
+  // One CS-asserted burst for the whole rectangle, matching op_xfer_rows_.
+  this->enable();
+  this->write_byte16(PACKET_TYPE_WRITE);
+  wait_for_hardware_ready(this->busy_pin_);
+  for (uint16_t row = 0; row < h; row++) {
+    App.feed_wdt();
+    // Native row `row` reads back from source row (h-1-row) when mirrored in Y.
+    const size_t source_row = mirror_y ? static_cast<size_t>(h - 1 - row) : row;
+    const size_t source_index = (static_cast<size_t>(y_offset) + source_row) * line_stride + x_offset;
+    this->pack_row_(x, static_cast<uint16_t>(y + row), w, ptr, order, bitness, big_endian, source_index, mirror_x);
+    this->write_array(this->row_buf_.get(), bytes_per_row);
+  }
+  this->disable();
+
+  this->spi_cmd_(TCON_LD_IMG_END);
+}
+
+void HOT IT8951DirectDisplay::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr,
+                                             ColorOrder order, ColorBitness bitness, bool big_endian, int x_offset,
+                                             int y_offset, int x_pad) {
+  // Pixels pushed before the controller handshake completes have nowhere to go;
+  // LVGL redraws everything once the display reports ready.
+  if (!this->initialised_ || this->row_buf_ == nullptr)
+    return;
+
+  const bool mirror_x = (this->effective_transform_ & TRANSFORM_MIRROR_X) != 0;
+  const bool mirror_y = (this->effective_transform_ & TRANSFORM_MIRROR_Y) != 0;
+
+  // Native (panel) top-left of this rectangle. Mirroring keeps an axis-aligned
+  // rectangle axis-aligned; swap_xy is rejected for this class at config time,
+  // because transposing a flush would need a chunk-sized scratch buffer —
+  // exactly what LVGL's own rotation already provides.
+  const int nx = mirror_x ? this->width_ - x_start - w : x_start;
+  const int ny = mirror_y ? this->height_ - y_start - h : y_start;
+  if (nx < 0 || ny < 0 || nx + w > this->width_ || ny + h > this->height_) {
+    ESP_LOGW(TAG, "Flush rect (%d,%d %dx%d) lies outside the panel", x_start, y_start, w, h);
+    return;
+  }
+
+  // The controller loads on a 4-pixel boundary in 4bpp, or a 16-pixel boundary
+  // for the 8bpp-packed monochrome trick. LVGL rounds redraw areas to
+  // draw_rounding (32, see display.py), and mirroring a 32-aligned rectangle on
+  // a 16-aligned panel width leaves it 16-aligned, so this should never trip.
+  const uint16_t align = this->grayscale_ ? 4 : 16;
+  if ((nx % align) != 0 || (w % align) != 0) {
+    if (!this->alignment_warned_) {
+      this->alignment_warned_ = true;
+      ESP_LOGE(TAG, "Flush rect x=%d w=%d is not %u-pixel aligned; dropping", nx, w, align);
+    }
+    return;
+  }
+
+  if (!this->prepare_direct_write_())
+    return;
+
+  const size_t line_stride = static_cast<size_t>(x_offset) + w + x_pad;
+  this->write_area_(static_cast<uint16_t>(nx), static_cast<uint16_t>(ny), static_cast<uint16_t>(w),
+                    static_cast<uint16_t>(h), ptr, order, bitness, big_endian, line_stride, x_offset, y_offset,
+                    mirror_x, mirror_y);
+
+  // Accumulate the region the next waveform has to present.
+  this->x_low_ = clamp_at_most(this->x_low_, nx);
+  this->x_high_ = clamp_at_least(this->x_high_, nx + w);
+  this->y_low_ = clamp_at_most(this->y_low_, ny);
+  this->y_high_ = clamp_at_least(this->y_high_, ny + h);
 }
 
 }  // namespace esphome::it8951

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -972,6 +972,19 @@ static uint8_t color_to_nibble(const Color &color) {
   return quantize_8bit_to_nibble(luma);
 }
 
+// Rec.601 luma straight from a 5/6/5 pixel, skipping the expansion to 8-bit
+// channels and the Color round-trip. The weights are the usual 0.299/0.587/0.114
+// pre-scaled so a full-white pixel lands on exactly 15, and the +2048 matches the
+// rounding quantize_8bit_to_nibble applies one byte further up.
+static inline uint8_t rgb565_to_nibble(uint16_t value) {
+  const uint32_t r = (value >> 11) & 0x1F;
+  const uint32_t g = (value >> 5) & 0x3F;
+  const uint32_t b = value & 0x1F;
+  const uint32_t luma = 634u * r + 607u * g + 239u * b;  // 0..65304
+  const uint8_t nibble = static_cast<uint8_t>((luma + 2048u) >> 12);
+  return nibble > 0x0F ? 0x0F : nibble;
+}
+
 // 4x4 ordered (Bayer) dither threshold over the weighted-luma range (0..65535).
 // A pixel whose luma is below the threshold renders black, so lighter pixels
 // produce progressively sparser black dots instead of vanishing to white. The
@@ -1238,6 +1251,31 @@ void HOT IT8951DirectDisplay::pack_row_(uint16_t native_x, uint16_t native_y, ui
                                         bool mirror_x, uint16_t source_w, uint16_t clip_left) {
   uint8_t *out = this->row_buf_.get();
   std::memset(out, 0, this->row_bytes_for_(w));
+
+  // LVGL is the only writer that reaches this class (anything drawing pixel by
+  // pixel routes to the buffered one), and it passes a compile-time-constant
+  // bitness with a fixed colour order and endianness. So for the whole flush the
+  // decode is one known shape: decide it once here rather than per pixel.
+  if (this->grayscale_ && bitness == COLOR_BITNESS_565 && order == COLOR_ORDER_RGB) {
+    const uint8_t *base = ptr + source_index * 2;
+    for (uint16_t c = 0; c < w; c++) {
+      const uint16_t column = static_cast<uint16_t>(clip_left + c);
+      const size_t i = (mirror_x ? static_cast<size_t>(source_w - 1 - column) : column) * 2;
+      const uint16_t value = big_endian ? static_cast<uint16_t>((static_cast<uint16_t>(base[i]) << 8) | base[i + 1])
+                                        : static_cast<uint16_t>(base[i] | (static_cast<uint16_t>(base[i + 1]) << 8));
+      uint8_t nibble = rgb565_to_nibble(value);
+      if (this->invert_colors_)
+        nibble = static_cast<uint8_t>(0x0F - nibble);
+      const uint16_t index = static_cast<uint16_t>(c >> 1);
+      if (c & 1) {
+        out[index] = static_cast<uint8_t>((out[index] & 0xF0) | nibble);
+      } else {
+        out[index] = static_cast<uint8_t>((out[index] & 0x0F) | (nibble << 4));
+      }
+    }
+    return;
+  }
+
   for (uint16_t c = 0; c < w; c++) {
     // Column c of the clipped rectangle is column clip_left + c of the source
     // rectangle, which in turn reads from the far end when mirrored in X.

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -288,6 +288,14 @@ void IT8951Display::advance_phase_() {
       break;
 
     case Phase::UPDATE_REFRESH:
+      // More than one region to present: the next one's LUT-idle poll waits for
+      // this waveform to finish, which is what serialises them.
+      if (++this->refresh_index_ < this->presenting_.size()) {
+        this->set_area_from_rect_(this->refresh_index_);
+        this->set_phase_(Phase::UPDATE_REFRESH);
+        this->enqueue_update_refresh_();
+        break;
+      }
       // Fire-and-forget: don't block here waiting for the refresh to complete.
       // The next update's pre-display LUT-idle poll (and the HW_RDY-gated
       // TCON_SLEEP) wait as needed, so the refresh time stays off this update's
@@ -703,53 +711,115 @@ void IT8951Display::op_set_1bpp_() {
 
 // --- Update prep / public API ------------------------------------------------
 
+void IT8951Display::mark_dirty_(int x, int y, int w, int h) {
+  const int x0 = std::max(0, x);
+  const int y0 = std::max(0, y);
+  const int x1 = std::min(x + w, static_cast<int>(this->width_));
+  const int y1 = std::min(y + h, static_cast<int>(this->height_));
+  if (x1 <= x0 || y1 <= y0)
+    return;
+  const DirtyRect incoming{static_cast<uint16_t>(x0), static_cast<uint16_t>(y0), static_cast<uint16_t>(x1 - x0),
+                           static_cast<uint16_t>(y1 - y0)};
+
+  if (this->dirty_.empty()) {
+    this->dirty_.push_back(incoming);
+    return;
+  }
+
+  // Find the rectangle this one is cheapest to merge with, "cheapest" being the
+  // number of untouched pixels the union would drag in.
+  size_t best = 0;
+  uint32_t best_waste = UINT32_MAX;
+  for (size_t i = 0; i < this->dirty_.size(); i++) {
+    const DirtyRect &r = this->dirty_[i];
+    const uint16_t ux = std::min(r.x, incoming.x);
+    const uint16_t uy = std::min(r.y, incoming.y);
+    const uint32_t uw = static_cast<uint32_t>(std::max(r.x + r.w, incoming.x + incoming.w)) - ux;
+    const uint32_t uh = static_cast<uint32_t>(std::max(r.y + r.h, incoming.y + incoming.h)) - uy;
+    const uint32_t drawn = r.area() + incoming.area();
+    const uint32_t united = uw * uh;
+    const uint32_t waste = united > drawn ? united - drawn : 0;
+    if (waste < best_waste) {
+      best_waste = waste;
+      best = i;
+    }
+  }
+
+  // Keep it separate while there is room and the merge would waste too much;
+  // once the list is full there is no choice but to merge somewhere. Regions can
+  // end up overlapping, which costs the shared pixels a second waveform but
+  // never shows anything wrong.
+  const bool room = this->dirty_.size() < this->max_dirty_rects();
+  if (room && best_waste > (this->dirty_[best].area() + incoming.area()) / DIRTY_MERGE_WASTE_DIVISOR) {
+    this->dirty_.push_back(incoming);
+    return;
+  }
+  DirtyRect &target = this->dirty_[best];
+  const uint16_t ux = std::min(target.x, incoming.x);
+  const uint16_t uy = std::min(target.y, incoming.y);
+  target.w = static_cast<uint16_t>(std::max(target.x + target.w, incoming.x + incoming.w) - ux);
+  target.h = static_cast<uint16_t>(std::max(target.y + target.h, incoming.y + incoming.h) - uy);
+  target.x = ux;
+  target.y = uy;
+}
+
+void IT8951Display::flush_pending_bbox_() {
+  if (this->x_high_ <= this->x_low_ || this->y_high_ <= this->y_low_)
+    return;
+  this->mark_dirty_(this->x_low_, this->y_low_, this->x_high_ - this->x_low_, this->y_high_ - this->y_low_);
+  this->x_low_ = this->width_;
+  this->x_high_ = 0;
+  this->y_low_ = this->height_;
+  this->y_high_ = 0;
+}
+
+void IT8951Display::set_area_from_rect_(size_t index) {
+  const DirtyRect &r = this->presenting_[index];
+  this->area_x_ = r.x;
+  this->area_y_ = r.y;
+  this->area_w_ = r.w;
+  this->area_h_ = r.h;
+  this->transfer_row_ = 0;
+}
+
 bool IT8951Display::prepare_update_region_(UpdateMode &mode) {
+  this->flush_pending_bbox_();
+
   this->partial_update_count_++;
   const bool full_update = this->partial_update_count_ >= this->full_update_every_;
+
+  // Take a snapshot to present. Anything drawn from here on belongs to the next
+  // update, not this one, so the two lists must not be the same object.
+  this->presenting_.clear();
   if (full_update) {
     this->partial_update_count_ = 0;
     mode = UPDATE_MODE_GC16;
-    this->x_low_ = 0;
-    this->y_low_ = 0;
-    this->x_high_ = this->width_;
-    this->y_high_ = this->height_;
+    this->presenting_.push_back(DirtyRect{0, 0, this->width_, this->height_});
   } else {
-    // Align the partial region's X extent to 32 pixels. The IT8951's partial
-    // display refresh snaps the X start/width to a 32-pixel boundary (the panel
-    // source driver fetches 32-pixel chunks); refreshing a region whose X is
-    // only 16-aligned makes the panel snap it down to the previous boundary,
-    // shifting that update ~16px to the left. 32-alignment also satisfies the
-    // load constraints (4bpp X must be a multiple of 4; the 8bpp-packed mono
-    // load needs x/8 even, i.e. X a multiple of 16).
-    this->x_low_ &= 0xFFE0;
-    uint16_t temp_max = this->x_high_ > 0 ? static_cast<uint16_t>(this->x_high_ - 1) : 0;
-    temp_max = static_cast<uint16_t>(temp_max | 0x001F);
-    if (temp_max >= this->width_)
-      temp_max = static_cast<uint16_t>(this->width_ - 1);
-    this->x_high_ = static_cast<uint16_t>(temp_max + 1);
+    for (const DirtyRect &rect : this->dirty_) {
+      // Align each region's X extent to 32 pixels. The IT8951's partial display
+      // refresh snaps the X start/width to a 32-pixel boundary (the panel source
+      // driver fetches 32-pixel chunks); refreshing a region whose X is only
+      // 16-aligned makes the panel snap it down to the previous boundary,
+      // shifting that update ~16px to the left.
+      const uint16_t x = static_cast<uint16_t>(rect.x & 0xFFE0);
+      uint16_t last = static_cast<uint16_t>((rect.x + rect.w - 1) | 0x001F);
+      if (last >= this->width_)
+        last = static_cast<uint16_t>(this->width_ - 1);
+      if (last < x)
+        continue;
+      const uint16_t w = static_cast<uint16_t>(last - x + 1);
+      if (rect.y >= this->height_ || (rect.y + rect.h) > this->height_) {
+        ESP_LOGE(TAG, "Dirty region (%u,%u %ux%u) out of bounds", rect.x, rect.y, rect.w, rect.h);
+        continue;
+      }
+      this->presenting_.push_back(DirtyRect{x, rect.y, w, rect.h});
+    }
   }
+  this->dirty_.clear();
 
-  if (this->x_high_ <= this->x_low_ || this->y_high_ <= this->y_low_) {
-    this->reset_dirty_region_();
+  if (this->presenting_.empty())
     return false;
-  }
-
-  const uint16_t x = this->x_low_;
-  const uint16_t y = this->y_low_;
-  const uint16_t width = static_cast<uint16_t>(this->x_high_ - this->x_low_);
-  const uint16_t height = static_cast<uint16_t>(this->y_high_ - this->y_low_);
-
-  if (x >= this->width_ || y >= this->height_ || (x + width) > this->width_ || (y + height) > this->height_) {
-    ESP_LOGE(TAG, "Dirty region (%u,%u %ux%u) out of bounds", x, y, width, height);
-    this->reset_dirty_region_();
-    return false;
-  }
-
-  this->area_x_ = x;
-  this->area_y_ = y;
-  this->area_w_ = width;
-  this->area_h_ = height;
-  this->transfer_row_ = 0;
 
   // On non-full updates, downgrade monochrome frames from the full, flashy GC16
   // clear to DU — a fast, low-flash absolute waveform — so full_update_every
@@ -766,11 +836,26 @@ bool IT8951Display::prepare_update_region_(UpdateMode &mode) {
   if (!full_update && mode == UPDATE_MODE_GC16 && !this->grayscale_)
     mode = UPDATE_MODE_DU;
 
-  this->reset_dirty_region_();
+  this->refresh_index_ = 0;
+  this->set_area_from_rect_(0);
 
-  ESP_LOGV(TAG, "Update: %ux%u@%u,%u mode=%u (%s)", width, height, x, y, static_cast<unsigned>(mode),
-           this->grayscale_ ? LOG_STR_LITERAL("grayscale") : LOG_STR_LITERAL("mono"));
+  for (size_t i = 0; i < this->presenting_.size(); i++) {
+    const DirtyRect &r = this->presenting_[i];
+    ESP_LOGV(TAG, "Update %u/%u: %ux%u@%u,%u mode=%u (%s)", static_cast<unsigned>(i + 1),
+             static_cast<unsigned>(this->presenting_.size()), r.w, r.h, r.x, r.y, static_cast<unsigned>(mode),
+             this->grayscale_ ? LOG_STR_LITERAL("grayscale") : LOG_STR_LITERAL("mono"));
+  }
   return true;
+}
+
+void IT8951Display::mark_whole_screen_dirty_() {
+  // Supersedes anything already recorded: a full-screen region subsumes every
+  // other, and leaving them in the list would spend a redundant waveform each.
+  this->dirty_.clear();
+  this->x_low_ = 0;
+  this->y_low_ = 0;
+  this->x_high_ = this->width_;
+  this->y_high_ = this->height_;
 }
 
 void IT8951Display::reset_dirty_region_() {
@@ -778,6 +863,7 @@ void IT8951Display::reset_dirty_region_() {
   this->x_high_ = 0;
   this->y_low_ = this->height_;
   this->y_high_ = 0;
+  this->dirty_.clear();
 }
 
 void IT8951Display::set_refresh_paused(bool paused, UpdateMode mode) {
@@ -812,10 +898,12 @@ void IT8951Display::refresh_now(UpdateMode mode) {
   // Mark the whole panel dirty so prepare_update_region_ yields a full-screen
   // area. Direct draw has nothing to transfer, so this is a waveform only; the
   // buffered class re-streams its framebuffer, which is equally correct.
-  this->x_low_ = 0;
-  this->y_low_ = 0;
-  this->x_high_ = this->width_;
-  this->y_high_ = this->height_;
+  this->dirty_.clear();
+  this->dirty_.push_back(DirtyRect{0, 0, this->width_, this->height_});
+  this->x_low_ = this->width_;
+  this->x_high_ = 0;
+  this->y_low_ = this->height_;
+  this->y_high_ = 0;
   this->refresh_paused_ = false;
   this->paused_present_pending_ = false;
   this->paused_mode_ = UPDATE_MODE_NONE;
@@ -893,10 +981,7 @@ void IT8951Display::recover_() {
   }
 
   // Force a full redraw on next opportunity.
-  this->x_low_ = 0;
-  this->y_low_ = 0;
-  this->x_high_ = this->width_;
-  this->y_high_ = this->height_;
+  this->mark_whole_screen_dirty_();
 
   this->set_phase_(Phase::INIT_RESET);
   this->enqueue_init_reset_();
@@ -1012,10 +1097,7 @@ void IT8951Display::fill(Color color) {
     fill_byte = (packed <= 0x07) ? 0xFF : 0x00;
   }
   memset(this->buffer_, fill_byte, this->buffer_length_);
-  this->x_low_ = 0;
-  this->y_low_ = 0;
-  this->x_high_ = this->width_;
-  this->y_high_ = this->height_;
+  this->mark_whole_screen_dirty_();
 }
 
 void HOT IT8951Display::draw_pixel_at(int x, int y, Color color) {
@@ -1221,10 +1303,7 @@ void IT8951DirectDisplay::fill(Color color) {
   // A fill covers the panel, so let the normal (time-sliced) transfer phase
   // stream the constant row for every line rather than blocking here.
   this->fill_pending_ = true;
-  this->x_low_ = 0;
-  this->y_low_ = 0;
-  this->x_high_ = this->width_;
-  this->y_high_ = this->height_;
+  this->mark_whole_screen_dirty_();
   this->update();
 }
 
@@ -1437,11 +1516,10 @@ void HOT IT8951DirectDisplay::draw_pixels_at(int x_start, int y_start, int w, in
                     mirror_x, mirror_y, static_cast<uint16_t>(w), static_cast<uint16_t>(h),
                     static_cast<uint16_t>(clip_left), static_cast<uint16_t>(clip_top));
 
-  // Accumulate the region the next waveform has to present.
-  this->x_low_ = clamp_at_most(this->x_low_, cx);
-  this->x_high_ = clamp_at_least(this->x_high_, cx + clipped_w);
-  this->y_low_ = clamp_at_most(this->y_low_, cy);
-  this->y_high_ = clamp_at_least(this->y_high_, cy + clipped_h);
+  // Record this rectangle rather than growing one box around every flush: LVGL
+  // tells us exactly what changed, and a waveform re-drives everything in the
+  // region it is given.
+  this->mark_dirty_(cx, cy, clipped_w, clipped_h);
 }
 
 }  // namespace esphome::it8951

--- a/esphome/components/it8951/it8951.cpp
+++ b/esphome/components/it8951/it8951.cpp
@@ -254,7 +254,7 @@ void IT8951Display::advance_phase_() {
       // RAM holds whatever was in it at power-on, and there is no framebuffer
       // to fill. Runs before the IDLE transition so the pending update it marks
       // is picked up by the advance_phase_ below.
-      this->on_initialised_();
+      this->on_initialised();
       this->set_phase_(Phase::IDLE);
       this->advance_phase_();
       break;
@@ -269,7 +269,7 @@ void IT8951Display::advance_phase_() {
         return;
       }
       this->active_mode_ = mode;
-      if (!this->needs_transfer_()) {
+      if (!this->needs_transfer()) {
         // Direct draw: the pixels were streamed into controller RAM as they
         // were drawn, so go straight to the waveform.
         this->set_phase_(Phase::UPDATE_REFRESH);
@@ -282,7 +282,7 @@ void IT8951Display::advance_phase_() {
     }
 
     case Phase::UPDATE_TRANSFER:
-      this->on_transfer_done_();
+      this->on_transfer_done();
       this->set_phase_(Phase::UPDATE_REFRESH);
       this->enqueue_update_refresh_();
       break;
@@ -341,10 +341,10 @@ void IT8951Display::setup() {
   // those writes would dereference a null pointer and crash.
   //
   // The direct-draw subclass has no framebuffer: it streams into controller RAM
-  // instead, and clears that RAM from on_initialised_() once the handshake is
-  // done. Its needs_transfer_() is false, so nothing reads buffer_.
+  // instead, and clears that RAM from on_initialised() once the handshake is
+  // done. Its needs_transfer() is false, so nothing reads buffer_.
   this->row_width_ = this->compute_row_width_();
-  if (this->needs_transfer_()) {
+  if (this->needs_transfer()) {
     this->buffer_length_ = static_cast<size_t>(this->row_width_) * static_cast<size_t>(this->height_);
     RAMAllocator<uint8_t> allocator{};
     this->buffer_ = allocator.allocate(this->buffer_length_);
@@ -637,7 +637,7 @@ bool IT8951Display::op_xfer_rows_() {
   // the buffer already holds the wire bytes — so stream it straight to SPI with
   // no per-pixel packing or temporary buffer.
   while (this->transfer_row_ < area_h) {
-    this->write_array(this->transfer_row_data_(this->transfer_row_), bytes_per_row);
+    this->write_array(this->transfer_row_data(this->transfer_row_), bytes_per_row);
     this->transfer_row_++;
     if (millis() - start_time >= MAX_TRANSFER_TIME_MS)
       break;
@@ -647,7 +647,7 @@ bool IT8951Display::op_xfer_rows_() {
   return this->transfer_row_ >= area_h;
 }
 
-const uint8_t *IT8951Display::transfer_row_data_(uint16_t row) const {
+const uint8_t *IT8951Display::transfer_row_data(uint16_t row) const {
   const uint16_t row_x_bytes =
       this->grayscale_ ? static_cast<uint16_t>(this->area_x_ >> 1) : static_cast<uint16_t>(this->area_x_ >> 3);
   const uint32_t offset = (static_cast<uint32_t>(this->area_y_) + row) * this->row_width_ + row_x_bytes;
@@ -1191,7 +1191,7 @@ void IT8951DirectDisplay::setup() {
   IT8951Display::setup();
 }
 
-void IT8951DirectDisplay::on_initialised_() {
+void IT8951DirectDisplay::on_initialised() {
   // Controller image RAM holds whatever survived power-on and there is no
   // framebuffer standing in for it, so clear it before the first waveform can
   // present undrawn regions as garbage.
@@ -1392,11 +1392,6 @@ void HOT IT8951DirectDisplay::draw_pixels_at(int x_start, int y_start, int w, in
 
   if (!this->prepare_direct_write_())
     return;
-
-  // Logging the rectangle LVGL asked for alongside the one finally presented
-  // (see prepare_update_region_) is how you tell an over-wide refresh caused by
-  // a parent-container invalidation from one caused by the 32-pixel X snap.
-  ESP_LOGV(TAG, "Flush %dx%d@%d,%d -> native %dx%d@%d,%d", w, h, x_start, y_start, clipped_w, clipped_h, cx, cy);
 
   const size_t line_stride = static_cast<size_t>(x_offset) + w + x_pad;
   this->write_area_(static_cast<uint16_t>(cx), static_cast<uint16_t>(cy), static_cast<uint16_t>(clipped_w),

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -194,6 +194,24 @@ class IT8951Display : public Display,
   // --- Display API ---
   void update() override;
   void update_mode(UpdateMode mode);
+
+  // --- Deferred presentation ---
+  // Only a waveform changes what the panel shows, so pixels can keep streaming
+  // into the controller's image memory while the previous frame stays on the
+  // glass. Pausing holds back the waveform: update requests are remembered
+  // rather than run, and resuming presents the result in one go.
+  //
+  // Note the frame is torn while paused — image memory holds part of the old
+  // frame and part of the new one — so nothing else may present it until the
+  // composition is finished. That is why update requests are swallowed rather
+  // than queued: on a panel this size there is no room in controller RAM for a
+  // second frame to compose into.
+  void set_refresh_paused(bool paused);
+  bool is_refresh_paused() const { return this->refresh_paused_; }
+  // Present the whole screen from controller image memory, clearing any pause.
+  // Nothing is transferred: this shows whatever was last written, which is the
+  // point of composing while paused.
+  void refresh_now(UpdateMode mode);
   DisplayType get_display_type() override { return this->grayscale_ ? DISPLAY_TYPE_GRAYSCALE : DISPLAY_TYPE_BINARY; }
   void fill(Color color) override;
   void clear() override { this->fill(Color::WHITE); }
@@ -308,6 +326,10 @@ class IT8951Display : public Display,
   // Pending update bookkeeping
   bool update_pending_{false};
   UpdateMode pending_update_mode_{UPDATE_MODE_NONE};
+  // Deferred presentation (see set_refresh_paused).
+  bool refresh_paused_{false};
+  bool paused_present_pending_{false};
+  UpdateMode paused_mode_{UPDATE_MODE_NONE};
   UpdateMode active_mode_{UPDATE_MODE_NONE};
   uint16_t area_x_{0}, area_y_{0}, area_w_{0}, area_h_{0};
   uint16_t transfer_row_{0};
@@ -369,6 +391,38 @@ class IT8951Display : public Display,
   // read after reset; the original driver retried up to 3 times with 100ms
   // between attempts).
   uint8_t dev_info_attempts_{0};
+};
+
+// it8951.pause / it8951.resume — hold back the waveform while a frame is
+// composed into controller memory, then present it.
+template<typename... Ts> class IT8951PauseAction : public Action<Ts...> {
+ public:
+  explicit IT8951PauseAction(IT8951Display *display) : display_(display) {}
+
+ protected:
+  void play(const Ts &...x) override { this->display_->set_refresh_paused(true); }
+
+  IT8951Display *display_;
+};
+
+template<typename... Ts> class IT8951ResumeAction : public Action<Ts...> {
+ public:
+  explicit IT8951ResumeAction(IT8951Display *display) : display_(display) {}
+  TEMPLATABLE_VALUE(UpdateMode, mode)
+
+ protected:
+  void play(const Ts &...x) override {
+    // With an explicit mode, present the whole screen from controller memory
+    // regardless of what was drawn; without one, present only what an update
+    // request asked for while paused.
+    if (this->mode_.has_value()) {
+      this->display_->refresh_now(this->mode_.value(x...));
+    } else {
+      this->display_->set_refresh_paused(false);
+    }
+  }
+
+  IT8951Display *display_;
 };
 
 // --- Direct-draw variant ------------------------------------------------------

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -222,9 +223,13 @@ class IT8951Display : public Display,
   // Bytes per row for the configured pixel format: 4bpp grayscale packs two
   // pixels per byte; monochrome packs eight bits per byte, rounded up to a
   // whole 16-pixel group (matching the controller's 8bpp-load / 1bpp trick).
-  uint16_t compute_row_width_() const {
-    return this->grayscale_ ? static_cast<uint16_t>((static_cast<uint32_t>(this->width_) + 1) / 2)
-                            : static_cast<uint16_t>(((static_cast<uint32_t>(this->width_) + 15) / 16) * 2);
+  uint16_t compute_row_width_() const { return this->row_bytes_for_(this->width_); }
+  // Bytes needed to hold `pixels` pixels in the configured native format. The
+  // direct-draw path uses this for a single flush rectangle's row, the buffered
+  // path for a full framebuffer row.
+  uint16_t row_bytes_for_(uint16_t pixels) const {
+    return this->grayscale_ ? static_cast<uint16_t>((static_cast<uint32_t>(pixels) + 1) / 2)
+                            : static_cast<uint16_t>(((static_cast<uint32_t>(pixels) + 15) / 16) * 2);
   }
   void set_mono_pixel_(uint16_t x, uint16_t y, bool value) const;
   // Write a 4bpp grayscale nibble into the framebuffer (two pixels per byte).
@@ -267,6 +272,22 @@ class IT8951Display : public Display,
   void enqueue_update_transfer_();
   void enqueue_update_refresh_();
   void enqueue_update_sleep_();
+  // Wake the controller if a previous update put it to sleep. Both the transfer
+  // and (when there is no transfer) the refresh phase must do this before
+  // touching the display engine.
+  void enqueue_wake_if_asleep_();
+
+  // --- Framebuffer hooks (overridden by the direct-draw subclass) ---
+  // True when the current update has to stream pixel data to the controller.
+  // The direct-draw subclass has already written the image as LVGL flushed it,
+  // so it only needs the transfer phase for whole-screen constant fills.
+  virtual bool needs_transfer_() const { return true; }
+  // Source bytes for one row of the current update area, in native wire format.
+  virtual const uint8_t *transfer_row_data_(uint16_t row) const;
+  // Called once the controller handshake has completed and initialised_ is set.
+  virtual void on_initialised_() {}
+  // Called when the transfer phase has streamed its last row.
+  virtual void on_transfer_done_() {}
 
   bool prepare_update_region_(UpdateMode &mode);
 
@@ -348,6 +369,58 @@ class IT8951Display : public Display,
   // read after reset; the original driver retried up to 3 times with 100ms
   // between attempts).
   uint8_t dev_info_attempts_{0};
+};
+
+// --- Direct-draw variant ------------------------------------------------------
+// Writes pixels straight into the controller's image RAM as they are drawn,
+// with no ESP-side framebuffer: each LVGL flush is converted to the native wire
+// format and streamed as its own LD_IMG_AREA load. On a 1872x1404 panel this
+// reclaims ~1.25 MiB of PSRAM.
+//
+// Only usable when every writer pushes rectangles (LVGL) rather than individual
+// pixels in arbitrary order, so display.py selects it exactly when the display
+// has no lambda/pages/test-card writer. Rotation is LVGL's job here (the driver
+// advertises has_hardware_rotation=false); only the panel's mirror_x/mirror_y
+// transform is applied, which costs nothing in the packing loop.
+class IT8951DirectDisplay : public IT8951Display {
+ public:
+  using IT8951Display::IT8951Display;
+
+  void setup() override;
+  void fill(Color color) override;
+  // Single-pixel drawing cannot be streamed; the config never routes a
+  // per-pixel writer to this class (see display.py).
+  void draw_pixel_at(int /*x*/, int /*y*/, Color /*color*/) override {}
+  void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, ColorOrder order,
+                      ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
+
+ protected:
+  // Only a whole-screen constant fill needs the streaming transfer phase; a
+  // normal update's pixels are already in controller RAM.
+  bool needs_transfer_() const override { return this->fill_pending_; }
+  const uint8_t *transfer_row_data_(uint16_t row) const override { return this->fill_row_.get(); }
+  void on_initialised_() override;
+  void on_transfer_done_() override { this->fill_pending_ = false; }
+
+  // Stream one flush rectangle, already in native panel coordinates and
+  // already alignment-checked, into controller image RAM.
+  void write_area_(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t *ptr, ColorOrder order,
+                   ColorBitness bitness, bool big_endian, size_t line_stride, int x_offset, int y_offset,
+                   bool mirror_x, bool mirror_y);
+  // Pack one native row of a flush rectangle into row_buf_.
+  void pack_row_(uint16_t native_x, uint16_t native_y, uint16_t w, const uint8_t *ptr, ColorOrder order,
+                 ColorBitness bitness, bool big_endian, size_t source_index, bool mirror_x);
+  // Bring the controller out of sleep before a direct write. Returns false if
+  // the controller is not in a state that can accept pixel data.
+  bool prepare_direct_write_();
+
+  // One native-format row of the widest possible flush rectangle.
+  std::unique_ptr<uint8_t[]> row_buf_;
+  // Constant row used by the whole-screen fill path.
+  std::unique_ptr<uint8_t[]> fill_row_;
+  bool fill_pending_{false};
+  // Logged once so a misconfigured panel doesn't flood the log every flush.
+  bool alignment_warned_{false};
 };
 
 // --- Automation action ---

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -458,12 +458,16 @@ class IT8951DirectDisplay : public IT8951Display {
 
   // Stream one flush rectangle, already in native panel coordinates and
   // already alignment-checked, into controller image RAM.
+  // The rectangle passed here is the clipped one; source_w/source_h and
+  // clip_left/clip_top describe where it sits inside the caller's rectangle, so
+  // a mirrored axis still reads from the right end of the source.
   void write_area_(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t *ptr, ColorOrder order,
                    ColorBitness bitness, bool big_endian, size_t line_stride, int x_offset, int y_offset, bool mirror_x,
-                   bool mirror_y);
+                   bool mirror_y, uint16_t source_w, uint16_t source_h, uint16_t clip_left, uint16_t clip_top);
   // Pack one native row of a flush rectangle into row_buf_.
   void pack_row_(uint16_t native_x, uint16_t native_y, uint16_t w, const uint8_t *ptr, ColorOrder order,
-                 ColorBitness bitness, bool big_endian, size_t source_index, bool mirror_x);
+                 ColorBitness bitness, bool big_endian, size_t source_index, bool mirror_x, uint16_t source_w,
+                 uint16_t clip_left);
   // Bring the controller out of sleep before a direct write. Returns false if
   // the controller is not in a state that can accept pixel data.
   bool prepare_direct_write_();

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -69,6 +69,24 @@ template<typename T, size_t N> class StaticOpQueue {
   size_t count_{0};
 };
 
+// A rectangle of the panel, in native (post-transform) coordinates.
+struct DirtyRect {
+  uint16_t x, y, w, h;
+  uint32_t area() const { return static_cast<uint32_t>(this->w) * this->h; }
+};
+
+// How many separate regions a single update may present. Each one costs its own
+// waveform — the LUT engine has to finish one before the next starts — so this
+// trades refresh time against how much untouched content gets re-driven.
+static constexpr size_t MAX_DIRTY_RECTS = 4;
+
+// Merging two dirty rectangles drags in whatever sits between them, and an
+// e-paper waveform re-drives every pixel of the region it is given: that is what
+// makes a neighbouring label visibly flash when an unrelated widget changes.
+// Merge only while the union wastes at most this fraction of the pixels actually
+// drawn, expressed as a divisor (4 = 25%).
+static constexpr uint32_t DIRTY_MERGE_WASTE_DIVISOR = 4;
+
 // Op queue capacity. See StaticOpQueue comment for sizing analysis.
 static constexpr size_t OP_QUEUE_SIZE = 32;
 
@@ -313,6 +331,19 @@ class IT8951Display : public Display,
   virtual void on_transfer_done() {}
 
   bool prepare_update_region_(UpdateMode &mode);
+  // Record a drawn rectangle, merging it into an existing one when that costs
+  // little. Cheap per call, so the direct-draw path calls it once per flush.
+  void mark_dirty_(int x, int y, int w, int h);
+  // Fold the pending bounding box (grown per pixel by the buffered draw path,
+  // where a call per pixel would be far too expensive) into the rectangle list.
+  void flush_pending_bbox_();
+  // Replace everything recorded with a single full-screen region.
+  void mark_whole_screen_dirty_();
+  // Point area_* at one of the rectangles being presented.
+  void set_area_from_rect_(size_t index);
+  // How many regions this instance may present separately. The buffered path
+  // stays on one, so its behaviour is unchanged.
+  virtual size_t max_dirty_rects() const { return 1; }
 
   // --- Recovery ---
   void recover_();
@@ -382,8 +413,15 @@ class IT8951Display : public Display,
   // GPIOs driven high during setup to power on the panel (empty if unused).
   std::vector<GPIOPin *> enable_pins_;
 
-  // Dirty region (pixel coordinates of bounding box of changes since last update)
+  // Pending dirty bounding box, grown per pixel by the buffered draw path and
+  // folded into dirty_ by flush_pending_bbox_.
   uint16_t x_low_{0}, y_low_{0}, x_high_{0}, y_high_{0};
+  // Regions drawn since the last update, and the snapshot being presented by the
+  // update currently running. They are separate so that drawing during a refresh
+  // accumulates for the next one instead of mutating the list being walked.
+  StaticVector<DirtyRect, MAX_DIRTY_RECTS> dirty_;
+  StaticVector<DirtyRect, MAX_DIRTY_RECTS> presenting_;
+  size_t refresh_index_{0};
 
   // Saved data rate so we can probe slow then run fast
   uint32_t configured_data_rate_{0};
@@ -467,6 +505,10 @@ class IT8951DirectDisplay : public IT8951Display {
   // Only a whole-screen constant fill needs the streaming transfer phase; a
   // normal update's pixels are already in controller RAM.
   bool needs_transfer() const override { return this->fill_pending_; }
+  // LVGL hands over one rectangle per flush, so the regions that actually
+  // changed are known exactly; presenting their bounding box would re-drive
+  // everything between them.
+  size_t max_dirty_rects() const override { return MAX_DIRTY_RECTS; }
   const uint8_t *transfer_row_data(uint16_t row) const override { return this->fill_row_.get(); }
   void on_initialised() override;
   void on_transfer_done() override { this->fill_pending_ = false; }

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -304,13 +304,13 @@ class IT8951Display : public Display,
   // True when the current update has to stream pixel data to the controller.
   // The direct-draw subclass has already written the image as LVGL flushed it,
   // so it only needs the transfer phase for whole-screen constant fills.
-  virtual bool needs_transfer_() const { return true; }
+  virtual bool needs_transfer() const { return true; }
   // Source bytes for one row of the current update area, in native wire format.
-  virtual const uint8_t *transfer_row_data_(uint16_t row) const;
+  virtual const uint8_t *transfer_row_data(uint16_t row) const;
   // Called once the controller handshake has completed and initialised_ is set.
-  virtual void on_initialised_() {}
+  virtual void on_initialised() {}
   // Called when the transfer phase has streamed its last row.
-  virtual void on_transfer_done_() {}
+  virtual void on_transfer_done() {}
 
   bool prepare_update_region_(UpdateMode &mode);
 
@@ -466,10 +466,10 @@ class IT8951DirectDisplay : public IT8951Display {
  protected:
   // Only a whole-screen constant fill needs the streaming transfer phase; a
   // normal update's pixels are already in controller RAM.
-  bool needs_transfer_() const override { return this->fill_pending_; }
-  const uint8_t *transfer_row_data_(uint16_t row) const override { return this->fill_row_.get(); }
-  void on_initialised_() override;
-  void on_transfer_done_() override { this->fill_pending_ = false; }
+  bool needs_transfer() const override { return this->fill_pending_; }
+  const uint8_t *transfer_row_data(uint16_t row) const override { return this->fill_row_.get(); }
+  void on_initialised() override;
+  void on_transfer_done() override { this->fill_pending_ = false; }
 
   // Stream one flush rectangle, already in native panel coordinates and
   // already alignment-checked, into controller image RAM.

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -206,7 +206,12 @@ class IT8951Display : public Display,
   // composition is finished. That is why update requests are swallowed rather
   // than queued: on a panel this size there is no room in controller RAM for a
   // second frame to compose into.
-  void set_refresh_paused(bool paused);
+  // Resuming presents whatever was requested while paused, using the region
+  // that accumulated across every render since. Passing a mode replaces the one
+  // the swallowed request carried, which is how a caller picks a waveform per
+  // present (DU for a tap, GC16 for a page change) even when something else —
+  // LVGL's update_when_display_idle, say — issued the request.
+  void set_refresh_paused(bool paused, UpdateMode mode = UPDATE_MODE_NONE);
   bool is_refresh_paused() const { return this->refresh_paused_; }
   // Present the whole screen from controller image memory, clearing any pause.
   // Nothing is transferred: this shows whatever was last written, which is the
@@ -412,14 +417,24 @@ template<typename... Ts> class IT8951ResumeAction : public Action<Ts...> {
 
  protected:
   void play(const Ts &...x) override {
-    // With an explicit mode, present the whole screen from controller memory
-    // regardless of what was drawn; without one, present only what an update
-    // request asked for while paused.
-    if (this->mode_.has_value()) {
-      this->display_->refresh_now(this->mode_.value(x...));
-    } else {
-      this->display_->set_refresh_paused(false);
-    }
+    this->display_->set_refresh_paused(false, this->mode_.has_value() ? this->mode_.value(x...) : UPDATE_MODE_NONE);
+  }
+
+  IT8951Display *display_;
+};
+
+// it8951.refresh — present the whole screen from controller memory, whatever is
+// in it, clearing any pause. Unlike resume this does not depend on an update
+// having been requested, which is what makes it the way to show a frame that was
+// composed earlier.
+template<typename... Ts> class IT8951RefreshAction : public Action<Ts...> {
+ public:
+  explicit IT8951RefreshAction(IT8951Display *display) : display_(display) {}
+  TEMPLATABLE_VALUE(UpdateMode, mode)
+
+ protected:
+  void play(const Ts &...x) override {
+    this->display_->refresh_now(this->mode_.has_value() ? this->mode_.value(x...) : UPDATE_MODE_NONE);
   }
 
   IT8951Display *display_;

--- a/esphome/components/it8951/it8951.h
+++ b/esphome/components/it8951/it8951.h
@@ -405,8 +405,8 @@ class IT8951DirectDisplay : public IT8951Display {
   // Stream one flush rectangle, already in native panel coordinates and
   // already alignment-checked, into controller image RAM.
   void write_area_(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t *ptr, ColorOrder order,
-                   ColorBitness bitness, bool big_endian, size_t line_stride, int x_offset, int y_offset,
-                   bool mirror_x, bool mirror_y);
+                   ColorBitness bitness, bool big_endian, size_t line_stride, int x_offset, int y_offset, bool mirror_x,
+                   bool mirror_y);
   // Pack one native row of a flush rectangle into row_buf_.
   void pack_row_(uint16_t native_x, uint16_t native_y, uint16_t w, const uint8_t *ptr, ColorOrder order,
                  ColorBitness bitness, bool big_endian, size_t source_index, bool mirror_x);

--- a/tests/components/it8951/test-direct.esp32-s3-idf.yaml
+++ b/tests/components/it8951/test-direct.esp32-s3-idf.yaml
@@ -56,7 +56,8 @@ lvgl:
 
   - id: lvgl_mono
     displays: [direct_mono]
-    update_when_display_idle: true
+    # No update_when_display_idle here: this config drives updates explicitly
+    # so it can pick a waveform per update, which that option would override.
     # Direct draw advertises has_hardware_rotation=false, so this exercises
     # LVGL's software rotation path rather than driver-side rotation.
     rotation: 90

--- a/tests/components/it8951/test-direct.esp32-s3-idf.yaml
+++ b/tests/components/it8951/test-direct.esp32-s3-idf.yaml
@@ -64,3 +64,16 @@ lvgl:
       - label:
           align: CENTER
           text: "Rotated"
+
+# Deferred presentation: compose the next frame into controller memory while
+# the current one stays on the panel, then present it with one waveform.
+interval:
+  - interval: 60s
+    then:
+      - it8951.pause: direct_gray
+      - lambda: lv_refr_now(nullptr);
+      - it8951.resume:
+          id: direct_gray
+          mode: GC16
+      - it8951.pause: direct_mono
+      - it8951.resume: direct_mono

--- a/tests/components/it8951/test-direct.esp32-s3-idf.yaml
+++ b/tests/components/it8951/test-direct.esp32-s3-idf.yaml
@@ -73,8 +73,15 @@ interval:
     then:
       - it8951.pause: direct_gray
       - lambda: lv_refr_now(nullptr);
+      # Resume presents the accumulated region with the given waveform.
       - it8951.resume:
+          id: direct_gray
+          mode: DU
+      # Refresh presents the whole screen from controller memory, whether or not
+      # an update was requested while paused.
+      - it8951.refresh:
           id: direct_gray
           mode: GC16
       - it8951.pause: direct_mono
       - it8951.resume: direct_mono
+      - it8951.refresh: direct_mono

--- a/tests/components/it8951/test-direct.esp32-s3-idf.yaml
+++ b/tests/components/it8951/test-direct.esp32-s3-idf.yaml
@@ -1,0 +1,66 @@
+# Direct-draw variant: no lambda/pages, so the driver streams LVGL's flush
+# rectangles straight into the controller's image RAM instead of allocating a
+# framebuffer. Covers both pixel formats and the software-rotation path that
+# direct draw forces LVGL onto.
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-s3-idf.yaml
+
+display:
+  # Grayscale (4bpp loads), with the panel's own mirror_x transform applied in
+  # the packing loop.
+  - platform: it8951
+    id: direct_gray
+    spi_id: spi_bus
+    model: seeed-reterminal-e1003
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+    vcom: 1400
+    sleep_when_done: false
+
+  # Monochrome (8bpp-packed 1bpp loads) with ordered dithering, so the dither
+  # threshold has to stay keyed to absolute panel coordinates across flushes.
+  - platform: it8951
+    id: direct_mono
+    spi_id: spi_bus
+    model: m5stack-m5paper
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+    grayscale: false
+    dithering: true
+    sleep_when_done: true
+
+lvgl:
+  - id: lvgl_gray
+    displays: [direct_gray]
+    # Required for a framebuffer-less it8951: withholds rendering while a
+    # waveform is in flight and drives the refresh once a render completes.
+    update_when_display_idle: true
+    widgets:
+      - label:
+          align: CENTER
+          text: "Direct draw"
+
+  - id: lvgl_mono
+    displays: [direct_mono]
+    update_when_display_idle: true
+    # Direct draw advertises has_hardware_rotation=false, so this exercises
+    # LVGL's software rotation path rather than driver-side rotation.
+    rotation: 90
+    widgets:
+      - label:
+          align: CENTER
+          text: "Rotated"


### PR DESCRIPTION
> [!IMPORTANT]
> Draft, opened to give @clydebarrow something concrete to react to rather than to ask for a merge. It implements the first two pieces suggested in https://github.com/esphome/esphome/pull/17527#issuecomment-5648763879 — direct draw avoiding the in-memory buffer, and a way to pause and resume display refresh. #17527 is now a draft; if this direction is right, it replaces it.

## What does this implement/fix?

`it8951` allocates a full framebuffer (~1.25 MiB on a 1872×1404 panel), draws into it, then streams the dirty rectangle to the controller on each update. When the only writer is LVGL — which pushes whole rectangles rather than individual pixels — that intermediate copy is unnecessary.

`IT8951DirectDisplay` converts each LVGL flush to the native wire format and streams it straight into the controller's image memory, one `LD_IMG_AREA` per flush. It is selected automatically, exactly when nothing draws pixel by pixel (no `lambda:`, `pages:` or test card), mirroring the `MipiSpi` / `MipiSpiBuffer` split. The buffered class is unchanged for `lambda:`/`pages:` configs.

### Deferred presentation

Only a waveform changes what an e-paper panel shows, so the next screen can be composed into controller memory while the current one stays on the glass, then presented in one waveform with no rendering and nothing sent over SPI. `it8951.pause` holds back the waveform, `it8951.resume` presents what was composed, `it8951.refresh` presents the whole screen from controller memory regardless of what was requested.

These are not separable from direct draw, and that is worth stating plainly:

1. A render landing mid-waveform overwrites the image the panel is still drawing from, so it has to be dropped.
2. Only LVGL's `update_when_display_idle` prevents that. Gating a configuration's own `lv_refr_now()` calls is not enough — LVGL's refresh timer renders on its own schedule. Measured: a dashboard whose every explicit render was already gated still produced 39 dropped flushes in a minute of logs.
3. That option presents at every render end using the display's default waveform, which rules out picking DU for a tap and GC16 for a page change.
4. `pause` swallows those requests and `resume` supplies the waveform the update actually wants.

So configuration now *requires* `update_when_display_idle` on any `lvgl:` driving a framebuffer-less display. The check currently lives in `it8951`'s own `_final_validate` — see the open questions.

### Notes on the implementation

**Alignment** was already satisfied: the driver declares `draw_rounding`, and mirroring a rounded rectangle on a 16-aligned panel width leaves it 16-aligned, covering the controller's 4-pixel (4bpp) and 16-pixel (8bpp-packed mono) load boundaries. Rounding is 16 rather than 32 because the 32-pixel snap that partial *refresh* needs is applied separately in `prepare_update_region_` and only on X; asking LVGL for 32 rounded both axes and turned a one-pixel text change into 32×32 of converted pixels.

**Rotation** goes to LVGL (`has_hardware_rotation=false`): transposing a flush needs a chunk-sized scratch buffer, which LVGL's software and ESP32-P4 PPA paths already provide. `mirror_x`/`mirror_y` fold into the packing loop for free. `swap_xy` is rejected, as is a hand-entered panel width that mirroring would knock out of alignment.

**Flush rectangles are clipped, not dropped.** LVGL rounds redraw areas up, and neither panel dimension is a multiple of 32, so the last stripe of a full redraw always overhangs — an 1872-wide panel gets 1888-wide flushes. The buffered path never noticed because its per-pixel bounds test silently skips the overhang.

**A second image buffer is not available** on the large panels, which constrains any deferred-presentation design: the IT8951's image buffer is 8bpp internally, so 1872×1404 costs ~2.5 MiB regardless of the 4bpp load format, and with ~4.3 MB reserved out of 8 MB there is no room for a second frame. Tested on hardware. The composed frame is therefore torn while paused, which is why paused refresh requests are swallowed rather than queued.

**Per-flush conversion** decides its shape once instead of per pixel: LVGL passes a compile-time-constant bitness with fixed colour order and endianness. The specialised path takes luma straight from the 5/6/5 fields; checked against the generic path across all 65536 values, 98.98% identical and the rest one level of sixteen apart at bin boundaries, with black, white and the primaries exact.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows from the review discussion on #17527

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- Drafted, held until the API stops moving.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Exercised on a Seeed reTerminal E1003 (1872×1404), running a real LVGL dashboard plus three purpose-built test pages:

| Exercised | Result |
|---|---|
| 4bpp grayscale, `mirror_x`, live dashboard | Working in daily use |
| Packed 1bpp mono (`grayscale: false`) with dithering | Text legible — 16-pixel group bit order correct; bands, dither continuity across flush boundaries, and partial updates correct |
| Edge clipping (border hard against all four edges) | Correct, right edge intact |
| LVGL software rotation (`rotation: 90`) | Correct: orientation, corners, edges, 4bpp levels under rotated writes |
| `mirror_y` + `invert_colors` | Correct: page appears 180° rotated (withheld `mirror_x` ∘ applied `mirror_y`), readable rather than mirror-written, colours inverted |

Each test page was rebuilt from `dad3d588d` and the compiled source checked, after an earlier round was found to have silently used a cached older revision.

Not yet validated: the ESP32-P4 PPA rotation path (no hardware).

## Example entry for `config.yaml`:

```yaml
display:
  - platform: it8951
    id: epaper
    model: seeed-reterminal-e1003
    update_interval: never

lvgl:
  displays: [epaper]
  update_when_display_idle: true
  widgets:
    - label:
        align: CENTER
        text: "No framebuffer"

script:
  # Compose the next screen without disturbing what is on the panel.
  - id: compose_next
    then:
      - it8951.pause: epaper
      - lvgl.page.show: page_b
      - lambda: lv_refr_now(nullptr);
  # Show it: one waveform, no render, nothing sent.
  - id: show_next
    then:
      - it8951.refresh:
          id: epaper
          mode: GC16
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).

### Open questions for review

1. **Where does the `update_when_display_idle` requirement belong?** It is enforced in `it8951`'s own final validation to keep the change local, but the option lives on `lvgl:`. A `DisplayMetaData` flag checked in `lvgl`'s `final_validation` would put the check where the option is, and `epaper_spi` would want the same.
2. **Should pause/resume be generic?** The review asked for a method to pause and resume display refresh; this is `it8951`-specific. A display-level "ignore `update()` from the polling layer" flag would cover the same use case with less machinery, but cannot express "compose now, present later" for a caller that does not drive updates itself.
3. **Selection is automatic.** Existing LVGL-only configs silently switch to direct draw and must add `update_when_display_idle: true`, which is a validation error until they do. Opt-in instead?
4. **`requires_buffer()`** lives in `mipi/__init__.py`; this duplicates the predicate. Worth promoting to `display/`?
5. **Class hierarchy.** `IT8951DirectDisplay` derives from the buffered class and overrides four methods to disable what it inherits, which is the opposite of `MipiSpi`/`MipiSpiBuffer`. Inverting it is mechanical but large; happy to do it if this direction is agreed.
6. **Presenting each changed region separately** was implemented and reverted (`it8951-multi-rect` branch). Each region costs its own waveform, and an area-based merge heuristic cannot tell blank background from a label: on a real dashboard the harmless vertical gap wasted 77% of the drawn pixels while merging two whole neighbouring columns wasted only 16%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dQotATq71G1Uxrzbq7c37
